### PR TITLE
:bug:Fix english translation

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -337,7 +337,7 @@ msgstr "Export Penpot %s files"
 
 #: src/app/main/ui/export.cljs
 msgid "dashboard.export-multiple.selected"
-msgstr "%s de %s elements selected"
+msgstr "%s of %s elements selected"
 
 #: src/app/main/ui/workspace/header.cljs
 msgid "dashboard.export-shapes"


### PR DESCRIPTION
`dashboard.export-multiple.selected` had "de" instead of "of".

Signed-off-by: yunusp <yunuspoonawala52@gmail.com>

