### PR TITLE
:sparkles: Divide file menu options in semantically groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ### :sparkles: New features
 
+- Improve file menu by adding semantically groups [Github #1203](https://github.com/penpot/penpot/issues/1203).
 - Create firsts e2e test [Taiga #2608](https://tree.taiga.io/project/penpot/task/2608).
 - Add an option to hide artboards names on the viewport [Taiga #2034](https://tree.taiga.io/project/penpot/issue/2034).
 - Limit pasted object position to container boundaries [Taiga #2449](https://tree.taiga.io/project/penpot/us/2449).

--- a/frontend/resources/styles/main/partials/workspace-header.scss
+++ b/frontend/resources/styles/main/partials/workspace-header.scss
@@ -132,7 +132,7 @@
     position: absolute;
     top: 40px;
     left: 40px;
-    width: 270px;
+    width: 183px;
     z-index: 12;
     @include animation(0, 0.2s, fadeInDown);
 
@@ -158,6 +158,54 @@
         margin: 0 $size-1;
       }
 
+      &:hover {
+        background-color: $color-primary-lighter;
+      }
+
+      &.feedback {
+        border-top: 1px solid $color-gray-10;
+      }
+    }
+  }
+
+  .sub-menu {
+    position: absolute;
+    left: 230px;
+    width: 270px;
+    z-index: 12;
+    @include animation(0, 0.2s, fadeInDown);
+    background-color: $color-white;
+    border-radius: $br-small;
+    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.25);
+
+    &.file {
+      top: 40px;
+    }
+
+    &.edit {
+      top: 77px;
+    }
+
+    &.view {
+      top: 114px;
+    }
+
+    &.preferences {
+      top: 150px;
+    }
+
+    li {
+      cursor: pointer;
+      font-size: $fs14;
+      padding: $size-2;
+      display: flex;
+      justify-content: space-between;
+
+      span {
+        color: $color-gray-60;
+        margin: 0 $size-1;
+      }
+
       .shortcut {
         color: $color-gray-20;
         font-size: $fs12;
@@ -165,10 +213,6 @@
 
       &:hover {
         background-color: $color-primary-lighter;
-      }
-
-      &.feedback {
-        border-top: 1px solid $color-gray-10;
       }
     }
   }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2010,6 +2010,22 @@ msgid "workspace.gradients.radial"
 msgstr "Radial gradient"
 
 #: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.file"
+msgstr "File"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.edit"
+msgstr "Edit"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.view"
+msgstr "View"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.preferences"
+msgstr "Preferences"
+
+#: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.disable-dynamic-alignment"
 msgstr "Disable dynamic alignment"
 
@@ -2022,6 +2038,10 @@ msgid "workspace.header.menu.disable-snap-grid"
 msgstr "Disable snap to grid"
 
 #: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.disable-snap-guides"
+msgstr "Disable snap to guides"
+
+#: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.enable-dynamic-alignment"
 msgstr "Enable dynamic alignment"
 
@@ -2032,6 +2052,10 @@ msgstr "Enable scale text"
 #: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.enable-snap-grid"
 msgstr "Snap to grid"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.enable-snap-guides"
+msgstr "Snap to guides"
 
 #: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.hide-artboard-names"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2025,6 +2025,22 @@ msgid "workspace.gradients.radial"
 msgstr "Degradado radial"
 
 #: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.file"
+msgstr "Archivo"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.edit"
+msgstr "Editar"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.view"
+msgstr "Ver"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.option.preferences"
+msgstr "Preferencias"
+
+#: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.disable-dynamic-alignment"
 msgstr "Desactivar alineamiento dinámico"
 
@@ -2037,6 +2053,10 @@ msgid "workspace.header.menu.disable-snap-grid"
 msgstr "Desactivar alinear a la rejilla"
 
 #: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.disable-snap-guides"
+msgstr "Desactivar alinear a las guias"
+
+#: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.enable-dynamic-alignment"
 msgstr "Activar alineamiento dinámico"
 
@@ -2047,6 +2067,10 @@ msgstr "Activar escalar texto"
 #: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.enable-snap-grid"
 msgstr "Alinear a la rejilla"
+
+#: src/app/main/ui/workspace/header.cljs
+msgid "workspace.header.menu.enable-snap-guides"
+msgstr "Alinear a las guias"
 
 #: src/app/main/ui/workspace/header.cljs
 msgid "workspace.header.menu.hide-artboard-names"


### PR DESCRIPTION
Closes [githab #1203 ](https://github.com/penpot/penpot/issues/1203)
