### PR TITLE
Alotor bugfixes 7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@
 - Fix manipulate duplicated project (delete, duplicate, rename, pin/unpin...) [Taiga #5027](https://tree.taiga.io/project/penpot/issue/5027)
 - Fix deleted files appear in search results [Taiga #5002](https://tree.taiga.io/project/penpot/issue/5002)
 - Fix problem with selected colors and texts [Taiga #5051](https://tree.taiga.io/project/penpot/issue/5051)
+- Fix problem when assigning color from palette or assets [Taiga #5050](https://tree.taiga.io/project/penpot/issue/5050)
 
 ### :heart: Community contributions by (Thank you!)
 - To @ondrejkonec: for contributing to the code with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
 - Font-Kerning does not work on Artboard Export to PNG/JPG/PDF [#3029](https://github.com/penpot/penpot/issues/3029)
 - Fix manipulate duplicated project (delete, duplicate, rename, pin/unpin...) [Taiga #5027](https://tree.taiga.io/project/penpot/issue/5027)
 - Fix deleted files appear in search results [Taiga #5002](https://tree.taiga.io/project/penpot/issue/5002)
+- Fix problem with selected colors and texts [Taiga #5051](https://tree.taiga.io/project/penpot/issue/5051)
 
 ### :heart: Community contributions by (Thank you!)
 - To @ondrejkonec: for contributing to the code with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@
 - Fix deleted files appear in search results [Taiga #5002](https://tree.taiga.io/project/penpot/issue/5002)
 - Fix problem with selected colors and texts [Taiga #5051](https://tree.taiga.io/project/penpot/issue/5051)
 - Fix problem when assigning color from palette or assets [Taiga #5050](https://tree.taiga.io/project/penpot/issue/5050)
+- Fix shortcuts for alignment [Taiga #5030](https://tree.taiga.io/project/penpot/issue/5030)
 
 ### :heart: Community contributions by (Thank you!)
 - To @ondrejkonec: for contributing to the code with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 - Fix problem with selected colors and texts [Taiga #5051](https://tree.taiga.io/project/penpot/issue/5051)
 - Fix problem when assigning color from palette or assets [Taiga #5050](https://tree.taiga.io/project/penpot/issue/5050)
 - Fix shortcuts for alignment [Taiga #5030](https://tree.taiga.io/project/penpot/issue/5030)
+- Fix path options not showing when editing rects or ellipses [Taiga #5053](https://tree.taiga.io/project/penpot/issue/5053)
 
 ### :heart: Community contributions by (Thank you!)
 - To @ondrejkonec: for contributing to the code with:

--- a/common/src/app/common/pages/helpers.cljc
+++ b/common/src/app/common/pages/helpers.cljc
@@ -37,8 +37,10 @@
    (= type :frame)))
 
 (defn group-shape?
-  [{:keys [type]}]
-  (= type :group))
+  ([objects id]
+   (group-shape? (get objects id)))
+  ([{:keys [type]}]
+   (= type :group)))
 
 (defn mask-shape?
   [{:keys [type masked-group?]}]

--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -339,7 +339,8 @@
 (defn change-text-color
   [old-color new-color index node]
   (let [fills (map #(dissoc % :fill-color-ref-id :fill-color-ref-file) (:fills node))
-        parsed-color (d/without-nils (color-att->text old-color))
+        parsed-color (-> (d/without-nils (color-att->text old-color))
+                         (dissoc :fill-color-ref-id :fill-color-ref-file))
         parsed-new-color (d/without-nils (color-att->text new-color))
         has-color? (d/index-of fills parsed-color)]
     (cond-> node

--- a/frontend/src/app/main/data/workspace/text/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/text/shortcuts.cljs
@@ -202,22 +202,22 @@
         (st/emit! (dwu/commit-undo-transaction undo-id)))))
 
 (def shortcuts
-  {:align-left    {:tooltip (ds/meta (ds/alt "l"))
-                   :command (ds/c-mod "alt+l")
-                   :subsections [:text-editor]
-                   :fn #(update-attrs-when-no-readonly {:text-align "left"})}
-   :align-right   {:tooltip (ds/meta (ds/alt "r"))
-                   :command (ds/c-mod "alt+r")
-                   :subsections [:text-editor]
-                   :fn #(update-attrs-when-no-readonly {:text-align "right"})}
-   :align-center  {:tooltip (ds/meta (ds/alt "t"))
-                   :command (ds/c-mod "alt+t")
-                   :subsections [:text-editor]
-                   :fn #(update-attrs-when-no-readonly {:text-align "center"})}
-   :align-justify {:tooltip (ds/meta (ds/alt "j"))
-                   :command (ds/c-mod "alt+j")
-                   :subsections [:text-editor]
-                   :fn #(update-attrs-when-no-readonly {:text-align "justify"})}
+  {:text-align-left    {:tooltip (ds/meta (ds/alt "l"))
+                        :command (ds/c-mod "alt+l")
+                        :subsections [:text-editor]
+                        :fn #(update-attrs-when-no-readonly {:text-align "left"})}
+   :text-align-right   {:tooltip (ds/meta (ds/alt "r"))
+                        :command (ds/c-mod "alt+r")
+                        :subsections [:text-editor]
+                        :fn #(update-attrs-when-no-readonly {:text-align "right"})}
+   :text-align-center  {:tooltip (ds/meta (ds/alt "t"))
+                        :command (ds/c-mod "alt+t")
+                        :subsections [:text-editor]
+                        :fn #(update-attrs-when-no-readonly {:text-align "center"})}
+   :text-align-justify {:tooltip (ds/meta (ds/alt "j"))
+                        :command (ds/c-mod "alt+j")
+                        :subsections [:text-editor]
+                        :fn #(update-attrs-when-no-readonly {:text-align "justify"})}
 
    :underline     {:tooltip (ds/meta "u")
                    :command (ds/c-mod "u")

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -1150,25 +1150,9 @@
                        (:color color) (:color color)
                        :else (:value color))
 
-        ;; TODO: looks like the first argument is not necessary
-        ;; TODO: this code should be out of this UI component
         apply-color
-        (fn [_ event]
-          (let [objects  (wsh/lookup-page-objects @st/state)
-                selected (->> (wsh/lookup-selected @st/state)
-                              (cph/clean-loops objects))
-                selected-obj (keep (d/getf objects) selected)
-                select-shapes-for-color (fn [shape objects]
-                                          (let [shapes (case (:type shape)
-                                                         :group (cph/get-children objects (:id shape))
-                                                         [shape])]
-                                            (->> shapes
-                                                 (remove cph/group-shape?)
-                                                 (map :id))))
-                ids (mapcat #(select-shapes-for-color % objects) selected-obj)]
-            (if (kbd/alt? event)
-              (st/emit! (dc/change-stroke ids (merge uc/empty-color color) 0))
-              (st/emit! (dc/change-fill ids (merge uc/empty-color color) 0)))))
+        (fn [event]
+          (st/emit! (dc/apply-color-from-palette (merge uc/empty-color color) (kbd/alt? event))))
 
         rename-color
         (fn [name]
@@ -1277,8 +1261,7 @@
                                         :selected (contains? selected-colors (:id color)))
                            :on-context-menu on-context-menu
                            :on-click (when-not (:editing @state)
-                                       #(on-asset-click % (:id color)
-                                                        (partial apply-color (:id color))))
+                                       #(on-asset-click % (:id color) apply-color))
                            :ref item-ref
                            :draggable (and (not workspace-read-only?) (not (:editing @state)))
                            :on-drag-start on-color-drag-start

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -11,6 +11,7 @@
    [app.common.uuid :as uuid]
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.libraries :as dwl]
+   [app.main.data.workspace.shortcuts :as sc]
    [app.main.data.workspace.texts :as dwt]
    [app.main.data.workspace.undo :as dwu]
    [app.main.fonts :as fonts]
@@ -25,8 +26,6 @@
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
-
-
 (mf/defc text-align-options
   [{:keys [values on-change on-blur] :as props}]
   (let [{:keys [text-align]} values
@@ -38,22 +37,22 @@
     ;; --- Align
     [:div.align-icons
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.align-left")
+      {:alt (tr "workspace.options.text-options.align-left" (sc/get-tooltip :text-align-left))
        :class (dom/classnames :current (= "left" text-align))
        :on-click #(handle-change % "left")}
       i/text-align-left]
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.align-center")
+      {:alt (tr "workspace.options.text-options.align-center" (sc/get-tooltip :text-align-center))
        :class (dom/classnames :current (= "center" text-align))
        :on-click #(handle-change % "center")}
       i/text-align-center]
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.align-right")
+      {:alt (tr "workspace.options.text-options.align-right" (sc/get-tooltip :text-align-right))
        :class (dom/classnames :current (= "right" text-align))
        :on-click #(handle-change % "right")}
       i/text-align-right]
      [:span.tooltip.tooltip-bottom
-      {:alt (tr  "workspace.options.text-options.align-justify")
+      {:alt (tr  "workspace.options.text-options.align-justify" (sc/get-tooltip :text-align-justify))
        :class (dom/classnames :current (= "justify" text-align))
        :on-click #(handle-change % "justify")}
       i/text-align-justify]]))
@@ -149,13 +148,13 @@
       i/minus]
 
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.underline")
+      {:alt (tr "workspace.options.text-options.underline" (sc/get-tooltip :underline))
        :class (dom/classnames :current (= "underline" text-decoration))
        :on-click #(handle-change % "underline")}
       i/underline]
 
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.strikethrough")
+      {:alt (tr "workspace.options.text-options.strikethrough" (sc/get-tooltip :line-through))
        :class (dom/classnames :current (= "line-through" text-decoration))
        :on-click #(handle-change % "line-through")}
       i/strikethrough]]))

--- a/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/widgets.cljs
@@ -58,7 +58,8 @@
         shape       (or drawing-obj (-> selected first))]
     (when (or (and (= (count selected) 1)
                    (= (:id shape) edition)
-                   (cph/path-shape? shape))
+                   (and (not (cph/text-shape? shape))
+                        (not (cph/frame-shape? shape))))
               (and (some? drawing-obj)
                    (cph/path-shape? drawing-obj)
                    (not= :curve (:tool drawing))))

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -3623,19 +3623,19 @@ msgstr "Alinea el centre"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justifica"
+msgstr "Justifica (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Alinea a l'esquerra"
+msgstr "Alinea a l'esquerra (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinea al centre"
+msgstr "Alinea al centre (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Alinea a la dreta"
+msgstr "Alinea a la dreta (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3679,7 +3679,7 @@ msgstr "Cap"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Ratllat"
+msgstr "Ratllat (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3699,7 +3699,7 @@ msgstr "Inicials en majúscules"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Subratllat"
+msgstr "Subratllat (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -3688,19 +3688,19 @@ msgstr "Zarovnat doprostřed"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Zarovnat"
+msgstr "Zarovnat (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Zarovnat vlevo"
+msgstr "Zarovnat vlevo (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Zarovnat na střed"
+msgstr "Zarovnat na střed (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Zarovnat vpravo"
+msgstr "Zarovnat vpravo (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3744,7 +3744,7 @@ msgstr "Žádné"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Přeškrtnutí"
+msgstr "Přeškrtnutí (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3764,7 +3764,7 @@ msgstr "První písmeno velké"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Podtrhnout"
+msgstr "Podtrhnout (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -3907,19 +3907,19 @@ msgstr "Zentrieren"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Ausrichtung in der Breite"
+msgstr "Ausrichtung in der Breite (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Linksbündig ausrichten"
+msgstr "Linksbündig ausrichten (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "An Mitte ausrichten"
+msgstr "An Mitte ausrichten (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Rechtsbündig ausrichten"
+msgstr "Rechtsbündig ausrichten (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3964,7 +3964,7 @@ msgstr "Keine"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Durchgestrichen"
+msgstr "Durchgestrichen (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3984,7 +3984,7 @@ msgstr "Kapitälchen"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Unterstrichen"
+msgstr "Unterstrichen (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/el.po
+++ b/frontend/translations/el.po
@@ -1797,19 +1797,19 @@ msgstr "Ευθυγράμμιση κέντρο"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Δικαιολόγηση"
+msgstr "Δικαιολόγηση (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Στοίχιση αριστερά"
+msgstr "Στοίχιση αριστερά (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Στοίχιση στο κέντρο"
+msgstr "Στοίχιση στο κέντρο (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Για ευθυγράμμιση προς τα δεξιά"
+msgstr "Για ευθυγράμμιση προς τα δεξιά (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -1849,7 +1849,7 @@ msgstr "Κανένας"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Διαγράμμιση"
+msgstr "Διαγράμμιση (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -1869,7 +1869,7 @@ msgstr "Τίτλος υπόθεση"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "υπογράμμιση"
+msgstr "υπογράμμιση (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -4001,19 +4001,19 @@ msgstr "Align center"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justify"
+msgstr "Justify (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Align left"
+msgstr "Align left (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Align middle"
+msgstr "Align middle (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Align right"
+msgstr "Align right (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -4057,7 +4057,7 @@ msgstr "None"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Strikethrough"
+msgstr "Strikethrough (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -4077,7 +4077,7 @@ msgstr "Title case"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Underline"
+msgstr "Underline (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -4193,19 +4193,19 @@ msgstr "Aliniear al centro"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justificar"
+msgstr "Justificar (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Alinear a la izquierda"
+msgstr "Alinear a la izquierda (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinear al centro"
+msgstr "Alinear al centro (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Alinear a la derecha"
+msgstr "Alinear a la derecha (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -4250,7 +4250,7 @@ msgstr "Nada"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Tachado"
+msgstr "Tachado (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -4270,7 +4270,7 @@ msgstr "Título"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Subrayado"
+msgstr "Subrayado (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/eu.po
+++ b/frontend/translations/eu.po
@@ -3800,19 +3800,19 @@ msgstr "Lerrokatu erdian"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justifikatu"
+msgstr "Justifikatu (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Lerrokatu ezkerrean"
+msgstr "Lerrokatu ezkerrean (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Lerrokatu erdian"
+msgstr "Lerrokatu erdian (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Lerrokatu eskuman"
+msgstr "Lerrokatu eskuman (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3856,7 +3856,7 @@ msgstr "Bat ere ez"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Gaineko marra"
+msgstr "Gaineko marra (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3876,7 +3876,7 @@ msgstr "Izenburuaren mota"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Azpimarra"
+msgstr "Azpimarra (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/fa.po
+++ b/frontend/translations/fa.po
@@ -2579,15 +2579,15 @@ msgstr "تراز در مرکز"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "تراز چپ"
+msgstr "تراز چپ (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "تراز وسط"
+msgstr "تراز وسط (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "تراز راست"
+msgstr "تراز راست (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -2644,7 +2644,7 @@ msgstr "متن انتخابی"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "خط‌زیر"
+msgstr "خط‌زیر (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -3647,19 +3647,19 @@ msgstr "Aligner au centre"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justifier"
+msgstr "Justifier (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Aligner à gauche"
+msgstr "Aligner à gauche (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Aligner verticalement au milieu"
+msgstr "Aligner verticalement au milieu (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Aligner à droite"
+msgstr "Aligner à droite (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3704,7 +3704,7 @@ msgstr "Aucune"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Barré"
+msgstr "Barré (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3724,7 +3724,7 @@ msgstr "Premières Lettres en Capitales"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Soulignage"
+msgstr "Soulignage (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -3863,19 +3863,19 @@ msgstr "יישור למרכז"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "יישור לשני הצדדים"
+msgstr "יישור לשני הצדדים (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "יישור שמאלה"
+msgstr "יישור שמאלה (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "יישור לאמצע"
+msgstr "יישור לאמצע (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "יישור ימינה"
+msgstr "יישור ימינה (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3920,7 +3920,7 @@ msgstr "ללא"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "קו חוצה"
+msgstr "קו חוצה (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3940,7 +3940,7 @@ msgstr "רישיות כותרת"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "קו תחתי"
+msgstr "קו תחתי (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/hr.po
+++ b/frontend/translations/hr.po
@@ -3812,19 +3812,19 @@ msgstr "Poravnaj sredinu"
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 #, fuzzy
 msgid "workspace.options.text-options.align-justify"
-msgstr "Složi u blok"
+msgstr "Složi u blok (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Poravnaj lijevo"
+msgstr "Poravnaj lijevo (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Poravnaj sredinu"
+msgstr "Poravnaj sredinu (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Poravnaj desno"
+msgstr "Poravnaj desno (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3869,7 +3869,7 @@ msgstr "Nijedan"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Precrtanko"
+msgstr "Precrtanko (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3889,7 +3889,7 @@ msgstr "Velika i mala slova"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Podcrtano"
+msgstr "Podcrtano (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -3673,19 +3673,19 @@ msgstr "Paskan ke tengah"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justify"
+msgstr "Justify (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Paskan ke kiri"
+msgstr "Paskan ke kiri (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Paskan ke tengah"
+msgstr "Paskan ke tengah (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Paskan ke kanan"
+msgstr "Paskan ke kanan (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3729,7 +3729,7 @@ msgstr "Tidak ada"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Coret"
+msgstr "Coret (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3749,7 +3749,7 @@ msgstr "Huruf Judul"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Garis bawah"
+msgstr "Garis bawah (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/pl.po
+++ b/frontend/translations/pl.po
@@ -3572,19 +3572,19 @@ msgstr "Wyrównaj do środka"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Wyjustuj"
+msgstr "Wyjustuj (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Wyrównaj do lewej"
+msgstr "Wyrównaj do lewej (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Wyrównaj do środka"
+msgstr "Wyrównaj do środka (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Wyrównaj do prawej"
+msgstr "Wyrównaj do prawej (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3628,7 +3628,7 @@ msgstr "Brak"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Przekreślenie"
+msgstr "Przekreślenie (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3648,7 +3648,7 @@ msgstr "Nazwy Własne"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Podkreślenie"
+msgstr "Podkreślenie (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/pt_BR.po
+++ b/frontend/translations/pt_BR.po
@@ -3794,19 +3794,19 @@ msgstr "Alinhar ao centro"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justificar"
+msgstr "Justificar (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Alinhar à esquerda"
+msgstr "Alinhar à esquerda (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinhar no meio"
+msgstr "Alinhar no meio (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Alinhar à direita"
+msgstr "Alinhar à direita (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3850,7 +3850,7 @@ msgstr "Nenhum"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Tachado"
+msgstr "Tachado (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3870,7 +3870,7 @@ msgstr "Capitalização de Título"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Sublinhado"
+msgstr "Sublinhado (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -3797,19 +3797,19 @@ msgstr "Alinhar ao centro"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justificar"
+msgstr "Justificar (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Alinhar à esquerda"
+msgstr "Alinhar à esquerda (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinhar ao meio"
+msgstr "Alinhar ao meio (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Alinhar à direita"
+msgstr "Alinhar à direita (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3853,7 +3853,7 @@ msgstr "Nenhum"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Rasurado"
+msgstr "Rasurado (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3873,7 +3873,7 @@ msgstr "Capitalizar iniciais"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Sublinhado"
+msgstr "Sublinhado (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -3766,19 +3766,19 @@ msgstr "Aliniază centru"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Justifică"
+msgstr "Justifică (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Aliniază la stânga"
+msgstr "Aliniază la stânga (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Aliniază la mijloc"
+msgstr "Aliniază la mijloc (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Aliniază la dreapta"
+msgstr "Aliniază la dreapta (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3822,7 +3822,7 @@ msgstr "Nici unul"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Barat"
+msgstr "Barat (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3842,7 +3842,7 @@ msgstr "Încadrare Titlu"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Subliniază"
+msgstr "Subliniază (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/ru.po
+++ b/frontend/translations/ru.po
@@ -2688,19 +2688,19 @@ msgstr "Выравнивание по центру"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "Выравнивание по ширине"
+msgstr "Выравнивание по ширине (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Выравнивание по левому краю"
+msgstr "Выравнивание по левому краю (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Выравнивание по центру"
+msgstr "Выравнивание по центру (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Выравнивание по правому краю"
+msgstr "Выравнивание по правому краю (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -2744,7 +2744,7 @@ msgstr "Не задано"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Перечеркнутый"
+msgstr "Перечеркнутый (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -2764,7 +2764,7 @@ msgstr "Каждое слово с заглавной буквы"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Подчеркнутый"
+msgstr "Подчеркнутый (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -3893,19 +3893,19 @@ msgstr "Ortaya hizala"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "İki yana yasla"
+msgstr "İki yana yasla (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "Sola hizala"
+msgstr "Sola hizala (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Merkeze hizala"
+msgstr "Merkeze hizala (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "Sağa hizala"
+msgstr "Sağa hizala (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3950,7 +3950,7 @@ msgstr "Hiçbiri"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "Üstü çizili"
+msgstr "Üstü çizili (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3970,7 +3970,7 @@ msgstr "İlk Harfi Büyük"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "Altı Çizili"
+msgstr "Altı Çizili (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -3677,19 +3677,19 @@ msgstr "居中对齐"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-justify"
-msgstr "整理"
+msgstr "整理 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-left"
-msgstr "靠左对齐"
+msgstr "靠左对齐 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "中间对齐"
+msgstr "中间对齐 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-right"
-msgstr "靠右对齐"
+msgstr "靠右对齐 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"
@@ -3733,7 +3733,7 @@ msgstr "无"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.strikethrough"
-msgstr "删除线"
+msgstr "删除线 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.title"
@@ -3753,7 +3753,7 @@ msgstr "首字母大写"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.underline"
-msgstr "下划线"
+msgstr "下划线 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
 msgid "workspace.options.text-options.uppercase"


### PR DESCRIPTION
- Fix problem with selected colors and texts [Taiga #5051](https://tree.taiga.io/project/penpot/issue/5051)
- Fix problem when assigning color from palette or assets [Taiga #5050](https://tree.taiga.io/project/penpot/issue/5050)
- Fix shortcuts for alignment [Taiga #5030](https://tree.taiga.io/project/penpot/issue/5030)
- Add tooltip in text alignment options