### PR TITLE
Eva polishing flex

### DIFF
--- a/frontend/src/app/main/data/workspace/shape_layout.cljs
+++ b/frontend/src/app/main/data/workspace/shape_layout.cljs
@@ -12,6 +12,7 @@
    [app.common.geom.shapes :as gsh]
    [app.common.math :as mth]
    [app.common.pages.helpers :as cph]
+   [app.common.types.component :as ctc]
    [app.common.types.modifiers :as ctm]
    [app.common.types.shape-tree :as ctt]
    [app.common.types.shape.layout :as ctl]
@@ -153,9 +154,11 @@
             selected-shapes (map (d/getf objects) selected)
             single?         (= (count selected-shapes) 1)
             has-group?      (->> selected-shapes (d/seek cph/group-shape?))
-            is-group?       (and single? has-group?)]
+            is-group?       (and single? has-group?)
+            has_component?  (some true? (map ctc/instance-root? selected-shapes))
+            is_component?   (and single? has_component?)]
 
-        (if is-group?
+        (if (and (not is_component?) is-group?)
           (let [new-shape-id (uuid/next)
                 parent-id    (:parent-id (first selected-shapes))
                 shapes-ids   (:shapes (first selected-shapes))

--- a/frontend/src/app/main/data/workspace/shape_layout.cljs
+++ b/frontend/src/app/main/data/workspace/shape_layout.cljs
@@ -155,10 +155,10 @@
             single?         (= (count selected-shapes) 1)
             has-group?      (->> selected-shapes (d/seek cph/group-shape?))
             is-group?       (and single? has-group?)
-            has_component?  (some true? (map ctc/instance-root? selected-shapes))
-            is_component?   (and single? has_component?)]
+            has-component?  (some true? (map ctc/instance-root? selected-shapes))
+            is-component?   (and single? has-component?)]
 
-        (if (and (not is_component?) is-group?)
+        (if (and (not is-component?) is-group?)
           (let [new-shape-id (uuid/next)
                 parent-id    (:parent-id (first selected-shapes))
                 shapes-ids   (:shapes (first selected-shapes))

--- a/frontend/src/app/main/ui/formats.cljs
+++ b/frontend/src/app/main/ui/formats.cljs
@@ -52,7 +52,7 @@
       {:p1 p1}
 
       (= 4 (count (set values)))
-      {:p1 p1 :p2 p2 :p3 p3}
+      {:p1 p1 :p2 p2 :p3 p3 :p4 p4}
 
       (and (= p1 p3) (= p2 p4))
       {:p1 p1 :p3 p3}

--- a/frontend/src/app/main/ui/viewer/inspect/attributes/layout_flex.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/attributes/layout_flex.cljs
@@ -68,6 +68,7 @@
   [{:keys [padding type]}]
   (let [values (fm/format-padding-margin-shorthand (vals padding))]
     [:div.attributes-value
+     {:title (str (str/join "px " (vals values)) "px")}
      (for [[k v] values]
        [:span.items {:key (str type "-" k "-" v)} v "px"])]))
 

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -372,27 +372,25 @@
         has-frame?         (->> shapes (d/seek cph/frame-shape?))
         is-frame?          (and single? has-frame?)
         is-flex-container? (and is-frame? (= :flex (:layout (first shapes))))
-        has-group?         (->> shapes (d/seek cph/group-shape?))
-        is-group?          (and single? has-group?)
         ids                (->> shapes (map :id))
         add-flex           #(st/emit! (if is-frame?
                                         (dwsl/create-layout-from-id ids :flex)
                                         (dwsl/create-layout-from-selection :flex)))
         remove-flex        #(st/emit! (dwsl/remove-layout ids))]
-    (cond
-      (or single? (and is-frame? (not is-flex-container?)) is-group?)
-      [:*
-       [:& menu-separator]
-       [:& menu-entry {:title (tr "workspace.shape.menu.add-flex")
-                       :shortcut (sc/get-tooltip :toggle-layout-flex)
-                       :on-click add-flex}]]
 
-      is-flex-container?
-      [:*
-       [:& menu-separator]
-       [:& menu-entry {:title (tr "workspace.shape.menu.remove-flex")
-                       :shortcut (sc/get-tooltip :toggle-layout-flex)
-                       :on-click remove-flex}]])))
+    [:*
+     (when (not is-flex-container?)
+       [:div
+        [:& menu-separator]
+        [:& menu-entry {:title (tr "workspace.shape.menu.add-flex")
+                        :shortcut (sc/get-tooltip :toggle-layout-flex)
+                        :on-click add-flex}]])
+     (when  is-flex-container?
+       [:div
+        [:& menu-separator]
+        [:& menu-entry {:title (tr "workspace.shape.menu.remove-flex")
+                        :shortcut (sc/get-tooltip :toggle-layout-flex)
+                        :on-click remove-flex}]])]))
 
 (mf/defc context-menu-component
   [{:keys [shapes]}]


### PR DESCRIPTION
This PR fixes https://tree.taiga.io/project/penpot/issue/4680
and some bugs detected during concurrency test
- shift+a over component change layer order
- context menu on multiselect don't show "add flex layout" option
