### PR TITLE
Add text outline to ruler dimensions.

### DIFF
--- a/frontend/src/uxbox/main/ui/workspace/ruler.cljs
+++ b/frontend/src/uxbox/main/ui/workspace/ruler.cljs
@@ -32,22 +32,22 @@
                      (mth/precision 2))
         angle (-> (gpt/angle pt center)
                   (mth/precision 2))
-        transform1 (str "translate(" (+ (:x pt) 35) "," (- (:y pt) 10) ")")
-        transform2 (str "translate(" (+ (:x pt) 25) "," (- (:y pt) 30) ")")]
+        translate (-> (str "translate(" (+ (:x pt) 15) "," (- (:y pt) 10) ")"))
+        attrs (-> {:transform translate})
+        tspans (-> (list [:tspan {:x "0"}
+                          (str distance " px")]
+                         [:tspan {:x "0" :y "20"}
+                          (str angle "°")]))]
+
     [:g
-     [:rect {:fill "black"
-             :fill-opacity "0.4"
-             :rx "3"
-             :ry "3"
-             :width "90"
-             :height "50"
-             :transform transform2}]
-     [:text {:transform transform1
-             :fill "white"}
-      [:tspan {:x "0"}
-       (str distance " px")]
-      [:tspan {:x "0" :y "20"}
-       (str angle "°")]]]))
+     [:text
+      (assoc attrs :stroke "white"
+                   :stroke-width "3.4"
+                   :stroke-opacity "0.8")
+      tspans]
+     [:text
+      (assoc attrs :fill "black")
+      tspans]]))
 
 (mx/defc ruler-line
   {:mixins [mx/static]}

--- a/frontend/src/uxbox/main/ui/workspace/ruler.cljs
+++ b/frontend/src/uxbox/main/ui/workspace/ruler.cljs
@@ -25,9 +25,12 @@
       (l/derive refs/workspace)))
 
 (mx/defc ruler-text
-  {:mixins [mx/static]}
+  {:mixins [mx/static mx/reactive]}
+
   [zoom [center pt]]
-  (let [distance (-> (gpt/distance (gpt/divide pt zoom)
+  (let [{:keys [id metadata] :as page} (mx/react refs/selected-page)
+        metadata (merge c/page-metadata metadata)
+        distance (-> (gpt/distance (gpt/divide pt zoom)
                                    (gpt/divide center zoom))
                      (mth/precision 2))
         angle (-> (gpt/angle pt center)
@@ -41,7 +44,7 @@
 
     [:g
      [:text
-      (assoc attrs :stroke "white"
+      (assoc attrs :stroke (or (:background metadata) "#ffffff")
                    :stroke-width "3.4"
                    :stroke-opacity "0.8")
       tspans]


### PR DESCRIPTION
First time, so I hope I'm doing this right ;-)
I have fixed #75 in a different way to @niwinz, by adding a text outline. I think this is a cleaner design. Sorry I couldn't do this before you got your solution finished. Let me know what you think.
![outline](https://cloud.githubusercontent.com/assets/4901306/23736811/b9577022-04e2-11e7-8d4c-e6dea160c2ea.jpg)

Signed-off-by: Sean Loughman <sean@studiospring.com.au>