### PR TITLE
[hotfix]: fix profile-by-email

### DIFF
--- a/backend/dev/user.clj
+++ b/backend/dev/user.clj
@@ -12,11 +12,12 @@
    [app.common.exceptions :as ex]
    [app.config :as cfg]
    [app.main :as main]
+   [app.util.blob :as blob]
+   [app.util.json :as json]
    [app.util.time :as dt]
    [app.util.transit :as t]
-   [app.util.json :as json]
    [clojure.java.io :as io]
-   [clojure.pprint :refer [pprint]]
+   [clojure.pprint :refer [pprint print-table]]
    [clojure.repl :refer :all]
    [clojure.spec.alpha :as s]
    [clojure.spec.gen.alpha :as sgen]
@@ -25,8 +26,7 @@
    [clojure.tools.namespace.repl :as repl]
    [clojure.walk :refer [macroexpand-all]]
    [criterium.core :refer [quick-bench bench with-progress-reporting]]
-   [integrant.core :as ig]
-   [taoensso.nippy :as nippy]))
+   [integrant.core :as ig]))
 
 (repl/disable-reload! (find-ns 'integrant.core))
 
@@ -91,3 +91,10 @@
   []
   (stop)
   (repl/refresh-all :after 'user/start))
+
+(defn compression-bench
+  [data]
+  (print-table
+   [{:v1 (alength (blob/encode data {:version 1}))
+     :v2 (alength (blob/encode data {:version 2}))
+     :v3 (alength (blob/encode data {:version 3}))}]))

--- a/backend/resources/log4j2.xml
+++ b/backend/resources/log4j2.xml
@@ -23,6 +23,7 @@
     <Logger name="com.zaxxer.hikari" level="error"/>
     <Logger name="io.lettuce" level="error" />
     <Logger name="org.eclipse.jetty" level="error" />
+    <Logger name="org.postgresql" level="error" />
 
     <Logger name="app.cli" level="debug" additivity="false">
       <AppenderRef ref="console"/>
@@ -32,7 +33,7 @@
       <AppenderRef ref="main" level="debug" />
     </Logger>
 
-    <Logger name="app" level="debug" additivity="false">
+    <Logger name="app" level="all" additivity="false">
       <AppenderRef ref="main" level="trace" />
       <AppenderRef ref="zmq" level="debug" />
     </Logger>

--- a/backend/scripts/repl
+++ b/backend/scripts/repl
@@ -2,7 +2,7 @@
 
 export PENPOT_ASSERTS_ENABLED=true
 
-export OPTIONS="-A:jmx-remote:dev -J-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory -J-Xms512m -J-Xmx512m"
+export OPTIONS="-A:jmx-remote:dev -J-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory -J-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -J-Xms512m -J-Xmx512m"
 export OPTIONS_EVAL="nil"
 # export OPTIONS_EVAL="(set! *warn-on-reflection* true)"
 

--- a/backend/src/app/http/session.clj
+++ b/backend/src/app/http/session.clj
@@ -147,7 +147,7 @@
           (mcnt :inc)
           (if (ex/exception? result)
             (log/error result "updater: unexpected error on update sessions")
-            (log/tracef "updater: updated %s sessions (reason: %s)." result (name reason)))
+            (log/debugf "updater: updated %s sessions (reason: %s)." result (name reason)))
           (recur))))))
 
 (defn- timeout-chan

--- a/backend/src/app/rpc/queries/profile.clj
+++ b/backend/src/app/rpc/queries/profile.clj
@@ -13,10 +13,8 @@
    [app.common.spec :as us]
    [app.common.uuid :as uuid]
    [app.db :as db]
-   [app.db.sql :as sql]
    [app.util.services :as sv]
-   [clojure.spec.alpha :as s]
-   [cuerdas.core :as str]))
+   [clojure.spec.alpha :as s]))
 
 ;; --- Helpers & Specs
 
@@ -97,12 +95,16 @@
 
     profile))
 
+(def sql:retrieve-profile-by-email
+  "select p.* from profile as p
+    where p.email = lower(?)
+      and p.deleted_at is null")
+
 (defn retrieve-profile-data-by-email
   [conn email]
-  (let [sql  (sql/select :profile {:email (str/lower email)})
-        data (db/exec-one! conn sql)]
-    (when (and data (nil? (:deleted-at data)))
-      (decode-profile-row data))))
+  (let [sql  [sql:retrieve-profile-by-email email]]
+    (some-> (db/exec-one! conn sql)
+            (decode-profile-row))))
 
 ;; --- Attrs Helpers
 

--- a/frontend/src/app/main/ui/components/forms.cljs
+++ b/frontend/src/app/main/ui/components/forms.cljs
@@ -23,7 +23,7 @@
 
 (mf/defc input
   [{:keys [label help-icon disabled form hint trim] :as props}]
-  (let [input-type   (get props :type)
+  (let [input-type   (get props :type "text")
         input-name   (get props :name)
         more-classes (get props :class)
 


### PR DESCRIPTION
This hotfix includes:
- A fix to retrieve-profile-by-email that does not handles properly the deleted profiles (rare case).
- Minor logging improvements.
- Backport the blob encoding v3 (deactivated, will help in a next release be able to rollback more easy).
- Visual bug in team invitation modal.