### PR TITLE
Fix(frontend/comments): Change word-break on comments to break-word

### DIFF
--- a/frontend/resources/styles/main/partials/comments.scss
+++ b/frontend/resources/styles/main/partials/comments.scss
@@ -191,7 +191,7 @@
         margin: 0 $size-2 0 26px;
         white-space: pre-wrap;
         display: inline-block;
-        word-break: break-all;
+        word-break: break-word;
       }
     }
   }


### PR DESCRIPTION
**Before**:

![image](https://user-images.githubusercontent.com/2552726/192739975-800ffe8c-c31e-4696-9e30-666d119a00b4.png)


Problems: Hard to read, no dashes to indicate that words have been broken across lines. 

**After**:

![image](https://user-images.githubusercontent.com/2552726/192740098-e0adaa7c-3848-4c42-b1bf-83a52fccc930.png)

Much easier to read, container overflows in the X direction for super long unbreakable words, which I think is preferable to the original behaviour.