### PR TITLE
:bug: Fix undo ungroup (shift+g) scrambles positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 - Fix ghost shapes after sync groups in components [Taiga #4649](https://tree.taiga.io/project/penpot/issue/4649)
 - Fix layer orders messed up on move, group, reparent and undo [Github #2672](https://github.com/penpot/penpot/issues/2672)
 - Fix max height in library dialog [Github #2335](https://github.com/penpot/penpot/issues/2335)
+- Fix undo ungroup (shift+g) scrambles positions [Taiga #4674](https://tree.taiga.io/project/penpot/issue/4674)
 
 ## 1.16.2-beta
 

--- a/common/src/app/common/pages/changes_builder.cljc
+++ b/common/src/app/common/pages/changes_builder.cljc
@@ -378,14 +378,16 @@
 
         add-undo-change-parent
         (fn [change-set id]
-          (let [shape (get objects id)]
+          (let [shape (get objects id)
+                prev-sibling (cph/get-prev-sibling objects (:id shape))]
             (d/preconj
              change-set
              {:type :mov-objects
               :page-id page-id
               :parent-id (:parent-id shape)
               :shapes [id]
-              :index (cph/get-position-on-parent objects id)
+              :after-shape prev-sibling
+              :index 0
               :ignore-touched true})))]
 
     (-> changes

--- a/frontend/src/app/main/data/workspace/groups.cljs
+++ b/frontend/src/app/main/data/workspace/groups.cljs
@@ -23,9 +23,8 @@
   [objects selected]
   (->> selected
        (cph/order-by-indexed-shapes objects)
-       (map #(get objects %))
-       (map #(assoc % ::index (cph/get-position-on-parent objects (:id %))))
-       (sort-by ::index)))
+       reverse
+       (map #(get objects %))))
 
 (defn- get-empty-groups-after-group-creation
   "An auxiliary function that finds and returns a set of ids that
@@ -77,7 +76,11 @@
                         (ctst/generate-unique-name base-name)))
 
         selrect   (gsh/selection-rect shapes)
-        group-idx (inc (::index (last shapes)))
+        group-idx (->> shapes
+                       last
+                       :id
+                       (cph/get-position-on-parent objects)
+                       inc)
         group     (-> (cts/make-minimal-group frame-id selrect gname)
                       (cts/setup-shape selrect)
                       (assoc :shapes (mapv :id shapes)
@@ -114,7 +117,8 @@
         (->> (:shapes parent)
              (map-indexed vector)
              (filter #(#{(:id group)} (second %)))
-             (ffirst))
+             (ffirst)
+             inc)
 
         ;; Shapes that are in a component (including root) must be detached,
         ;; because cannot be easyly synchronized back to the main component.
@@ -133,7 +137,9 @@
                       (cph/order-by-indexed-shapes objects)
                       (mapv #(get objects %)))
         parent-id     (cph/get-parent-id objects (:id frame))
-        idx-in-parent (cph/get-position-on-parent objects (:id frame))]
+        idx-in-parent (->> (:id frame)
+                          (cph/get-position-on-parent objects)
+                           inc)]
 
     (-> (pcb/empty-changes it page-id)
         (pcb/with-objects objects)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4674