### PR TITLE
Eva ungroup groups in bulk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 
 ### :sparkles: New features
 
+- Allow ungroup groups in bulk [Taiga #2211](https://tree.taiga.io/project/penpot/us/2211).
 - Enhance corner radius behavior [Taiga #2190](https://tree.taiga.io/project/penpot/issue/2190).
 - Allow preserve scroll position in interactions [Taiga #2250](https://tree.taiga.io/project/penpot/us/2250).
 - Add new onboarding modals.
@@ -353,7 +354,7 @@
 - Transform shapes to path on double click
 - Translate automatic names of new files and projects.
 - Use shift instead of ctrl/cmd to keep aspect ratio [Taiga 1697](https://tree.taiga.io/project/penpot/issue/1697).
-- New translations: Portuguese (Brazil) and Romanias. 
+- New translations: Portuguese (Brazil) and Romanias.
 
 
 ### :bug: Bugs fixed

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2998,7 +2998,7 @@ msgstr "Ir al archivo del componente principal"
 
 #: src/app/main/ui/workspace/context_menu.cljs
 msgid "workspace.shape.menu.group"
-msgstr "Grupo"
+msgstr "Agrupar"
 
 #: src/app/main/ui/workspace/context_menu.cljs
 msgid "workspace.shape.menu.hide"
@@ -3013,7 +3013,7 @@ msgstr "Bloquear"
 
 #: src/app/main/ui/workspace/context_menu.cljs, src/app/main/ui/workspace/context_menu.cljs
 msgid "workspace.shape.menu.mask"
-msgstr "Máscara"
+msgstr "Crear máscara"
 
 #: src/app/main/ui/workspace/context_menu.cljs, src/app/main/ui/workspace/context_menu.cljs
 msgid "workspace.shape.menu.paste"


### PR DESCRIPTION
:sparkles: : Allow ungroup groups in bulk
<BLANK LINE>
In this PR I modified options in shape context menu. 
If you have selected several shapes and at least one of them is a group, Ungroup option will show in menu.
When activated this action will ungroup all first level groups in selection. 
If  there is a nested group in your selection, inside group won't be ungrouped.

I modified unmask mask in bulk in the same way.

This PR closes [#2211](https://tree.taiga.io/project/penpot/us/2211)

<BLANK LINE>
Eva Marco


