### PR TITLE
Refactor backend (part3)

### DIFF
--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -19,12 +19,12 @@
   io.lettuce/lettuce-core {:mvn/version "6.1.6.RELEASE"}
   java-http-clj/java-http-clj {:mvn/version "0.4.3"}
 
-  funcool/yetti {:git/tag "v5.0" :git/sha "f7d61e2"
-                 :git/url "https://github.com/funcool/yetti"
+  funcool/yetti {:git/tag "v6.0" :git/sha "4c8690e"
+                 :git/url "https://github.com/funcool/yetti.git"
                  :exclusions [org.slf4j/slf4j-api]}
 
   com.github.seancorfield/next.jdbc {:mvn/version "1.2.772"}
-  metosin/reitit-ring {:mvn/version "0.5.16"}
+  metosin/reitit-core {:mvn/version "0.5.16"}
   org.postgresql/postgresql {:mvn/version "42.3.3"}
   com.zaxxer/HikariCP {:mvn/version "5.0.1"}
   funcool/datoteka {:mvn/version "2.0.0"}

--- a/backend/scripts/repl
+++ b/backend/scripts/repl
@@ -8,25 +8,25 @@
 # export PENPOT_DATABASE_URI="postgresql://172.17.0.1:5432/penpot_pre"
 # export PENPOT_DATABASE_USERNAME="penpot_pre"
 # export PENPOT_DATABASE_PASSWORD="penpot_pre"
-# export PENPOT_FLAGS="enable-asserts enable-audit-log $PENPOT_FLAGS"
+export PENPOT_FLAGS="enable-asserts enable-audit-log $PENPOT_FLAGS"
 
 # Initialize MINIO config
 # mc alias set penpot-s3/ http://minio:9000 minioadmin minioadmin
 # mc admin user add penpot-s3 penpot-devenv penpot-devenv
 # mc admin policy set penpot-s3 readwrite user=penpot-devenv
 # mc mb penpot-s3/penpot -p
-# export AWS_ACCESS_KEY_ID=penpot-devenv
-# export AWS_SECRET_ACCESS_KEY=penpot-devenv
-# export PENPOT_ASSETS_STORAGE_BACKEND=assets-s3
-# export PENPOT_STORAGE_ASSETS_S3_ENDPOINT=http://minio:9000
-# export PENPOT_STORAGE_ASSETS_S3_REGION=eu-central-1
-# export PENPOT_STORAGE_ASSETS_S3_BUCKET=penpot
+export AWS_ACCESS_KEY_ID=penpot-devenv
+export AWS_SECRET_ACCESS_KEY=penpot-devenv
+export PENPOT_ASSETS_STORAGE_BACKEND=assets-fs
+export PENPOT_STORAGE_ASSETS_S3_ENDPOINT=http://minio:9000
+export PENPOT_STORAGE_ASSETS_S3_REGION=eu-central-1
+export PENPOT_STORAGE_ASSETS_S3_BUCKET=penpot
 
 export OPTIONS="
-       -A:dev \
+       -A:dev:jmx-remote \
        -J-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
        -J-Dlog4j2.configurationFile=log4j2-devenv.xml \
-       -J-XX:+UseZGC \
+       -J-XX:+UseG1GC \
        -J-XX:-OmitStackTraceInFastThrow \
        -J-Xms50m -J-Xmx1024m \
        -J-Djdk.attach.allowAttachSelf \

--- a/backend/src/app/http.clj
+++ b/backend/src/app/http.clj
@@ -10,18 +10,18 @@
    [app.common.exceptions :as ex]
    [app.common.logging :as l]
    [app.common.spec :as us]
-   [app.config :as cf]
    [app.http.doc :as doc]
    [app.http.errors :as errors]
    [app.http.middleware :as middleware]
    [app.metrics :as mtx]
+   [app.worker :as wrk]
    [clojure.spec.alpha :as s]
    [integrant.core :as ig]
-   [reitit.ring :as rr]
-   [yetti.adapter :as yt])
-  (:import
-   org.eclipse.jetty.server.Server
-   org.eclipse.jetty.server.handler.StatisticsHandler))
+   [reitit.core :as r]
+   [reitit.middleware :as rr]
+   [yetti.adapter :as yt]
+   [yetti.request :as yrq]
+   [yetti.response :as yrs]))
 
 (declare wrap-router)
 
@@ -29,55 +29,43 @@
 ;; HTTP SERVER
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def ::session map?)
 (s/def ::handler fn?)
 (s/def ::router some?)
 (s/def ::port ::us/integer)
 (s/def ::host ::us/string)
 (s/def ::name ::us/string)
