### PR TITLE
Safari/MacOS Fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@
 - Fix clickable area in layers [#1680](https://github.com/penpot/penpot/issues/1680)
 - Fix problems with trackpad zoom and scroll in MacOS [#1161](https://github.com/penpot/penpot/issues/1161)
 - Fix problem with copy/paste in Safari [#1209](https://github.com/penpot/penpot/issues/1209)
+- Fix paste ordering for frames not being respected [Taiga #3097](https://tree.taiga.io/project/penpot/issue/3097)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@
 - Fix inconsistency with radius in SVG an CSS [#1587](https://github.com/penpot/penpot/issues/1587)
 - Fix clickable area in layers [#1680](https://github.com/penpot/penpot/issues/1680)
 - Fix problems with trackpad zoom and scroll in MacOS [#1161](https://github.com/penpot/penpot/issues/1161)
+- Fix problem with copy/paste in Safari [#1209](https://github.com/penpot/penpot/issues/1209)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@
 - Fix problem when importing SVG's with uses with overriding properties [#Taiga 2884](https://tree.taiga.io/project/penpot/issue/2884)
 - Fix inconsistency with radius in SVG an CSS [#1587](https://github.com/penpot/penpot/issues/1587)
 - Fix clickable area in layers [#1680](https://github.com/penpot/penpot/issues/1680)
+- Fix problems with trackpad zoom and scroll in MacOS [#1161](https://github.com/penpot/penpot/issues/1161)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
 - Fix problem with copy/paste in Safari [#1209](https://github.com/penpot/penpot/issues/1209)
 - Fix paste ordering for frames not being respected [Taiga #3097](https://tree.taiga.io/project/penpot/issue/3097)
 - Improved command support for MacOS [Taiga #2789](https://tree.taiga.io/project/penpot/issue/2789)
+- Fix shift+2 shortcut in MacOS with non-english keyboards [Taiga #3038](https://tree.taiga.io/project/penpot/issue/3038)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,7 @@
 - Fix problems with trackpad zoom and scroll in MacOS [#1161](https://github.com/penpot/penpot/issues/1161)
 - Fix problem with copy/paste in Safari [#1209](https://github.com/penpot/penpot/issues/1209)
 - Fix paste ordering for frames not being respected [Taiga #3097](https://tree.taiga.io/project/penpot/issue/3097)
+- Improved command support for MacOS [Taiga #2789](https://tree.taiga.io/project/penpot/issue/2789)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/common/src/app/common/pages/changes.cljc
+++ b/common/src/app/common/pages/changes.cljc
@@ -81,9 +81,7 @@
                 shapes
 
                 (nil? index)
-                (if (= :frame (:type obj))
-                  (into [id] shapes)
-                  (conj shapes id))
+                (conj shapes id)
 
                 :else
                 (cph/insert-at-index shapes index [id]))))

--- a/common/src/app/common/pages/changes_builder.cljc
+++ b/common/src/app/common/pages/changes_builder.cljc
@@ -198,8 +198,7 @@
    (assert-page-id changes)
    (let [obj (cond-> obj
                (not= index ::undefined)
-               (assoc :index index))
-
+               (assoc ::index index))
          add-change
          {:type           :add-obj
           :id             (:id obj)

--- a/docker/devenv/docker-compose.yaml
+++ b/docker/devenv/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       - PENPOT_SMTP_PASSWORD=
       - PENPOT_SMTP_SSL=false
       - PENPOT_SMTP_TLS=false
-      - PENPOT_FLAGS="enable-cors enable-insecure-register enable-audit-log"
+      - PENPOT_FLAGS="enable-cors enable-insecure-register enable-audit-log disable-secure-session-cookies"
 
       # LDAP setup
       - PENPOT_LDAP_HOST=ldap

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1750,3 +1750,4 @@
 (dm/export dwz/zoom-to-fit-all)
 (dm/export dwz/decrease-zoom)
 (dm/export dwz/increase-zoom)
+(dm/export dwz/set-zoom)

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1198,13 +1198,10 @@
   []
   (letfn [;; Sort objects so they have the same relative ordering
           ;; when pasted later.
-          (sort-selected [state data]
-            (let [selected (:selected data)
-                  page-id (:current-page-id state)
-                  objects (get-in state [:workspace-data
-                                         :pages-index
-                                         page-id
-                                         :objects])]
+          (sort-selected-async [state data]
+            (let [selected (wsh/lookup-selected state)
+                  objects  (wsh/lookup-page-objects state)
+                  page-id  (:current-page-id state)]
               (->> (uw/ask! {:cmd :selection/query-z-index
                              :page-id page-id
                              :objects objects
@@ -1215,6 +1212,24 @@
                                          (sort-by second)
                                          (map first)
                                          (into (d/ordered-set)))))))))
+
+          ;; We cannot call to a remote procedure in Safari (for the copy) so we need
+          ;; to calculate it here instead of on the worker
+          (sort-selected-sync [state data]
+            (let [selected (wsh/lookup-selected state)
+                  objects (wsh/lookup-page-objects state)
+                  z-index (cp/calculate-z-index objects)
+                  z-values (->> selected
+                                (map #(vector %
+                                              (+ (get z-index %)
+                                                 (get z-index (get-in objects [% :frame-id]))))))
+                  selected
+                  (->> z-values
+                       (sort-by second)
+                       (map first)
+                       (into (d/ordered-set)))]
+
+              (assoc data :selected selected)))
 
           ;; Retrieve all ids of selected shapes with corresponding
           ;; children; this is needed because each shape should be
@@ -1277,11 +1292,18 @@
                         :file-id (:current-file-id state)
                         :selected selected
                         :objects {}
-                        :images #{}}]
+                        :images #{}}
+
+              sort-results
+              (fn [obs]
+                ;; Safari doesn't allow asynchronous sorting on the copy
+                (if (cfg/check-browser? :safari)
+                  (rx/map (partial sort-selected-sync state) obs)
+                  (rx/mapcat (partial sort-selected-async state) obs)))]
           (->> (rx/from (seq (vals pdata)))
                (rx/merge-map (partial prepare-object objects selected))
                (rx/reduce collect-data initial)
-               (rx/mapcat (partial sort-selected state))
+               (sort-results)
                (rx/map t/encode-str)
                (rx/map wapi/write-to-clipboard)
                (rx/catch on-copy-error)

--- a/frontend/src/app/main/data/workspace/common.cljs
+++ b/frontend/src/app/main/data/workspace/common.cljs
@@ -325,7 +325,7 @@
                      selected)
 
              changes  (-> (pcb/empty-changes it page-id)
-                          (pcb/add-object shape))]
+                          (pcb/add-object shape {:index (when (= :frame (:type shape)) 0)}))]
 
          (rx/concat
           (rx/of (dch/commit-changes changes)

--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -140,7 +140,7 @@
                           :fn #(st/emit! dw/zoom-to-fit-all)}
 
    :zoom-selected        {:tooltip (ds/shift "2")
-                          :command "shift+2"
+                          :command ["shift+2" "@" "\""]
                           :fn #(st/emit! dw/zoom-to-selected-shape)}
 
    :duplicate            {:tooltip (ds/meta "D")

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -541,13 +541,13 @@
             initial-angle   (gpt/angle @ms/mouse-position group-center)
 
             calculate-angle
-            (fn [pos ctrl? shift?]
+            (fn [pos mod? shift?]
               (let [angle (- (gpt/angle pos group-center) initial-angle)
                     angle (if (neg? angle) (+ 360 angle) angle)
                     angle (if (= angle 360)
                             0
                             angle)
-                    angle (if ctrl?
+                    angle (if mod?
                             (* (mth/floor (/ angle 45)) 45)
                             angle)
                     angle (if shift?
@@ -556,11 +556,11 @@
                 angle))]
         (rx/concat
          (->> ms/mouse-position
-              (rx/with-latest vector ms/mouse-position-ctrl)
+              (rx/with-latest vector ms/mouse-position-mod)
               (rx/with-latest vector ms/mouse-position-shift)
               (rx/map
-               (fn [[[pos ctrl?] shift?]]
-                 (let [delta-angle (calculate-angle pos ctrl? shift?)]
+               (fn [[[pos mod?] shift?]]
+                 (let [delta-angle (calculate-angle pos mod? shift?)]
                    (set-rotation-modifiers delta-angle shapes group-center))))
               (rx/take-until stoper))
          (rx/of (apply-modifiers (map :id shapes))

--- a/frontend/src/app/main/ui/settings/sidebar.cljs
+++ b/frontend/src/app/main/ui/settings/sidebar.cljs
@@ -14,6 +14,7 @@
    [app.main.ui.dashboard.sidebar :refer [profile-section]]
    [app.main.ui.icons :as i]
    [app.util.i18n :as i18n :refer [tr]]
+   [app.util.keyboard :as kbd]
    [app.util.router :as rt]
    [potok.core :as ptk]
    [rumext.alpha :as mf]))
@@ -55,8 +56,7 @@
          (fn [event]
            (let [version (:main @cf/version)]
              (st/emit! (ptk/event ::ev/event {::ev/name "show-release-notes" :version version}))
-             (if (and (.-ctrlKey ^js event)
-                      (.-altKey ^js event))
+             (if (and (kbd/alt? event) (kbd/mod? event))
                (st/emit! (modal/show {:type :onboarding}))
                (st/emit! (modal/show {:type :release-notes :version version}))))))]
 

--- a/frontend/src/app/main/ui/shapes/text/svg_text.cljs
+++ b/frontend/src/app/main/ui/shapes/text/svg_text.cljs
@@ -51,8 +51,8 @@
      [:> :g group-props
       (for [[index data] (d/enumerate position-data)]
         (let [props (-> #js {:x (mth/round (:x data))
-                             :y (mth/round (:y data))
-                             :dominantBaseline "ideographic"
+                             :y (mth/round (- (:y data) (:height data)))
+                             :alignmentBaseline "text-before-edge"
                              :style (-> #js {:fontFamily (:font-family data)
                                              :fontSize (:font-size data)
                                              :fontWeight (:font-weight data)

--- a/frontend/src/app/main/ui/viewer/handoff.cljs
+++ b/frontend/src/app/main/ui/viewer/handoff.cljs
@@ -28,7 +28,7 @@
   [{:keys [local file page frame]}]
   (let [on-mouse-wheel
         (fn [event]
-          (when (or (kbd/ctrl? event) (kbd/meta? event))
+          (when (kbd/mod? event)
             (dom/prevent-default event)
             (let [event (.getBrowserEvent ^js event)
                   delta (+ (.-deltaY ^js event)

--- a/frontend/src/app/main/ui/viewer/handoff/left_sidebar.cljs
+++ b/frontend/src/app/main/ui/viewer/handoff/left_sidebar.cljs
@@ -45,7 +45,7 @@
           (dom/prevent-default event)
           (let [id (:id item)]
             (cond
-              (or (kbd/ctrl? event) (kbd/meta? event))
+              (kbd/mod? event)
               (st/emit! (dv/toggle-selection id))
 
               (kbd/shift? event)

--- a/frontend/src/app/main/ui/viewer/interactions.cljs
+++ b/frontend/src/app/main/ui/viewer/interactions.cljs
@@ -61,7 +61,7 @@
 
         on-mouse-wheel
         (fn [event]
-          (when (or (kbd/ctrl? event) (kbd/meta? event))
+          (when (kbd/mod? event)
             (dom/prevent-default event)
             (let [event (.getBrowserEvent ^js event)
                   delta (+ (.-deltaY ^js event) (.-deltaX ^js event))]

--- a/frontend/src/app/main/ui/workspace/shapes/path/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/path/editor.cljs
@@ -47,15 +47,15 @@
             (st/emit! (drp/create-node-at-position (meta position))))
 
           (let [shift? (kbd/shift? event)
-                ctrl? (kbd/ctrl? event)]
+                mod?   (kbd/mod? event)]
             (cond
               last-p?
               (st/emit! (drp/reset-last-handler))
 
-              (and (= edit-mode :move) ctrl? (not curve?))
+              (and (= edit-mode :move) mod? (not curve?))
               (st/emit! (drp/make-curve position))
 
-              (and (= edit-mode :move) ctrl? curve?)
+              (and (= edit-mode :move) mod? curve?)
               (st/emit! (drp/make-corner position))
 
               (= edit-mode :move)

--- a/frontend/src/app/main/ui/workspace/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text.cljs
@@ -27,6 +27,7 @@
    [app.util.timers :as timers]
    [app.util.webapi :as wapi]
    [beicon.core :as rx]
+   [debug :refer [debug?]]
    [okulary.core :as l]
    [rumext.alpha :as mf]))
 
@@ -224,4 +225,22 @@
 
       (when show-svg-text?
         [:g.text-svg {:pointer-events "none"}
-         [:& svg/text-shape {:shape shape}]])]]))
+         [:& svg/text-shape {:shape shape}]])
+
+      (when (debug? :text-outline)
+        (for [data (:position-data shape)]
+          (let [{:keys [x y width height]} data]
+            [:*
+             ;; Text fragment bounding box
+             [:rect {:x x
+                     :y (- y height)
+                     :width width
+                     :height height
+                     :style {:fill "none" :stroke "red"}}]
+
+             ;; Text baselineazo
+             [:line {:x1 (mth/round x)
+                     :y1 (mth/round (- (:y data) (:height data)))
+                     :x2 (mth/round (+ x width))
+                     :y2 (mth/round (- (:y data) (:height data)))
+                     :style {:stroke "blue"}}]])))]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -1491,7 +1491,7 @@
          (mf/deps extend-selected-assets selected-assets)
          (fn [asset-type asset-groups event asset-id default-click]
            (cond
-             (kbd/ctrl? event)
+             (kbd/mod? event)
              (do
                (dom/stop-propagation event)
                (st/emit! (dw/toggle-selected-assets asset-id asset-type)))

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -134,7 +134,7 @@
               (kbd/shift? event)
               (st/emit! (dw/shift-select-shapes id))
 
-              (or (kbd/ctrl? event) (kbd/meta? event))
+              (kbd/mod? event)
               (st/emit! (dw/select-shape id true))
 
               (> (count selected) 1)

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -77,7 +77,7 @@
 
         ;; STATE
         alt?              (mf/use-state false)
-        ctrl?             (mf/use-state false)
+        mod?              (mf/use-state false)
         space?            (mf/use-state false)
         cursor            (mf/use-state (utils/get-cursor :pointer-inner))
         hover-ids         (mf/use-state nil)
@@ -171,9 +171,9 @@
 
     (hooks/setup-dom-events viewport-ref zoom disable-paste in-viewport?)
     (hooks/setup-viewport-size viewport-ref)
-    (hooks/setup-cursor cursor alt? ctrl? space? panning drawing-tool drawing-path? node-editing?)
-    (hooks/setup-keyboard alt? ctrl? space?)
-    (hooks/setup-hover-shapes page-id move-stream base-objects transform selected ctrl? hover hover-ids @hover-disabled? focus zoom)
+    (hooks/setup-cursor cursor alt? mod? space? panning drawing-tool drawing-path? node-editing?)
+    (hooks/setup-keyboard alt? mod? space?)
+    (hooks/setup-hover-shapes page-id move-stream base-objects transform selected mod? hover hover-ids @hover-disabled? focus zoom)
     (hooks/setup-viewport-modifiers modifiers base-objects)
     (hooks/setup-shortcuts node-editing? drawing-path?)
     (hooks/setup-active-frames base-objects vbox hover active-frames)
@@ -258,7 +258,7 @@
           {:objects base-objects
            :selected selected
            :hover (cond
-                    (and @hover (or @ctrl? (not= :frame (:type @hover))))
+                    (and @hover (or @mod? (not= :frame (:type @hover))))
                     #{(:id @hover)}
 
                     @frame-hover
@@ -271,7 +271,7 @@
           {:shapes selected-shapes
            :zoom zoom
            :edition edition
-           :disable-handlers (or drawing-tool edition @space? @ctrl?)
+           :disable-handlers (or drawing-tool edition @space? @mod?)
            :on-move-selected on-move-selected
            :on-context-menu on-menu-selected}])
 

--- a/frontend/src/app/util/keyboard.cljs
+++ b/frontend/src/app/util/keyboard.cljs
@@ -4,37 +4,45 @@
 ;;
 ;; Copyright (c) UXBOX Labs SL
 
-(ns app.util.keyboard)
+(ns app.util.keyboard
+  (:require
+   [app.config :as cfg]))
 
 (defn is-key?
-  [key]
-  (fn [e]
+  [^string key]
+  (fn [^js e]
     (= (.-key e) key)))
 
 (defn ^boolean alt?
-  [event]
+  [^js event]
   (.-altKey event))
 
 (defn ^boolean ctrl?
-  [event]
+  [^js event]
   (.-ctrlKey event))
 
 (defn ^boolean meta?
-  [event]
+  [^js event]
   (.-metaKey event))
 
 (defn ^boolean shift?
-  [event]
+  [^js event]
   (.-shiftKey event))
+
+(defn ^boolean mod?
+  [^js event]
+  (if (cfg/check-platform? :macos)
+    (meta? event)
+    (ctrl? event)))
 
 (def esc? (is-key? "Escape"))
 (def enter? (is-key? "Enter"))
 (def space? (is-key? " "))
 (def up-arrow? (is-key? "ArrowUp"))
 (def down-arrow? (is-key? "ArrowDown"))
-(def altKey? (is-key? "Alt"))
-(def ctrlKey? (or (is-key? "Control")
-                  (is-key? "Meta")))
+(def alt-key? (is-key? "Alt"))
+(def ctrl-key? (is-key? "Control"))
+(def meta-key? (is-key? "Meta"))
 (def comma? (is-key? ","))
 (def backspace? (is-key? "Backspace"))
 

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -46,6 +46,9 @@
 
     ;; When active we can check in the browser the export values
     :show-export-metadata
+
+    ;; Show text fragments outlines
+    :text-outline
     })
 
 ;; These events are excluded when we activate the :events flag


### PR DESCRIPTION
- Fix problems with trackpad zoom and scroll in MacOS [#1161](https://github.com/penpot/penpot/issues/1161)
- Fix problem with copy/paste in Safari [#1209](https://github.com/penpot/penpot/issues/1209)
- Fix paste ordering for frames not being respected [Taiga #3097](https://tree.taiga.io/project/penpot/issue/3097)
- Improved command support for MacOS [Taiga #2789](https://tree.taiga.io/project/penpot/issue/2789)
- Fix shift+2 shortcut in MacOS with non-english keyboards [Taiga #3038](https://tree.taiga.io/project/penpot/issue/3038)