### PR TITLE
✨ Added darker color for hover button in zoom widget to improve a11y

### DIFF
--- a/frontend/resources/styles/main/partials/zoom-widget.scss
+++ b/frontend/resources/styles/main/partials/zoom-widget.scss
@@ -77,7 +77,7 @@
         background-color: $color-white;
         border: none;
         &:hover {
-          color: $color-primary;
+          color: $color-primary-darker;
         }
       }
       .reset-btn {


### PR DESCRIPTION
**What**
Hover color for button in zoom widget is very light, and low contrast is:
1. Undreadable
2. Hurts the eyes

https://user-images.githubusercontent.com/28909808/216605686-30b1cec5-a565-49b2-b11d-4d9ce4b5ef41.mov

![Snímek obrazovky 2023-02-03 v 13 00 54](https://user-images.githubusercontent.com/28909808/216604420-4028dc0a-7135-439c-bfe2-2e256f0ebed5.png)
![Snímek obrazovky 2023-02-03 v 13 31 46](https://user-images.githubusercontent.com/28909808/216604428-826a3a5b-e9f0-4718-9ac0-869a3832a2c4.png)

I changed color for button hover, that:
1. Improve accessibility
2. Is pleasing to the eyes

![Snímek obrazovky 2023-02-03 v 13 04 41](https://user-images.githubusercontent.com/28909808/216604469-2150cf37-3f73-4053-9c14-154d3374c3b8.png)
![Snímek obrazovky 2023-02-03 v 13 39 24](https://user-images.githubusercontent.com/28909808/216605780-95cfdd1d-79ff-4d15-b30c-7d767c62ebf2.png)

https://user-images.githubusercontent.com/28909808/216605812-9d674750-a294-49e1-828a-53542436b186.mov

**Info**
It's just little improvement which does not affect other components. It's still does not match with WCAG requirements, but I did not want to change it drastically (and there is no darker shade of the primary color yet). 

Hope you'll like my request.

Btw. this is my 2nd PR, and I did not found if I should open Issues every time or can contribute to code directly, so please, correct my if there is something wrong.
