### PR TITLE
🐋 Add environment variables for specifying the export and backend url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### :boom: Breaking changes & Deprecations
 
+- Adds environment variables for specifying the export and backend url for the frontend docker image. [Github #2983](https://github.com/penpot/penpot/pull/2983)
+
 ### :sparkles: New features
 - Adds more accessibility improvements in dashboard [Taiga #4577](https://tree.taiga.io/project/penpot/us/4577)
 - Adds paddings and gaps prediction on layout creation [Taiga #4838](https://tree.taiga.io/project/penpot/task/4838)

--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -82,7 +82,7 @@ http {
         }
 
         location /assets {
-            proxy_pass http://penpot-backend:6060/assets;
+            proxy_pass $BACKEND_URL/assets;
             recursive_error_pages on;
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_redirect;
@@ -95,11 +95,11 @@ http {
         }
 
         location /api/export {
-            proxy_pass http://penpot-exporter:6061;
+            proxy_pass $EXPORT_URL;
         }
 
         location /api {
-            proxy_pass http://penpot-backend:6060/api;
+            proxy_pass $BACKEND_URL/api;
         }
 
         # location /admin {
@@ -109,7 +109,7 @@ http {
         location /ws/notifications {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
-            proxy_pass http://penpot-backend:6060/ws/notifications;
+            proxy_pass $BACKEND_URL/ws/notifications;
         }
 
         location / {


### PR DESCRIPTION
This PR is for the `frontend` docker image.
`penpotapp/frontend`

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Why was this change made?

When deploying Penpot, I use a weird docker combination that doesn't use compose files.
Penpot has the URLs hardcoded by default into the `nginx.conf` which is bad practice.

[Documentation PR](https://github.com/penpot/penpot-docs/pull/134)

closes #2984 