### PR TITLE
:bug: Do not copy the atribute use-for-thumbnail on frame duplicate

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -277,7 +277,10 @@
             page    (get-in state [:workspace-data :pages-index page-id])
             name    (dwc/generate-unique-name unames (:name page))
 
-            page (-> page (assoc :name name :id id))
+            no_thumbnails_objects (->> (:objects page)
+                                      (d/mapm (fn [_ val] (dissoc val :use-for-thumbnail?))))
+
+            page (-> page (assoc :name name :id id :objects no_thumbnails_objects))
 
             changes (-> (pcb/empty-changes it)
                         (pcb/add-page id page))]

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -324,6 +324,7 @@
                               :name frame-name
                               :frame-id uuid/zero
                               :shapes [])
+                       (dissoc :use-for-thumbnail?)
                        (geom/move delta)
                        (d/update-when :interactions #(cti/remap-interactions % ids-map objects)))
 


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/3362