### PR TITLE
:bug: Fix comments modal remains open on page change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix comments modal when changing pages [Taiga #2597](https://tree.taiga.io/project/penpot/issue/2508)
 - On dashboard enter on empty search refresh the page [Taiga #2597](https://tree.taiga.io/project/penpot/issue/2597)
 - Pencil cursor changes when activated [Taiga #2276](https://tree.taiga.io/project/penpot/issue/2276)
 - Fix icon placement in Mixed message [Taiga #3037](https://tree.taiga.io/project/penpot/issue/3037)

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -33,7 +33,7 @@
         state       (mf/use-state {:menu-open false})
 
         delete-fn   (mf/use-callback (mf/deps id) #(st/emit! (dw/delete-page id)))
-        navigate-fn (mf/use-callback (mf/deps id) #(st/emit! (dw/go-to-page id)))
+        navigate-fn (mf/use-callback (mf/deps id) #(st/emit! :interrupt (dw/go-to-page id)))
 
         on-context-menu
         (mf/use-callback


### PR DESCRIPTION
This PR Solves [Taiga #2508](https://tree.taiga.io/project/penpot/issue/2508)
