### PR TITLE
🐛 Add min-width property to avoid shrinking on icons

### DIFF
--- a/frontend/resources/styles/main/partials/modal.scss
+++ b/frontend/resources/styles/main/partials/modal.scss
@@ -1403,6 +1403,7 @@
           align-items: center;
           justify-content: center;
           background: #31efb8;
+          min-width: 28px;
           width: 28px;
           height: 28px;
           border-radius: 50%;


### PR DESCRIPTION
This PR fixing shrinking icons on onboarding modal discussed here #2907 (it's @myfunnyandy comment [here](https://github.com/penpot/penpot/issues/2907#issuecomment-1420964376))

When using flexbox, items can shrink. That how flex container item works. This should be safe fix, but since I could not reproduce this onboarding screen, would be nice to double check it.

There are more options using `flex-shrink: 0` and so, but it has to be tested. I can improve code later when I'm available to reproduce it. 