### PR TITLE
:bug: Fix missing flex props on code generation

### DIFF
--- a/frontend/src/app/main/ui/formats.cljs
+++ b/frontend/src/app/main/ui/formats.cljs
@@ -55,7 +55,7 @@
       {:p1 p1 :p2 p2 :p3 p3 :p4 p4}
 
       (and (= p1 p3) (= p2 p4))
-      {:p1 p1 :p3 p3}
+      {:p1 p1 :p2 p2}
 
       (and (not= p1 p3) (= p2 p4))
       {:p1 p1 :p2 p2 :p3 p3}
@@ -67,9 +67,11 @@
   (let [sizing (if (= type :width)
                  (:layout-item-h-sizing shape)
                  (:layout-item-v-sizing shape))]
-    (if (= sizing :fill)
-      "100%"
-      (str (format-pixels value)))))
+    (if (string? value)
+      value
+      (if (= sizing :fill)
+        "100%"
+        (str (format-pixels value))))))
 
 (defn format-padding
   [padding-values type]

--- a/frontend/src/app/main/ui/viewer/inspect/attributes.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/attributes.cljs
@@ -27,7 +27,7 @@
    :group    [:layout :svg :layout-flex-item]
    :rect     [:layout :fill :stroke :shadow :blur :svg :layout-flex-item]
    :circle   [:layout :fill :stroke :shadow :blur :svg :layout-flex-item]
-   :path     [:layout :fill :stroke :shadow :blur :svg]
+   :path     [:layout :fill :stroke :shadow :blur :svg :layout-flex-item]
    :image    [:image :layout :fill :stroke :shadow :blur :svg :layout-flex-item]
    :text     [:layout :text :shadow :blur :stroke :layout-flex-item]})
 

--- a/frontend/src/app/main/ui/viewer/inspect/attributes/layout.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/attributes/layout.cljs
@@ -23,31 +23,31 @@
              :rx "border-radius"
              :r1 "border-radius"}
    :format  {:rotation #(str/fmt "rotate(%sdeg)" %)
-             :r1 #(apply str/fmt "%spx, %spx, %spx, %spx" %)
-             :width (partial fmt/format-size :width)
-             :height (partial fmt/format-size :height)}
+             :r1       #(apply str/fmt "%spx, %spx, %spx, %spx" %)
+             :width    #(cg/get-size :width %)
+             :height   #(cg/get-size :height %)}
    :multi   {:r1 [:r1 :r2 :r3 :r4]}})
 
 (defn copy-data
   ([shape]
    (apply copy-data shape properties))
-  ([shape & properties] 
+  ([shape & properties]
    (cg/generate-css-props shape properties params)))
 
 (mf/defc layout-block
   [{:keys [shape]}]
   (let [selrect (:selrect shape)
-        {:keys [x y]} selrect]
+        {:keys [x y width height]} selrect]
     [:*
      [:div.attributes-unit-row
       [:div.attributes-label (tr "inspect.attributes.layout.width")]
-      [:div.attributes-value (fmt/format-size :width (:width shape) shape)]
-      [:& copy-button {:data (copy-data shape :width)}]]
+      [:div.attributes-value (fmt/format-size :width width shape)]
+      [:& copy-button {:data (copy-data selrect :width)}]]
 
      [:div.attributes-unit-row
       [:div.attributes-label (tr "inspect.attributes.layout.height")]
-      [:div.attributes-value (fmt/format-size :height (:height shape) shape)]
-      [:& copy-button {:data (copy-data shape :height)}]]
+      [:div.attributes-value (fmt/format-size :height height shape)]
+      [:& copy-button {:data (copy-data selrect :height)}]]
 
      (when (not= (:x shape) 0)
        [:div.attributes-unit-row
@@ -73,7 +73,7 @@
         [:div.attributes-value
          (fmt/format-number (:r1 shape)) ", "
          (fmt/format-number (:r2 shape)) ", "
-         (fmt/format-number (:r3 shape))", "
+         (fmt/format-number (:r3 shape)) ", "
          (fmt/format-pixels (:r4 shape))]
         [:& copy-button {:data (copy-data shape :r1)}]])
 

--- a/frontend/src/app/main/ui/viewer/inspect/attributes/layout_flex.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/attributes/layout_flex.cljs
@@ -39,10 +39,10 @@
              :layout-gap "gap"
              :layout-padding "padding"}
    :format  {:layout name
-             :layout-flex-dir name
+             :layout-flex-dir cg/get-layout-direction
              :layout-align-items name
              :layout-justify-content name
-             :layout-wrap-type name
+             :layout-wrap-type cg/get-layout-orientation
              :layout-gap fm/format-gap
              :layout-padding fm/format-padding}})
 
@@ -72,7 +72,7 @@
      (for [[k v] values]
        [:span.items {:key (str type "-" k "-" v)} v "px"])]))
 
-(mf/defc layout-block
+(mf/defc layout-flex-block
   [{:keys [shape]}]
   [:*
    [:div.attributes-unit-row
@@ -82,7 +82,7 @@
 
    [:div.attributes-unit-row
     [:div.attributes-label "Direction"]
-    [:div.attributes-value (str/capital (d/name (:layout-flex-dir shape)))]
+    [:div.attributes-value (str/capital (cg/get-layout-direction (:layout-flex-dir shape)))]
     [:& copy-button {:data (copy-data shape :layout-flex-dir)}]]
 
    [:div.attributes-unit-row
@@ -97,7 +97,7 @@
 
    [:div.attributes-unit-row
     [:div.attributes-label "Flex wrap"]
-    [:div.attributes-value (str/capital (d/name (:layout-wrap-type shape)))]
+    [:div.attributes-value (str/capital (cg/get-layout-orientation (:layout-wrap-type shape)))]
     [:& copy-button {:data (copy-data shape :layout-wrap-type)}]]
    
    (when (= :wrap (:layout-wrap-type shape))
@@ -129,11 +129,11 @@
   (let [shapes (->> shapes (filter has-flex?))] 
    (when (seq shapes)
     [:div.attributes-block
-   [:div.attributes-block-title
-    [:div.attributes-block-title-text "Layout"]
-    (when (= (count shapes) 1)
-      [:& copy-button {:data (copy-data (first shapes))}])]
+     [:div.attributes-block-title
+      [:div.attributes-block-title-text "Layout"]
+      (when (= (count shapes) 1)
+        [:& copy-button {:data (copy-data (first shapes))}])]
 
-   (for [shape shapes]
-     [:& layout-block {:shape shape
-                       :key (:id shape)}])])))
+     (for [shape shapes]
+       [:& layout-flex-block {:shape shape
+                              :key (:id shape)}])])))


### PR DESCRIPTION
This PR solves this issue https://tree.taiga.io/project/penpot/issue/4681 (Check message on issue.)
Fixed css value properties as (nowrap, row-reverse, column-reverse, line height without px"
Fixed copy button on code tab