### PR TITLE
:bug: Fix text alignment undefined after paste text

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/editor.cljs
@@ -152,12 +152,9 @@
          (fn [state]
            (let [old-state (mf/ref-val prev-value)]
              (if (and (some? state) (some? old-state))
-               (let [block-changes (ted/get-content-changes old-state state)
-
-                     prev-data (-> (ted/get-editor-current-inline-styles old-state)
-                                   (dissoc :text-align :text-direction))
-
-                     block-to-setup (get-blocks-to-setup block-changes)
+               (let [block-changes       (ted/get-content-changes old-state state)
+                     prev-data           (ted/get-editor-current-inline-styles old-state)
+                     block-to-setup      (get-blocks-to-setup block-changes)
                      block-to-add-styles (get-blocks-to-add-styles block-changes)]
                  (-> state
                      (ted/setup-block-styles block-to-setup prev-data)
@@ -211,11 +208,12 @@
 
         handle-pasted-text
         (fn [text _ _]
-          (let [style (ted/get-editor-current-inline-styles state)
-                state (-> (ted/insert-text state text style)
-                          (handle-change))]
+          (let [current-block-styles (ted/get-editor-current-block-data state)
+                inline-styles        (ted/get-editor-current-inline-styles state)
+                style                (merge current-block-styles inline-styles)
+                state                (-> (ted/insert-text state text style)
+                                         (handle-change))]
             (st/emit! (dwt/update-editor-state shape state)))
-
           "handled")]
 
     (mf/use-layout-effect on-mount)

--- a/frontend/src/app/util/text_editor.cljs
+++ b/frontend/src/app/util/text_editor.cljs
@@ -72,10 +72,10 @@
 (defn get-editor-current-inline-styles
   [state]
   (if (impl/isCurrentEmpty state)
-    (let [block (impl/getCurrentBlock state)]
-      (get-editor-block-data block))
+    (get-editor-current-block-data state)
     (-> (.getCurrentInlineStyle ^js state)
-        (txt/styles-to-attrs))))
+        (txt/styles-to-attrs)
+        (dissoc :text-align :text-direction))))
 
 (defn update-editor-current-block-data
   [state attrs]
@@ -89,7 +89,8 @@
             (impl/updateBlockData state block-key (clj->js attrs))
 
             (let [attrs (-> (impl/getInlineStyle state block-key 0)
-                            (txt/styles-to-attrs))]
+                            (txt/styles-to-attrs)
+                            (dissoc :text-align :text-direction))]
               (impl/updateBlockData state block-key (clj->js attrs)))))
 
         state (impl/applyInlineStyle state (txt/attrs-to-styles attrs))


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/3629

This MR solves two different situations:

- When pasting text in something aligned


https://user-images.githubusercontent.com/1579633/185552139-5c7aabb1-e7d2-4528-9d2f-3783d5f58c38.mp4

- A more general problem when using block styles while editing pieces of text


https://user-images.githubusercontent.com/1579633/185552176-4b45658c-37e5-4810-8e90-0cc14faae45d.mp4

