### PR TITLE
:bug: Fix outline corner radius

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/outline.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/outline.cljs
@@ -35,11 +35,11 @@
             (or (ex/ignoring (upf/format-path (:content shape)))
                 "")))
 
-        {:keys [x y width height selrect rx ry]} shape
+        {:keys [x y width height selrect]} shape
 
-        border-radius-attrs (.-d (attrs/extract-border-radius shape))
+        border-radius-attrs (attrs/extract-border-radius shape)
 
-        path? (some? border-radius-attrs)
+        path? (some? (.-d border-radius-attrs))
 
         outline-type (case (:type shape)
                        :circle "ellipse"
@@ -67,8 +67,8 @@
                  :y (:y selrect)
                  :width (:width selrect)
                  :height (:height selrect)
-                 :rx rx
-                 :ry ry
+                 :rx (.-rx border-radius-attrs)
+                 :ry (.-ry border-radius-attrs)
                  :d border-radius-attrs})]
 
     [:> outline-type (map->obj (merge common props))]))


### PR DESCRIPTION
When a corner radius exceeds the max the shape is rendered ok but no the outline

![image](https://user-images.githubusercontent.com/1579633/215026108-a6233c2c-655f-4edc-a671-cc5247ccafe0.png)
