### PR TITLE
:bug: Fix doubled quotes in frontend config

### DIFF
--- a/docker/images/config.env
+++ b/docker/images/config.env
@@ -10,7 +10,7 @@ PENPOT_TENANT=pro
 
 ## Feature flags.
 
-PENPOT_FLAGS="enable-registration enable-login"
+PENPOT_FLAGS=enable-registration enable-login
 
 ## Temporal workaround because of bad builtin default
 


### PR DESCRIPTION
Docker parses environment variables literally, delivering quoted flags in the $PENPOT_FLAGS variable. This in turn leads to doubled quotes in the resulting config.js in front and after the flags, omitting them completely.

This PR fixes this behaviour.