### PR TITLE
Bugfixing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fix problem when flattening booleans losing styles [Taiga #2217](https://tree.taiga.io/project/penpot/issue/2217)
 - Add shortcuts to boolean icons popups [Taiga #2220](https://tree.taiga.io/project/penpot/issue/2220)
 - Fix a worker error when transforming a rectangle into path
+- Fix max/min values for opacity fields [Taiga #2183](https://tree.taiga.io/project/penpot/issue/2183)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 - Remove change style on hover for options [Taiga #2172](https://tree.taiga.io/project/penpot/issue/2172)
 - Fix problem in viewer with dropdowns when comments active [#1303](https://github.com/penpot/penpot/issues/1303)
 - Add placeholder to create shareable link
+- Fix project files count not refreshing correctly after import [Taiga #2216](https://tree.taiga.io/project/penpot/issue/2216)
+- Remove button after import process finish [Taiga #2215](https://tree.taiga.io/project/penpot/issue/2215)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Fix problem with text rendering on export [Taiga #2223](https://tree.taiga.io/project/penpot/issue/2223)
 - Fix problem when flattening booleans losing styles [Taiga #2217](https://tree.taiga.io/project/penpot/issue/2217)
 - Add shortcuts to boolean icons popups [Taiga #2220](https://tree.taiga.io/project/penpot/issue/2220)
+- Fix a worker error when transforming a rectangle into path
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Fix problem with view mode comments [Taiga #2226](https://tree.taiga.io/project/penpot/issue/2226).
 - Disallow to create a component when already has one [Taiga #2237](https://tree.taiga.io/project/penpot/issue/2237).
 - Add ellipsis in long labels for input fields [Taiga #2224](https://tree.taiga.io/project/penpot/issue/2224)
+- Fix problem with text rendering on export [Taiga #2223](https://tree.taiga.io/project/penpot/issue/2223)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Add ellipsis in long labels for input fields [Taiga #2224](https://tree.taiga.io/project/penpot/issue/2224)
 - Fix problem with text rendering on export [Taiga #2223](https://tree.taiga.io/project/penpot/issue/2223)
 - Fix problem when flattening booleans losing styles [Taiga #2217](https://tree.taiga.io/project/penpot/issue/2217)
+- Add shortcuts to boolean icons popups [Taiga #2220](https://tree.taiga.io/project/penpot/issue/2220)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Disallow to create a component when already has one [Taiga #2237](https://tree.taiga.io/project/penpot/issue/2237).
 - Add ellipsis in long labels for input fields [Taiga #2224](https://tree.taiga.io/project/penpot/issue/2224)
 - Fix problem with text rendering on export [Taiga #2223](https://tree.taiga.io/project/penpot/issue/2223)
+- Fix problem when flattening booleans losing styles [Taiga #2217](https://tree.taiga.io/project/penpot/issue/2217)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - Add shortcuts to boolean icons popups [Taiga #2220](https://tree.taiga.io/project/penpot/issue/2220)
 - Fix a worker error when transforming a rectangle into path
 - Fix max/min values for opacity fields [Taiga #2183](https://tree.taiga.io/project/penpot/issue/2183)
+- Fix viewer comment position when zoom applied [Taiga #2240](https://tree.taiga.io/project/penpot/issue/2240)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - Fix max/min values for opacity fields [Taiga #2183](https://tree.taiga.io/project/penpot/issue/2183)
 - Fix viewer comment position when zoom applied [Taiga #2240](https://tree.taiga.io/project/penpot/issue/2240)
 - Remove change style on hover for options [Taiga #2172](https://tree.taiga.io/project/penpot/issue/2172)
+- Fix problem in viewer with dropdowns when comments active [#1303](https://github.com/penpot/penpot/issues/1303)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - Fix a worker error when transforming a rectangle into path
 - Fix max/min values for opacity fields [Taiga #2183](https://tree.taiga.io/project/penpot/issue/2183)
 - Fix viewer comment position when zoom applied [Taiga #2240](https://tree.taiga.io/project/penpot/issue/2240)
+- Remove change style on hover for options [Taiga #2172](https://tree.taiga.io/project/penpot/issue/2172)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,9 @@
 - Fix undo stacking when changing color from color-picker [Taiga #2191](https://tree.taiga.io/project/penpot/issue/2191).
 - Fix pages dropdown in viewer [Taiga #2087](https://tree.taiga.io/project/penpot/issue/2087).
 - Fix problem when exporting texts with gradients or opacity [Taiga #2200](https://tree.taiga.io/project/penpot/issue/2200).
-- Fix problem with view mode comments [Taiga #226](https://tree.taiga.io/project/penpot/issue/2226).
+- Fix problem with view mode comments [Taiga #2226](https://tree.taiga.io/project/penpot/issue/2226).
 - Disallow to create a component when already has one [Taiga #2237](https://tree.taiga.io/project/penpot/issue/2237).
+- Add ellipsis in long labels for input fields [Taiga #2224](https://tree.taiga.io/project/penpot/issue/2224)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Fix viewer comment position when zoom applied [Taiga #2240](https://tree.taiga.io/project/penpot/issue/2240)
 - Remove change style on hover for options [Taiga #2172](https://tree.taiga.io/project/penpot/issue/2172)
 - Fix problem in viewer with dropdowns when comments active [#1303](https://github.com/penpot/penpot/issues/1303)
+- Add placeholder to create shareable link
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/common/src/app/common/geom/shapes/intersect.cljc
+++ b/common/src/app/common/geom/shapes/intersect.cljc
@@ -6,6 +6,7 @@
 
 (ns app.common.geom.shapes.intersect
   (:require
+   [app.common.data :as d]
    [app.common.geom.matrix :as gmt]
    [app.common.geom.point :as gpt]
    [app.common.geom.shapes.path :as gpp]
@@ -172,22 +173,23 @@
   "Checks if the given rect overlaps with the path in any point"
   [shape rect]
 
-  (let [;; If paths are too complex the intersection is too expensive
-        ;; we fallback to check its bounding box otherwise the performance penalty
-        ;; is too big
-        ;; TODO: Look for ways to optimize this operation
-        simple? (> (count (:content shape)) 100)
+  (when (d/not-empty? (:content shape))
+    (let [ ;; If paths are too complex the intersection is too expensive
+          ;; we fallback to check its bounding box otherwise the performance penalty
+          ;; is too big
+          ;; TODO: Look for ways to optimize this operation
+          simple? (> (count (:content shape)) 100)
 
-        rect-points  (gpr/rect->points rect)
-        rect-lines   (points->lines rect-points)
-        path-lines   (if simple?
-                       (points->lines (:points shape))
-                       (gpp/path->lines shape))
-        start-point (-> shape :content (first) :params (gpt/point))]
+          rect-points  (gpr/rect->points rect)
+          rect-lines   (points->lines rect-points)
+          path-lines   (if simple?
+                         (points->lines (:points shape))
+                         (gpp/path->lines shape))
+          start-point (-> shape :content (first) :params (gpt/point))]
 
-    (or (is-point-inside-nonzero? (first rect-points) path-lines)
-        (is-point-inside-nonzero? start-point rect-lines)
-        (intersects-lines? rect-lines path-lines))))
+      (or (is-point-inside-nonzero? (first rect-points) path-lines)
+          (is-point-inside-nonzero? start-point rect-lines)
+          (intersects-lines? rect-lines path-lines)))))
 
 (defn is-point-inside-ellipse?
   "checks if a point is inside an ellipse"

--- a/common/src/app/common/path/shapes_to_path.cljc
+++ b/common/src/app/common/path/shapes_to_path.cljc
@@ -177,12 +177,7 @@
                       (map #(get objects %))
                       (map #(convert-to-path % objects)))
         bool-type (:bool-type shape)
-        head (if (= bool-type :difference) (first children) (last children))
-        head (cond-> head
-               (and (contains? head :svg-attrs) (nil? (:fill-color head)))
-               (assoc :fill-color "#000000"))
-
-        content (pb/content-bool (:bool-type shape) (mapv :content children))]
+        content (pb/content-bool bool-type (mapv :content children))]
 
     (-> shape
         (assoc :type :path)

--- a/common/src/app/common/path/shapes_to_path.cljc
+++ b/common/src/app/common/path/shapes_to_path.cljc
@@ -182,13 +182,11 @@
                (and (contains? head :svg-attrs) (nil? (:fill-color head)))
                (assoc :fill-color "#000000"))
 
-        head-data (select-keys head style-properties)
         content (pb/content-bool (:bool-type shape) (mapv :content children))]
 
     (-> shape
         (assoc :type :path)
         (assoc :content content)
-        (merge head-data)
         (d/without-keys dissoc-attrs))))
 
 (defn convert-to-path

--- a/exporter/src/app/browser.cljs
+++ b/exporter/src/app/browser.cljs
@@ -104,7 +104,7 @@
 (def browser-pool-factory
   (letfn [(create []
             (let [path (cf/get :browser-executable-path "/usr/bin/google-chrome")]
-              (-> (pp/launch #js {:executablePath path :args #js ["--no-sandbox"]})
+              (-> (pp/launch #js {:executablePath path :args #js ["--no-sandbox" "--font-render-hinting=none"]})
                   (p/then (fn [browser]
                             (let [id (deref pool-browser-id)]
                               (log/info :origin "factory" :action "create" :browser-id id)

--- a/frontend/resources/styles/common/framework.scss
+++ b/frontend/resources/styles/common/framework.scss
@@ -396,6 +396,11 @@ ul.slider-dots {
     text-align: right;
     top: 26%;
     width: 18px;
+
+    pointer-events: none;
+    max-width: 4rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .after {

--- a/frontend/resources/styles/main/partials/comments.scss
+++ b/frontend/resources/styles/main/partials/comments.scss
@@ -336,7 +336,7 @@
 .viewer-comments-container {
   width: 100%;
   height: 100%;
-  z-index: 1000;
+  z-index: 1;
   position: absolute;
   top: 0px;
   left: 0px;

--- a/frontend/resources/styles/main/partials/sidebar-element-options.scss
+++ b/frontend/resources/styles/main/partials/sidebar-element-options.scss
@@ -70,12 +70,6 @@
       width: 100%;
       align-items: center;
     }
-
-    &:hover {
-      .element-set-title {
-        color: $color-gray-10;
-      }
-    }
   }
 
   .element-list {

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -187,10 +187,12 @@
     (ptk/reify ::files-fetched
       ptk/UpdateEvent
       (update [_ state]
-        (update state :dashboard-files
-                (fn [state]
-                  (let [state (remove-project-files state)]
-                    (reduce #(assoc %1 (:id %2) %2) state files))))))))
+        (-> state
+            (update :dashboard-files
+                    (fn [state]
+                      (let [state (remove-project-files state)]
+                        (reduce #(assoc %1 (:id %2) %2) state files))))
+            (assoc-in [:dashboard-projects project-id :count] (count files)))))))
 
 (defn fetch-files
   [{:keys [project-id] :as params}]

--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -34,9 +34,18 @@
 
         value (d/parse-integer value-str 0)
 
-        min-val (when (string? min-val-str)
+        min-val (cond
+                  (number? min-val-str)
+                  min-val-str
+
+                  (string? min-val-str)
                   (d/parse-integer min-val-str))
-        max-val (when (string? max-val-str)
+
+        max-val (cond
+                  (number? max-val-str)
+                  max-val-str
+
+                  (string? max-val-str)
                   (d/parse-integer max-val-str))
 
         num? (fn [val] (and (number? val)

--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -24,6 +24,7 @@
         max-val-str (obj/get props "max")
         wrap-value? (obj/get props "data-wrap")
         on-change   (obj/get props "onChange")
+        title       (obj/get props "title")
 
         ;; We need a ref pointing to the input dom element, but the user
         ;; of this component may provide one (that is forwarded here).
@@ -144,6 +145,7 @@
                   (obj/set! "type" "text")
                   (obj/set! "ref" ref)
                   (obj/set! "defaultValue" value-str)
+                  (obj/set! "title" title)
                   (obj/set! "onWheel" handle-mouse-wheel)
                   (obj/set! "onKeyDown" handle-key-down)
                   (obj/set! "onBlur" handle-blur))]

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -331,10 +331,11 @@
 
       [:div.modal-footer
        [:div.action-buttons
-        [:input.cancel-button
-         {:type "button"
-          :value (tr "labels.cancel")
-          :on-click handle-cancel}]
+        (when (or (= :analyzing (:status @state)) pending-import?)
+          [:input.cancel-button
+           {:type "button"
+            :value (tr "labels.cancel")
+            :on-click handle-cancel}])
 
         (when (= :analyzing (:status @state))
           [:input.accept-button

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -98,7 +98,8 @@
         on-import
         (mf/use-callback
          (fn []
-           (st/emit! (dd/fetch-recent-files)
+           (st/emit! (dd/fetch-files {:project-id (:id project)})
+                     (dd/fetch-recent-files)
                      (dd/clear-selected-files))))]
 
     [:div.dashboard-project-row {:class (when first? "first")}

--- a/frontend/src/app/main/ui/onboarding.cljs
+++ b/frontend/src/app/main/ui/onboarding.cljs
@@ -356,7 +356,9 @@
 
         on-finish-import
         (fn []
-          (st/emit! (dd/fetch-recent-files)))
+          (st/emit! (dd/fetch-files {:project-id project-id})
+                    (dd/fetch-recent-files)
+                    (dd/clear-selected-files)))
 
         open-import-modal
         (fn [file]

--- a/frontend/src/app/main/ui/shapes/text/styles.cljs
+++ b/frontend/src/app/main/ui/shapes/text/styles.cljs
@@ -46,7 +46,7 @@
 
 (defn generate-paragraph-styles
   [shape data]
-  (let [line-height (:line-height data)
+  (let [line-height (:line-height data 1.2)
         text-align  (:text-align data "start")
         grow-type   (:grow-type shape)
 
@@ -60,10 +60,10 @@
 
 (defn generate-text-styles
   [data]
-  (let [letter-spacing  (:letter-spacing data)
+  (let [letter-spacing  (:letter-spacing data 0)
         text-decoration (:text-decoration data)
         text-transform  (:text-transform data)
-        line-height     (:line-height data)
+        line-height     (:line-height data 1.2)
 
         font-id         (:font-id data (:font-id txt/default-text-attrs))
         font-variant-id (:font-variant-id data)

--- a/frontend/src/app/main/ui/share_link.cljs
+++ b/frontend/src/app/main/ui/share_link.cljs
@@ -127,10 +127,14 @@
        [:div.share-link-section
         [:label (tr "labels.link")]
         [:div.custom-input.with-icon
-         [:input {:type "text" :value (or @link "") :read-only true}]
-         [:div.help-icon {:title (tr "labels.copy")
-                          :on-click copy-link}
-          i/copy]]
+         [:input {:type "text"
+                  :value (or @link "")
+                  :placeholder (tr "common.share-link.placeholder")
+                  :read-only true}]
+         (when (some? @link)
+           [:div.help-icon {:title (tr "labels.copy")
+                            :on-click copy-link}
+            i/copy])]
 
         [:div.hint (tr "common.share-link.permissions-hint")]]]
 

--- a/frontend/src/app/main/ui/viewer/comments.cljs
+++ b/frontend/src/app/main/ui/viewer/comments.cljs
@@ -105,14 +105,15 @@
 
         on-click
         (mf/use-callback
-         (mf/deps cstate frame page file)
+         (mf/deps cstate frame page file zoom)
          (fn [event]
            (dom/stop-propagation event)
            (if (some? (:open cstate))
              (st/emit! (dcm/close-thread))
              (let [event    (.-nativeEvent ^js event)
-                   position (-> (dom/get-offset-position event)
-                                (gpt/transform modifier2))
+                   viewport-point (dom/get-offset-position event)
+                   viewport-point (-> viewport-point (update :x #(/ % zoom)) (update :y #(/ % zoom)))
+                   position (gpt/transform viewport-point modifier2)
                    params   {:position position
                              :page-id (:id page)
                              :file-id (:id file)}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/booleans.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/booleans.cljs
@@ -7,6 +7,7 @@
 (ns app.main.ui.workspace.sidebar.options.menus.booleans
   (:require
    [app.main.data.workspace :as dw]
+   [app.main.data.workspace.shortcuts :as sc]
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.icons :as i]
@@ -51,28 +52,28 @@
     [:div.align-options
      [:div.align-group
       [:div.align-button.tooltip.tooltip-bottom
-       {:alt (tr "workspace.shape.menu.union")
+       {:alt (str (tr "workspace.shape.menu.union") " (" (sc/get-tooltip :boolean-union) ")")
         :class (dom/classnames :disabled disabled-bool-btns
                                :selected (= head-bool-type :union))
         :on-click (set-bool :union)}
        i/boolean-union]
 
       [:div.align-button.tooltip.tooltip-bottom
-       {:alt (tr "workspace.shape.menu.difference")
+       {:alt (str (tr "workspace.shape.menu.difference") " (" (sc/get-tooltip :boolean-difference) ")")
         :class (dom/classnames :disabled disabled-bool-btns
                                :selected (= head-bool-type :difference))
         :on-click (set-bool :difference)}
        i/boolean-difference]
 
       [:div.align-button.tooltip.tooltip-bottom
-       {:alt (tr "workspace.shape.menu.intersection")
+       {:alt (str (tr "workspace.shape.menu.intersection") " (" (sc/get-tooltip :boolean-intersection) ")")
         :class (dom/classnames :disabled disabled-bool-btns
                                :selected (= head-bool-type :intersection))
         :on-click (set-bool :intersection)}
        i/boolean-intersection]
 
       [:div.align-button.tooltip.tooltip-bottom
-       {:alt (tr "workspace.shape.menu.exclude")
+       {:alt (str (tr "workspace.shape.menu.exclude") " (" (sc/get-tooltip :boolean-exclude) ")")
         :class (dom/classnames :disabled disabled-bool-btns
                                :selected (= head-bool-type :exclude))
         :on-click (set-bool :exclude)}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
@@ -79,6 +79,7 @@
 
        [:div.element-set-content
         [:& color-row {:color color
+                       :title (tr "workspace.options.fill")
                        :on-change on-change
                        :on-detach on-detach}]]]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -130,7 +130,7 @@
                   :on-change handle-change-type}]
 
       (if (= type :square)
-        [:div.input-element.pixels
+        [:div.input-element.pixels {:title (tr "workspace.options.size")}
          [:> numeric-input {:min 1
                             :no-validate true
                             :value (:size params)
@@ -214,6 +214,7 @@
                         :on-change (handle-change :params :margin)}]])
 
       [:& color-row {:color (:color params)
+                     :title (tr "workspace.options.grid.params.color")
                      :disable-gradient true
                      :on-change handle-change-color
                      :on-detach handle-detach-color}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
@@ -270,11 +270,12 @@
          (when (cti/has-delay interaction)
            [:div.interactions-element
             [:span.element-set-subtitle.wide (tr "workspace.options.interaction-delay")]
-            [:div.input-element
+            [:div.input-element {:title (tr "workspace.options.interaction-ms")}
              [:> numeric-input {:ref ext-delay-ref
                                 :on-click (select-text ext-delay-ref)
                                 :on-change change-delay
-                                :value (:delay interaction)}]
+                                :value (:delay interaction)
+                                :title (tr "workspace.options.interaction-ms")}]
              [:span.after (tr "workspace.options.interaction-ms")]]])
 
          ; Action select

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layer.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layer.cljs
@@ -112,8 +112,7 @@
         [:option {:value "color"} (tr "workspace.options.layer-options.blend-mode.color")]
         [:option {:value "luminosity"} (tr "workspace.options.layer-options.blend-mode.luminosity")]]
 
-       [:div.input-element
-        {:class "percentail"}
+       [:div.input-element {:title (tr "workspace.options.opacity") :class "percentail"}
         [:> numeric-input {:value (-> values :opacity opacity->string)
                            :placeholder (tr "settings.multiple")
                            :on-click select-all

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -165,7 +165,7 @@
        (when (options :size)
          [:div.row-flex
           [:span.element-set-subtitle (tr "workspace.options.size")]
-          [:div.input-element.width
+          [:div.input-element.width {:title (tr "workspace.options.width")}
            [:> numeric-input {:min 1
                               :no-validate true
                               :placeholder "--"
@@ -173,7 +173,7 @@
                               :on-change on-width-change
                               :value (attr->string :width values)}]]
 
-          [:div.input-element.height
+          [:div.input-element.height {:title (tr "workspace.options.height")}
            [:> numeric-input {:min 1
                               :no-validate true
                               :placeholder "--"
@@ -193,13 +193,13 @@
        (when (options :position)
          [:div.row-flex
           [:span.element-set-subtitle (tr "workspace.options.position")]
-          [:div.input-element.Xaxis
+          [:div.input-element.Xaxis {:title (tr "workspace.options.x")}
            [:> numeric-input {:no-validate true
                               :placeholder "--"
                               :on-click select-all
                               :on-change on-pos-x-change
                               :value (attr->string :x values)}]]
-          [:div.input-element.Yaxis
+          [:div.input-element.Yaxis {:title (tr "workspace.options.y")}
            [:> numeric-input {:no-validate true
                               :placeholder "--"
                               :on-click select-all
@@ -210,7 +210,7 @@
        (when (options :rotation)
          [:div.row-flex
           [:span.element-set-subtitle (tr "workspace.options.rotation")]
-          [:div.input-element.degrees
+          [:div.input-element.degrees {:title (tr "workspace.options.rotation")}
            [:> numeric-input
             {:no-validate true
              :min 0
@@ -247,9 +247,8 @@
             i/radius-4]]
 
           (cond
-
             (= radius-mode :radius-1)
-            [:div.input-element.mini
+            [:div.input-element.mini {:title (tr "workspace.options.radius")}
              [:> numeric-input
               {:placeholder "--"
                :ref radius-input-ref
@@ -259,7 +258,7 @@
                :value (attr->string :rx values)}]]
 
             @radius-multi?
-            [:div.input-element.mini
+            [:div.input-element.mini {:title (tr "workspace.options.radius")}
              [:input.input-text
               {:type "number"
                :placeholder "--"
@@ -269,28 +268,31 @@
 
             (= radius-mode :radius-4)
             [:*
-             [:div.input-element.mini
+             [:div.input-element.mini {:title (tr "workspace.options.radius")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
                 :on-click select-all
                 :on-change on-radius-r1-change
                 :value (attr->string :r1 values)}]]
-             [:div.input-element.mini
+
+             [:div.input-element.mini {:title (tr "workspace.options.radius")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
                 :on-click select-all
                 :on-change on-radius-r2-change
                 :value (attr->string :r2 values)}]]
-             [:div.input-element.mini
+
+             [:div.input-element.mini {:title (tr "workspace.options.radius")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0
                 :on-click select-all
                 :on-change on-radius-r3-change
                 :value (attr->string :r3 values)}]]
-             [:div.input-element.mini
+
+             [:div.input-element.mini {:title (tr "workspace.options.radius")}
               [:> numeric-input
                {:placeholder "--"
                 :min 0

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
@@ -146,7 +146,7 @@
         [:option {:value ":inner-shadow"} (tr "workspace.options.shadow-options.inner-shadow")]]]
 
       [:div.row-grid-2
-       [:div.input-element
+       [:div.input-element {:title (tr "workspace.options.shadow-options.offsetx")}
         [:> numeric-input {:ref adv-offset-x-ref
                            :no-validate true
                            :placeholder "--"
@@ -155,7 +155,7 @@
                            :value (:offset-x value)}]
         [:span.after (tr "workspace.options.shadow-options.offsetx")]]
 
-       [:div.input-element
+       [:div.input-element {:title (tr "workspace.options.shadow-options.offsety")}
         [:> numeric-input {:ref adv-offset-y-ref
                            :no-validate true
                            :placeholder "--"
@@ -165,7 +165,7 @@
         [:span.after (tr "workspace.options.shadow-options.offsety")]]]
 
       [:div.row-grid-2
-       [:div.input-element
+       [:div.input-element {:title (tr "workspace.options.shadow-options.blur")}
         [:> numeric-input {:ref adv-blur-ref
                            :no-validate true
                            :placeholder "--"
@@ -175,7 +175,7 @@
                            :value (:blur value)}]
         [:span.after (tr "workspace.options.shadow-options.blur")]]
 
-       [:div.input-element
+       [:div.input-element {:title (tr "workspace.options.shadow-options.spread")}
         [:> numeric-input {:ref adv-spread-ref
                            :no-validate true
                            :placeholder "--"
@@ -190,6 +190,7 @@
                                ;; Support for old format colors
                                {:color (:color value) :opacity (:opacity value)}
                                (:color value))
+                      :title (tr "workspace.options.shadow-options.color")
                       :disable-gradient true
                       :on-change (update-color index)
                       :on-detach (detach-color index)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -198,13 +198,15 @@
        [:div.element-set-content
         ;; Stroke Color
         [:& color-row {:color current-stroke-color
+                       :title (tr "workspace.options.stroke-color")
                        :on-change handle-change-stroke-color
                        :on-detach handle-detach}]
 
         ;; Stroke Width, Alignment & Style
         [:div.row-flex
          [:div.input-element
-          {:class (dom/classnames :pixels (not= (:stroke-width values) :multiple))}
+          {:class (dom/classnames :pixels (not= (:stroke-width values) :multiple))
+           :title (tr "workspace.options.stroke-width")}
           [:input.input-text {:type "number"
                               :min "0"
                               :value (-> (:stroke-width values) width->string)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/page.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/page.cljs
@@ -37,6 +37,7 @@
      [:div.element-set-content
       [:& color-row {:disable-gradient true
                      :disable-opacity true
+                     :title (tr "workspace.options.canvas-background")
                      :color {:color (get options :background "#E8E9EA")
                              :opacity 1}
                      :on-change on-change

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -61,7 +61,7 @@
   (if (= v :multiple) nil v))
 
 (mf/defc color-row
-  [{:keys [color disable-gradient disable-opacity on-change on-detach on-open on-close]}]
+  [{:keys [color disable-gradient disable-opacity on-change on-detach on-open on-close title]}]
   (let [current-file-id (mf/use-ctx ctx/current-file-id)
         file-colors     (mf/deref refs/workspace-file-colors)
         shared-libs     (mf/deref refs/workspace-libraries)
@@ -123,7 +123,7 @@
        (when (not= prev-color color)
          (modal/update-props! :colorpicker {:data (parse-color color)}))))
 
-    [:div.row-flex.color-data
+    [:div.row-flex.color-data {:title title}
      [:& cb/color-bullet {:color color
                           :on-click handle-click-color}]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -87,7 +87,7 @@
       ;; WIDTH & HEIGHT
       [:div.row-flex
        [:span.element-set-subtitle (tr "workspace.options.size")]
-       [:div.input-element.pixels
+       [:div.input-element.pixels {:title (tr "workspace.options.width")}
         [:> numeric-input {:min 1
                            :on-click select-all
                            :on-change on-width-change
@@ -95,7 +95,7 @@
                                       (math/precision 2)
                                       (d/coalesce-str "1"))}]]
 
-       [:div.input-element.pixels
+       [:div.input-element.pixels {:title (tr "workspace.options.height")}
         [:> numeric-input {:min 1
                            :on-click select-all
                            :on-change on-height-change
@@ -112,14 +112,14 @@
       ;; POSITION
       [:div.row-flex
        [:span.element-set-subtitle (tr "workspace.options.position")]
-       [:div.input-element.pixels
+       [:div.input-element.pixels {:title (tr "workspace.options.x")}
         [:> numeric-input {:placeholder "x"
                            :on-click select-all
                            :on-change on-pos-x-change
                            :value (-> (:x shape)
                                       (math/precision 2)
                                       (d/coalesce-str "0"))}]]
-       [:div.input-element.pixels
+       [:div.input-element.pixels {:title (tr "workspace.options.y")}
         [:> numeric-input {:placeholder "y"
                            :on-click select-all
                            :on-change on-pos-y-change

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3232,3 +3232,5 @@ msgstr "X"
 msgid "workspace.options.y"
 msgstr "Y"
 
+msgid "common.share-link.placeholder"
+msgstr "Shareable link will appear here"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3204,3 +3204,31 @@ msgstr "Update"
 
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Click to close the path"
+
+msgid "workspace.options.grid.params.color"
+msgstr "Color"
+
+msgid "workspace.options.height"
+msgstr "Height"
+
+msgid "workspace.options.opacity"
+msgstr "Opacity"
+
+msgid "workspace.options.shadow-options.color"
+msgstr "Shadow color"
+
+msgid "workspace.options.stroke-color"
+msgstr "Stroke color"
+
+msgid "workspace.options.stroke-width"
+msgstr "Stroke width"
+
+msgid "workspace.options.width"
+msgstr "Width"
+
+msgid "workspace.options.x"
+msgstr "X"
+
+msgid "workspace.options.y"
+msgstr "Y"
+

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3228,3 +3228,6 @@ msgstr "X"
 
 msgid "workspace.options.y"
 msgstr "Y"
+
+msgid "common.share-link.placeholder"
+msgstr "El enlace para compartir aparecerá aquí"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3201,3 +3201,30 @@ msgstr "Actualizar"
 
 msgid "workspace.viewport.click-to-close-path"
 msgstr "Pulsar para cerrar la ruta"
+
+msgid "workspace.options.grid.params.color"
+msgstr "Color"
+
+msgid "workspace.options.height"
+msgstr "Altura"
+
+msgid "workspace.options.opacity"
+msgstr "Opacidad"
+
+msgid "workspace.options.shadow-options.color"
+msgstr "Color de sombra"
+
+msgid "workspace.options.stroke-color"
+msgstr "Color del trazo"
+
+msgid "workspace.options.stroke-width"
+msgstr "Ancho del trazo"
+
+msgid "workspace.options.width"
+msgstr "Ancho"
+
+msgid "workspace.options.x"
+msgstr "X"
+
+msgid "workspace.options.y"
+msgstr "Y"


### PR DESCRIPTION
- Add ellipsis in long labels for input fields [Taiga #2224](https://tree.taiga.io/project/penpot/issue/2224)
- Fix problem with text rendering on export [Taiga #2223](https://tree.taiga.io/project/penpot/issue/2223)
- Fix problem when flattening booleans losing styles [Taiga #2217](https://tree.taiga.io/project/penpot/issue/2217)
- Add shortcuts to boolean icons popups [Taiga #2220](https://tree.taiga.io/project/penpot/issue/2220)
- Fix a worker error when transforming a rectangle into path
- Fix max/min values for opacity fields [Taiga #2183](https://tree.taiga.io/project/penpot/issue/2183)
- Fix viewer comment position when zoom applied [Taiga #2240](https://tree.taiga.io/project/penpot/issue/2240)
- Remove change style on hover for options [Taiga #2172](https://tree.taiga.io/project/penpot/issue/2172)
- Fix problem in viewer with dropdowns when comments active [#1303](https://github.com/penpot/penpot/issues/1303)
- Add placeholder to create shareable link

Closes #1303 