### PR TITLE
:bug: Fix boards name do not disappear in focus mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Fix justify alignes text left [Taiga #4322](https://tree.taiga.io/project/penpot/issue/4322)
 - Fix text out of borders with "auto width" and center align [Taiga #4308](https://tree.taiga.io/project/penpot/issue/4308)
 - Fix auto-width for texts can make text appear stretched [Github #2482](https://github.com/penpot/penpot/issues/2482)
+- Fix boards name do not disappear in focus mode [#4272](https://tree.taiga.io/project/penpot/issue/4272)
 
 ## 1.16.0-beta
 

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -330,7 +330,8 @@
          :show-artboard-names? show-artboard-names?
          :on-frame-enter on-frame-enter
          :on-frame-leave on-frame-leave
-         :on-frame-select on-frame-select}]
+         :on-frame-select on-frame-select
+         :focus focus}]
 
        (when show-prototypes?
          [:& widgets/frame-flows

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -163,11 +163,15 @@
         on-frame-enter  (unchecked-get props "on-frame-enter")
         on-frame-leave  (unchecked-get props "on-frame-leave")
         on-frame-select (unchecked-get props "on-frame-select")
-        frames          (ctt/get-frames objects)]
+        frames          (ctt/get-frames objects)
+        focus           (unchecked-get props "focus")]
 
     [:g.frame-titles
      (for [frame frames]
-       (when (= (:parent-id frame) uuid/zero)
+       (when (and
+              (= (:parent-id frame) uuid/zero)
+              (or (empty? focus)
+                  (contains? focus (:id frame))))
          [:& frame-title {:key (dm/str "frame-title-" (:id frame))
                           :frame frame
                           :selected? (contains? selected (:id frame))


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4272