### PR TITLE
:recycle: Refactor session management

### DIFF
--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -20,7 +20,7 @@
   io.lettuce/lettuce-core {:mvn/version "6.1.8.RELEASE"}
   java-http-clj/java-http-clj {:mvn/version "0.4.3"}
 
-  funcool/yetti {:git/tag "v9.3" :git/sha "c6e2d0d"
+  funcool/yetti {:git/tag "v9.8" :git/sha "fbe1d7d"
                  :git/url "https://github.com/funcool/yetti.git"
                  :exclusions [org.slf4j/slf4j-api]}
 

--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -42,8 +42,7 @@
     data))
 
 (def defaults
-  {
-   :database-uri "postgresql://postgres/penpot"
+  {:database-uri "postgresql://postgres/penpot"
    :database-username "penpot"
    :database-password "penpot"
 
@@ -101,10 +100,14 @@
 (s/def ::blocking-executor-parallelism ::us/integer)
 (s/def ::worker-executor-parallelism ::us/integer)
 
+(s/def ::authenticated-cookie-domain ::us/string)
+(s/def ::authenticated-cookie-name ::us/string)
+(s/def ::auth-token-cookie-name ::us/string)
+(s/def ::auth-token-cookie-max-age ::dt/duration)
+
 (s/def ::secret-key ::us/string)
 (s/def ::allow-demo-users ::us/boolean)
 (s/def ::assets-path ::us/string)
-(s/def ::authenticated-cookie-domain ::us/string)
 (s/def ::database-password (s/nilable ::us/string))
 (s/def ::database-uri ::us/string)
 (s/def ::database-username (s/nilable ::us/string))
@@ -140,7 +143,6 @@
 (s/def ::http-server-max-multipart-body-size ::us/integer)
 (s/def ::http-server-io-threads ::us/integer)
 (s/def ::http-server-worker-threads ::us/integer)
-(s/def ::http-session-idle-max-age ::dt/duration)
 (s/def ::http-session-updater-batch-max-age ::dt/duration)
 (s/def ::http-session-updater-batch-max-size ::us/integer)
 (s/def ::initial-project-skey ::us/string)
@@ -206,6 +208,9 @@
                    ::allow-demo-users
                    ::audit-log-archive-uri
                    ::audit-log-gc-max-age
+                   ::auth-token-cookie-name
+                   ::auth-token-cookie-max-age
+                   ::authenticated-cookie-name
                    ::authenticated-cookie-domain
                    ::database-password
                    ::database-uri
@@ -246,7 +251,6 @@
                    ::http-server-max-multipart-body-size
                    ::http-server-io-threads
                    ::http-server-worker-threads
-                   ::http-session-idle-max-age
                    ::http-session-updater-batch-max-age
                    ::http-session-updater-batch-max-size
                    ::initial-project-skey

--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -98,15 +98,7 @@
 
    :app.http.session/gc-task
    {:pool        (ig/ref :app.db/pool)
-    :max-age     (cf/get :http-session-idle-max-age)}
-
-   :app.http.session/updater
-   {:pool           (ig/ref :app.db/pool)
-    :metrics        (ig/ref :app.metrics/metrics)
-    :executor       (ig/ref [::worker :app.worker/executor])
-    :session        (ig/ref :app.http/session)
-    :max-batch-age  (cf/get :http-session-updater-batch-max-age)
-    :max-batch-size (cf/get :http-session-updater-batch-max-size)}
+    :max-age     (cf/get :auth-token-cookie-max-age)}
 
    :app.http.awsns/handler
    {:tokens      (ig/ref :app.tokens/tokens)


### PR DESCRIPTION
This PR refactors how session is managed. 

I have replaced the previous session updated mechanism that uses a "dedicated thread loop" for updating all sessions of received requests with a more efficient one that just does on demand on user requests.

The new approach consists on setting a default expiration of 7 days to all sessions. If you enter the application every day, the session will be transparently renewed on some random request from the user. If user stays for 7 days not connection, the session will expire without renovation and then deleted from the table by the GC.

This also solves the problem that causes [session removal after browser closing](https://tree.taiga.io/project/penpot/issue/3937) because previous cookies without expiration are identified by browser as "session" cookie and all session cookies are removed on browser close. Now with proper expiration and transparent token renovation, the user experience will improve considerably.