### PR TITLE
🔨 In frontend build script get TAG value from environment.

### DIFF
--- a/frontend/scripts/build-app.sh
+++ b/frontend/scripts/build-app.sh
@@ -3,7 +3,9 @@
 source ~/.bashrc
 set -ex
 
-TAG=`git log -n 1 --pretty=format:%H -- ./`
+if [ -z "${TAG}" ]; then
+    export TAG=`git log -n 1 --pretty=format:%H -- ./`
+fi
 
 yarn install
 


### PR DESCRIPTION
To build frontend inside docker with `build-app.sh` it is useful to set TAG explicitly or without version control.
We keep the value from `git log -n 1` as a fallback.