### PR TITLE
:bug: Fix project file count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fix problem with rulers not placing correctly [Taiga #5093](https://tree.taiga.io/project/penpot/issue/5093)
 - Fix page context menu [Taiga #5145](https://tree.taiga.io/project/penpot/issue/5145)
+- Fix project file count [Taiga #5148](https://tree.taiga.io/project/penpot/issue/5148)
 
 ### :arrow_up: Deps updates
 

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -851,7 +851,7 @@
 (declare file-created)
 
 (defn file-created
-  [{:keys [id] :as file}]
+  [{:keys [id project-id] :as file}]
   (us/verify ::file file)
   (ptk/reify ::file-created
     IDeref
@@ -862,7 +862,8 @@
     (update [_ state]
       (-> state
           (assoc-in [:dashboard-files id] file)
-          (assoc-in [:dashboard-recent-files id] file)))))
+          (assoc-in [:dashboard-recent-files id] file)
+          (update-in [:dashboard-projects project-id :count] inc)))))
 
 (defn create-file
   [{:keys [project-id] :as params}]


### PR DESCRIPTION
Fixes Issue [Taiga #5148](https://tree.taiga.io/project/penpot/issue/5148)

**Describe the bug:**
When user has added new file on 'Drafts' page and moved to 'Projects' page then invalid files amount is set for 'Drafts'.

**Pre-conditions:**
User is logged in

**To Reproduce:**

1. Open 'Drafts' page
2. Add new file
3. Open 'Projects' page
4. Take a look at the 'Drafts'

**Actual behavior:**
Invalid files amount is set near project header

**Expected behavior:**
Valid files amount should be set near project header
