### PR TITLE
:bug: Fix alignment on justify content space between

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -476,9 +476,14 @@
                                                  component-id
                                                  position
                                                  page
-                                                 libraries)]
-        (rx/of (dch/commit-changes changes)
-               (dws/select-shapes (d/ordered-set (:id new-shape))))))))
+                                                 libraries)
+            undo-id (js/Symbol)]
+        (rx/of (dwu/start-undo-transaction undo-id)
+               (dch/commit-changes changes)
+               (ptk/data-event :layout/update [(:id new-shape)])
+               (dws/select-shapes (d/ordered-set (:id new-shape))) 
+               
+               (dwu/commit-undo-transaction undo-id))))))
 
 (defn detach-component
   "Remove all references to components in the shape with the given id,


### PR DESCRIPTION
This PR fixes this feedback line 
> When using "Justify content space between", the remaining elements within a Flex Layout board don't get center-aligned automatically after removing one of them