-(s/def ::max-threads ::cf/http-server-max-threads)
-(s/def ::min-threads ::cf/http-server-min-threads)
+(s/def ::executors (s/map-of keyword? ::wrk/executor))
+
+;; (s/def ::max-threads ::cf/http-server-max-threads)
+;; (s/def ::min-threads ::cf/http-server-min-threads)
 
 (defmethod ig/prep-key ::server
   [_ cfg]
   (merge {:name "http"
-          :min-threads 4
-          :max-threads 60
           :port 6060
           :host "0.0.0.0"}
          (d/without-nils cfg)))
 
 (defmethod ig/pre-init-spec ::server [_]
-  (s/keys :req-un [::port ::host ::name ::min-threads ::max-threads ::session]
-          :opt-un [::mtx/metrics ::router ::handler]))
-
-(defn- instrument-metrics
-  [^Server server metrics]
-  (let [stats (doto (StatisticsHandler.)
-                (.setHandler (.getHandler server)))]
-    (.setHandler server stats)
-    (mtx/instrument-jetty! (:registry metrics) stats)
-    server))
+  (s/keys :req-un [::port ::host ::name ::executors]
+          :opt-un [::router ::handler]))
 
 (defmethod ig/init-key ::server
-  [_ {:keys [handler router port name metrics host] :as cfg}]
+  [_ {:keys [handler router port name host executors] :as cfg}]
   (l/info :hint "starting http server"
-          :port port :host host :name name
-          :min-threads (:min-threads cfg)
-          :max-threads (:max-threads cfg))
+          :port port :host host :name name)
+
   (let [options {:http/port port
                  :http/host host
-                 :thread-pool/max-threads (:max-threads cfg)
-                 :thread-pool/min-threads (:min-threads cfg)
-                 :ring/async true}
+                 :ring/async true
+                 :xnio/dispatch (:default executors)}
         handler (cond
                   (fn? handler)  handler
                   (some? router) (wrap-router cfg router)
                   :else (ex/raise :type :internal
                                   :code :invalid-argument
                                   :hint "Missing `handler` or `router` option."))
-        server  (-> (yt/server handler (d/without-nils options))
-                    (cond-> metrics (instrument-metrics metrics)))]
+        server  (yt/server handler (d/without-nils options))]
     (assoc cfg :server (yt/start! server))))
 
 (defmethod ig/halt-key! ::server
@@ -85,24 +73,34 @@
   (l/info :msg "stoping http server" :name name :port port)
   (yt/stop! server))
 
