### PR TITLE
Add server CORS env var in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Available at runtime:
 -	`-e LC_ALL=...` (defaults to `C.UTF-8`)
 -	`-e UXBOX_HTTP_SERVER_PORT=...` (defaults to `6060`)
 -	`-e UXBOX_HTTP_SERVER_DEBUG=...` (defaults to `true`)
+-	`-e UXBOX_HTTP_SERVER_CORS=...` (defaults to `http://localhost:3449`)
 -	`-e UXBOX_DATABASE_USERNAME="..."` (defaults to `nil`)
 -	`-e UXBOX_DATABASE_PASSWORD="..."` (defaults to `nil`)
 -	`-e UXBOX_DATABASE_URI="..."` (defaults to ` `, will be computed based on other DATABASE parameters if empty)


### PR DESCRIPTION
:memo: Add server CORS env var in doc

@niwinz I saw you added CORS settings, so I add the documentation that goes with it.

By the way, I do not know if it's still in progress or CORS should be working, but I cannot contact the backend due to CORS error `The Same Origin Policy disallows reading the remote resource at http://localhost:6060/api/auth/login` even though I'm working on http://localhost:3449.

