### PR TITLE
:sparkles: Remove duplicate require of clojure.test

### DIFF
--- a/backend/dev/user.clj
+++ b/backend/dev/user.clj
@@ -25,7 +25,6 @@
    [clojure.spec.alpha :as s]
    [clojure.spec.gen.alpha :as sgen]
    [clojure.test :as test]
-   [clojure.test :as test]
    [clojure.tools.namespace.repl :as repl]
    [clojure.walk :refer [macroexpand-all]]
    [datoteka.core]


### PR DESCRIPTION
Small clean up, only affecting `backend/dev/user.clj`.