### PR TITLE
:bug: Fix guides are not duplicated with the artboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,7 @@
 - Fix component name in sidebar widget [Taiga #3144](https://tree.taiga.io/project/penpot/issue/3144)
 - Fix resize rotated shape with top&down constraints [Taiga #3167](https://tree.taiga.io/project/penpot/issue/3167)
 - Fix multi user not working [Taiga #3195](https://tree.taiga.io/project/penpot/issue/3195)
+- Fix guides are not duplicated with the artboard [Taiga #3072](https://tree.taiga.io/project/penpot/issue/3072)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/frontend/src/app/main/data/workspace/common.cljs
+++ b/frontend/src/app/main/data/workspace/common.cljs
@@ -393,6 +393,11 @@
                               interactions)))
                     (vals objects))
 
+            ;; If any of the deleted shapes is a frame with guides
+            guides (into {} (map (juxt :id identity) (->> (get-in page [:options :guides])
+                                                          (vals)
+                                                          (filter #(not (contains? ids (:frame-id %)))))))
+
             starting-flows
             (filter (fn [flow]
                       ;; If any of the deleted is a frame that starts a flow,
@@ -432,6 +437,7 @@
             changes (-> (pcb/empty-changes it page-id)
                         (pcb/with-page page)
                         (pcb/with-objects objects)
+                        (pcb/set-page-option :guides guides)
                         (pcb/remove-objects all-children)
                         (pcb/remove-objects ids)
                         (pcb/remove-objects empty-parents)


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/3072