### PR TITLE
Improve scale matrix

### DIFF
--- a/common/src/app/common/geom/matrix.cljc
+++ b/common/src/app/common/geom/matrix.cljc
@@ -187,10 +187,11 @@
 
 (defn scale-matrix
   ([pt center]
-   (-> (matrix)
-       (multiply! (translate-matrix center))
-       (multiply! (scale-matrix pt))
-       (multiply! (translate-matrix (gpt/negate center)))))
+   (let [sx (dm/get-prop pt :x)
+         sy (dm/get-prop pt :y)
+         cx (dm/get-prop center :x)
+         cy (dm/get-prop center :y)]
+     (Matrix. sx 0 0 sy (- cx (* cx sx)) (- cy (* cy sy)))))
   ([pt]
    (assert (gpt/point? pt))
    (Matrix. (dm/get-prop pt :x) 0 0 (dm/get-prop pt :y) 0 0)))


### PR DESCRIPTION
`scale-matrix` function used a lot of matrix multiplications that could be simplified.