### PR TITLE
:bug: Fix copy paste inside a text layer leaves pasted text transparent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 
 ### :bug: Bugs fixed
 
+- Copy paste inside a text layer leaves pasted text transparent [Taiga #3096](https://tree.taiga.io/project/penpot/issue/3096)
 - On dashboard enter on empty search refresh the page [Taiga #2597](https://tree.taiga.io/project/penpot/issue/2597)
 - Pencil cursor changes when activated [Taiga #2276](https://tree.taiga.io/project/penpot/issue/2276)
 - Fix icon placement in Mixed message [Taiga #3037](https://tree.taiga.io/project/penpot/issue/3037)

--- a/frontend/src/app/util/text_editor.cljs
+++ b/frontend/src/app/util/text_editor.cljs
@@ -15,7 +15,8 @@
 
 (defn immutable-map->map
   [obj]
-  (into {} (map (fn [[k v]] [(keyword k) v])) (seq obj)))
+  (let [data (into {} (map (fn [[k v]] [(keyword k) v])) (seq obj))]
+    (assoc data :fills (js->clj (:fills data) :keywordize-keys true))))
 
 ;; --- DRAFT-JS HELPERS
 


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/3096