### PR TITLE
:bug: Fix typing CMD+Z on MacOS turns the cursor into a Zoom cursor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### :bug: Bugs fixed
 - Fix components groups items show the component name in list mode [Taiga #4770](https://tree.taiga.io/project/penpot/issue/4770)
+- Fix typing CMD+Z on MacOS turns the cursor into a Zoom cursor [Taiga #4778](https://tree.taiga.io/project/penpot/issue/4778)
 
 
 ## 1.17.0

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -109,7 +109,8 @@
 
 (defn setup-keyboard [alt? mod? space? z?]
   (hooks/use-stream ms/keyboard-alt #(reset! alt? %))
-  (hooks/use-stream ms/keyboard-mod #(reset! mod? %))
+  (hooks/use-stream ms/keyboard-mod #((reset! mod? %)
+                                      (when-not % (reset! z? false)))) ;; In mac after command+z there is no event for the release of the z key
   (hooks/use-stream ms/keyboard-space #(reset! space? %))
   (hooks/use-stream ms/keyboard-z #(reset! z? %)))
 


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4778