### PR TITLE
:bug: Fix first level board "Show in view mode" is automatically unchecked

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## 1.18.2
 
+### :bug: Bugs fixed
+
 - Fix problem with frame title rotation
+- Fix first level board "Show in view mode" is automatically unchecked [Taiga #5136](https://tree.taiga.io/project/penpot/issue/5136)
 
 ## 1.18.1
 

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -137,7 +137,9 @@
                   (pcb/with-objects objects)
                   (cond-> (not (ctl/any-layout? objects frame-id))
                     (pcb/update-shapes ordered-indexes  ctl/remove-layout-item-data))
-                  (pcb/update-shapes ordered-indexes #(cond-> % (cph/frame-shape? %) (assoc :hide-in-viewer true)))
+                  (pcb/update-shapes ordered-indexes #(cond-> %
+                                                        (and (cph/frame-shape? %) (not= (:parent-id %) uuid/zero))
+                                                        (assoc :hide-in-viewer true)))
                   (pcb/change-parent frame-id to-move-shapes 0)
                   (cond-> (ctl/grid-layout? objects frame-id)
                     (pcb/update-shapes [frame-id] ctl/assign-cells))))]


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/5136