### PR TITLE
:sparkles: Allow to cancel and resume later remove graphics

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1891,7 +1891,7 @@
   [file-id file-name]
   (ptk/reify ::remove-graphics
     ptk/WatchEvent
-    (watch [it state _]
+    (watch [it state stream]
       (let [file-data (wsh/get-file state file-id)
 
             grid-gap 50
@@ -1911,7 +1911,9 @@
                  media)
 
             shape-grid
-            (ctst/generate-shape-grid media-points start-pos grid-gap)]
+            (ctst/generate-shape-grid media-points start-pos grid-gap)
+            
+            stoper (rx/filter (ptk/type? ::finalize-file) stream)]
 
         (rx/concat
          (rx/of (modal/show {:type :remove-graphics-dialog :file-name file-name})
@@ -1920,8 +1922,9 @@
            (rx/of (dch/commit-changes (-> (pcb/empty-changes it)
                                           (pcb/set-save-undo? false)
                                           (pcb/add-page (:id page) page)))))
-         (rx/mapcat (partial remove-graphic it file-data' page)
-                    (rx/from (d/enumerate (d/zip media shape-grid))))
+         (->> (rx/mapcat (partial remove-graphic it file-data' page)
+                         (rx/from (d/enumerate (d/zip media shape-grid))))
+              (rx/take-until stoper))
          (rx/of (complete-remove-graphics)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -35,6 +35,7 @@
    [app.util.globals :as globals]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.object :as obj]
+   [app.util.router :as rt]
    [debug :refer [debug?]]
    [goog.events :as events]
    [okulary.core :as l]
@@ -199,8 +200,12 @@
    ::mf/register-as :remove-graphics-dialog}
   [{:keys [] :as ctx}]
   (let [remove-state (mf/deref refs/remove-graphics)
-        close #(modal/hide!)
-        reload-file #(dom/reload-current-window)]
+        project      (mf/deref refs/workspace-project)
+        close        #(modal/hide!)
+        reload-file  #(dom/reload-current-window)
+        nav-out      #(st/emit! (rt/navigate :dashboard-files
+                                             {:team-id (:team-id project)
+                                                               :project-id (:id project)}))]
     (mf/use-effect
       (fn []
         #(st/emit! (dw/clear-remove-graphics))))
@@ -209,9 +214,12 @@
       [:div.modal-header
        [:div.modal-header-title
         [:h2 (tr "workspace.remove-graphics.title" (:file-name ctx))]]
-       (when (and (:completed remove-state) (:error remove-state))
+       (if (and (:completed remove-state) (:error remove-state))
          [:div.modal-close-button
-          {:on-click close} i/close])]
+          {:on-click close} i/close]
+         [:div.modal-close-button
+          {:on-click nav-out}
+          i/close])]
       (if-not (and (:completed remove-state) (:error remove-state))
         [:div.modal-content
          [:p (tr "workspace.remove-graphics.text1")]


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/task/5025

And also allows to navigate out easily by closing the popup.