### PR TITLE
:bug: Bugfixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix default project name in all languages [Taiga #2280](https://tree.taiga.io/project/penpot/issue/2280)
 - Fix line-height and letter-spacing inputs to allow negative values [Taiga #2381](https://tree.taiga.io/project/penpot/issue/2381)
 - Fix typo in Handoff tooltip [Taiga #2428](https://tree.taiga.io/project/penpot/issue/2428).
 - Fix crash when pressing Shift+1 on empty file [#1435](https://github.com/penpot/penpot/issues/1435).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,9 @@
 
 ### :bug: Bugs fixed
 
-- Fix default project name in all languages [Taiga #2280](https://tree.taiga.io/project/penpot/issue/2280)
-- Fix line-height and letter-spacing inputs to allow negative values [Taiga #2381](https://tree.taiga.io/project/penpot/issue/2381)
+- Fix add fill color from palette to groups and components [Taiga #2313](https://tree.taiga.io/project/penpot/issue/2313).
+- Fix default project name in all languages [Taiga #2280](https://tree.taiga.io/project/penpot/issue/2280).
+- Fix line-height and letter-spacing inputs to allow negative values [Taiga #2381](https://tree.taiga.io/project/penpot/issue/2381).
 - Fix typo in Handoff tooltip [Taiga #2428](https://tree.taiga.io/project/penpot/issue/2428).
 - Fix crash when pressing Shift+1 on empty file [#1435](https://github.com/penpot/penpot/issues/1435).
 - Fix masked group resize strange behavior [Taiga #2317](https://tree.taiga.io/project/penpot/issue/2317).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix crash when pressing Shift+1 on empty file [#1435](https://github.com/penpot/penpot/issues/1435)
 - Fix masked group resize strange behavior [Taiga #2317](https://tree.taiga.io/project/penpot/issue/2317).
 - Fix problems when exporting all artboards [Taiga #2234](https://tree.taiga.io/project/penpot/issue/2234).
 - Fix problems with team management [#1353](https://github.com/penpot/penpot/issues/1353)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,8 @@
 
 ### :bug: Bugs fixed
 
-- Fix crash when pressing Shift+1 on empty file [#1435](https://github.com/penpot/penpot/issues/1435)
+- Fix typo in Handoff tooltip [Taiga #2428](https://tree.taiga.io/project/penpot/issue/2428).
+- Fix crash when pressing Shift+1 on empty file [#1435](https://github.com/penpot/penpot/issues/1435).
 - Fix masked group resize strange behavior [Taiga #2317](https://tree.taiga.io/project/penpot/issue/2317).
 - Fix problems when exporting all artboards [Taiga #2234](https://tree.taiga.io/project/penpot/issue/2234).
 - Fix problems with team management [#1353](https://github.com/penpot/penpot/issues/1353)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix Enter as key action to exit edit path [Taiga #2444](https://tree.taiga.io/project/penpot/issue/2444).
 - Fix add fill color from palette to groups and components [Taiga #2313](https://tree.taiga.io/project/penpot/issue/2313).
 - Fix default project name in all languages [Taiga #2280](https://tree.taiga.io/project/penpot/issue/2280).
 - Fix line-height and letter-spacing inputs to allow negative values [Taiga #2381](https://tree.taiga.io/project/penpot/issue/2381).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix line-height and letter-spacing inputs to allow negative values [Taiga #2381](https://tree.taiga.io/project/penpot/issue/2381)
 - Fix typo in Handoff tooltip [Taiga #2428](https://tree.taiga.io/project/penpot/issue/2428).
 - Fix crash when pressing Shift+1 on empty file [#1435](https://github.com/penpot/penpot/issues/1435).
 - Fix masked group resize strange behavior [Taiga #2317](https://tree.taiga.io/project/penpot/issue/2317).

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -635,9 +635,7 @@
             objects (wsh/lookup-page-objects state page-id)
             shapes  (cp/select-toplevel-shapes objects {:include-frames? true})
             srect   (gsh/selection-rect shapes)]
-
-        (if (or (mth/nan? (:width srect))
-                (mth/nan? (:height srect)))
+        (if (= 0 (count shapes))
           state
           (update state :workspace-local
                   (fn [{:keys [vport] :as local}]

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -635,7 +635,7 @@
             objects (wsh/lookup-page-objects state page-id)
             shapes  (cp/select-toplevel-shapes objects {:include-frames? true})
             srect   (gsh/selection-rect shapes)]
-        (if (= 0 (count shapes))
+        (if (empty? shapes)
           state
           (update state :workspace-local
                   (fn [{:keys [vport] :as local}]

--- a/frontend/src/app/main/data/workspace/path/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/path/shortcuts.cljs
@@ -28,7 +28,7 @@
                            (get-in state [:workspace-local :edition]))
             path-edit-mode (get-in state [:workspace-local :edit-path edition-id :edit-mode])]
         (if-not (= :draw path-edit-mode)
-          (rx/of :interrupt (dw/deselect-all true))
+          (rx/of :interrupt)
           (rx/empty))))))
 
 (def shortcuts
@@ -73,12 +73,8 @@
                      :fn #(st/emit! (drp/toggle-snap))}
 
    :escape          {:tooltip (ds/esc)
-                     :command "escape"
+                     :command ["escape" "enter"]
                      :fn #(st/emit! (esc-pressed))}
-
-   :start-editing   {:tooltip (ds/enter)
-                     :command "enter"
-                     :fn #(st/emit! (dw/start-editing-selected))}
 
    :undo            {:tooltip (ds/meta "Z")
                      :command (ds/c-mod "z")

--- a/frontend/src/app/main/ui/components/context_menu.cljs
+++ b/frontend/src/app/main/ui/components/context_menu.cljs
@@ -6,9 +6,11 @@
 
 (ns app.main.ui.components.context-menu
   (:require
+   [app.main.refs :as refs]
    [app.main.ui.components.dropdown :refer [dropdown']]
    [app.main.ui.icons :as i]
    [app.util.dom :as dom]
+   [app.util.i18n :as i18n :refer [tr]]
    [app.util.object :as obj]
    [goog.object :as gobj]
    [rumext.alpha :as mf]))
@@ -29,6 +31,8 @@
         left          (gobj/get props "left" 0)
         fixed?        (gobj/get props "fixed?" false)
         min-width?    (gobj/get props "min-width?" false)
+        route         (mf/deref refs/route)
+        in-dashboard? (= :dashboard-projects (:name (:data route)))
 
         local         (mf/use-state {:offset 0
                                      :levels nil})
@@ -107,7 +111,9 @@
                     [:a.context-menu-action {:on-click #(do (dom/stop-propagation %)
                                                             (on-close)
                                                             (option-handler %))}
-                     option-name]
+                     (if (and in-dashboard? (= option-name "Default"))
+                       (tr "dashboard.default-team-name")
+                       option-name)]
                     [:a.context-menu-action.submenu
                      {:data-no-close true
                       :on-click (enter-submenu option-name sub-options)}

--- a/frontend/src/app/main/ui/share_link.cljs
+++ b/frontend/src/app/main/ui/share_link.cljs
@@ -155,7 +155,7 @@
 
            ;; [:div.input-checkbox.check-primary
            ;;  [:input.check-primary.input-checkbox {:type "checkbox"}]
-           ;;  [:label "Handsoff" ]]
+           ;;  [:label "Handoff" ]]
            ]])
 
        (let [mode (:pages-mode @opts)]

--- a/frontend/src/app/main/ui/viewer/header.cljs
+++ b/frontend/src/app/main/ui/viewer/header.cljs
@@ -168,7 +168,7 @@
         [:button.mode-zone-button.tooltip.tooltip-bottom
          {:on-click #(navigate :handoff)
           :class (dom/classnames :active (= section :handoff))
-          :alt (tr "viewer.header.handsoff-section" (sc/get-tooltip :open-handoff))}
+          :alt (tr "viewer.header.handoff-section" (sc/get-tooltip :open-handoff))}
          i/code])]
 
      [:& header-options {:section section

--- a/frontend/src/app/main/ui/workspace/colorpalette.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpalette.cljs
@@ -8,7 +8,6 @@
   (:require
    [app.common.math :as mth]
    [app.main.data.workspace.colors :as mdc]
-   [app.main.data.workspace.state-helpers :as wsh]
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.color-bullet :as cb]
@@ -40,12 +39,12 @@
 ;; --- Components
 (mf/defc palette-item
   [{:keys [color size]}]
-  (let [select-color
+  (let [ids-with-children (map :id (mf/deref refs/selected-shapes-with-children))
+        select-color
         (fn [event]
-          (let [ids (wsh/lookup-selected @st/state)]
-            (if (kbd/alt? event)
-              (st/emit! (mdc/change-stroke ids (merge uc/empty-color color)))
-              (st/emit! (mdc/change-fill ids (merge uc/empty-color color))))))]
+          (if (kbd/alt? event)
+              (st/emit! (mdc/change-stroke ids-with-children (merge uc/empty-color color)))
+              (st/emit! (mdc/change-fill ids-with-children (merge uc/empty-color color)))))]
 
     [:div.color-cell {:class (str "cell-"(name size))
                       :on-click select-color}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -362,7 +362,7 @@
       [:input.input-text
        {:type "number"
         :step "0.1"
-        :min "0"
+        :min "-200"
         :max "200"
         :value (attr->string line-height)
         :placeholder (tr "settings.multiple")
@@ -376,7 +376,7 @@
       [:input.input-text
        {:type "number"
         :step "0.1"
-        :min "0"
+        :min "-200"
         :max "200"
         :value (attr->string letter-spacing)
         :placeholder (tr "settings.multiple")

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -1722,7 +1722,7 @@ msgstr "Edita el fitxer"
 msgid "viewer.header.fullscreen"
 msgstr "Pantalla completa"
 
-msgid "viewer.header.handsoff-section"
+msgid "viewer.header.handoff-section"
 msgstr "Lliurament (%s)"
 
 #: src/app/main/ui/viewer/header.cljs

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -1767,7 +1767,7 @@ msgstr "Seite bearbeiten"
 msgid "viewer.header.fullscreen"
 msgstr "Vollbildmodus"
 
-msgid "viewer.header.handsoff-section"
+msgid "viewer.header.handoff-section"
 msgstr "Übergabe (%s)"
 
 #: src/app/main/ui/viewer/header.cljs

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1767,8 +1767,8 @@ msgstr "Don't show interactions"
 msgid "viewer.header.fullscreen"
 msgstr "Full Screen"
 
-msgid "viewer.header.handsoff-section"
-msgstr "Handsoff (%s)"
+msgid "viewer.header.handoff-section"
+msgstr "Handoff (%s)"
 
 #: src/app/main/ui/viewer/header.cljs
 msgid "viewer.header.interactions"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1766,7 +1766,7 @@ msgstr "No mostrar interacciones"
 msgid "viewer.header.fullscreen"
 msgstr "Pantalla completa"
 
-msgid "viewer.header.handsoff-section"
+msgid "viewer.header.handoff-section"
 msgstr "Handoff (%s)"
 
 #: src/app/main/ui/viewer/header.cljs

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -1715,7 +1715,7 @@ msgstr "לא להציג אינטראקציות"
 msgid "viewer.header.fullscreen"
 msgstr "מסך מלא"
 
-msgid "viewer.header.handsoff-section"
+msgid "viewer.header.handoff-section"
 msgstr "מסירות"
 
 #: src/app/main/ui/viewer/header.cljs


### PR DESCRIPTION
With this pull request these issues will: 

- Fix crash when pressing Shift+1 on empty file. Close [#1435 ](https://github.com/penpot/penpot/issues/1435)
- Fix typo in Handoff tooltip [Taiga #2428](https://tree.taiga.io/project/penpot/issue/2428).
- Fix line-height and letter-spacing inputs to allow negative values [Taiga #2381](https://tree.taiga.io/project/penpot/issue/2381).
- Fix default project name in all languages [Taiga #2280](https://tree.taiga.io/project/penpot/issue/2280).
- Fix add fill color from the palette to groups and components [Taiga #2313](https://tree.taiga.io/project/penpot/issue/2313).
- Fix Enter as the key action to exit edit path [Taiga #2444](https://tree.taiga.io/project/penpot/issue/2444).