### PR TITLE
:tada: Add blob encoding v3.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### :sparkles: New features
 
 - Add more chinese translations [#726](https://github.com/penpot/penpot/pull/726)
+- Add blob-encoding v3 (uses ZSTD+transit) [#738](https://github.com/penpot/penpot/pull/738)
 - Duplicate and move files and projects [Taiga #267](https://tree.taiga.io/project/penpot/us/267)
 - Improve french translations [#731](https://github.com/penpot/penpot/pull/731)
 

--- a/backend/dev/user.clj
+++ b/backend/dev/user.clj
@@ -12,11 +12,12 @@
    [app.common.exceptions :as ex]
    [app.config :as cfg]
    [app.main :as main]
+   [app.util.blob :as blob]
+   [app.util.json :as json]
    [app.util.time :as dt]
    [app.util.transit :as t]
-   [app.util.json :as json]
    [clojure.java.io :as io]
-   [clojure.pprint :refer [pprint]]
+   [clojure.pprint :refer [pprint print-table]]
    [clojure.repl :refer :all]
    [clojure.spec.alpha :as s]
    [clojure.spec.gen.alpha :as sgen]
@@ -25,8 +26,7 @@
    [clojure.tools.namespace.repl :as repl]
    [clojure.walk :refer [macroexpand-all]]
    [criterium.core :refer [quick-bench bench with-progress-reporting]]
-   [integrant.core :as ig]
-   [taoensso.nippy :as nippy]))
+   [integrant.core :as ig]))
 
 (repl/disable-reload! (find-ns 'integrant.core))
 
@@ -91,3 +91,10 @@
   []
   (stop)
   (repl/refresh-all :after 'user/start))
+
+(defn compression-bench
+  [data]
+  (print-table
+   [{:v1 (alength (blob/encode data {:version 1}))
+     :v2 (alength (blob/encode data {:version 2}))
+     :v3 (alength (blob/encode data {:version 3}))}]))


### PR DESCRIPTION
After testing a lot the v2, I'm not completelly convinced using nippy for long storage. We have used transit+json exstensivelly and we know it works as expected; The v3 format uses the same underlying serialization as v1 (current default) but changes LZ4 compression with ZSTD. The result is the following in terms of compression:

```
user=> (compression-bench (:data file))

|   :v1 |   :v2 |   :v3 |
|-------+-------+-------|
| 83735 | 32103 | 37800 |
nil
```

- v1 -> LZ4 + transit + json (current default)
- v2 -> ZSTD + nippy
- v3 -> ZSTD + transit + json

In terms of performance v3 is slightly faster than v2, and slightly slower than v1.