### PR TITLE
:bug: Fix text alignment becoming undefined on pasting text from clipboard

### DIFF
--- a/frontend/src/app/util/text_editor_impl.js
+++ b/frontend/src/app/util/text_editor_impl.js
@@ -378,10 +378,7 @@ export function insertText(state, text, attrs, inlineStyles) {
   );
 
   blockArray = blockArray.map((b) => {
-    if (b.getText() === "") {
-      return mergeBlockData(b, attrs)
-    }
-    return b;
+      return mergeBlockData(b, attrs);
   });
 
   const fragment = BlockMapBuilder.createFromArray(blockArray);


### PR DESCRIPTION
https://user-images.githubusercontent.com/13056889/182093310-7e03bb96-8c3b-49a6-b032-3c98b40f0801.mp4

I'm not solid about the fix, as I don't get the purpose of the removed 'if' clause.
Could somebody with more domain knowledge shine the light?

Closes https://tree.taiga.io/project/penpot/issue/3629
Based on https://github.com/penpot/penpot/issues/2007
(I have omitted autoclosing referencing of the GH issue, asuming it's desired to be done manually)
