### PR TITLE
Authorized cookie

### DIFF
--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -48,6 +48,7 @@
    :database-uri "postgresql://postgres/penpot"
    :database-username "penpot"
    :database-password "penpot"
+   :authenticated-cookie-domain "penpot.app"
 
    :default-blob-version 3
    :loggers-zmq-uri "tcp://localhost:45556"

--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -109,6 +109,7 @@
 (s/def ::secret-key ::us/string)
 (s/def ::allow-demo-users ::us/boolean)
 (s/def ::assets-path ::us/string)
+(s/def ::authenticated-cookie-domain ::us/string)
 (s/def ::database-password (s/nilable ::us/string))
 (s/def ::database-uri ::us/string)
 (s/def ::database-username (s/nilable ::us/string))
@@ -199,6 +200,7 @@
                    ::allow-demo-users
                    ::audit-log-archive-uri
                    ::audit-log-gc-max-age
+                   ::authenticated-cookie-domain
                    ::database-password
                    ::database-uri
                    ::database-username


### PR DESCRIPTION
This MR sets a cookie that we can use to check from other sites of the same domain if a user is registered. Is not intended for on premise installations, although nothing prevents using it if some one wants to.