### PR TITLE
:sparkles: Change parent/children constraint for problematic configur…

### DIFF
--- a/frontend/src/app/main/data/workspace/shape_layout.cljs
+++ b/frontend/src/app/main/data/workspace/shape_layout.cljs
@@ -271,16 +271,89 @@
                (ptk/data-event :layout/update ids)
                (dwu/commit-undo-transaction undo-id))))))
 
+(defn fix-child-sizing
+  [objects parent-changes shape]
+
+  (let [parent (-> (cph/get-parent objects (:id shape))
+                   (d/deep-merge parent-changes))
+
+        auto-width? (ctl/auto-width? parent)
+        auto-height? (ctl/auto-height? parent)
+        col? (ctl/col? parent)
+        row? (ctl/row? parent)
+
+        all-children (->> parent :shapes (map (d/getf objects)))]
+
+    (cond-> shape
+      ;; If the parent is hug width and the direction column
+      ;; change to fixed when ALL children are fill
+      (and col? auto-width? (every? ctl/fill-width? all-children))
+      (assoc :layout-item-h-sizing :fix)
+
+      ;; If the parent is hug height and the direction is column
+      ;; change to fixed when ANY children is fill
+      (and col? auto-height? (ctl/fill-height? shape))
+      (assoc :layout-item-v-sizing :fix)
+
+      ;; If the parent is hug width and the direction row
+      ;; change to fixed when ANY children is fill
+      (and row? auto-width? (ctl/fill-width? shape))
+      (assoc :layout-item-h-sizing :fix)
+
+      ;; If the parent is hug height and the direction row
+      ;; change to fixed when ALL children are fill
+      (and row? auto-height? (every? ctl/fill-height? all-children))
+      (assoc :layout-item-v-sizing :fix))))
+
+(defn fix-parent-sizing
+  [objects ids-set changes parent]
+
+  (let [auto-width? (ctl/auto-width? parent)
+        auto-height? (ctl/auto-height? parent)
+        col? (ctl/col? parent)
+        row? (ctl/row? parent)
+
+        all-children
+        (->> parent :shapes
+             (map (d/getf objects))
+             (map (fn [shape]
+                    (if (contains? ids-set (:id shape))
+                      (d/deep-merge shape changes)
+                      shape))))]
+
+    (cond-> parent
+      ;; Col layout and parent is hug-width if all children are fill-width
+      ;; change parent to fixed
+      (and col? auto-width? (every? ctl/fill-width? all-children))
+      (assoc :layout-item-h-sizing :fix)
+
+      ;; Col layout and parent is hug-height if any children is fill-height
+      ;; change parent to fixed
+      (and col? auto-height? (some ctl/fill-height? all-children))
+      (assoc :layout-item-v-sizing :fix)
+
+      ;; Row layout and parent is hug-width if any children is fill-width
+      ;; change parent to fixed
+      (and row? auto-width? (some ctl/fill-width? all-children))
+      (assoc :layout-item-h-sizing :fix)
+
+      ;; Row layout and parent is hug-height if all children are fill-height
+      ;; change parent to fixed
+      (and row? auto-height? (every? ctl/fill-height? all-children))
+      (assoc :layout-item-v-sizing :fix))))
+
 (defn update-layout-child
   [ids changes]
   (ptk/reify ::update-layout-child
     ptk/WatchEvent
     (watch [_ state _]
       (let [objects (wsh/lookup-page-objects state)
+            children-ids (->> ids (mapcat #(cph/get-children-ids objects %)))
             parent-ids (->> ids (map #(cph/get-parent-id objects %)))
-            layout-ids (->> ids (filter (comp ctl/layout? (d/getf objects))))
             undo-id (js/Symbol)]
         (rx/of (dwu/start-undo-transaction undo-id)
                (dwc/update-shapes ids #(d/deep-merge (or % {}) changes))
-               (ptk/data-event :layout/update (d/concat-vec layout-ids parent-ids))
+               (dwc/update-shapes children-ids (partial fix-child-sizing objects changes))
+               (dwc/update-shapes parent-ids (partial fix-parent-sizing objects (set ids) changes))
+               (ptk/data-event :layout/update ids)
                (dwu/commit-undo-transaction undo-id))))))


### PR DESCRIPTION
:sparkles: Change parent/children constraint for problematic configurations

This will solve the problems we have when there is a "hug content" parent with "fill" children. When we detect an incompatible configuration we change the parent or the children to fix it.