+(defn- not-found-handler
+  [_ respond _]
+  (respond (yrs/response 404)))
+
+(defn- ring-handler
+  [router]
+  (fn [request respond raise]
+    (if-let [match (r/match-by-path router (yrq/path request))]
+      (let [params  (:path-params match)
+            result  (:result match)
+            handler (or (:handler result) not-found-handler)
+            request (-> request
+                        (assoc :path-params params)
+                        (update :params merge params))]
+        (handler request respond raise))
+      (not-found-handler request respond raise))))
+
 (defn- wrap-router
-  [{:keys [session] :as cfg} router]
-  (let [default (rr/routes
-                 (rr/create-resource-handler {:path "/"})
-                 (rr/create-default-handler))
-        options {:middleware [[middleware/wrap-server-timing]
-                              [middleware/cookies]
-                              [(:middleware session)]]
-                 :inject-match? false
-                 :inject-router? false}
-        handler (rr/ring-handler router default options)]
+  [_ router]
+  (let [handler (ring-handler router)]
     (fn [request respond _]
-      (handler request respond (fn [cause]
-                                 (l/error :hint "unexpected error processing request"
-                                          ::l/context (errors/get-error-context request cause)
-                                          :query-string (:query-string request)
-                                          :cause cause)
-                                 (respond {:status 500 :body "internal server error"}))))))
+      (handler request respond
+               (fn [cause]
+                 (l/error :hint "unexpected error processing request"
+                          ::l/context (errors/get-error-context request cause)
+                          :query-string (yrq/query request)
+                          :cause cause)
+                 (respond (yrs/response 500 "internal server error")))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HTTP ROUTER
@@ -117,62 +115,64 @@
 (s/def ::audit-handler fn?)
 (s/def ::debug map?)
 (s/def ::awsns-handler fn?)
+(s/def ::session map?)
 
 (defmethod ig/pre-init-spec ::router [_]
   (s/keys :req-un [::rpc ::mtx/metrics ::ws ::oauth ::storage ::assets
-                   ::feedback ::awsns-handler ::debug ::audit-handler]))
+                   ::session ::feedback ::awsns-handler ::debug ::audit-handler]))
 
 (defmethod ig/init-key ::router
   [_ {:keys [ws session rpc oauth metrics assets feedback debug] :as cfg}]
   (rr/router
-   [["/metrics" {:get (:handler metrics)}]
-    ["/assets" {:middleware [[middleware/format-response-body]
-                             [middleware/errors errors/handle]]}
-     ["/by-id/:id" {:get (:objects-handler assets)}]
-     ["/by-file-media-id/:id" {:get (:file-objects-handler assets)}]
-     ["/by-file-media-id/:id/thumbnail" {:get (:file-thumbnails-handler assets)}]]
+   [["" {:middleware [[middleware/server-timing]
+                      [middleware/format-response]
+                      [middleware/errors errors/handle]
+                      [middleware/restrict-methods]]}
+     ["/metrics" {:handler (:handler metrics)}]
+     ["/assets" {:middleware [(:middleware session)]}
+      ["/by-id/:id" {:handler (:objects-handler assets)}]
+      ["/by-file-media-id/:id" {:handler (:file-objects-handler assets)}]
+      ["/by-file-media-id/:id/thumbnail" {:handler (:file-thumbnails-handler assets)}]]
 
-    ["/dbg" {:middleware [[middleware/multipart-params]
-                          [middleware/params]
-                          [middleware/keyword-params]
-                          [middleware/format-response-body]
-                          [middleware/errors errors/handle]]}
-     ["" {:get (:index debug)}]
-     ["/error-by-id/:id" {:get (:retrieve-error debug)}]
-     ["/error/:id" {:get (:retrieve-error debug)}]
-     ["/error" {:get (:retrieve-error-list debug)}]
-     ["/file/data" {:get (:retrieve-file-data debug)
-                    :post (:upload-file-data debug)}]
-     ["/file/changes" {:get (:retrieve-file-changes debug)}]]
+     ["/dbg" {:middleware [[middleware/params]
+                           [middleware/parse-request]
+                           (:middleware session)]}
+      ["" {:handler (:index debug)}]
+      ["/error-by-id/:id" {:handler (:retrieve-error debug)}]
+      ["/error/:id" {:handler (:retrieve-error debug)}]
+      ["/error" {:handler (:retrieve-error-list debug)}]
+      ["/file/data" {:handler (:file-data debug)}]
+      ["/file/changes" {:handler (:retrieve-file-changes debug)}]]
 
-    ["/webhooks"
-     ["/sns" {:post (:awsns-handler cfg)}]]
+     ["/webhooks"
+      ["/sns" {:handler (:awsns-handler cfg)
+               :allowed-methods #{:post}}]]
 
-    ["/ws/notifications"
-     {:middleware [[middleware/params]
-                   [middleware/keyword-params]
-                   [middleware/format-response-body]
-                   [middleware/errors errors/handle]]
-      :get ws}]
+     ["/ws/notifications" {:middleware [[middleware/params]
+                                        [middleware/parse-request]
+                                        (:middleware session)]
+                           :handler ws
+                           :allowed-methods #{:get}}]
 
-    ["/api" {:middleware [[middleware/cors]
-                          [middleware/params]
-                          [middleware/multipart-params]
-                          [middleware/keyword-params]
-                          [middleware/format-response-body]
-                          [middleware/parse-request-body]
-                          [middleware/errors errors/handle]]}
+     ["/api" {:middleware [[middleware/cors]
+                           [middleware/params]
+                           [middleware/parse-request]
+                           (:middleware session)]}
+      ["/health" {:handler (:health-check debug)}]
+      ["/_doc" {:handler (doc/handler rpc)
+                :allowed-methods #{:get}}]
+      ["/feedback" {:handler feedback
+                    :allowed-methods #{:post}}]
 
-     ["/health" {:get (:health-check debug)}]
-     ["/_doc" {:get (doc/handler rpc)}]
-     ["/feedback" {:middleware [(:middleware session)]
-                   :post feedback}]
-     ["/auth/oauth/:provider" {:post (:handler oauth)}]
-     ["/auth/oauth/:provider/callback" {:get (:callback-handler oauth)}]
+      ["/auth/oauth/:provider" {:handler (:handler oauth)
+                                :allowed-methods #{:post}}]
+      ["/auth/oauth/:provider/callback" {:handler (:callback-handler oauth)
+                                         :allowed-methods #{:get}}]
 
-     ["/audit/events" {:post (:audit-handler cfg)}]
+      ["/audit/events" {:handler (:audit-handler cfg)
+                        :allowed-methods #{:post}}]
 
-     ["/rpc"
-      ["/query/:type" {:get (:query-handler rpc)
-                       :post (:query-handler rpc)}]
-      ["/mutation/:type" {:post (:mutation-handler rpc)}]]]]))
+      ["/rpc"
+       ["/query/:type" {:handler (:query-handler rpc)}]
+       ["/mutation/:type" {:handler (:mutation-handler rpc)
+                           :allowed-methods #{:post}}]]]]]))

--- a/backend/src/app/http/assets.clj
+++ b/backend/src/app/http/assets.clj
@@ -18,7 +18,8 @@
    [clojure.spec.alpha :as s]
    [integrant.core :as ig]
    [promesa.core :as p]
-   [promesa.exec :as px]))
+   [promesa.exec :as px]
+   [yetti.response :as yrs]))
 
 (def ^:private cache-max-age
   (dt/duration {:hours 24}))
@@ -53,27 +54,25 @@
     (case (:type backend)
       :db
       (p/let [body (sto/get-object-bytes storage obj)]
-        {:status 200
-         :headers {"content-type" (:content-type mdata)
-                   "cache-control" (str "max-age=" (inst-ms cache-max-age))}
-         :body body})
+        (yrs/response :status  200
+                      :body    body
+                      :headers {"content-type" (:content-type mdata)
+                                "cache-control" (str "max-age=" (inst-ms cache-max-age))}))
 
       :s3
       (p/let [{:keys [host port] :as url} (sto/get-object-url storage obj {:max-age signature-max-age})]
-        {:status 307
-         :headers {"location" (str url)
-                   "x-host"   (cond-> host port (str ":" port))
-                   "cache-control" (str "max-age=" (inst-ms cache-max-age))}
-         :body ""})
+        (yrs/response :status  307
+                      :headers {"location" (str url)
+                                "x-host"   (cond-> host port (str ":" port))
+                                "cache-control" (str "max-age=" (inst-ms cache-max-age))}))
 
       :fs
       (p/let [purl (u/uri (:assets-path cfg))
               purl (u/join purl (sto/object->relative-path obj))]
-        {:status 204
-         :headers {"x-accel-redirect" (:path purl)
-                   "content-type" (:content-type mdata)
-                   "cache-control" (str "max-age=" (inst-ms cache-max-age))}
-         :body ""}))))
+        (yrs/response :status  204
+                      :headers {"x-accel-redirect" (:path purl)
+                                "content-type" (:content-type mdata)
+                                "cache-control" (str "max-age=" (inst-ms cache-max-age))})))))
 
 (defn objects-handler
   "Handler that servers storage objects by id."
@@ -84,7 +83,7 @@
                 obj (sto/get-object storage id)]
           (if obj
             (serve-object cfg obj)
-            {:status 404 :body ""})))
+            (yrs/response 404))))
 
       (p/bind p/wrap)
       (p/then' respond)
@@ -98,7 +97,7 @@
           obj  (sto/get-object storage (kf mobj))]
     (if obj
       (serve-object cfg obj)
-      {:status 404 :body ""})))
+      (yrs/response 404))))
 
 (defn file-objects-handler
   "Handler that serves storage objects by file media id."

--- a/backend/src/app/http/awsns.clj
+++ b/backend/src/app/http/awsns.clj
@@ -15,7 +15,8 @@
    [cuerdas.core :as str]
    [integrant.core :as ig]
    [jsonista.core :as j]
-   [promesa.exec :as px]))
+   [promesa.exec :as px]
+   [yetti.response :as yrs]))
 
 (declare parse-json)
 (declare handle-request)
