### PR TITLE
:bug: Fix multiple edition

### DIFF
--- a/common/src/app/common/pages/common.cljc
+++ b/common/src/app/common/pages/common.cljc
@@ -247,8 +247,6 @@
           :width :height
           :x :y
           :rotation
-          :rx :ry
-          :r1 :r2 :r3 :r4
           :selrect
 
           :constraints-h

--- a/common/src/app/common/spec/radius.cljc
+++ b/common/src/app/common/spec/radius.cljc
@@ -6,8 +6,9 @@
 
 (ns app.common.spec.radius
   (:require
-   [app.common.spec :as us]
-   [clojure.spec.alpha :as s]))
+    [app.common.pages.common :refer [editable-attrs]]
+    [app.common.spec :as us]
+    [clojure.spec.alpha :as s]))
 
 (s/def ::rx ::us/safe-number)
 (s/def ::ry ::us/safe-number)
@@ -29,6 +30,10 @@
 ;; All operations take into account that the shape may not be a one of those 
 ;; shapes that has border radius, and so it hasn't :rx nor :r1. 
 ;; In this case operations must leave shape untouched.
+
+(defn has-radius?
+  [shape]
+  ((get editable-attrs (:type shape)) :rx))
 
 (defn radius-mode
   [shape]

--- a/common/src/app/common/spec/radius.cljc
+++ b/common/src/app/common/spec/radius.cljc
@@ -33,7 +33,7 @@
 
 (defn has-radius?
   [shape]
-  ((get editable-attrs (:type shape)) :rx))
+  (contains? (get editable-attrs (:type shape)) :rx))
 
 (defn radius-mode
   [shape]

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -12,6 +12,7 @@
    [app.common.geom.point :as gpt]
    [app.common.geom.shapes :as gsh]
    [app.common.math :as mth]
+   [app.common.pages.common :as cpc]
    [app.common.pages.helpers :as cph]
    [app.common.spec :as us]
    [app.main.data.workspace.changes :as dch]
@@ -145,7 +146,8 @@
              shapes  (->> shapes
                           (remove #(get % :blocked false))
                           (mapcat #(cph/get-children objects (:id %)))
-                          (concat shapes))
+                          (concat shapes)
+                          (filter #((cpc/editable-attrs (:type %)) :rotation)))
 
              update-shape
              (fn [modifiers shape]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -27,7 +27,7 @@
 ;;   - children: read it from all the children, and then merging it.
 ;;   - ignore: do not read this attribute from this shape.
 ;;   - text: read it from all the content nodes, and then merging it.
-(def type->props
+(def type->read-mode
   {:frame
    {:measure    :shape
     :layer      :shape
@@ -118,7 +118,7 @@
     :stroke     :shape
     :text       :ignore}})
 
-(def props->attrs
+(def group->attrs
   {:measure    measure-attrs
    :layer      layer-attrs
    :constraint constraint-attrs
@@ -157,36 +157,47 @@
   (when v (select-keys v blur-keys)))
 
 (defn get-attrs*
-  "Given a `type` of options that we want to extract and the shapes to extract them from
+  "Given a group of attributes that we want to extract and the shapes to extract them from
   returns a list of tuples [id, values] with the extracted properties for the shapes that
   applies (some of them ignore some attributes)"
-  [shapes objects attr-type]
-  (let [attrs (props->attrs attr-type)
+  [shapes objects attr-group]
+  (let [attrs (group->attrs attr-group)
+
         merge-attrs
         (fn [v1 v2]
           (cond
-            (= attr-type :shadow) (attrs/get-attrs-multi [v1 v2] attrs shadow-eq shadow-sel)
-            (= attr-type :blur)   (attrs/get-attrs-multi [v1 v2] attrs blur-eq blur-sel)
-            :else                 (attrs/get-attrs-multi [v1 v2] attrs)))
+            (= attr-group :shadow) (attrs/get-attrs-multi [v1 v2] attrs shadow-eq shadow-sel)
+            (= attr-group :blur)   (attrs/get-attrs-multi [v1 v2] attrs blur-eq blur-sel)
+            :else                  (attrs/get-attrs-multi [v1 v2] attrs)))
 
         extract-attrs
         (fn [[ids values] {:keys [id type content] :as shape}]
-          (let [props (get-in type->props [type attr-type])]
-            (case props
+          (let [read-mode      (get-in type->read-mode [type attr-group])
+                editable-attrs (filter (get cpc/editable-attrs (:type shape)) attrs)]
+            (case read-mode
               :ignore   [ids values]
-              :shape    (let [editable-attrs (filter (get cpc/editable-attrs (:type shape)) attrs)]
+
+              :shape    (let [;; Get the editable attrs from the shape, ensuring that all attributes
+                              ;; are present, with value nil if they are not present in the shape.
+                              shape-values (merge
+                                             (into {} (map #(hash-map % nil) editable-attrs))
+                                             (select-keys shape editable-attrs))]
                           [(conj ids id)
-                           (merge-attrs values (select-keys shape editable-attrs))])
+                           (merge-attrs values shape-values)])
+
               :text     [(conj ids id)
                          (-> values
                              (merge-attrs (select-keys shape attrs))
                              (merge-attrs (merge
-                                           (select-keys txt/default-text-attrs attrs)
-                                           (attrs/get-attrs-multi (txt/node-seq content) attrs))))]
+                                            (select-keys txt/default-text-attrs attrs)
+                                            (attrs/get-attrs-multi (txt/node-seq content) attrs))))]
+
               :children (let [children (->> (:shapes shape []) (map #(get objects %)))
-                              [new-ids new-values] (get-attrs* children objects attr-type)]
+                              [new-ids new-values] (get-attrs* children objects attr-group)]
                           [(d/concat-vec ids new-ids) (merge-attrs values new-values)])
+
               [])))]
+
     (reduce extract-attrs [[] []] shapes)))
 
 (def get-attrs (memoize get-attrs*))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -180,7 +180,7 @@
               :shape    (let [;; Get the editable attrs from the shape, ensuring that all attributes
                               ;; are present, with value nil if they are not present in the shape.
                               shape-values (merge
-                                             (into {} (map #(hash-map % nil) editable-attrs))
+                                             (into {} (map #(vector % nil)) editable-attrs)
                                              (select-keys shape editable-attrs))]
                           [(conj ids id)
                            (merge-attrs values shape-values)])


### PR DESCRIPTION
Now multi edition of rotation and border radius works ok. Even if the selection contains mixed shapes that have or not these features, or if there are old artboards that do not have :rx attribute.