### PR TITLE
:bug: Fix undo after moving layers will wrongly order the layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Fix problem when hovering over nested frames [Taiga #4018](https://tree.taiga.io/project/penpot/issue/4018)
 - Fix problem editing rotated texts [Taiga #4026](https://tree.taiga.io/project/penpot/issue/4026)
 - Fix problem with texts for non existing fonts [Taiga #4087](https://tree.taiga.io/project/penpot/issue/4087)
+- Fix undo after moving layers will wrongly order the layers [Taiga #3344](https://tree.taiga.io/project/penpot/issue/3344)
 
 ## 1.15.2-beta
 

--- a/common/src/app/common/pages/changes_builder.cljc
+++ b/common/src/app/common/pages/changes_builder.cljc
@@ -243,13 +243,20 @@
 
          mk-undo-change
          (fn [change-set shape]
+           (let [idx (or (cph/get-position-on-parent objects (:id shape)) 0)
+                 ;; Different index if the movement was from top to bottom or the other way
+                 ;; Similar that on frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+                 ;; with the 'side' property of the on-drop
+                 idx (if (< index idx)
+                       (inc idx)
+                       idx)]
            (d/preconj
              change-set
              {:type :mov-objects
               :page-id (::page-id (meta changes))
               :parent-id (:parent-id shape)
               :shapes [(:id shape)]
-              :index (cph/get-position-on-parent objects (:id shape))}))]
+              :index idx})))] 
 
      (-> changes
          (update :redo-changes conj set-parent-change)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/3344