### PR TITLE
🔨 Fix default port for penpot-exporter

### DIFF
--- a/docker/images/files/nginx-entrypoint.sh
+++ b/docker/images/files/nginx-entrypoint.sh
@@ -20,7 +20,7 @@ update_flags /var/www/app/js/config.js
 #########################################
 
 export PENPOT_BACKEND_URI=${PENPOT_BACKEND_URI:-http://penpot-backend:6060};
-export PENPOT_EXPORTER_URI=${PENPOT_EXPORTER_URI:-http://penpot-exporter};
+export PENPOT_EXPORTER_URI=${PENPOT_EXPORTER_URI:-http://penpot-exporter:6061};
 
 envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 


### PR DESCRIPTION
By default, penpot-frontend will try to reach penpot-export on port 80, this is wrong, the exporter listens by default to port 6061.

An alternative solution is to add the following environment variable to the penpot-frontend container spec in [`docker-compose.yaml`](https://github.com/penpot/penpot/blob/develop/docker/images/docker-compose.yaml#L97):
`      - PENPOT_EXPORTER_URI=http://penpot-exporter:6061`
