### PR TITLE
Avoid creating component with shapes that belong to other one

### DIFF
--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -10,6 +10,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.pages.helpers :as cph]
+   [app.common.types.component :as ctk]
    [app.common.types.components-list :as ctkl]
    [app.common.types.file :as ctf]
    [app.common.types.page :as ctp]
@@ -398,6 +399,7 @@
 
         has-component?      (some true? (map #(contains? % :component-id) shapes))
         is-component?       (and single? (-> shapes first :component-id some?))
+        is-non-root?        (and single? (ctk/in-component-instance-not-root? (first shapes)))
 
         shape-id            (-> shapes first :id)
         component-id        (-> shapes first :component-id)
@@ -452,10 +454,12 @@
                                        :on-accept do-update-component-in-bulk}))]
     [:*
      [:*
-      [:& menu-separator]
-      [:& menu-entry {:title (tr "workspace.shape.menu.create-component")
-                      :shortcut (sc/get-tooltip :create-component)
-                      :on-click do-add-component}]
+      (when (or (not is-non-root?) (and has-component? (not single?)))
+        [:& menu-separator])
+      (when-not is-non-root?
+        [:& menu-entry {:title (tr "workspace.shape.menu.create-component")
+                        :shortcut (sc/get-tooltip :create-component)
+                        :on-click do-add-component}])
       (when (and has-component? (not single?))
         [:*
          [:& menu-entry {:title (tr "workspace.shape.menu.detach-instances-in-bulk")
@@ -468,7 +472,6 @@
        ;; WARNING: this menu is the same as the context menu at the sidebar.
        ;;          If you change it, you must change equally the file
        ;;          app/main/ui/workspace/sidebar/options/menus/component.cljs
-
        [:*
         [:& menu-separator]
         (if main-component?

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -36,6 +36,7 @@
         main-instance?     (if components-v2
                              (:main-instance? values)
                              true)
+        main-component?    (:main-instance? values)
         local-component?    (= library-id current-file-id)
         workspace-data      (deref refs/workspace-data)
         workspace-libraries (deref refs/workspace-libraries)
@@ -101,7 +102,7 @@
           [:& context-menu {:on-close on-menu-close
                             :show (:menu-open @local)
                             :options
-                            (if main-instance?
+                            (if main-component?
                               [[(tr "workspace.shape.menu.show-in-assets") do-show-in-assets]]
                               (if local-component?
                                 (if is-dangling?

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -11,6 +11,7 @@
    [app.main.refs :as refs]
    [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-attrs component-menu]]
    [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
    [app.main.ui.workspace.sidebar.options.menus.fill :refer [fill-attrs-shape fill-menu]]
    [app.main.ui.workspace.sidebar.options.menus.frame-grid :refer [frame-grid]]
@@ -33,6 +34,7 @@
         constraint-values (select-keys shape constraint-attrs)
         layout-container-values (select-keys shape layout-container-flex-attrs)
         layout-item-values (select-keys shape layout-item-attrs)
+        [comp-ids comp-values] [[(:id shape)] (select-keys shape component-attrs)]
 
         is-layout-child-ref (mf/use-memo (mf/deps ids) #(refs/is-layout-child? ids))
         is-layout-child? (mf/deref is-layout-child-ref)
@@ -42,6 +44,9 @@
                         :values measure-values
                         :type type
                         :shape shape}]
+     [:& component-menu {:ids comp-ids
+                         :values comp-values
+                         :shape-name (:name shape)}]
      (when (not is-layout-child?)
        [:& constraints-menu {:ids ids
                              :values constraint-values}])


### PR DESCRIPTION
Solves https://tree.taiga.io/project/penpot/issue/4712

Also (for free) fixes the right sidebar component menu (was broken with components-v2 deactivated and was not implemented for board components).