### PR TITLE
:sparkles: Renamed Export boards to PDF option

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -312,11 +312,11 @@ msgid "dashboard.export-binary-multi"
 msgstr "Download %s Penpot files (.penpot)"
 
 msgid "dashboard.export-frames"
-msgstr "Export boards to PDF"
+msgstr "Export boards as PDF"
 
 #: src/app/main/ui/export.cljs
 msgid "dashboard.export-frames.title"
-msgstr "Export to PDF"
+msgstr "Export as PDF"
 
 msgid "dashboard.export-multi"
 msgstr "Export Penpot %s files"


### PR DESCRIPTION
Closes #2791 

Two instances of this have been changed, **_as_** to **_to_**

Signed-off-by: Prithvi Tharun <ptrithu8@gmail.com>

