### PR TITLE
:bug: Filter gfonts variants for figma exporter plugin

### DIFF
--- a/frontend/src/app/main/fonts.cljs
+++ b/frontend/src/app/main/fonts.cljs
@@ -280,10 +280,11 @@
   (let [{:keys [backend family variants]} (get @fontsdb font-id)]
     (cond
       (= :google backend)
-      (-> (generate-gfonts-url
-           {:family family
-            :variants [{:id font-variant-id}]})
-          (http/fetch-text))
+      (let [variant (d/seek #(= (:id %) font-variant-id) variants)]
+        (-> (generate-gfonts-url
+             {:family family
+              :variants [{:id variant}]})
+            (http/fetch-text)))
 
       (= :custom backend)
       (let [variant (d/seek #(= (:id %) font-variant-id) variants)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4679