### PR TITLE
:bug: Fix paste frame removes all guides

### DIFF
--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -425,11 +425,9 @@
                                                       (assoc :position (if (= (:axis %) :x)
                                                                          (+ (:position %) (- (:x new-frame) (:x frame)))
                                                                          (+ (:position %) (- (:y new-frame) (:y frame))))))))]
-
-                        (if-not (empty? new-guides)
-                          (conj g
-                                (into {} (map (juxt :id identity) new-guides)))
-                          {})))
+                        (cond-> g
+                          (not-empty new-guides)
+                          (conj (into {} (map (juxt :id identity) new-guides))))))
                     guides
                     frames)]
     (-> (pcb/with-page changes page)


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/13056889/181445726-1c89e05b-242f-470d-bab3-cf5a728706d3.mp4

After:

https://user-images.githubusercontent.com/13056889/181448228-ab2cd5a9-1788-47f6-a888-a39dbd84ed62.mp4


The bug is due to that we are mistakenly set guides to none if no new guides is to be added, as can be found [here](https://github.com/penpot/penpot/commit/048919ae20cf777f3f346b21dfebb35da50471af#diff-94039651a9d69b73133501abb4a231aefbfcdf6874c8335d82c8bc194954e6b1L432).

Closes https://tree.taiga.io/project/penpot/issue/3887

I have chosen cond-> due to it's semantics of 'modifying the original collection' with each clause, it fits well 'add new guides if any' op we want to perform, which spares us the cognitive load of parsing it from an `if`. It's not a biggie, but I want to give rational behind 'why there is a cond with one clause', may seem out-of-place at a glance.:)