### PR TITLE
:bug: Fix confirm group name with enter doesn't work in assets modal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 - Fix "currentColor" is not converted when importing SVG [Github 2276](https://github.com/penpot/penpot/issues/2276)
 - Fix incorrect color in properties of multiple bool shapes [Taiga #4355](https://tree.taiga.io/project/penpot/issue/4355)
 - Fix pressing the enter key gives you an internal error [Github 2675](https://github.com/penpot/penpot/issues/2675) [Github 2577](https://github.com/penpot/penpot/issues/2577)
+- Fix confirm group name with enter doesn't work in assets modal [Taiga #4506](https://tree.taiga.io/project/penpot/issue/4506)
 
 ### :arrow_up: Deps updates
 

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -157,7 +157,7 @@
         {:on-click on-close} i/close]]
 
       [:div.modal-content.generic-form
-       [:& fm/form {:form form}
+       [:& fm/form {:form form :on-submit on-accept}
         [:& fm/input {:name :asset-name
                       :auto-focus? true
                       :label (tr "workspace.assets.group-name")


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4506