### PR TITLE
:bug: Fix typo in workspace.scss

### DIFF
--- a/frontend/resources/styles/main/partials/workspace.scss
+++ b/frontend/resources/styles/main/partials/workspace.scss
@@ -157,7 +157,7 @@
     position: relative;
 
     svg {
-      widht: 100%;
+      width: 100%;
       height: 100%;
     }
 


### PR DESCRIPTION
Correct the spelling of `width` to ensure it is set to `100%` properly and does not default to `auto`.

Since `auto` behaves as expected, this was probably missed, however it should be set to `100%` probably if intended, and will avoid confusion later down the line.
