### PR TITLE
:sparkles: 2645 Hovering layers bounding box

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -45,6 +45,7 @@
    [app.main.data.workspace.path.shapes-to-path :as dwps]
    [app.main.data.workspace.persistence :as dwp]
    [app.main.data.workspace.selection :as dws]
+   [app.main.data.workspace.highlight :as dwh]
    [app.main.data.workspace.shape-layout :as dwsl]
    [app.main.data.workspace.shapes :as dwsh]
    [app.main.data.workspace.state-helpers :as wsh]
@@ -1731,6 +1732,10 @@
 (dm/export dws/select-inside-group)
 (dm/export dws/select-shape)
 (dm/export dws/shift-select-shapes)
+
+;; Highlight
+(dm/export dwh/highlight-shape)
+(dm/export dwh/dehighlight-shape)
 
 ;; Groups
 (dm/export dwg/mask-group)

--- a/frontend/src/app/main/data/workspace/highlight.cljs
+++ b/frontend/src/app/main/data/workspace/highlight.cljs
@@ -1,0 +1,28 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) UXBOX Labs SL
+
+(ns app.main.data.workspace.highlight
+  (:require
+   [app.common.spec :as us]
+   [potok.core :as ptk]))
+
+;; --- Manage shape's highlight status
+
+(defn highlight-shape
+  [id]
+  (us/verify ::us/uuid id)
+  (ptk/reify ::highlight-shape
+    ptk/UpdateEvent
+    (update [_ state]
+      (update-in state [:workspace-local :highlighted] clojure.set/union #{id}))))
+
+(defn dehighlight-shape
+  [id]
+  (us/verify ::us/uuid id)
+  (ptk/reify ::dehighlight-shape
+    ptk/UpdateEvent
+    (update [_ state]
+      (update-in state [:workspace-local :highlighted] disj id))))

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -117,6 +117,9 @@
      (wsh/process-selected-shapes objects selected))
    selected-shapes-data))
 
+(def highlighted-shapes
+  (l/derived :highlighted workspace-local))
+
 (defn make-selected-ref
   [id]
   (l/derived #(contains? % id) selected-shapes))

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -38,7 +38,7 @@
   (dom/stop-propagation event))
 
 (mf/defc menu-entry
-  [{:keys [title shortcut on-click children selected? icon] :as props}]
+  [{:keys [title shortcut on-click on-pointer-enter on-pointer-leave on-unmount children selected? icon] :as props}]
   (let [submenu-ref (mf/use-ref nil)
         hovering? (mf/use-ref false)
 
@@ -48,7 +48,8 @@
            (mf/set-ref-val! hovering? true)
            (let [submenu-node (mf/ref-val submenu-ref)]
              (when (some? submenu-node)
-               (dom/set-css-property! submenu-node "display" "block")))))
+               (dom/set-css-property! submenu-node "display" "block")))
+           (when on-pointer-enter (on-pointer-enter))))
 
         on-pointer-leave
         (mf/use-callback
@@ -59,7 +60,8 @@
                (timers/schedule
                 200
                 #(when-not (mf/ref-val hovering?)
-                   (dom/set-css-property! submenu-node "display" "none")))))))
+                   (dom/set-css-property! submenu-node "display" "none")))))
+           (when on-pointer-leave (on-pointer-leave))))
 
         set-dom-node
         (mf/use-callback
@@ -67,6 +69,10 @@
            (let [submenu-node (mf/ref-val submenu-ref)]
              (when (and (some? dom) (some? submenu-node))
                (dom/set-css-property! submenu-node "top" (str (.-offsetTop dom) "px"))))))]
