### PR TITLE
:sparkles: Add preset for ReMarkable 2 screen size

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -200,6 +200,11 @@
     :width 1368
     :height 912}
 
+   {:name "ReMarkable"}
+   {:name "Remarkable 2"
+    :width 840
+    :height 1120}
+
    {:name "WEB"}
    {:name "Web 1280"
     :width 1280
@@ -313,4 +318,3 @@
      [:& blur-menu {:ids ids
                     :values (select-keys shape [:blur])}]
      [:& frame-grid {:shape shape}]]))
-


### PR DESCRIPTION
Logged in issue: https://tree.taiga.io/project/penpot/issue/2298

This page size (840x1120)(for the ReMarkable2 was tested with an exported PDF
test page, and does not appear to correspond directly to the resolution of the
device.

closes #2298

Signed-off-by: Paul Schulz <paul@mawsonlakes.org>
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
