### PR TITLE
❇️  "Invitations" page improvements 

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -61,7 +61,7 @@
         [:a {:on-click go-settings} (tr "labels.settings")]]]]
      [:div.dashboard-buttons
       (if (and (or invitations-section? members-section?) (:is-admin permissions))
-        [:a.btn-secondary.btn-small {:on-click invite-member :data-test "invite-member"}
+        [:a.btn-primary.btn-small {:on-click invite-member :data-test "invite-member"}
          (tr "dashboard.invite-profile")]
         [:div.blank-space])]]))
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -460,7 +460,7 @@ msgstr "Uploading file: %s"
 
 #: src/app/main/ui/dashboard/team.cljs
 msgid "dashboard.invite-profile"
-msgstr "Invite to team"
+msgstr "Invite people"
 
 #: src/app/main/ui/dashboard/sidebar.cljs, src/app/main/ui/dashboard/sidebar.cljs
 msgid "dashboard.leave-team"
@@ -1285,11 +1285,11 @@ msgstr "You have no pending comment notifications"
 
 #: src/app/main/ui/dashboard/team.cljs
 msgid "labels.no-invitations"
-msgstr "There are no invitations."
+msgstr "No pending invitations."
 
 #: src/app/main/ui/dashboard/team.cljs
 msgid "labels.no-invitations-hint"
-msgstr "Press the button \"Invite to team\" to invite more members to this team."
+msgstr "Click the **Invite people** button to invite people to this team."
 
 #: src/app/main/ui/static.cljs
 msgid "labels.not-found.desc-message"


### PR DESCRIPTION
Closes #2588 

### Button

- Changed button type to primary.
- Changed button name to **Invite people** from **Invite to team**.
- **Invite people** is actionable, clear, and accurate.
- Using people instead of members because one has to accept the invitation to become a member.

### Empty state

 - Concise title. 
 - In the description, using bold instead of double quotes to highlight the button name. 
 