### PR TITLE
:bug: Libraries templates missing fills and texts

### DIFF
--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -234,7 +234,8 @@
              :xmlns:penpot (when include-metadata? "https://penpot.app/xmlns")
              :style {:width "100%"
                      :height "100%"
-                     :background bgcolor}}
+                     :background bgcolor}
+             :fill "none"}
 
        (when include-metadata?
          [:& export/export-page {:options (:options data)}])
@@ -300,7 +301,8 @@
            :version "1.1"
            :xmlns "http://www.w3.org/2000/svg"
            :xmlnsXlink "http://www.w3.org/1999/xlink"
-           :xmlns:penpot (when include-metadata? "https://penpot.app/xmlns")}
+           :xmlns:penpot (when include-metadata? "https://penpot.app/xmlns")
+           :fill "none"}
      (if (or (not show-thumbnails?) (nil? (:thumbnail frame)))
        [:& wrapper {:shape frame :view-box vbox}]
 
@@ -352,7 +354,8 @@
            :version "1.1"
            :xmlns "http://www.w3.org/2000/svg"
            :xmlnsXlink "http://www.w3.org/1999/xlink"
-           :xmlns:penpot (when include-metadata? "https://penpot.app/xmlns")}
+           :xmlns:penpot (when include-metadata? "https://penpot.app/xmlns")
+           :fill "none"}
 
      [:> shape-container {:shape group}
       [:& group-wrapper {:shape group :view-box vbox}]]]))
@@ -399,7 +402,8 @@
             :xmlnsXlink "http://www.w3.org/1999/xlink"
             ;; Fix Chromium bug about color of html texts
             ;; https://bugs.chromium.org/p/chromium/issues/detail?id=1244560#c5
-            :style {:-webkit-print-color-adjust :exact}}
+            :style {:-webkit-print-color-adjust :exact}
+            :fill "none"}
 
       (let [shapes (cph/get-children objects obj-id)]
         [:& ff/fontfaces-style {:shapes shapes}])
@@ -421,7 +425,8 @@
             :height (:height object)
             :version "1.1"
             :xmlns "http://www.w3.org/2000/svg"
-            :xmlnsXlink "http://www.w3.org/1999/xlink"}
+            :xmlnsXlink "http://www.w3.org/1999/xlink"
+            :fill "none"}
            [:& shape-wrapper {:shape (assoc object :x 0 :y 0)}]]]))]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -464,7 +469,8 @@
              :xmlns "http://www.w3.org/2000/svg"
              :xmlnsXlink "http://www.w3.org/1999/xlink"
              :xmlns:penpot (when include-metadata? "https://penpot.app/xmlns")
-             :style {:display (when-not (some? children) "none")}}
+             :style {:display (when-not (some? children) "none")}
+             :fill "none"}
        [:defs
         (for [[id data] (:components data)]
           [:& component-symbol {:id id :key (dm/str id) :data data}])]

--- a/frontend/src/app/main/ui/export.cljs
+++ b/frontend/src/app/main/ui/export.cljs
@@ -104,7 +104,8 @@
                            :xmlnsXlink "http://www.w3.org/1999/xlink"
                            ;; Fix Chromium bug about color of html texts
                            ;; https://bugs.chromium.org/p/chromium/issues/detail?id=1244560#c5
-                           :style {:-webkit-print-color-adjust :exact}}
+                           :style {:-webkit-print-color-adjust :exact}
+                           :fill "none"}
 
                      [:& shape-wrapper {:shape shape}]])]
 

--- a/frontend/src/app/main/ui/shapes/custom_stroke.cljs
+++ b/frontend/src/app/main/ui/shapes/custom_stroke.cljs
@@ -334,7 +334,7 @@
 
                         ;; There are no strokes  and a blur
                         (and (:blur shape) (-> shape :blur :hidden not) (not (cph/frame-shape? shape)) (empty? (:strokes shape))))
-                        (obj/set! "filter" (dm/fmt "url(#filter_%)" render-id)))
+                       (obj/set! "filter" (dm/fmt "url(#filter_%)" render-id)))
 
         svg-defs  (:svg-defs shape {})
         svg-attrs (:svg-attrs shape {})
@@ -380,7 +380,10 @@
 
         (cond-> (obj/merge! props fill-props)
           (some? style)
-          (obj/set! "style" style))))))
+          (obj/set! "style" style)))
+
+      :else
+      props)))
 
 (defn build-stroke-props [position child value render-id]
   (let [props (-> (obj/get child "props")

--- a/frontend/src/app/main/ui/viewer/handoff/render.cljs
+++ b/frontend/src/app/main/ui/viewer/handoff/render.cljs
@@ -215,7 +215,8 @@
       :height height
       :version "1.1"
       :xmlnsXlink "http://www.w3.org/1999/xlink"
-      :xmlns "http://www.w3.org/2000/svg"}
+      :xmlns "http://www.w3.org/2000/svg"
+      :fill "none"}
 
      [:& render {:shape frame :view-box vbox}]
      [:& selection-feedback

--- a/frontend/src/app/main/ui/viewer/interactions.cljs
+++ b/frontend/src/app/main/ui/viewer/interactions.cljs
@@ -94,7 +94,8 @@
              :height (:height size)
              :version "1.1"
              :xmlnsXlink "http://www.w3.org/1999/xlink"
-             :xmlns "http://www.w3.org/2000/svg"}
+             :xmlns "http://www.w3.org/2000/svg"
+             :fill "none"}
        [:& wrapper {:shape frame
                     :view-box (:vbox size)}]]]]))
 

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -217,7 +217,8 @@
        :height (:height vport 0)
        :view-box (utils/format-viewbox vbox)
        :style {:background-color background
-               :pointer-events "none"}}
+               :pointer-events "none"}
+       :fill "none"}
 
       (when (debug? :show-export-metadata)
         [:& use/export-page {:options options}])


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/3193