@@ -32,7 +33,7 @@
   (fn [request respond _]
     (let [data (slurp (:body request))]
       (px/run! executor #(handle-request cfg data))
-      (respond {:status 200 :body ""}))))
+      (respond (yrs/response 200)))))
 
 (defn handle-request
   [{:keys [http-client] :as cfg} data]

--- a/backend/src/app/http/doc.clj
+++ b/backend/src/app/http/doc.clj
@@ -13,7 +13,8 @@
    [app.util.template :as tmpl]
    [clojure.java.io :as io]
    [clojure.spec.alpha :as s]
-   [pretty-spec.core :as ps]))
+   [pretty-spec.core :as ps]
+   [yetti.response :as yrs]))
 
 (defn get-spec-str
   [k]
@@ -47,8 +48,7 @@
   (let [context (prepare-context rpc)]
     (if (contains? cf/flags :backend-api-doc)
       (fn [_ respond _]
-        (respond {:status 200
-                  :body (-> (io/resource "api-doc.tmpl")
-                            (tmpl/render context))}))
+        (respond (yrs/response 200 (-> (io/resource "api-doc.tmpl")
+                                       (tmpl/render context)))))
       (fn [_ respond _]
-        (respond {:status 404 :body ""})))))
+        (respond (yrs/response 404))))))

--- a/backend/src/app/http/oauth.clj
+++ b/backend/src/app/http/oauth.clj
@@ -22,7 +22,8 @@
    [cuerdas.core :as str]
    [integrant.core :as ig]
    [promesa.core :as p]
-   [promesa.exec :as px]))
+   [promesa.exec :as px]
+   [yetti.response :as yrs]))
 
 (defn- build-redirect-uri
   [{:keys [provider] :as cfg}]
@@ -175,9 +176,7 @@
 
 (defn- redirect-response
   [uri]
-  {:status 302
-   :headers {"location" (str uri)}
-   :body ""})
+  (yrs/response :status 302 :headers {"location" (str uri)}))
 
 (defn- generate-error-redirect
   [cfg error]
@@ -233,7 +232,7 @@
                        :props props
                        :exp (dt/in-future "15m")})
         uri   (build-auth-uri cfg state)]
