### PR TITLE
:tada: Allow to create a nested component in one step

### DIFF
--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -5,6 +5,10 @@
 ;; Copyright (c) UXBOX Labs SL
 
 (ns app.common.types.component)
+
+(defn instance-root?
+  [shape]
+  (some? (:component-id shape)))
  
 (defn instance-of?
   [shape file-id component-id]

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -407,20 +407,19 @@
                                         :accept-style :primary
                                         :on-accept do-update-component-in-bulk}))]
     [:*
-     (when (and (not has-frame?) (not is-component?))
+     (when (not has-frame?)
        [:*
         [:& menu-separator]
         [:& menu-entry {:title (tr "workspace.shape.menu.create-component")
                         :shortcut (sc/get-tooltip :create-component)
                         :on-click do-add-component}]
-        (when has-component?
+        (when (and has-component? (not single?))
           [:*
            [:& menu-entry {:title (tr "workspace.shape.menu.detach-instances-in-bulk")
                            :shortcut (sc/get-tooltip :detach-component)
                            :on-click do-detach-component-in-bulk}]
-           (when (not single?)
-             [:& menu-entry {:title (tr "workspace.shape.menu.update-components-in-bulk")
-                             :on-click do-update-in-bulk}])])])
+           [:& menu-entry {:title (tr "workspace.shape.menu.update-components-in-bulk")
+                           :on-click do-update-in-bulk}]])])
 
      (when is-component?
        ;; WARNING: this menu is the same as the context menu at the sidebar.

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -207,7 +207,7 @@
   (dump-selected' @st/state))
 
 (defn dump-tree'
-  ([state ] (dump-tree' state false false))
+  ([state] (dump-tree' state false false))
   ([state show-ids] (dump-tree' state show-ids false))
   ([state show-ids show-touched]
    (let [page-id    (get state :current-page-id)

--- a/frontend/test/app/test_helpers/libraries.cljs
+++ b/frontend/test/app/test_helpers/libraries.cljs
@@ -77,39 +77,44 @@
 (defn resolve-instance-and-main
   "Get the shape with the given id and all its children, and also
    the main component and all its shapes."
-  [state root-inst-id]
-  (let [page          (thp/current-page state)
-        root-inst     (ctn/get-shape page root-inst-id)
+  ([state root-inst-id]
+   (resolve-instance-and-main state root-inst-id false))
 
-        libs          (wsh/get-libraries state)
-        component     (cph/get-component libs (:component-id root-inst))
+  ([state root-inst-id subinstance?]
+   (let [page          (thp/current-page state)
+         root-inst     (ctn/get-shape page root-inst-id)
 
-        shapes-inst   (cph/get-children-with-self (:objects page) root-inst-id)
-        shapes-main   (cph/get-children-with-self (:objects component) (:shape-ref root-inst))
+         libs          (wsh/get-libraries state)
+         component     (cph/get-component libs (:component-id root-inst))
 
-        unique-refs   (into #{} (map :shape-ref) shapes-inst)
+         shapes-inst   (cph/get-children-with-self (:objects page) root-inst-id)
+         shapes-main   (cph/get-children-with-self (:objects component) (:shape-ref root-inst))
 
-        main-exists?  (fn [shape]
-                        (let [component-shape
-                              (cph/get-component-shape (:objects page) shape)
+         unique-refs   (into #{} (map :shape-ref) shapes-inst)
 
-                              component
-                              (cph/get-component libs (:component-id component-shape))
+         main-exists?  (fn [shape]
+                         (let [component-shape
+                               (cph/get-component-shape (:objects page) shape)
 
-                              main-shape
-                              (ctn/get-shape component (:shape-ref shape))]
+                               component
+                               (cph/get-component libs (:component-id component-shape))
 
-                        (t/is (some? main-shape))))]
+                               main-shape
+                               (ctn/get-shape component (:shape-ref shape))]
 
-    ;; Validate that the instance tree is well constructed
-    (is-instance-root (first shapes-inst))
-    (run! is-instance-inner (rest shapes-inst))
-    (t/is (= (count shapes-inst)
-             (count shapes-main)
-             (count unique-refs)))
-    (run! main-exists? shapes-inst)
+                           (t/is (some? main-shape))))]
 
-    [shapes-inst shapes-main component]))
+     ;; Validate that the instance tree is well constructed
+     (if subinstance?
+       (is-instance-subroot (first shapes-inst))
+       (is-instance-root (first shapes-inst)))
+     (run! is-instance-inner (rest shapes-inst))
+     (t/is (= (count shapes-inst)
+              (count shapes-main)
+              (count unique-refs)))
+     (run! main-exists? shapes-inst)
+
+     [shapes-inst shapes-main component])))
 
 (defn resolve-instance-and-main-allow-dangling
   "Get the shape with the given id and all its children, and also


### PR DESCRIPTION
Now you can create a component directly from another component, thus creating a nested component.

In addition, a small bug has been fixed about the names of the components created in some cases.

https://tree.taiga.io/project/penpot/task/3900