### PR TITLE
Fix WOFF fonts disabled in font file selection dialog

### DIFF
--- a/common/src/app/common/media.cljc
+++ b/common/src/app/common/media.cljc
@@ -9,7 +9,7 @@
    [clojure.spec.alpha :as s]
    [cuerdas.core :as str]))
 
-(def valid-font-types #{"font/ttf" "font/woff", "font/otf"})
+(def valid-font-types #{"font/ttf" "font/woff", "application/font-woff", "font/otf"})
 (def valid-image-types #{"image/jpeg", "image/png", "image/webp", "image/gif", "image/svg+xml"})
 (def str-image-types (str/join "," valid-image-types))
 (def str-font-types (str/join "," valid-font-types))


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

Looks like `font/woff` mimetype is indeed recommended for WOFF fonts, but e.g. Microsoft Edge uses `application/font-woff`, making it impossible to select WOFF fonts  in file selection dialog.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

Before:

<img width="1624" alt="Zrzut ekranu 2022-09-16 o 23 07 21" src="https://user-images.githubusercontent.com/5426427/190748825-edaa0400-cec8-4ded-9fe5-ba9e8ea0fe35.png">

After:

<img width="1624" alt="Zrzut ekranu 2022-09-16 o 23 07 45" src="https://user-images.githubusercontent.com/5426427/190748979-a5fc03ac-4bd9-4c4e-91b9-a76988ca5aea.png">


<!-- Add images/recordings to better visualize the change: expected/current behviour -->
