### PR TITLE
Typo: land must be lang

### DIFF
--- a/frontend/src/uxbox/main/data/users.cljs
+++ b/frontend/src/uxbox/main/data/users.cljs
@@ -49,7 +49,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (assoc state :profile (cond-> data
-                              (nil? (:land data)) (assoc :lang cfg/default-language)
+                              (nil? (:lang data)) (assoc :lang cfg/default-language)
                               (nil? (:theme data)) (assoc :theme cfg/default-theme))))
 
     ptk/EffectEvent


### PR DESCRIPTION
:bug: Typo: `land` must be `lang` in profile fetched