### PR TITLE
:bug: Fix recent color bullets in assets, closes #2321

### DIFF
--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -498,7 +498,7 @@
       (update state :colorpicker
               (fn [state]
                 (let [state (-> state
-                                (update :current-color merge changes)
+                                (update :current-color merge (split-color-components changes))
                                 (update :current-color materialize-color-components)
                                 ;; current color can be a library one I'm changing via colorpicker
                                 (d/dissoc-in [:current-color :id])

--- a/frontend/src/app/main/ui/workspace/colorpicker.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker.cljs
@@ -88,7 +88,8 @@
 
         on-select-library-color
         (mf/use-fn
-         (fn [color]
+         (fn [{:keys [color]}]
+           (handle-change-color { :hex color })
            (on-change color)))
 
         on-add-library-color


### PR DESCRIPTION
Expected behaviour:
When clicking a color bullet in recent colors list, the current color values (hex and rgba) should be updated to the values of the clicked color bullet.

Bug:
When adding a new color asset in Assets sidebar menu, clicking recent color bullet does not update the color picker hex nor rgba values.

Fix:
When color bullet is clicked, on-select-library-color is called. However, this function never called handle-change-color which is responsible for updating the color picker state.

Another issue here is that colorpicker state handler received the new color value, but did not calculate the corresponding rgba values from the hex value, leaving all the other properties in the state stale.

Testing:
This bug was tested manually. Other colorpicking methods (mouse click on the colormap, hex & rgba input fields) were also tested for regression.

Closes #2321