### PR TITLE
:sparkles: Select all inside a group select only the objects at this …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,8 @@
 - Improved share link options. Now you can allow non-team members to comment and/or inspect [Taiga #3056] (https://tree.taiga.io/project/penpot/us/3056)
 - Signin/Signup from shared link [Taiga #3472](https://tree.taiga.io/project/penpot/us/3472)
 - Support for import/export binary format [Taiga #2991](https://tree.taiga.io/project/penpot/us/2991)
-- Comments positioning [Taiga #https://2007](tree.taiga.io/project/penpot/us/2007)
+- Comments positioning [Taiga #2007](https://tree.taiga.io/project/penpot/us/2007)
+- Select all inside a group select only the objects at this group level [Taiga #2382](https://tree.taiga.io/project/penpot/issue/2382)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -178,29 +178,56 @@
       (let [objects (wsh/lookup-page-objects state)]
         (rx/of (dwc/expand-all-parents ids objects))))))
 
+
+
+(defn- select-siblings
+  [state parent]
+  (let [children (wsh/lookup-shapes state (:shapes parent))
+        selected (into (d/ordered-set)
+                       (comp (remove :blocked) (map :id))
+                       children)]
+    (rx/of (select-shapes selected))))
+
+(defn- select-all-frame
+  [state]
+  (let [focus (:workspace-focus-selected state)
+        objects  (-> (wsh/lookup-page-objects state)
+                     (cp/focus-objects focus))
+
+        selected (let [frame-ids (into #{} (comp
+                                            (map (d/getf objects))
+                                            (map :frame-id))
+                                       (wsh/lookup-selected state))
+                       frame-id  (if (= 1 (count frame-ids))
+                                   (first frame-ids)
+                                   uuid/zero)]
+                   (cph/get-immediate-children objects frame-id))
+
+        selected (into (d/ordered-set)
+                       (comp (remove :blocked) (map :id))
+                       selected)]
+
+    (rx/of (select-shapes selected))))
+
+
 (defn select-all
   []
   (ptk/reify ::select-all
     ptk/WatchEvent
     (watch [_ state _]
-      (let [focus (:workspace-focus-selected state)
-            objects  (-> (wsh/lookup-page-objects state)
-                         (cp/focus-objects focus))
+           (let [current-selection-parents (->> (wsh/lookup-selected state)
+                                                (wsh/lookup-shapes state)
+                                                (into #{} (map :parent-id)))
+                 num-parents (count current-selection-parents)
+                 parent (when (= num-parents 1)
+                          (wsh/lookup-shape state (first current-selection-parents)))]
 
-            selected (let [frame-ids (into #{} (comp
-                                                (map (d/getf objects))
-                                                (map :frame-id))
-                                           (wsh/lookup-selected state))
-                           frame-id  (if (= 1 (count frame-ids))
-                                       (first frame-ids)
-                                       uuid/zero)]
-                       (cph/get-immediate-children objects frame-id))
-
-            selected (into (d/ordered-set)
-                           (comp (remove :blocked) (map :id))
-                           selected)]
-
-        (rx/of (select-shapes selected))))))
+             (case num-parents
+               0 (select-all-frame state)
+               1 (if (cph/frame-shape? parent)
+                   (select-all-frame state)
+                   (select-siblings state parent))
+               nil)))))
 
 (defn deselect-all
   "Clear all possible state of drawing, edition


### PR DESCRIPTION
Resolves Ctrl+A inside a group should select only the objects at this group level