### PR TITLE
:bug: Fix components groups items show the component name in list mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.17.1
+
+### :bug: Bugs fixed
+- Fix components groups items show the component name in list mode [Taiga #4770](https://tree.taiga.io/project/penpot/issue/4770)
+
+
 ## 1.17.0
 
 ### :sparkles: New features

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -446,10 +446,7 @@
                         :editing renaming?)
           :value (cph/merge-path-item (:path component) (:name component))
           :tooltip (cph/merge-path-item (:path component) (:name component))
-          :display-value (if listing-thumbs?
-                           (:name component)
-                           (cph/compact-name (:path component)
-                                             (:name component)))
+          :display-value (:name component)
           :editing? renaming?
           :disable-dbl-click? true
           :on-change do-rename
@@ -831,10 +828,7 @@
                           :editing renaming?)
              :value (cph/merge-path-item (:path object) (:name object))
              :tooltip (cph/merge-path-item (:path object) (:name object))
-             :display-value (if listing-thumbs?
-                              (:name object)
-                              (cph/compact-name (:path object)
-                                                (:name object)))
+             :display-value (:name object)
              :editing? renaming?
              :disable-dbl-click? true
              :on-change do-rename


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4770