### PR TITLE
:bug: Fix ignore file library sync status

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -962,7 +962,8 @@
   [{:keys [pool] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
   (db/with-atomic [conn pool]
     (check-edition-permissions! conn profile-id file-id)
-    (ignore-sync conn params)))
+    (->  (ignore-sync conn params)
+         (update :features db/decode-pgarray #{}))))
 
 
 ;; --- MUTATION COMMAND: upsert-file-object-thumbnail


### PR DESCRIPTION
- Adds missing `update` of `:features` using `db/decode-pgarray`

## How to reproduce it

1. Create File 1.
2. Add File 1 as Shared Library
3. Create File 2
4. Import File 1 as shared library to File 2
5. Both files are opened in different browser tabs
6. Add color/image/text to File library in File 1
7. Open tab with File 2
8. Click Dismiss in "There are updates in shared libraries" pop-up

## Actual behaviour

Internal Error

An exception is thrown on the backend:
![image](https://user-images.githubusercontent.com/478699/212058161-49210176-33d6-4350-9e78-507f8f53f00b.png)

## Expected behaviour

Changes are dismissed

## Taiga Issue

[Issue](https://tree.taiga.io/project/penpot/issue/4446)