### PR TITLE
:bug: Fix Paths have a black fill while being drawn

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -257,6 +257,7 @@
        :ref viewport-ref
        :class (when drawing-tool "drawing")
        :style {:cursor @cursor}
+       :fill "none"
 
        :on-click         on-click
        :on-context-menu  on-context-menu


### PR DESCRIPTION
Related to: https://tree.taiga.io/project/penpot/issue/3376