### PR TITLE
:bug: Fix strage cursor behaviour after clicking viewport with text pool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.16.2-beta
+- Fix strage cursor behaviour after clicking viewport with text pool [Github #2447](https://github.com/penpot/penpot/issues/2447)
 
 ## 1.16.1-beta
 

--- a/common/src/app/common/geom/shapes/text.cljc
+++ b/common/src/app/common/geom/shapes/text.cljc
@@ -22,7 +22,9 @@
   (let [points    (->> shape
                        :position-data
                        (mapcat (comp gpr/rect->points position-data->rect)))]
-    (-> points (gpr/points->selrect))))
+    (if (empty? points)
+      (:selrect shape)
+      (-> points (gpr/points->selrect)))))
 
 (defn position-data-bounding-box
   [shape]


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/4363