### PR TITLE
:bug: Fix boards grouped shouldn't show the title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 - Fix ungroup does not work for typographies [Taiga #4195](https://tree.taiga.io/project/penpot/issue/4195)
 - Fix inviting to non existing users can fail [Taiga #4108](https://tree.taiga.io/project/penpot/issue/4108)
 - Fix components marked as touched when moved [Taiga #4061](https://tree.taiga.io/project/penpot/task/4061)
+- Fix boards grouped shouldn't show the title [Taiga #4251](https://tree.taiga.io/project/penpot/issue/4251)
 
 ### :arrow_up: Deps updates
 ### :heart: Community contributions by (Thank you!)

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -167,7 +167,7 @@
 
     [:g.frame-titles
      (for [frame frames]
-       (when (= (:frame-id frame) uuid/zero)
+       (when (= (:parent-id frame) uuid/zero)
          [:& frame-title {:key (dm/str "frame-title-" (:id frame))
                           :frame frame
                           :selected? (contains? selected (:id frame))


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4251