### PR TITLE
:bug: Fix nginx user for devenv

### DIFF
--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -1,4 +1,4 @@
-user www-data;
+user root;
 worker_processes auto;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;


### PR DESCRIPTION
The original user "www-data" will lead to 403 Forbidden when serving files under `/home/penpot/penpot/frontend/resources/public` because of these files are owned by user `penpot`. 