### PR TITLE
fix(docker): adds mailcatch to penpot network

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -259,6 +259,8 @@ services:
       - '1025'
     ports:
       - "1080:1080"
+    networks:
+      - penpot
 
   ## Example configuration of MiniIO (S3 compatible object storage service); If you don't
   ## have preference, then just use filesystem, this is here just for the completeness.


### PR DESCRIPTION
Without this the backend complains that it cannot connect to the smtp host (when using mailcatcher). The reason is because the mailcatcher is not on the same network as the backend application.