### PR TITLE
:bug: Fix alignment of 'no boards' message in viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,11 +24,9 @@
 - Fix Terms and Privacy links overlapping [Taiga #4137](https://tree.taiga.io/project/penpot/issue/4137)
 - Fix Cannot take out an element from a group at layers panel by drag [Taiga #4209](https://tree.taiga.io/project/penpot/issue/4209)
 - Fix Internal error when resending invitation email [Taiga #4212](https://tree.taiga.io/project/penpot/issue/4212)
-<<<<<<< HEAD
 - Fix PDF exportation order [Taiga #4216](https://tree.taiga.io/project/penpot/issue/4216)
-=======
 - Fix some typos [Taiga #4215](https://tree.taiga.io/project/penpot/issue/4215)
->>>>>>> 093b14d28 (:bug: Fix some typos)
+- Fix "no boards" message in viewer [Taiga #4243](https://tree.taiga.io/project/penpot/issue/4243)
 
 ## 1.15.3-beta
 

--- a/frontend/resources/styles/main/partials/viewer.scss
+++ b/frontend/resources/styles/main/partials/viewer.scss
@@ -141,11 +141,6 @@
     align-items: center;
     overflow: hidden;
 
-    .empty-state {
-      justify-content: center;
-      align-items: center;
-    }
-
     svg {
       transform-origin: center;
     }
@@ -167,6 +162,13 @@
     width: 256px;
     height: 100%;
     z-index: 10;
+  }
+
+  .empty-state {
+    width: 100vw;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
This PR solves https://tree.taiga.io/project/penpot/issue/4243