-    (respond {:status 200 :body {:redirect-uri uri}})))
+    (respond (yrs/response 200 {:redirect-uri uri}))))
 
 (defn- callback-handler
   [cfg request respond _]

--- a/backend/src/app/loggers/zmq.clj
+++ b/backend/src/app/loggers/zmq.clj
@@ -87,7 +87,7 @@
 (s/def ::time-millis integer?)
 (s/def ::message string?)
 (s/def ::context-map map?)
-(s/def ::throw map?)
+(s/def ::thrown map?)
 
 (s/def ::log4j-event
   (s/keys :req-un [::logger-name ::level ::thread ::time-millis ::message]
@@ -101,8 +101,8 @@
             :logger/name  (:logger-name event)
             :logger/level (str/lower (:level event))}
 
-           (when-let [thrown (:thrown event)]
-             {:trace (:extended-stack-trace thrown)})
+           (when-let [trace (-> event :thrown :extended-stack-trace)]
+             {:trace trace})
 
            (:context-map event))
     (do

--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -83,6 +83,9 @@
    {:executor (ig/ref [::default :app.worker/executor])}
 
    :app.http/session
+   {:store (ig/ref :app.http.session/store)}
+
+   :app.http.session/store
    {:pool     (ig/ref :app.db/pool)
     :tokens   (ig/ref :app.tokens/tokens)
     :executor (ig/ref [::default :app.worker/executor])}
@@ -110,14 +113,12 @@
     :host        (cf/get :http-server-host)
     :router      (ig/ref :app.http/router)
     :metrics     (ig/ref :app.metrics/metrics)
-    :executor    (ig/ref [::default :app.worker/executor])
-    :session     (ig/ref :app.http/session)
-    :max-threads (cf/get :http-server-max-threads)
-    :min-threads (cf/get :http-server-min-threads)}
+    :executors   (ig/ref :app.worker/executors)}
 
    :app.http/router
    {:assets        (ig/ref :app.http.assets/handlers)
     :feedback      (ig/ref :app.http.feedback/handler)
+    :session       (ig/ref :app.http/session)
     :awsns-handler (ig/ref :app.http.awsns/handler)
     :oauth         (ig/ref :app.http.oauth/handler)
     :debug         (ig/ref :app.http.debug/handlers)

--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -314,9 +314,9 @@
     :pool     (ig/ref :app.db/pool)}
 
    :app.loggers.loki/reporter
-   {:uri      (cf/get :loggers-loki-uri)
-    :receiver (ig/ref :app.loggers.zmq/receiver)
-    :executor (ig/ref [::worker :app.worker/executor])}
+   {:uri         (cf/get :loggers-loki-uri)
+    :receiver    (ig/ref :app.loggers.zmq/receiver)
+    :http-client (ig/ref :app.http/client)}
 
    :app.loggers.mattermost/reporter
    {:uri         (cf/get :error-report-webhook)

--- a/backend/src/app/media.clj
+++ b/backend/src/app/media.clj
@@ -28,28 +28,30 @@
    org.im4java.core.IMOperation
    org.im4java.core.Info))
 
-(s/def ::image-content-type cm/valid-image-types)
-(s/def ::font-content-type cm/valid-font-types)
-
-(s/def :internal.http.upload/filename ::us/string)
-(s/def :internal.http.upload/size ::us/integer)
-(s/def :internal.http.upload/content-type ::us/string)
-(s/def :internal.http.upload/tempfile any?)
+(s/def ::path fs/path?)
+(s/def ::filename string?)
+(s/def ::size integer?)
+(s/def ::headers (s/map-of string? string?))
+(s/def ::mtype string?)
 
 (s/def ::upload
-  (s/keys :req-un [:internal.http.upload/filename
-                   :internal.http.upload/size
-                   :internal.http.upload/tempfile
-                   :internal.http.upload/content-type]))
+  (s/keys :req-un [::filename ::size ::path]
+          :opt-un [::mtype ::headers]))
+
+;; A subset of fields from the ::upload spec
+(s/def ::input
+  (s/keys :req-un [::path]
+          :opt-un [::mtype]))
 
 (defn validate-media-type!
-  ([mtype] (validate-media-type! mtype cm/valid-image-types))
-  ([mtype allowed]
-   (when-not (contains? allowed mtype)
+  ([upload] (validate-media-type! upload cm/valid-image-types))
+  ([upload allowed]
+   (when-not (contains? allowed (:mtype upload))
      (ex/raise :type :validation
                :code :media-type-not-allowed
                :hint "Seems like you are uploading an invalid media object"))
-   mtype))
+
+   upload))
 
 (defmulti process :cmd)
 (defmulti process-error class)
@@ -72,18 +74,8 @@
       (process-error e))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; --- Thumbnails Generation
+;; IMAGE THUMBNAILS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(s/def ::cmd keyword?)
-
-(s/def ::path (s/or :path fs/path?
-                    :string string?
-                    :file fs/file?))
-
-(s/def ::input
-  (s/keys :req-un [::path]
-          :opt-un [::cm/mtype]))
 
 (s/def ::width integer?)
 (s/def ::height integer?)
@@ -91,7 +83,7 @@
 (s/def ::quality #(< 0 % 101))
 
 (s/def ::thumbnail-params
-  (s/keys :req-un [::cmd ::input ::format ::width ::height]))
+  (s/keys :req-un [::input ::format ::width ::height]))
 
 ;; Related info on how thumbnails generation
 ;;  http://www.imagemagick.org/Usage/thumbnails/