+
+    (when on-unmount
+      (mf/use-effect
+       (fn [] on-unmount)))
 
     (if icon
       [:li.icon-menu-item {:ref set-dom-node
@@ -128,7 +134,10 @@
         do-bring-to-front #(st/emit! (dw/vertical-order-selected :top))
         do-send-backward  #(st/emit! (dw/vertical-order-selected :down))
         do-send-to-back   #(st/emit! (dw/vertical-order-selected :bottom))
-        select-shapes     (fn [id] #(st/emit! (dws/select-shape id)))]
+        select-shapes     (fn [id] #(st/emit! (dws/select-shape id)))
+        on-pointer-enter  (fn [id] #(st/emit! (dw/highlight-shape id)))
+        on-pointer-leave  (fn [id] #(st/emit! (dw/dehighlight-shape id)))
+        on-unmount        (fn [id] #(st/emit! (dw/dehighlight-shape id)))]
     [:*
      (when (> (count hover-objs) 1)
        [:& menu-entry {:title (tr "workspace.shape.menu.select-layer")}
@@ -136,6 +145,9 @@
           [:& menu-entry {:title (:name object)
                           :selected? (some #(= object %) shapes)
                           :on-click (select-shapes (:id object))
+                          :on-pointer-enter (on-pointer-enter (:id object))
+                          :on-pointer-leave (on-pointer-leave (:id object))
+                          :on-unmount (on-unmount (:id object))
                           :icon (si/element-icon {:shape object})}])])
      [:& menu-entry {:title (tr "workspace.shape.menu.forward")
                      :shortcut (sc/get-tooltip :bring-forward)

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -144,6 +144,16 @@
               :else
               (st/emit! (dw/select-shape id)))))
 
+        on-pointer-enter
+        (fn [event]
+          (let [id (:id item)]
+            (st/emit! (dw/highlight-shape id))))
+
+        on-pointer-leave
+        (fn [event]
+          (let [id (:id item)]
+            (st/emit! (dw/dehighlight-shape id))))
+
         on-context-menu
         (fn [event]
           (dom/prevent-default event)
@@ -217,6 +227,8 @@
      [:div.element-list-body {:class (dom/classnames :selected selected?
                                                      :icon-layer (= (:type item) :icon))
                               :on-click select-shape
+                              :on-pointer-enter on-pointer-enter
+                              :on-pointer-leave on-pointer-leave
                               :on-double-click #(dom/stop-propagation %)}
       [:& si/element-icon {:shape item}]
       [:& layer-name {:shape item

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -70,6 +70,7 @@
         drawing           (mf/deref refs/workspace-drawing)
         options           (mf/deref refs/workspace-page-options)
         focus             (mf/deref refs/workspace-focus-selected)
+        highlighted       (mf/deref refs/highlighted-shapes)
 
         objects-ref       (mf/use-memo #(refs/workspace-page-objects-by-id page-id))
         objects           (mf/deref objects-ref)
@@ -296,6 +297,7 @@
           {:objects base-objects
            :selected selected
            :hover #{(:id @hover) @frame-hover}
+           :highlighted highlighted
            :edition edition
            :zoom zoom}])
 

--- a/frontend/src/app/main/ui/workspace/viewport/outline.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/outline.cljs
@@ -78,8 +78,9 @@
 (mf/defc shape-outlines
   {::mf/wrap-props false}
   [props]
-  (let [selected  (or (obj/get props "selected") #{})
-        hover     (or (obj/get props "hover") #{})
+  (let [selected        (or (obj/get props "selected") #{})
+        hover           (or (obj/get props "hover") #{})
+        highlighted     (or (obj/get props "highlighted") #{})
 
         objects   (obj/get props "objects")
         edition   (obj/get props "edition")
@@ -89,12 +90,18 @@
         show-outline? (fn [shape] (and (not (:hidden shape))
                                        (not (:blocked shape))))
 
-        shapes (->> outlines-ids
-                    (filter #(not= edition %))
-                    (map #(get objects %))
-                    (filterv show-outline?)
-                    (filter some?))]
-
+        shapes (set
+                (into
+                 (->> outlines-ids
+                      (filter #(not= edition %))
+                      (map #(get objects %))
+                      (filterv show-outline?)
+                      (filter some?))
+                 ;; outline highlighted shapes even if they are hidden or blocked
+                 (->> highlighted
+                      (filter #(not= edition %))
+                      (map #(get objects %))
+                      (filter some?))))]
     [:g.outlines
      [:& shape-outlines-render {:shapes shapes
                                 :zoom zoom}]]))


### PR DESCRIPTION
This PR introduces outlining of shapes on hover upon their representation in Design hierarchy and Layer selection menu.

![record](https://user-images.githubusercontent.com/13056889/180990461-6400a598-cb05-4735-9717-785a08dc7a29.gif)

Closes https://tree.taiga.io/project/penpot/us/2645