### PR TITLE
:bug: Fix svg upload

### DIFF
--- a/backend/src/app/rpc/mutations/media.clj
+++ b/backend/src/app/rpc/mutations/media.clj
@@ -134,7 +134,7 @@
                                   :bucket "file-media-object"}))))
 
           (create-image [info]
-            (p/let [data    (cond-> (:path info) (= (:mtype info) "image/svg+xml") slurp)
+            (p/let [data    (:path info)
                     hash    (calculate-hash data)
                     content (-> (sto/content data)
                                 (sto/wrap-with-hash hash))]


### PR DESCRIPTION
SVGs were failing to upload
![image](https://user-images.githubusercontent.com/13056889/182108318-90ce7cb7-f32b-426c-81b1-daa68d596dac.png)

Thus not appearing in the Assets
![image](https://user-images.githubusercontent.com/13056889/182109106-c59168c3-7737-46be-96b5-0dd6def355ca.png)
As reported in https://tree.taiga.io/project/penpot/issue/3885

After the fix it's back to normal
![image](https://user-images.githubusercontent.com/13056889/182109797-ec98e75d-5f59-48b2-a2fb-394d6ec6f588.png)

Here is the director's cut of the upload process comparison

https://user-images.githubusercontent.com/13056889/182109918-c08e9366-0809-4589-9b7f-597324c9c719.mp4