@@ -178,7 +170,7 @@
           (ex/raise :type :validation
                     :code :invalid-svg-file
                     :hint "uploaded svg does not provides dimensions"))
-        (assoc info :mtype mtype))
+        (merge input info))
 
       (let [instance (Info. (str path))
             mtype'   (.getProperty instance "Mime type")]
@@ -191,9 +183,9 @@
         ;; For an animated GIF, getImageWidth/Height returns the delta size of one frame (if no frame given
         ;; it returns size of the last one), whereas getPageWidth/Height always return the full size of
         ;; any frame.
-        {:width  (.getPageWidth instance)
-         :height (.getPageHeight instance)
-         :mtype  mtype}))))
+        (assoc input
+               :width  (.getPageWidth instance)
+               :height (.getPageHeight instance))))))
 
 (defmethod process-error org.im4java.core.InfoException
   [error]
@@ -203,7 +195,7 @@
             :cause error))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Fonts Generation
+;; FONTS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmethod process :generate-fonts
@@ -326,11 +318,10 @@
 
 (defn configure-assets-storage
   "Given storage map, returns a storage configured with the appropriate
-  backend for assets."
+  backend for assets and optional connection attached."
   ([storage]
    (assoc storage :backend (cf/get :assets-storage-backend :assets-fs)))
   ([storage conn]
    (-> storage
        (assoc :conn conn)
        (assoc :backend (cf/get :assets-storage-backend :assets-fs)))))
-

--- a/backend/src/app/metrics.clj
+++ b/backend/src/app/metrics.clj
@@ -23,8 +23,6 @@
    io.prometheus.client.Histogram$Child
    io.prometheus.client.exporter.common.TextFormat
    io.prometheus.client.hotspot.DefaultExports
-   io.prometheus.client.jetty.JettyStatisticsCollector
-   org.eclipse.jetty.server.handler.StatisticsHandler
    java.io.StringWriter))
 
 (set! *warn-on-reflection* true)
@@ -265,9 +263,9 @@
     :summary (make-summary props)
     :histogram (make-histogram props)))
 
-(defn instrument-jetty!
-  [^CollectorRegistry registry ^StatisticsHandler handler]
-  (doto (JettyStatisticsCollector. handler)
-    (.register registry))
-  nil)
+;; (defn instrument-jetty!
+;;   [^CollectorRegistry registry ^StatisticsHandler handler]
+;;   (doto (JettyStatisticsCollector. handler)
+;;     (.register registry))
+;;   nil)
 

--- a/backend/src/app/rpc/mutations/fonts.clj
+++ b/backend/src/app/rpc/mutations/fonts.clj
@@ -32,7 +32,6 @@
 (s/def ::weight valid-weight)
 (s/def ::style valid-style)
 (s/def ::font-id ::us/uuid)
-(s/def ::content-type ::media/font-content-type)
 (s/def ::data (s/map-of ::us/string any?))
 
 (s/def ::create-font-variant

--- a/backend/src/app/storage.clj
+++ b/backend/src/app/storage.clj
@@ -257,7 +257,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; A task responsible to permanently delete already marked as deleted
-;; storage files.
+;; storage files. The storage objects are practically never marked to
+;; be deleted directly by the api call. The touched-gc is responsible
+;; collect the usage of the object and mark it as deleted.
 
 (declare sql:retrieve-deleted-objects-chunk)
 
@@ -308,7 +310,7 @@
         and s.deleted_at < (now() - ?::interval)
         and s.created_at < ?
       order by s.created_at desc
-      limit 100
+      limit 25
    )
    delete from storage_object
     where id in (select id from items_part)
@@ -318,9 +320,9 @@
 ;; Garbage Collection: Analyze touched objects
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; This task is part of the garbage collection of storage objects and
-;; is responsible on analyzing the touched objects and mark them for
-;; deletion if corresponds.
+;; This task is part of the garbage collection process of storage
+;; objects and is responsible on analyzing the touched objects and
+;; mark them for deletion if corresponds.
 ;;
 ;; For example: when file_media_object is deleted, the depending
 ;; storage_object are marked as touched. This means that some files

--- a/backend/src/app/tasks/objects_gc.clj
+++ b/backend/src/app/tasks/objects_gc.clj
@@ -51,7 +51,6 @@
 
     (count result)))
 
-
 ;; --- IMPL: file deletion
 
 (defmethod delete-objects "file"

--- a/backend/src/app/util/websocket.clj
+++ b/backend/src/app/util/websocket.clj
@@ -13,10 +13,10 @@
    [app.metrics :as mtx]
    [app.util.time :as dt]
    [clojure.core.async :as a]
+   [yetti.util :as yu]
    [yetti.websocket :as yws])
   (:import
-   java.nio.ByteBuffer
-   org.eclipse.jetty.io.EofException))
+   java.nio.ByteBuffer))
 
 (declare decode-beat)
 (declare encode-beat)
