### PR TITLE
:sparkles: Login error message updated

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -813,7 +813,7 @@ msgstr "Unknown token"
 
 #: src/app/main/ui/auth/login.cljs
 msgid "errors.wrong-credentials"
-msgstr "Username or password seems to be wrong."
+msgstr "Email or password is incorrect."
 
 #: src/app/main/ui/settings/password.cljs
 msgid "errors.wrong-old-password"


### PR DESCRIPTION
Closes #2579 

Updated the message to be accurate and concise.

- Using "is" instead of seems to be accurate and to remove doubts.



