### PR TITLE
:bug: Fix layer orders messed up on move, group, reparent and undo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@
 - Fix wrong update of text in components [Taiga #4646](https://tree.taiga.io/project/penpot/issue/4646)
 - Fix problem with SVG imports with style [#2605](https://github.com/penpot/penpot/issues/2605)
 - Fix ghost shapes after sync groups in components [Taiga #4649](https://tree.taiga.io/project/penpot/issue/4649)
+- Fix layer orders messed up on move, group, reparent and undo [Github #2672](https://github.com/penpot/penpot/issues/2672)
 
 ## 1.16.2-beta
 

--- a/common/src/app/common/pages/changes.cljc
+++ b/common/src/app/common/pages/changes.cljc
@@ -182,7 +182,7 @@
       (d/update-in-when data [:components component-id :objects] reg-objects))))
 
 (defmethod process-change :mov-objects
-  [data {:keys [parent-id shapes index page-id component-id ignore-touched]}]
+  [data {:keys [parent-id shapes index page-id component-id ignore-touched after-shape]}]
   (letfn [(calculate-invalid-targets [objects shape-id]
             (let [reduce-fn #(into %1 (calculate-invalid-targets objects %2))]
               (->> (get-in objects [shape-id :shapes])
@@ -260,9 +260,12 @@
                 (not= :frame (:type obj))
                 (as-> $$ (reduce (partial assign-frame-id frame-id) $$ (:shapes obj))))))
 
+
+
           (move-objects [objects]
             (let [valid?   (every? (partial is-valid-move? objects) shapes)
                   parent   (get objects parent-id)
+                  index (if (nil? after-shape) index (inc (d/index-of (:shapes parent) after-shape)))
                   frame-id (if (= :frame (:type parent))
                              (:id parent)
                              (:frame-id parent))]
@@ -283,7 +286,7 @@
                   ;; Ensure that all shapes of the new parent has a
                   ;; correct link to the topside frame.
                   (reduce (partial assign-frame-id frame-id) $ shapes))
-              objects)))]
+                objects)))]
 
     (if page-id
       (d/update-in-when data [:pages-index page-id :objects] move-objects)

--- a/common/src/app/common/pages/helpers.cljc
+++ b/common/src/app/common/pages/helpers.cljc
@@ -147,6 +147,16 @@
         prt (get objects pid)]
     (d/index-of (:shapes prt) id)))
 
+(defn get-prev-sibling
+  [objects id]
+  (let [obj (get objects id)
+        pid (:parent-id obj)
+        prt (get objects pid)
+        shapes (:shapes prt)
+        pos (d/index-of shapes id)]
+    (if (= 0 pos) nil (nth shapes (dec pos)))))
+
+
 (defn get-immediate-children
   "Retrieve resolved shape objects that are immediate children
    of the specified shape-id"
@@ -335,6 +345,13 @@
          (filter (fn [[idx _]] (and (>= idx from) (<= idx to))))
          (map second)
          (into #{}))))
+
+(defn order-by-indexed-shapes
+  [objects ids]
+  (->> (indexed-shapes objects)
+       (sort-by first)
+       (filter (comp (into #{} ids) second))
+       (map second)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; SHAPES ORGANIZATION (PATH MANAGEMENT)

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -639,14 +639,15 @@
 (defn relocate-shapes-changes [it objects parents parent-id page-id to-index ids
                                groups-to-delete groups-to-unmask shapes-to-detach
                                shapes-to-reroot shapes-to-deroot shapes-to-unconstraint]
-  (let [shapes (map (d/getf objects) ids)]
+  (let [ordered-indexes (cph/order-by-indexed-shapes objects ids)
+        shapes (map (d/getf objects) ordered-indexes)]
 
     (-> (pcb/empty-changes it page-id)
         (pcb/with-objects objects)
 
         ; Move the shapes
         (pcb/change-parent parent-id
-                           (reverse shapes)
+                           shapes
                            to-index)
 
         ; Remove empty groups

--- a/frontend/src/app/main/data/workspace/bool.cljs
+++ b/frontend/src/app/main/data/workspace/bool.cljs
@@ -20,15 +20,11 @@
    [cuerdas.core :as str]
    [potok.core :as ptk]))
 
-(defn selected-shapes
+(defn selected-shapes-idx
   [state]
   (let [objects (wsh/lookup-page-objects state)]
     (->> (wsh/lookup-selected state)
-         (cph/clean-loops objects)
-         (map (d/getf objects))
-         (remove cph/frame-shape?)
-         (map #(assoc % ::index (cph/get-position-on-parent objects (:id %))))
-         (sort-by ::index))))
+         (cph/clean-loops objects))))
 
 (defn create-bool-data
   [bool-type name shapes objects]
@@ -92,10 +88,15 @@
             base-name (-> bool-type d/name str/capital (str "-1"))
             name (-> (ctt/retrieve-used-names objects)
                      (ctt/generate-unique-name base-name))
-            shapes  (selected-shapes state)]
+            ids  (selected-shapes-idx state)
+            ordered-indexes (cph/order-by-indexed-shapes objects ids)
+            shapes (->> ordered-indexes
+                        (map (d/getf objects))
+                        (remove cph/frame-shape?))]
 
         (when-not (empty? shapes)
-          (let [[boolean-data index] (create-bool-data bool-type name shapes objects)
+          (let [[boolean-data index] (create-bool-data bool-type name (reverse shapes) objects)
+                index (inc index)
                 shape-id (:id boolean-data)
                 changes (-> (pcb/empty-changes it page-id)
                             (pcb/with-objects objects)

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -118,10 +118,8 @@
       (let [page-id  (:current-page-id state)
             objects (wsh/lookup-page-objects state page-id)
 
-            to-move-shapes
-            (into []
-                  (map (d/getf objects))
-                  (reverse (ctst/sort-z-index objects shapes)))
+            ordered-indexes (cph/order-by-indexed-shapes objects shapes)
+            to-move-shapes (map (d/getf objects) ordered-indexes)
 
             changes
             (when (d/not-empty? to-move-shapes)

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -685,6 +685,7 @@
 
             shapes (->> ids (cph/clean-loops objects) (keep lookup))
 
+
             moving-shapes
             (cond->> shapes
               (not layout?)
@@ -693,6 +694,9 @@
               layout?
               (remove #(and (= (:frame-id %) frame-id)
                             (not= (:parent-id %) frame-id))))
+
+            ordered-indexes (cph/order-by-indexed-shapes objects (map :id moving-shapes))
+            moving-shapes (map (d/getf objects) ordered-indexes)
 
             all-parents
             (reduce (fn [res id]


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4613

To check (with 3 or more layers at the same time, with others layers before and after):

![image](https://user-images.githubusercontent.com/782558/210507868-5362e773-d18b-4b29-b3be-bc9896dc46f9.png)


* Moving layers 
* Moving layers inside a group 
* Moving layers outside a group 
* Moving layers inside a board 
* Moving layers outside a board 
* Create a group 
* Create a bool 
* Create a component
* And undo (ctrl+z) all the previous actions
