### PR TITLE
:sparkles: Adds method `to-fixed`

### DIFF
--- a/common/src/app/common/geom/matrix.cljc
+++ b/common/src/app/common/geom/matrix.cljc
@@ -27,23 +27,13 @@
                    ^double f]
   Object
   (toString [_]
-    #?(:clj
-       (dm/fmt "matrix(%, %, %, %, %, %)"
-               (mth/precision a precision)
-               (mth/precision b precision)
-               (mth/precision c precision)
-               (mth/precision d precision)
-               (mth/precision e precision)
-               (mth/precision f precision))
-
-       :cljs
-       (dm/fmt "matrix(%, %, %, %, %, %)"
-               (.toFixed a precision)
-               (.toFixed b precision)
-               (.toFixed c precision)
-               (.toFixed d precision)
-               (.toFixed e precision)
-               (.toFixed f precision)))))
+    (dm/fmt "matrix(%, %, %, %, %, %)"
+      (mth/to-fixed a precision)
+      (mth/to-fixed b precision)
+      (mth/to-fixed c precision)
+      (mth/to-fixed d precision)
+      (mth/to-fixed e precision)
+      (mth/to-fixed f precision))))
 
 (defn matrix?
   "Return true if `v` is Matrix instance."

--- a/common/src/app/common/math.cljc
+++ b/common/src/app/common/math.cljc
@@ -127,6 +127,12 @@
     (let [d (pow 10 n)]
       (/ (round (* v d)) d))))
 
+(defn to-fixed
+  "Returns a string representing the given number, using fixed precision."
+  [v n]
+  #?(:cljs (.toFixed ^js v n)
+     :clj (str (precision v n))))
+
 (defn radians
   "Converts degrees to radians."
   [degrees]


### PR DESCRIPTION
- Adds method `to-fixed` to `math`
- Changes `matrix/toString` to use `to-fixed` instead of conditional reader