### PR TITLE
:bug: Fix naming of duplicated objects in copy&paste and others

### DIFF
--- a/frontend/src/app/main/data/workspace/common.cljs
+++ b/frontend/src/app/main/data/workspace/common.cljs
@@ -68,19 +68,17 @@
 
 (defn generate-unique-name
   "A unique name generator"
-  ([used basename]
-   (generate-unique-name used basename false))
-  ([used basename prefix-first?]
-   (s/assert ::set-of-string used)
-   (s/assert ::us/string basename)
-   (let [[prefix initial] (extract-numeric-suffix basename)]
-     (loop [counter initial]
-       (let [candidate (if (and (= 1 counter) prefix-first?)
-                         (str prefix)
-                         (str prefix "-" counter))]
-         (if (contains? used candidate)
-           (recur (inc counter))
-           candidate))))))
+  [used basename]
+  (s/assert ::set-of-string used)
+  (s/assert ::us/string basename)
+  (if-not (contains? used basename)
+    basename
+    (let [[prefix initial] (extract-numeric-suffix basename)]
+      (loop [counter initial]
+        (let [candidate (str prefix "-" counter)]
+          (if (contains? used candidate)
+            (recur (inc counter))
+            candidate))))))
 
 ;; --- Shape attrs (Layers Sidebar)
 

--- a/frontend/src/app/main/data/workspace/groups.cljs
+++ b/frontend/src/app/main/data/workspace/groups.cljs
@@ -182,7 +182,7 @@
             shapes   (shapes-for-grouping objects selected)]
         (when-not (empty? shapes)
           (let [[group rchanges uchanges]
-                (prepare-create-group objects page-id shapes "Group" false)]
+                (prepare-create-group objects page-id shapes "Group-1" false)]
             (rx/of (dch/commit-changes {:redo-changes rchanges
                                         :undo-changes uchanges
                                         :origin it})
@@ -221,7 +221,7 @@
                 (if (and (= (count shapes) 1)
                          (= (:type (first shapes)) :group))
                   [(first shapes) [] []]
-                  (prepare-create-group objects page-id shapes "Group" true))
+                  (prepare-create-group objects page-id shapes "Group-1" true))
 
                 rchanges (d/concat rchanges
                                    [{:type :mod-obj

--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -129,7 +129,7 @@
         (if (and (= (count shapes) 1)
                  (= (:type (first shapes)) :group))
           [(first shapes) [] []]
-          (dwg/prepare-create-group objects page-id shapes "Component" true))
+          (dwg/prepare-create-group objects page-id shapes "Component-1" true))
 
         [new-shape new-shapes updated-shapes]
         (make-component-shape group objects file-id)

--- a/frontend/src/app/main/data/workspace/svg_upload.cljs
+++ b/frontend/src/app/main/data/workspace/svg_upload.cljs
@@ -331,7 +331,7 @@
   (let [{:keys [tag attrs]} element-data
         attrs (usvg/format-styles attrs)
         element-data (cond-> element-data (map? element-data) (assoc :attrs attrs))
-        name (dwc/generate-unique-name unames (or (:id attrs) (tag->name tag)) true)
+        name (dwc/generate-unique-name unames (or (:id attrs) (tag->name tag)))
         att-refs (usvg/find-attr-references attrs)
         references (usvg/find-def-references (:defs svg-data) att-refs)
 

--- a/frontend/test/app/test_helpers/pages.cljs
+++ b/frontend/test/app/test_helpers/pages.cljs
@@ -80,7 +80,7 @@
                :obj shape}]))))
 
 (defn group-shapes
-  ([state label ids] (group-shapes state label ids "Group"))
+  ([state label ids] (group-shapes state label ids "Group-1"))
   ([state label ids prefix]
    (let [page  (current-page state)
          shapes (dwg/shapes-for-grouping (:objects page) ids)]


### PR DESCRIPTION
US en Taiga: Stop adding numbers to layer names when copy&paste to other file

https://tree.taiga.io/project/penpot/us/1929?no-milestone=1