### PR TITLE
Increase nginx timeout for exporting large artboards to pdf

### DIFF
--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -78,6 +78,7 @@ http {
 
         location /export {
             proxy_pass http://penpot-exporter:6061;
+            proxy_read_timeout 300;
         }
 
         location /ws/notifications {


### PR DESCRIPTION
It can take more than 60 seconds to export large artboards (nginx default timeout is 60 seconds). 