### PR TITLE
:bug: Fix selection stroke missing in properties of multiple texts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Fix problem when moving texts with keyboard [#2690](https://github.com/penpot/penpot/issues/2690)
 - Fix problem when drawing boxes won't detect mouse-up [Taiga #4618](https://tree.taiga.io/project/penpot/issue/4618)
 - Fix missing loading icon on shared libraries [Taiga #4148](https://tree.taiga.io/project/penpot/issue/4148)
+- Fix selection stroke missing in properties of multiple texts [Taiga #4048](https://tree.taiga.io/project/penpot/issue/4048)
 
 ### :arrow_up: Deps updates
 

--- a/common/src/app/common/pages/common.cljc
+++ b/common/src/app/common/pages/common.cljc
@@ -373,6 +373,7 @@
            :fill-color-ref-file
            :fill-color-gradient
 
+           :strokes
            :stroke-style
            :stroke-alignment
            :stroke-width


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4048