### PR TITLE
:bug: Fix fills and strokes on inspect code

### DIFF
--- a/frontend/src/app/main/ui/viewer/inspect/code.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/code.cljs
@@ -29,7 +29,7 @@
                 (dom/query js/document "#svg-frame"))
         markup-shape
         (fn [shape]
-          (let [selector (str "#shape-" (:id shape) (when (= :text (:type shape)) " .root"))]
+          (let [selector (str "#shape-" (:id shape))]
             (when-let [el (and frame (dom/query frame selector))]
               (str
                (str/fmt "<!-- %s -->" (:name shape))


### PR DESCRIPTION
Fixes and improves code gen for:
 - Generated svg for texts
 - Fills (single and multiple for shapes)
 - Strokes (only showing the first one)
- Position/left/top depending on shape, frame and layout

Pending:
 - Multiple strokes 
 - Texts with multiple styles 