### PR TITLE
:bug: Avoid marking component as touched when moving into a group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@
 - Restored rules color [Taiga #2460](https://tree.taiga.io/project/penpot/issue/2460)
 - Fix thumbnail not taking frame blending mode [Taiga #2301](https://tree.taiga.io/project/penpot/issue/2301)
 - Fix import/export with SVG edge cases [Taiga #2389](https://tree.taiga.io/project/penpot/issue/2389)
+- Avoid modifying component when moving into a group [Taiga #2534](https://tree.taiga.io/project/penpot/issue/2534)
 
 ### :arrow_up: Deps updates
 

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -922,11 +922,13 @@
                   :operations [{:type :set
                                 :attr :constraints-h
                                 :val (spec/default-constraints-h
-                                       (assoc obj :parent-id parent-id :frame-id frame-id))}
+                                       (assoc obj :parent-id parent-id :frame-id frame-id))
+                                :ignore-touched true}
                                {:type :set
                                 :attr :constraints-v
                                 :val (spec/default-constraints-v
-                                       (assoc obj :parent-id parent-id :frame-id frame-id))}]}))
+                                       (assoc obj :parent-id parent-id :frame-id frame-id))
+                                :ignore-touched true}]}))
              shapes-to-unconstraint)
 
         u-unconstraint-change
@@ -937,10 +939,12 @@
                   :id id
                   :operations [{:type :set
                                 :attr :constraints-h
-                                :val (:constraints-h obj)}
+                                :val (:constraints-h obj)
+                                :ignore-touched true}
                                {:type :set
                                 :attr :constraints-v
-                                :val (:constraints-v obj)}]}))
+                                :val (:constraints-v obj)
+                                :ignore-touched true}]}))
              shapes-to-unconstraint)
 
         r-reg-change


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/issue/2534