### PR TITLE
:sparkles: Scale content now scales strokes, shadows, blur and corners

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Add visualization and mouse control to paddings in frames with layout [Taiga #4839](https://tree.taiga.io/project/penpot/task/4839)
 - Allow for absolute positioned elements inside layout [Taiga #4834](https://tree.taiga.io/project/penpot/us/4834)
 - Add z-index option for flex layout items [Taiga #2980](https://tree.taiga.io/project/penpot/us/2980)
+- Scale content proportionally affects strokes, shadows, blurs and corners [Taiga #1951](https://tree.taiga.io/project/penpot/us/1951)
 
 ### :bug: Bugs fixed
 

--- a/common/src/app/common/geom/shapes/corners.cljc
+++ b/common/src/app/common/geom/shapes/corners.cljc
@@ -54,3 +54,27 @@
   (if (and (some? r1) (some? r2) (some? r3) (some? r4))
     (fix-radius width height r1 r2 r3 r4)
     [r1 r2 r3 r4]))
+
+(defn update-corners-scale-1
+  "Scales round corners (using a single value)"
+  [shape scale]
+  (update shape :rx * scale))
+
+(defn update-corners-scale-4
+  "Scales round corners (using four values)"
+  [shape scale]
+  (-> shape
+      (update :r1 * scale)
+      (update :r2 * scale)
+      (update :r3 * scale)
+      (update :r4 * scale)))
+
+(defn update-corners-scale
+  "Scales round corners"
+  [shape scale]
+  (cond-> shape
+    (and (some? (:rx shape)) (> (:rx shape) 0))
+    (update-corners-scale-1 scale)
+
+    (and (some? (:r1 shape)) (> (:r1 shape) 0))
+    (update-corners-scale-4 scale)))

--- a/common/src/app/common/geom/shapes/effects.cljc
+++ b/common/src/app/common/geom/shapes/effects.cljc
@@ -1,0 +1,20 @@
+(ns app.common.geom.shapes.effects)
+
+(defn update-shadow-scale
+  [shadow scale]
+  (-> shadow
+      (update :offset-x * scale)
+      (update :offset-y * scale)
+      (update :spread * scale)
+      (update :blur * scale)))
+
+(defn update-shadows-scale
+  [shape scale]
+  (update shape :shadow
+          (fn [shadow]
+            (mapv #(update-shadow-scale % scale) shadow))))
+
+(defn update-blur-scale
+  [shape scale]
+  (update-in shape [:blur :value] * scale))
+

--- a/common/src/app/common/geom/shapes/strokes.cljc
+++ b/common/src/app/common/geom/shapes/strokes.cljc
@@ -1,0 +1,11 @@
+(ns app.common.geom.shapes.strokes)
+
+(defn update-stroke-width
+  [stroke scale]
+  (update stroke :stroke-width * scale))
+
+(defn update-strokes-width
+  [shape scale]
+  (update shape :strokes 
+    (fn [strokes] 
+      (mapv #(update-stroke-width % scale) strokes))))

--- a/common/src/app/common/pages/helpers.cljc
+++ b/common/src/app/common/pages/helpers.cljc
@@ -54,6 +54,10 @@
   [{:keys [type]}]
   (= type :text))
 
+(defn rect-shape?
+  [{:keys [type]}]
+  (= type :rect))
+
 (defn image-shape?
   [{:keys [type]}]
   (= type :image))

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -419,6 +419,15 @@
                            :points
                            :x
                            :y
+                           :rx
+                           :ry
+                           :r1
+                           :r2
+                           :r3
+                           :r4
+                           :shadow
+                           :blur
+                           :strokes
                            :width
                            :height
                            :content


### PR DESCRIPTION
Now, when you press the [K] key, strokes, shadows, blurs and corners of a shape are scaled proportionally.