### PR TITLE
Fix duplicate with alt and undo only undo one step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,11 @@
 
 - Fix invite members button text [Taiga #4794](https://tree.taiga.io/project/penpot/issue/4794)
 - Fix problem with opacity in frames [Taiga #4795](https://tree.taiga.io/project/penpot/issue/4795)
+<<<<<<< HEAD
 - Fix correct behaviour for space-around and added space-evenly option
+=======
+- Fix duplicate with alt and undo only undo one step [Taiga #4746](https://tree.taiga.io/project/penpot/issue/4746)
+>>>>>>> d262fc2b7 (:bug: Fix duplicate with alt and undo only undo one step)
 
 ## 1.17.2
 

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -485,7 +485,10 @@
 
         (gpt/subtract new-pos pt-obj)))))
 
-(defn duplicate-selected [move-delta?]
+(defn duplicate-selected
+  ([move-delta?]
+   (duplicate-selected move-delta? false))
+  ([move-delta? add-group-id?]
   (ptk/reify ::duplicate-selected
     ptk/WatchEvent
     (watch [it state _]
@@ -501,6 +504,8 @@
 
                   changes         (->> (prepare-duplicate-changes objects page selected delta it)
                                        (duplicate-changes-update-indices objects selected))
+
+                  changes         (cond-> changes add-group-id? (assoc :group-id (uuid/random)))
 
                   id-original     (first selected)
 
@@ -525,7 +530,7 @@
                 (select-shapes new-selected)
                 (ptk/data-event :layout/update frames)
                 (memorize-duplicated id-original id-duplicated)
-                (dwu/commit-undo-transaction undo-id)))))))))
+                (dwu/commit-undo-transaction undo-id))))))))))
 
 (defn change-hover-state
   [id value]

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -382,7 +382,7 @@
                     (if alt?
                       ;; When alt is down we start a duplicate+move
                       (rx/of (start-move-duplicate initial)
-                             (dws/duplicate-selected false))
+                             (dws/duplicate-selected false true))
 
                       ;; Otherwise just plain old move
                       (rx/of (start-move initial selected))))))

--- a/frontend/src/app/main/data/workspace/undo.cljs
+++ b/frontend/src/app/main/data/workspace/undo.cljs
@@ -55,10 +55,11 @@
     state))
 
 (defn- accumulate-undo-entry
-  [state {:keys [undo-changes redo-changes]}]
+  [state {:keys [undo-changes redo-changes group-id]}]
   (-> state
       (update-in [:workspace-undo :transaction :undo-changes] #(into undo-changes %))
-      (update-in [:workspace-undo :transaction :redo-changes] #(into % redo-changes))))
+      (update-in [:workspace-undo :transaction :redo-changes] #(into % redo-changes))
+      (assoc-in [:workspace-undo :transaction :group-id] group-id)))
 
 (defn append-undo
   [entry]


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/4746 and introduces a new undo concept: changes-group-id