### PR TITLE
:sparkles: add V as shortcut to exit path editor

### DIFF
--- a/frontend/src/app/main/data/workspace/path/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/path/shortcuts.cljs
@@ -73,7 +73,7 @@
                      :fn #(st/emit! (drp/toggle-snap))}
 
    :escape          {:tooltip (ds/esc)
-                     :command ["escape" "enter"]
+                     :command ["escape" "enter" "v"]
                      :fn #(st/emit! (esc-pressed))}
 
    :undo            {:tooltip (ds/meta "Z")
@@ -138,9 +138,7 @@
 
    :move-unit-right {:tooltip ds/left-arrow
                      :command "left"
-                     :fn #(st/emit! (drp/move-selected :left false))}
-
-   })
+                     :fn #(st/emit! (drp/move-selected :left false))}})
 
 (defn get-tooltip [shortcut]
   (assert (contains? shortcuts shortcut) (str shortcut))


### PR DESCRIPTION
Fix comment on https://tree.taiga.io/project/penpot/us/2411
