### PR TITLE
:bug: Fix blend modes are ignored in component updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix blend modes ignored in component updates [Taiga #2626](https://tree.taiga.io/project/penpot/issue/2626)
 - Fix internal error when hoverin over shape [Taiga #3237](https://tree.taiga.io/project/penpot/issue/3237)
 - Fix mouse leave in handoff close overlay animation breaks [Taiga #3173](https://tree.taiga.io/project/penpot/issue/3173)
 - Fix different behaviour during image drag [Taiga #2279](https://tree.taiga.io/project/penpot/issue/2279)

--- a/common/src/app/common/pages/common.cljc
+++ b/common/src/app/common/pages/common.cljc
@@ -60,6 +60,8 @@
    :height                :geometry-group
    :transform             :geometry-group
    :transform-inverse     :geometry-group
+   :opacity               :layer-effects-group
+   :blend-mode            :layer-effects-group
    :shadow                :shadow-group
    :blur                  :blur-group
    :masked-group?         :mask-group


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/2626