### PR TITLE
:whale: Fix run-devenv on systems with SELinux

### DIFF
--- a/docker/devenv/docker-compose.yaml
+++ b/docker/devenv/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
     volumes:
       - "user_data:/home/penpot/"
-      - "${PWD}:/home/penpot/penpot"
+      - "${PWD}:/home/penpot/penpot:z"
 
     ports:
       - 3447:3447
@@ -98,7 +98,7 @@ services:
 
     volumes:
       - "user_data:/home/penpot/"
-      - "${PWD}:/home/penpot/penpot"
+      - "${PWD}:/home/penpot/penpot:z"
 
     ports:
       - 6060:6060
@@ -161,8 +161,8 @@ services:
       - POSTGRES_USER=penpot
       - POSTGRES_PASSWORD=penpot
     volumes:
-      - ./files/postgresql.conf:/etc/postgresql.conf
-      - ./files/postgresql_init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./files/postgresql.conf:/etc/postgresql.conf:z
+      - ./files/postgresql_init.sql:/docker-entrypoint-initdb.d/init.sql:z
       - postgres_data:/var/lib/postgresql/data
 
   redis:


### PR DESCRIPTION
`./manage.sh run-devenv` doesn't work on systems with SELinux (like Fedora 34). To reproduce the issue, on a fresh Fedora 34 installation:

* Install Docker and Docker Compose v2
* Clone the Penpot repo and checkout to `9964360656f7f74051cdf192a28b59b4671f07cc`
* `./manage.sh pull-devenv`
* `./manage.sh run-devenv`

Postgres container will keep restarting with this errors:
```
2022-02-24 21:46:01.071 GMT [1] LOG:  could not open configuration file "/etc/postgresql.conf": Permission denied
2022-02-24 21:46:01.072 GMT [1] FATAL:  configuration file "/etc/postgresql.conf" contains errors
```

This PR sets the selinux label on bind mounts (https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label), which is necessary so that containers can read the files. It fixes `run-devenv` on Fedora 34.

I also tested this PR on a system without SELinux (Debian 11), it doesn't break `run-devenv`.