### PR TITLE
:bug: Fix layers get out of their group when moved

### DIFF
--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -736,14 +736,6 @@
         (rx/of (set-modifiers [id] {:displacement displ} false true)
                (apply-modifiers))))))
 
-(defn check-frame-move?
-  [target-frame-id objects position shape]
-
-  (let [current-frame (get objects (:frame-id shape))]
-    ;; If the current frame contains the point and it's a child of the target
-    (and (gsh/has-point? current-frame position)
-         (cph/is-child? objects target-frame-id (:id current-frame)))))
-
 (defn- calculate-frame-for-move
   [ids]
   (ptk/reify ::calculate-frame-for-move
@@ -758,7 +750,7 @@
             (->> ids
                  (cph/clean-loops objects)
                  (keep #(get objects %))
-                 (remove (partial check-frame-move? frame-id objects position)))
+                 (remove #(= (:frame-id %) frame-id)))
 
             moving-frames
             (->> ids


### PR DESCRIPTION

https://user-images.githubusercontent.com/13056889/182096235-c6b77f9d-011e-4f73-bfb2-0cfcae225a81.mp4

Am I breaking something by removing that function?
I tried to get my head around of what can fall out and fell short, but there got to be something..

Closes https://tree.taiga.io/project/penpot/issue/3932