### PR TITLE
:bug: Fix github auth without name

### DIFF
--- a/backend/src/app/http/oauth.clj
+++ b/backend/src/app/http/oauth.clj
@@ -119,7 +119,7 @@
                           (get-email info))]
               {:backend  (:name provider)
                :email    email
-               :fullname (get-name info)
+               :fullname (or (get-name info) email)
                :props (->> (dissoc info :name :email)
                            (qualify-props provider))}))
 


### PR DESCRIPTION
Related to: https://tree.taiga.io/project/penpot/issue/3476