### PR TITLE
:bug: Fix recent fonts info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix recent fonts info [Taiga #3953](https://tree.taiga.io/project/penpot/issue/3953)
 - Fix clipped elements affect boards and centering [Taiga #3666](https://tree.taiga.io/project/penpot/issue/3666)
 - Fix intro action in multi input [Taiga #3541](https://tree.taiga.io/project/penpot/issue/3541)
 - Fix team default image [Taiga #3919](https://tree.taiga.io/project/penpot/issue/3919)

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -209,7 +209,7 @@
 
 (def workspace-recent-fonts
   (l/derived (fn [data]
-               (get data :workspace-data []))
+               (get data :recent-fonts []))
              workspace-data))
 
 (def workspace-file-typography


### PR DESCRIPTION
This PR solves  recent fonts info [Taiga #3953](https://tree.taiga.io/project/penpot/issue/3953)
