### PR TITLE
:sparkles: Allow negative values for shadow spread

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
@@ -181,7 +181,6 @@
                            :placeholder "--"
                            :on-click (select-text adv-spread-ref)
                            :on-change (update-attr index :spread valid-number?)
-                           :min 0
                            :value (:spread value)}]
         [:span.after (tr "workspace.options.shadow-options.spread")]]]
 


### PR DESCRIPTION
Fix #2525

# Description:

This PR remove the prop `:min` to allow the use of negative values for drop and inner shadow
 
![Screenshot from 2023-02-03 11-26-52](https://user-images.githubusercontent.com/18740980/216577463-97950588-0cb9-474e-81cc-93f7c266f0bd.png)
