### PR TITLE
:arrow_up: Update im4java version to our internal fork version

### DIFF
--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -34,7 +34,9 @@
   buddy/buddy-sign {:mvn/version "3.4.333"}
 
   org.jsoup/jsoup {:mvn/version "1.15.1"}
-  org.im4java/im4java {:mvn/version "1.4.0"}
+  org.im4java/im4java {:git/tag "1.4.0-penpot-2" :git/sha "e2b3e16"
+                       :git/url "https://github.com/penpot/im4java"}
+
   org.lz4/lz4-java {:mvn/version "1.8.0"}
 
   org.clojars.pntblnk/clj-ldap {:mvn/version "0.0.17"}

--- a/backend/scripts/repl
+++ b/backend/scripts/repl
@@ -40,6 +40,9 @@ export OPTIONS="
        -J-XX:+UnlockDiagnosticVMOptions \
        -J-XX:+DebugNonSafepoints";
 
+# Uncomment for use the ImageMagick v7.x
+# export OPTIONS="-J-Dim4java.useV7=true $OPTIONS";
+
 export OPTIONS_EVAL="nil"
 # export OPTIONS_EVAL="(set! *warn-on-reflection* true)"
 


### PR DESCRIPTION
It fixes the v7 compatibility issues. Now, adding the `-Dim4java.useV7=true` property to the java command when executing the penpot backend bundle it switches to use the `magick` (ImageMagick v7 CLI) instead of `convert` and `identify`.

The internal (public) fork of im4java has the following changes from the base 1.4.0 version:

https://github.com/penpot/im4java/compare/e6c1d31586c7d55e99927573a1ddff72df9e89f0...1.4.0-penpot-2

Related to https://tree.taiga.io/project/penpot/issue/3579