### PR TITLE
:bug: Fix import dialog React duplicate key warning

### DIFF
--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -384,7 +384,7 @@
          (let [editing? (and (some? (:file-id file))
                              (= (:file-id file) (:editing @state)))]
            [:& import-entry {:state state
-                             :key (dm/str (:id file))
+                             :key (dm/str (:uri file))
                              :file file
                              :editing? editing?
                              :can-be-deleted? (> (count files) 1)}]))


### PR DESCRIPTION
Fixes the following error:

![image](https://user-images.githubusercontent.com/478699/211284414-c18db9cc-d12a-4d67-85c7-45e9f2c4357a.png)