@@ -48,15 +48,17 @@
                          output-buff-size 64
                          idle-timeout 30000}
                     :as options}]
-   (fn [_]
+   (fn [{:keys [::yws/channel] :as request}]
      (let [input-ch   (a/chan input-buff-size)
            output-ch  (a/chan output-buff-size)
            pong-ch    (a/chan (a/sliding-buffer 6))
            close-ch   (a/chan)
+
            options    (-> options
                           (assoc ::input-ch input-ch)
                           (assoc ::output-ch output-ch)
                           (assoc ::close-ch close-ch)
+                          (assoc ::channel channel)
                           (dissoc ::metrics))
 
            terminated (atom false)
@@ -76,32 +78,9 @@
            on-error
            (fn [_ error]
              (on-terminate)
-             (when-not (or (instance? org.eclipse.jetty.websocket.api.exceptions.WebSocketTimeoutException error)
-                           (instance? java.nio.channels.ClosedChannelException error))
+             ;; TODO: properly log timeout exceptions
+             (when-not (instance? java.nio.channels.ClosedChannelException error)
                (l/error :hint (ex-message error) :cause error)))
-
-           on-connect
-           (fn [conn]
-             (mtx/run! metrics {:id :websocket-active-connections :inc 1})
-
-             (let [wsp (atom (assoc options ::conn conn))]
-               ;; Handle heartbeat
-               (yws/idle-timeout! conn (dt/duration idle-timeout))
-               (-> @wsp
-                   (assoc ::pong-ch pong-ch)
-                   (assoc ::on-close on-terminate)
-                   (process-heartbeat))
-
-               ;; Forward all messages from output-ch to the websocket
-               ;; connection
-               (a/go-loop []
-                 (when-let [val (a/<! output-ch)]
-                   (mtx/run! metrics {:id :websocket-messages-total :labels ["send"] :inc 1})
-                   (a/<! (ws-send! conn (t/encode-str val)))
-                   (recur)))
-
-               ;; React on messages received from the client
-               (process-input wsp handle-message)))
 
            on-message
            (fn [_ message]
@@ -116,35 +95,55 @@
                  (on-terminate))))
 
            on-pong
-           (fn [_ buffer]
-             (a/>!! pong-ch buffer))]
+           (fn [_ buffers]
+             (a/>!! pong-ch (yu/copy-many buffers)))]
 
-       {:on-connect on-connect
-        :on-error on-error
-        :on-close on-terminate
-        :on-text on-message
-        :on-pong on-pong}))))
+       (mtx/run! metrics {:id :websocket-active-connections :inc 1})
+
+       (let [wsp (atom options)]
+         ;; Handle heartbeat
+         (yws/idle-timeout! channel (dt/duration idle-timeout))
+         (-> @wsp
+             (assoc ::pong-ch pong-ch)
+             (assoc ::on-close on-terminate)
+             (process-heartbeat))
+
+         ;; Forward all messages from output-ch to the websocket
+         ;; connection
+         (a/go-loop []
+           (when-let [val (a/<! output-ch)]
+             (mtx/run! metrics {:id :websocket-messages-total :labels ["send"] :inc 1})
+             (a/<! (ws-send! channel (t/encode-str val)))
+             (recur)))
+
+         ;; React on messages received from the client
+         (process-input wsp handle-message)
+
+         {:on-error on-error
+          :on-close on-terminate
+          :on-text on-message
+          :on-pong on-pong})))))
 
 (defn- ws-send!
-  [conn s]
+  [channel s]
   (let [ch (a/chan 1)]
     (try
-      (yws/send! conn s (fn [e]
-                          (when e (a/offer! ch e))
-                          (a/close! ch)))
-      (catch EofException cause
+      (yws/send! channel s (fn [e]
+                             (when e (a/offer! ch e))
+                             (a/close! ch)))
+      (catch java.io.IOException cause
         (a/offer! ch cause)
         (a/close! ch)))
     ch))
 
 (defn- ws-ping!
-  [conn s]
+  [channel s]
   (let [ch (a/chan 1)]
     (try
-      (yws/ping! conn s (fn [e]
+      (yws/ping! channel s (fn [e]
                           (when e (a/offer! ch e))
                           (a/close! ch)))
-      (catch EofException cause
+      (catch java.io.IOException cause
         (a/offer! ch cause)
         (a/close! ch)))
     ch))
@@ -184,19 +183,19 @@
       (a/<! (handler wsp {:type :disconnect})))))
 
 (defn- process-heartbeat
-  [{:keys [::conn ::close-ch ::on-close ::pong-ch
+  [{:keys [::channel ::close-ch ::on-close ::pong-ch
            ::heartbeat-interval ::max-missed-heartbeats]
     :or {heartbeat-interval 2000
          max-missed-heartbeats 4}}]
   (let [beats (atom #{})]
     (a/go-loop [i 0]
       (let [[_ port] (a/alts! [close-ch (a/timeout heartbeat-interval)])]
-        (when (and (yws/connected? conn)
+        (when (and (yws/connected? channel)
                    (not= port close-ch))
-          (a/<! (ws-ping! conn (encode-beat i)))
+          (a/<! (ws-ping! channel (encode-beat i)))
           (let [issued (swap! beats conj (long i))]
             (if (>= (count issued) max-missed-heartbeats)
-              (on-close conn -1 "heartbeat-timeout")
+              (on-close channel -1 "heartbeat-timeout")
               (recur (inc i)))))))
 
     (a/go-loop []

--- a/backend/test/app/services_files_test.clj
+++ b/backend/test/app/services_files_test.clj
@@ -120,8 +120,8 @@
 (t/deftest file-media-gc-task
   (letfn [(create-file-media-object [{:keys [profile-id file-id]}]
             (let [mfile  {:filename "sample.jpg"
-                          :tempfile (th/tempfile "app/test_files/sample.jpg")
-                          :content-type "image/jpeg"
+                          :path (th/tempfile "app/test_files/sample.jpg")
+                          :mtype "image/jpeg"
                           :size 312043}
                   params {::th/type :upload-file-media-object
                           :profile-id profile-id

--- a/backend/test/app/services_media_test.clj
+++ b/backend/test/app/services_media_test.clj
@@ -57,8 +57,8 @@
                                    :project-id (:default-project-id prof)
                                    :is-shared false})
         mfile  {:filename "sample.jpg"
-                :tempfile (th/tempfile "app/test_files/sample.jpg")
-                :content-type "image/jpeg"
+                :path (th/tempfile "app/test_files/sample.jpg")
+                :mtype "image/jpeg"
                 :size 312043}
 
         params {::th/type :upload-file-media-object
@@ -96,8 +96,8 @@
                                    :project-id (:default-project-id prof)
                                    :is-shared false})
         mfile  {:filename "sample.jpg"
-                :tempfile (th/tempfile "app/test_files/sample.jpg")
-                :content-type "image/jpeg"
+                :path (th/tempfile "app/test_files/sample.jpg")
+                :mtype "image/jpeg"
                 :size 312043}
 
         params {::th/type :upload-file-media-object

--- a/backend/test/app/services_profile_test.clj
+++ b/backend/test/app/services_profile_test.clj
@@ -110,8 +110,8 @@
                   :profile-id (:id profile)
                   :file {:filename "sample.jpg"
                          :size 123123
-                         :tempfile (th/tempfile "app/test_files/sample.jpg")
-                         :content-type "image/jpeg"}}
+                         :path (th/tempfile "app/test_files/sample.jpg")
+                         :mtype "image/jpeg"}}
             out  (th/mutation! data)]
 
         ;; (th/print-result! out)

--- a/backend/test/app/storage_test.clj
+++ b/backend/test/app/storage_test.clj
@@ -126,8 +126,8 @@
                                     :is-shared false})
 
         mfile   {:filename "sample.jpg"
-                 :tempfile (th/tempfile "app/test_files/sample.jpg")
-                 :content-type "image/jpeg"
+                 :path (th/tempfile "app/test_files/sample.jpg")
+                 :mtype "image/jpeg"
                  :size 312043}
 
         params  {::th/type :upload-file-media-object
@@ -200,8 +200,8 @@
                     (fs/slurp-bytes))
 
         mfile   {:filename "sample.jpg"
-                 :tempfile (th/tempfile "app/test_files/sample.jpg")
-                 :content-type "image/jpeg"
+                 :path (th/tempfile "app/test_files/sample.jpg")
+                 :mtype "image/jpeg"
                  :size 312043}
 
         params1 {::th/type :upload-file-media-object
@@ -266,8 +266,8 @@
                                     :project-id (:default-project-id prof)
                                     :is-shared false})
         mfile   {:filename "sample.jpg"
-                 :tempfile (th/tempfile "app/test_files/sample.jpg")
-                 :content-type "image/jpeg"
+                 :path (th/tempfile "app/test_files/sample.jpg")
+                 :mtype "image/jpeg"
                  :size 312043}
 
         params  {::th/type :upload-file-media-object

--- a/common/src/app/common/logging.cljc
+++ b/common/src/app/common/logging.cljc
@@ -337,5 +337,3 @@
        (glog/removeHandler l default-console-handler)
        (glog/addHandler l default-console-handler)
        nil)))
-
-


### PR DESCRIPTION
This PR includes the migration from JETTY to UNDERTOW as http backend. This all is donde throught the library we are using: yetti.

1. It makes the http layer fully async (no need to sync operations on websocket handlers, limitation that can't be easy solved in jetty). And enables more control on how to model the execution model.
2. The session store now can be asynchronous (previously forced to by sync because of websockets); now we can think in implement it using redis.
3. Start using ring-2.0 upcoming changes that simplifies the request and response models and make them more performant.
4. The threading model change also improves the resource usages. Now we use probably half of threads for the same workload.

It also fixes some other, bugs already present on the codebase or introduced by part 2 refactor merge.