### PR TITLE
Azazeln28 wasm resize

### DIFF
--- a/common/src/app/common/types/modifiers.cljc
+++ b/common/src/app/common/types/modifiers.cljc
@@ -20,6 +20,7 @@
    [app.common.spec :as us]
    [app.common.text :as txt]
    [app.common.types.shape.layout :as ctl]
+   #?(:cljs [app.wasm.transform :as wasm-transform])
    #?(:cljs [cljs.core :as c]
       :clj [clojure.core :as c])))
 
@@ -651,14 +652,15 @@
   (let [modifiers (->> (concat (dm/get-prop modifiers :geometry-parent)
                                (dm/get-prop modifiers :geometry-child))
                        (sort-by :order))]
-    (loop [matrix    (gmt/matrix)
-           modifiers (seq modifiers)]
-      (if (c/empty? modifiers)
-        matrix
-        (let [modifier (first modifiers)
-              matrix (transform! matrix modifier)]
-          (recur matrix (next modifiers))))))
-    )
+    #?(:cljs (wasm-transform/modifiers->transform modifiers)
+       :clj (loop [matrix    (gmt/matrix)
+                   modifiers (seq modifiers)]
+              (if (c/empty? modifiers)
+                matrix
+                (let [modifier (first modifiers)
+                      matrix (transform! matrix modifier)]
+                  (recur matrix (next modifiers))))))
+    ))
 
 (defn transform-text-node [value attrs]
   (let [font-size   (-> (get attrs :font-size 14) d/parse-double (* value) str)

--- a/frontend/asconfig.json
+++ b/frontend/asconfig.json
@@ -1,0 +1,24 @@
+{
+  "targets": {
+    "debug": {
+      "outFile": "resources/public/wasm/resize.debug.wasm",
+      "textFile": "resources/public/wasm/resize.debug.wat",
+      "runtime": "stub",
+      "sourceMap": true,
+      "debug": true
+    },
+    "release": {
+      "outFile": "resources/public/wasm/resize.release.wasm",
+      "textFile": "resources/public/wasm/resize.release.wat",
+      "runtime": "stub",
+      "sourceMap": true,
+      "optimizeLevel": 3,
+      "shrinkLevel": 0,
+      "converge": false,
+      "noAssert": false
+    }
+  },
+  "options": {
+    "bindings": "raw"
+  }
+}

--- a/frontend/asconfig.resize.json
+++ b/frontend/asconfig.resize.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./asconfig.json",
+  "targets": {
+    "debug": {
+      "outFile": "resources/public/wasm/resize.debug.wasm",
+      "textFile": "resources/public/wasm/resize.debug.wat",
+      "runtime": "stub",
+      "sourceMap": true,
+      "debug": true
+    },
+    "release": {
+      "outFile": "resources/public/wasm/resize.release.wasm",
+      "textFile": "resources/public/wasm/resize.release.wat",
+      "runtime": "stub",
+      "sourceMap": true,
+      "optimizeLevel": 3,
+      "shrinkLevel": 0,
+      "converge": false,
+      "noAssert": false
+    }
+  }
+}

--- a/frontend/asconfig.transform.json
+++ b/frontend/asconfig.transform.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./asconfig.json",
+  "targets": {
+    "debug": {
+      "outFile": "resources/public/wasm/transform.debug.wasm",
+      "textFile": "resources/public/wasm/transform.debug.wat",
+      "runtime": "stub",
+      "sourceMap": true,
+      "debug": true
+    },
+    "release": {
+      "outFile": "resources/public/wasm/transform.release.wasm",
+      "textFile": "resources/public/wasm/transform.release.wat",
+      "runtime": "stub",
+      "sourceMap": true,
+      "optimize": "speed",
+      "optimizeLevel": 3,
+      "shrinkLevel": 0,
+      "converge": true,
+      "noAssert": false
+    }
+  }
+}

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -301,7 +301,21 @@ gulp.task("wasm:resize", async function(next) {
   }
 })
 
-gulp.task("wasm", gulp.parallel("wasm:resize"))
+gulp.task("wasm:transform", async function(next) {
+  const asc = await getAssemblyScriptCompiler()
+  const { error, stdout, stderr, stats } = await asc.main([
+    "wasm/transform.ts",
+    "--config", "asconfig.transform.json",
+    "--target", "debug"
+  ])
+  if (error) {
+    return next(error)
+  } else {
+    return next()
+  }
+})
+
+gulp.task("wasm", gulp.parallel("wasm:resize", "wasm:transform"))
 
 gulp.task("watch:main", function() {
   gulp.watch("wasm/*.ts", gulp.series("wasm"));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,14 @@
     "defaults"
   ],
   "scripts": {
+    "wasm-build:resize:debug": "asc wasm/resize.ts --config asconfig.resize.json --target debug",
+    "wasm-build:resize:release": "asc wasm/resize.ts --config asconfig.resize.json --target release",
+    "wasm-build:resize": "yarn run wasm-build:resize:debug && yarn run wasm-build:resize:release",
+    "wasm-build:transform:debug": "asc wasm/transform.ts --config asconfig.transform.json --target debug",
+    "wasm-build:transform:release": "asc wasm/transform.ts --config asconfig.transform.json --target release",
+    "wasm-build:transform": "yarn run wasm-build:transform:debug && yarn run wasm-build:transform:release",
+    "wasm-build": "yarn run wasm-build:resize && yarn run wasm-build:transform",
+    "wasm-generate-types": "npx asc --transform ./scripts/wasm-generate-types.mjs wasm/resize.ts wasm/transform.ts",
     "compile-test": "clojure -M:dev:shadow-cljs compile test --config-merge '{:autorun false}'",
     "lint": "clj-kondo --parallel --lint src/",
     "lint-scss": "yarn run prettier -c resources/styles",
@@ -26,6 +34,7 @@
     "test-e2e-gui": "cypress open"
   },
   "devDependencies": {
+    "assemblyscript": "^0.27.1",
     "autoprefixer": "^10.4.13",
     "cypress": "^10.3.0",
     "cypress-file-upload": "^5.0.8",

--- a/frontend/scripts/wasm-generate-types.mjs
+++ b/frontend/scripts/wasm-generate-types.mjs
@@ -1,0 +1,34 @@
+import { ClassPrototype, PropertyPrototype } from 'assemblyscript'
+import prettier from 'prettier'
+
+/**
+ * After initialization all types are available, so we can generate
+ * exported types safely.
+ *
+ * TODO: This will export everything under `wasm` folder, maybe we can
+ *       make it more specific? Or even use exported (global?) variables
+ *       to register only exported types?
+ *
+ * @param {Program} program
+ */
+export function afterInitialize(program) {
+  const types = new Map()
+  for (const [name, element] of program.elementsByName) {
+    if (name.includes("wasm") && element instanceof ClassPrototype) {
+      const properties = new Map()
+      for (const [name, member] of element.instanceMembers) {
+        if (member instanceof PropertyPrototype && member.isField) {
+          properties.set(name, { type: member.typeNode.name.identifier.text });
+        }
+      }
+      types.set(element.name, properties);
+    }
+  }
+
+  let str = ''
+  for (const [name, properties] of types) {
+    str += `TypeRegistry.register("${name}", ${JSON.stringify(Object.fromEntries(properties), null, 2)});\n\n`
+  }
+  console.log(prettier.format(str, { parser: 'babel' }))
+}
+

--- a/frontend/src/app/main.cljs
+++ b/frontend/src/app/main.cljs
@@ -24,6 +24,7 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n]
    [app.util.theme :as theme]
+   [app.wasm :as wasm]
    [beicon.core :as rx]
    [debug]
    [features]
@@ -73,6 +74,7 @@
 
 (defn ^:export init
   []
+  (wasm/init!)
   (worker/init!)
   (i18n/init! cf/translations)
   (theme/init! cf/themes)

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -30,67 +30,12 @@
    [app.main.snap :as snap]
    [app.main.streams :as ms]
    [app.util.dom :as dom]
+   [app.wasm.resize :as wasm]
    [beicon.core :as rx]
    [cljs.spec.alpha :as s]
    [potok.core :as ptk]))
 
 ;; -- Helpers --------------------------------------------------------
-
-;; For each of the 8 handlers gives the multiplier for resize
-;; for example, right will only grow in the x coordinate and left
-;; will grow in the inverse of the x coordinate
-(def ^:private handler-multipliers
-  {:right        [ 1  0]
-   :bottom       [ 0  1]
-   :left         [-1  0]
-   :top          [ 0 -1]
-   :top-right    [ 1 -1]
-   :top-left     [-1 -1]
-   :bottom-right [ 1  1]
-   :bottom-left  [-1  1]})
-
-(defn- handler-resize-origin
-  "Given a handler, return the coordinate origin for resizes.
-   This is the opposite of the handler so for right we want the
-   left side as origin of the resize.
-
-   sx, sy => start x/y
-   mx, my => middle x/y
-   ex, ey => end x/y
-  "
-  [{sx :x sy :y :keys [width height]} handler]
-  (let [mx (+ sx (/ width 2))
-        my (+ sy (/ height 2))
-        ex (+ sx width)
-        ey (+ sy height)
-
-        [x y] (case handler
-                :right [sx my]
-                :bottom [mx sy]
-                :left [ex my]
-                :top [mx ey]
-                :top-right [sx ey]
-                :top-left [ex ey]
-                :bottom-right [sx sy]
-                :bottom-left [ex sy])]
-    (gpt/point x y)))
-
-(defn- fix-init-point
-  "Fix the initial point so the resizes are accurate"
-  [initial handler shape]
-  (let [{:keys [x y width height]} (:selrect shape)]
-    (cond-> initial
-      (contains? #{:left :top-left :bottom-left} handler)
-      (assoc :x x)
-
-      (contains? #{:right :top-right :bottom-right} handler)
-      (assoc :x (+ x width))
-
-      (contains? #{:top :top-right :top-left} handler)
-      (assoc :y y)
-
-      (contains? #{:bottom :bottom-right :bottom-left} handler)
-      (assoc :y (+ y height)))))
 
 (defn finish-transform []
   (ptk/reify ::finish-transform
@@ -105,77 +50,82 @@
   "Enter mouse resize mode, until mouse button is released."
   [handler ids shape]
   (letfn [(resize
-           [shape initial layout [point lock? center? point-snap]]
-            (let [{:keys [width height]} (:selrect shape)
-                  {:keys [rotation]} shape
+           ;; shape initial layout [point lock? center? point-snap]
+            [shape _ layout [point lock? center? point-snap]]
+            (let [scale-text (dm/get-prop layout :scale-text)
+                  
+                  ;; shape initial point point-snap lock? center?
+                  _ (wasm/resize-update shape point point-snap (or lock? scale-text) center?)
 
-                  shape-center (gsh/center-shape shape)
-                  shape-transform (:transform shape)
-                  shape-transform-inverse (:transform-inverse shape)
+                  ;; shape-center (gpt/point x y)
+                  shape-transform (dm/get-prop shape :transform)
+                  shape-transform-inverse (dm/get-prop shape :transform-inverse)
 
-                  rotation (or rotation 0)
+                  ;; rotation (or rotation 0)
 
-                  initial (gmt/transform-point-center initial shape-center shape-transform-inverse)
-                  initial (fix-init-point initial handler shape)
+                  ;; initial (gmt/transform-point-center initial shape-center shape-transform-inverse)
+                  ;; initial (fix-init-point initial handler shape)
 
-                  point (gmt/transform-point-center (if (= rotation 0) point-snap point)
-                                                    shape-center shape-transform-inverse)
+                  ;; current (if (= rotation 0) point-snap point)
+                  ;; point (gmt/transform-point-center current shape-center shape-transform-inverse)
 
-                  shapev (-> (gpt/point width height))
+                  ;; shapev (-> (gpt/point width height))
 
-                  scale-text (:scale-text layout)
+                  ;; scale-text (:scale-text layout)
 
                   ;; Force lock if the scale text mode is active
-                  lock? (or lock? scale-text)
+                  ;; lock? (or lock? scale-text)
 
                   ;; Vector modifiers depending on the handler
-                  handler-mult (let [[x y] (handler-multipliers handler)] (gpt/point x y))
+                  ;; handler-mult (let [[x y] (handler-multipliers handler)] (gpt/point x y))
 
                   ;; Difference between the origin point in the coordinate system of the rotation
-                  deltav (-> (gpt/to-vec initial point)
-                             (gpt/multiply handler-mult))
+                  ;; deltav (gpt/to-vec initial point)
+                  ;; deltav (gpt/multiply deltav handler-mult)
 
                   ;; Resize vector
-                  scalev (-> (gpt/divide (gpt/add shapev deltav) shapev)
-                             (gpt/no-zeros))
+                  ;; scalev (gpt/add shapev deltav)
+                  ;; scalev (gpt/divide scalev shapev)
+                  ;; scalev (gpt/no-zeros scalev)
 
-                  scalev (if lock?
-                           (let [v (cond
-                                     (#{:right :left} handler) (:x scalev)
-                                     (#{:top :bottom} handler) (:y scalev)
-                                     :else (max (:x scalev) (:y scalev)))]
-                             (gpt/point v v))
-
-                           scalev)
+                  ;; scalev (if lock?
+                  ;;          (let [v (cond
+                  ;;                    (#{:right :left} handler) (:x scalev)
+                  ;;                    (#{:top :bottom} handler) (:y scalev)
+                  ;;                    :else (max (:x scalev) (:y scalev)))]
+                  ;;            (gpt/point v v))
+                  ;;          scalev)
+                  scalev (.-vector wasm/resize-output)
 
                   ;; Resize origin point given the selected handler
-                  handler-origin  (handler-resize-origin (:selrect shape) handler)
-
+                  ;; handler-origin  (handler-resize-origin (:selrect shape) handler)
 
                   ;; If we want resize from center, displace the shape
                   ;; so it is still centered after resize.
-                  displacement
-                  (when center?
-                    (-> shape-center
-                        (gpt/subtract handler-origin)
-                        (gpt/multiply scalev)
-                        (gpt/add handler-origin)
-                        (gpt/subtract shape-center)
-                        (gpt/multiply (gpt/point -1 -1))
-                        (gpt/transform shape-transform)))
+                  ;; displacement
+                  ;; (when center?
+                  ;;   (-> shape-center
+                  ;;       (gpt/subtract handler-origin)
+                  ;;       (gpt/multiply scalev)
+                  ;;       (gpt/add handler-origin)
+                  ;;       (gpt/subtract shape-center)
+                  ;;       (gpt/multiply (gpt/point -1 -1))
+                  ;;       (gpt/transform shape-transform)))
+                  displacement (.-displacement wasm/resize-output)
 
-                  resize-origin
-                  (cond-> (gmt/transform-point-center handler-origin shape-center shape-transform)
-                    (some? displacement)
-                    (gpt/add displacement))
+                  ;; resize-origin
+                  ;; (cond-> (gmt/transform-point-center handler-origin shape-center shape-transform)
+                  ;;   (some? displacement)
+                  ;;   (gpt/add displacement))
+                  resize-origin (.-origin wasm/resize-output)
 
                   ;; When the horizontal/vertical scale a flex children with auto/fill
                   ;; we change it too fixed
                   set-fix-width?
-                  (not (mth/close? (:x scalev) 1))
+                  (not (mth/close? (dm/get-prop scalev :x) 1))
 
                   set-fix-height?
-                  (not (mth/close? (:y scalev) 1))
+                  (not (mth/close? (dm/get-prop scalev :y) 1))
 
                   modifiers
                   (-> (ctm/empty)
@@ -190,7 +140,7 @@
                         (ctm/change-property :layout-item-v-sizing :fix))
 
                       (cond-> scale-text
-                        (ctm/scale-content (:x scalev))))
+                        (ctm/scale-content (dm/get-prop scalev :x))))
 
                   modif-tree (dwm/create-modif-tree ids modifiers)]
               (rx/of (dwm/set-modifiers modif-tree scale-text))))
@@ -217,6 +167,10 @@
               zoom    (get-in state [:workspace-local :zoom] 1)
               objects (wsh/lookup-page-objects state page-id)
               resizing-shapes (map #(get objects %) ids)]
+
+          ;; It would be great if we could move more "constant"
+          ;; values during resize transformation to this part.  
+          (wasm/resize-start handler initial-position)
 
           (rx/concat
            (->> ms/mouse-position

--- a/frontend/src/app/util/wasm.js
+++ b/frontend/src/app/util/wasm.js
@@ -1,0 +1,73 @@
+/**
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) KALEIDOS INC
+ */
+
+"use strict";
+
+goog.provide("app.util.wasm");
+
+goog.scope(function () {
+  const self = app.util.wasm;
+
+  async function instantiate(module, imports = {}) {
+    const adaptedImports = {
+      env: Object.assign(Object.create(globalThis), imports.env || {}, {
+        abort(message, fileName, lineNumber, columnNumber) {
+          // ~lib/builtins/abort(~lib/string/String | null?, ~lib/string/String | null?, u32?, u32?) => void
+          message = __liftString(message >>> 0);
+          fileName = __liftString(fileName >>> 0);
+          lineNumber = lineNumber >>> 0;
+          columnNumber = columnNumber >>> 0;
+          (() => {
+            // @external.js
+            throw Error(`${message} in ${fileName}:${lineNumber}:${columnNumber}`);
+          })();
+        },
+        "console.log"(text) {
+          text = __liftString(text >>> 0);
+          console.log(text);
+        },
+      }),
+    };
+
+    const {
+      instance: { exports },
+    } = await WebAssembly.instantiate(module, adaptedImports);
+    const memory = exports.memory || imports.env.memory;
+    const adaptedExports = Object.setPrototypeOf({}, exports);
+
+    function __liftString(pointer) {
+      if (!pointer) return null;
+      const end = (pointer + new Uint32Array(memory.buffer)[(pointer - 4) >>> 2]) >>> 1,
+        memoryU16 = new Uint16Array(memory.buffer);
+      let start = pointer >>> 1,
+        string = "";
+      while (end - start > 1024) string += String.fromCharCode(...memoryU16.subarray(start, (start += 1024)));
+      return string + String.fromCharCode(...memoryU16.subarray(start, end));
+    }
+
+    return adaptedExports;
+  }
+
+  async function load(uri, imports = {}) {
+    console.log("load", uri, imports);
+    const response = await fetch(uri);
+    console.log(response);
+    const arrayBuffer = await response.arrayBuffer();
+    console.log(arrayBuffer);
+    return instantiate(arrayBuffer, imports);
+  }
+
+  /**
+   * This is part of the AssemblyScript runtime.
+   *
+   * See resize.debug.js for more information.
+   */
+  self.instantiate = instantiate
+  self.load = load
+});

--- a/frontend/src/app/util/wasm/types.js
+++ b/frontend/src/app/util/wasm/types.js
@@ -1,0 +1,419 @@
+/**
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) KALEIDOS INC
+ */
+
+"use strict";
+
+goog.provide("app.util.wasm.types");
+
+goog.scope(function() {
+  const self = app.util.wasm.types;
+
+  /**
+   * Primitive types supported by WebAssembly
+   * Memory.
+   */
+  const PrimitiveTypes = {
+    // type: size, getter, setter
+    "u8": [1, "getUint8", "setUint8"],
+    "u16": [2, "getUint16", "setUint16"],
+    "u32": [4, "getUint32", "setUint32"],
+    "u64": [8, "getBigUint64", "setBigUint64"],
+    "s8": [1, "getInt8", "setInt8"],
+    "s16": [2, "getInt16", "setInt16"],
+    "s32": [4, "getInt32", "setInt32"],
+    "s64": [8, "getBigInt64", "setBigInt64"],
+    "f32": [4, "getFloat32", "setFloat32"],
+    "f64": [8, "getFloat64", "setFloat64"],
+    "pointer": [4, "getUint32", null],
+  };
+
+  /**
+   * This is a type register for interacting with
+   * WebAssembly Memory.
+   */
+  const TypeRegistry = (() => {
+    const types = new Map();
+    return {
+      has(type) {
+        return types.has(type);
+      },
+      get(type) {
+        if (!types.has(type)) {
+          throw new Error(`Type ${type} doesn't exists`);
+        }
+        return types.get(type);
+      },
+      register(type, ...args) {
+        if (types.has(type)) {
+          throw new Error(`Redefinition of type ${type}`);
+        }
+        const newType = Type.create(...args);
+        types.set(type, newType);
+        return newType;
+      },
+      unregister(type) {
+        return types.delete(type);
+      },
+    };
+  })();
+
+  /**
+   * This is a Type reference (pointer into
+   * a type).
+   */
+  class TypeRef {
+    /**
+     * Constructor
+     *
+     * @param {WebAssembly.Memory} memory
+     * @param {number} offset
+     * @param {Type} type
+     */
+    constructor(memory, offset, type) {
+      this._memory = memory;
+      this._offset = offset;
+      this._type = type;
+      this._dataView = null;
+      this._proxyCache = new Map();
+    }
+
+    /**
+     * @type {DataView}
+     */
+    get dataView() {
+      if (!this._dataView || this._dataView.buffer !== this._memory.buffer) {
+        this._dataView = new DataView(
+          this._memory.buffer,
+          this._offset,
+          this._type.size
+        );
+      }
+      return this._dataView;
+    }
+
+    /**
+     * @type {Type}
+     */
+    get type() {
+      return this._type
+    }
+
+    /**
+     * Clears the cache and the DataView.
+     */
+    clear() {
+      this._proxyCache.clear();
+      this._dataView = null;
+    }
+
+    /**
+     * Disposes the TypeRef.
+     */
+    dispose() {
+      this.clear();
+      this._type = null;
+      this._memory = null;
+    }
+
+    /**
+     * Gets a property value.
+     *
+     * @param {string} name
+     * @returns {any}
+     */
+    get(name) {
+      const property = this._type.get(name);
+      if (property.type in PrimitiveTypes) {
+        return this.dataView[property.getter](property.offset, true);
+      }
+      if (!this._proxyCache.has(name)) {
+        this._proxyCache.set(
+          name,
+          TypeRegistry.get(property.type).ref(
+            this._memory,
+            this.dataView[property.getter](property.offset, true)
+          )
+        );
+      }
+      return this._proxyCache.get(name);
+    }
+
+    /**
+     * Sets a property value.
+     *
+     * @param {string} name
+     * @param {any} value
+     * @returns {boolean}
+     */
+    set(name, value) {
+      const property = this._type.get(name);
+      if (property.type in PrimitiveTypes) {
+        return this.dataView[property.setter](property.offset, value, true);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Alternative to create a new Type Proxy.
+   *
+   * @param {Function} ProxyConstructor
+   * @param {TypeRef} typeRef
+   * @param {TypeProxyOptions} options
+   * @param {...any} args
+   * @returns {Object<ProxyConstructor>}
+   */
+  function createTypeProxyAlt(ProxyConstructor, typeRef, options, ...args) {
+    const obj = {}
+    for (const [name] of typeRef.type.properties) {
+      Object.defineProperty(obj, name, {
+        get() {
+          return typeRef.get(name)
+        },
+        set(value) {
+          typeRef.set(name, value)
+        },
+      })
+    }
+    Object.setPrototypeOf(obj, ProxyConstructor.prototype)
+    return obj
+  }
+
+  /**
+   * Creates a new Type Proxy.
+   *
+   * @param {Function} ProxyConstructor
+   * @param {TypeRef} typeRef
+   * @param {Type} type
+   * @param {TypeProxyOptions} options
+   * @param {...any} args
+   * @returns {Proxy<ProxyConstructor>}
+   */
+  function createTypeProxy(ProxyConstructor, typeRef, options, ...args) {
+    return new Proxy(
+      new ProxyConstructor(...args),
+      {
+        has(target, name) {
+          return typeRef.type.has(name) || Reflect.has(target, name);
+        },
+        get(target, name) {
+          if (!typeRef.type.has(name)) {
+            return Reflect.get(target, name);
+          }
+          return typeRef.get(name);
+        },
+        set(target, name, value) {
+          if (options && options.readOnly) {
+            return false;
+          }
+          if (!typeRef.type.has(name)) {
+            return Reflect.set(target, name, value);
+          }
+          return typeRef.set(name, value);
+        },
+      }
+    );
+  }
+
+  /**
+   * Type.
+   */
+  class Type {
+    /**
+     * Create a new type (this is a factory method and you
+     * should never use the constructor directly)
+     *
+     * @param {Object} props
+     * @param {Function} proxyConstructor
+     * @returns {Type}
+     */
+    static create(props, proxyConstructor = Object) {
+      let offset = 0;
+      const properties = new Map();
+      for (const [name, definition] of Object.entries(props)) {
+        const [size, getter, setter] =
+        definition.type in PrimitiveTypes
+          ? PrimitiveTypes[definition.type]
+          : PrimitiveTypes.pointer;
+        properties.set(
+          name,
+          {
+            type: definition.type,
+            offset: definition.offset ?? offset,
+            size: size,
+            getter: getter,
+            setter: setter,
+          }
+        );
+        offset += size;
+      }
+      return new Type(properties, proxyConstructor);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param {Map<string, TypeProperty>} properties
+     * @param {Function} [proxyConstructor=Object]
+     */
+    constructor(properties, proxyConstructor = Object) {
+      this._properties = properties;
+      this._size = Array.from(this._properties.values()).reduce((acc, prop) => acc + prop.size, 0);
+      this._proxyConstructor = proxyConstructor;
+    }
+
+    /**
+     * Type properties
+     *
+     * @type {Map<string, TypeProperty>}
+     */
+    get properties() {
+      return this._properties
+    }
+
+    /**
+     * Type size
+     *
+     * @type {number}
+     */
+    get size() {
+      return this._size;
+    }
+
+    /**
+     * Check if a type has a property definition by name.
+     *
+     * @param {string} name
+     * @returns {boolean}
+     */
+    has(name) {
+      return this._properties.has(name);
+    }
+
+    /**
+     * Get a type property definition by name.
+     *
+     * @param {string} name
+     * @returns {TypeProperty}
+     */
+    get(name) {
+      const property = this._properties.get(name);
+      if (!property) {
+        throw new Error(`Property ${name} doesn't exists`);
+      }
+      return property
+    }
+
+    /**
+     * Creates a new TypeRef to a Type.
+     *
+     * @param {WebAssembly.Memory} memory
+     * @param {number} offset
+     * @param {object} options
+     * @param {...any} args
+     * @returns {Proxy}
+     */
+    ref(memory, offset, options, ...args) {
+      const typeRef = new TypeRef(memory, offset, this);
+      const ProxyConstructor = this._proxyConstructor;
+      return createTypeProxyAlt(
+        ProxyConstructor,
+        typeRef,
+        this,
+        options,
+        ...args
+      );
+    }
+  }
+
+  /**
+   * Now we need to register some types to
+   * interact with the resize process.
+   */
+  // in here we register some useful schemas.
+  TypeRegistry.register(
+    "Point",
+    {
+      x: { type: "f32" },
+      y: { type: "f32" },
+    },
+    app.common.geom.point.Point
+  );
+
+  TypeRegistry.register(
+    "Rect",
+    {
+      position: { type: "Point" },
+      size: { type: "Point" },
+    }
+  );
+
+  TypeRegistry.register(
+    "Matrix",
+    {
+      a: { type: "f32" },
+      b: { type: "f32" },
+      c: { type: "f32" },
+      d: { type: "f32" },
+      e: { type: "f32" },
+      f: { type: "f32" },
+    },
+    app.common.geom.matrix.Matrix
+  );
+
+  TypeRegistry.register(
+    "ResizeInput",
+    {
+      rotation: { type: "f32" },
+      handler: { type: "u32" },
+      shouldLock: { type: "u32" },
+      shouldCenter: { type: "u32" },
+      selRect: { type: "Rect" },
+      start: { type: "Point" },
+      current: { type: "Point" },
+      snap: { type: "Point" },
+      shouldTransform: { type: "u32" },
+      transform: { type: "Matrix" },
+      transformInverse: { type: "Matrix" },
+    }
+  );
+
+  TypeRegistry.register(
+    "ResizeOutput",
+    {
+      origin: { type: "Point" },
+      vector: { type: "Point" },
+      displacement: { type: "Point" },
+    }
+  );
+
+  TypeRegistry.register(
+    "TransformInput",
+    {
+      matrix: { type: "Matrix" },
+      shouldTransform: { type: "u32" },
+      transform: { type: "Matrix" },
+      transformInverse: { type: "Matrix" },
+      origin: { type: "Point" },
+      vector: { type: "Point" },
+      center: { type: "Point" },
+      rotation: { type: "f32" },
+    }
+  );
+
+  TypeRegistry.register("TransformOutput", {
+    matrix: { type: "Matrix" },
+  });
+
+  self.from = function from(assembly, varName, typeName) {
+    const type = TypeRegistry.get(typeName)
+    const ref = type.ref(assembly.memory, assembly[varName].value);
+    return ref
+  };
+})

--- a/frontend/src/app/wasm.cljs
+++ b/frontend/src/app/wasm.cljs
@@ -1,0 +1,9 @@
+(ns app.wasm
+  (:require
+   [app.wasm.resize :as resize] 
+   [app.wasm.transform :as transform]))
+
+(defn init!
+  []
+  (transform/init!)
+  (resize/init!))

--- a/frontend/src/app/wasm/common.cljs
+++ b/frontend/src/app/wasm/common.cljs
@@ -1,0 +1,27 @@
+(ns app.wasm.common
+  (:require
+   [app.common.data.macros :as dm]))
+
+(defn set-point
+  [target point]
+  (set! (.-x target) (dm/get-prop point :x))
+  (set! (.-y target) (dm/get-prop point :y)))
+
+(defn set-point-from
+  [target x y]
+  (set! (.-x target) x)
+  (set! (.-y target) y))
+
+(defn set-matrix
+  [target matrix]
+  (set! (.-a target) (dm/get-prop matrix :a))
+  (set! (.-b target) (dm/get-prop matrix :b))
+  (set! (.-c target) (dm/get-prop matrix :c))
+  (set! (.-d target) (dm/get-prop matrix :d))
+  (set! (.-e target) (dm/get-prop matrix :e))
+  (set! (.-f target) (dm/get-prop matrix :f)))
+
+(defn set-rect
+  [target rect]
+  (set-point-from (.-position target) (:x rect) (:y rect))
+  (set-point-from (.-size target) (:width rect) (:height rect)))

--- a/frontend/src/app/wasm/resize.cljs
+++ b/frontend/src/app/wasm/resize.cljs
@@ -1,0 +1,64 @@
+(ns app.wasm.resize
+  (:require 
+   [app.common.data.macros :as dm]
+   [app.util.wasm :as wasm]
+   [app.util.wasm.types :as types]
+   [app.wasm.common :as common]
+   [promesa.core :as p]))
+
+(defonce instance nil)
+(defonce memory nil)
+(defonce resize-input nil)
+(defonce resize-output nil)
+
+(defn- init-proxies
+  [asm]
+  (js/console.log "init resize proxies")
+  (set! resize-input (types/from asm "resizeInput" "ResizeInput"))
+  (set! resize-output (types/from asm "resizeOutput" "ResizeOutput")))
+
+(defn- resize-get-handler
+  [handler]
+  (case handler
+    :right 0
+    :bottom-right 1
+    :bottom 2
+    :bottom-left 3
+    :left 4
+    :top-left 5
+    :top 6
+    :top-right 7))
+
+(defn resize-start
+  [handler initial]
+  (common/set-point (.-start resize-input) initial)
+  (set! (.-handler resize-input) (resize-get-handler handler)))
+
+(defn resize-update-transforms
+  [shape]
+  (common/set-matrix (.-transform resize-input) (dm/get-prop shape :transform))
+  (common/set-matrix (.-transformInverse resize-input) (dm/get-prop shape :transform-inverse)))
+
+(defn resize-update
+  [shape point point-snap lock? center?]
+  (let [transform (dm/get-prop shape :transform)]
+    (set! (.-rotation resize-input) (or (dm/get-prop shape :rotation) 0))
+    (set! (.-shouldLock resize-input) (if lock? 1 0))
+    (set! (.-shouldCenter resize-input) (if center? 1 0))
+    (common/set-rect (.-selRect resize-input) (:selrect shape))
+    (common/set-point (.-current resize-input) point)
+    (common/set-point (.-snap resize-input) point-snap)
+    (set! (. resize-input -shouldTransform) (some? transform))
+    (when (some? transform) (resize-update-transforms shape))
+    (.resize instance)))
+
+(defn init!
+  "Loads WebAssembly module"
+  []
+  (p/then
+   (wasm/load "wasm/resize.release.wasm")
+   (fn [asm]
+     (js/console.log asm)
+     (set! instance asm)
+     (set! memory asm.memory)
+     (init-proxies asm))))

--- a/frontend/src/app/wasm/transform.cljs
+++ b/frontend/src/app/wasm/transform.cljs
@@ -1,0 +1,109 @@
+(ns app.wasm.transform
+  (:require
+   [app.common.data.macros :as dm]
+   [app.util.wasm :as wasm]
+   [app.util.wasm.types :as types]
+   [app.wasm.common :as common]
+   [promesa.core :as p]))
+
+(defonce instance nil)
+(defonce memory nil)
+(defonce transform-input nil)
+(defonce transform-output nil)
+
+(defn- init-proxies
+  [asm]
+  (js/console.log "init transform proxies")
+  (set! transform-input (types/from asm "transformInput" "TransformInput"))
+  (set! transform-output (types/from asm "transformOutput" "TransformOutput")))
+
+(defn set-transform-matrix
+  [matrix]
+  (let [^js matrix' (.-matrix transform-input)]
+    (common/set-matrix matrix' matrix)))
+
+(defn set-transform-transform
+  [tf]
+  (let [^js matrix' (.-transform transform-input)]
+    (common/set-matrix matrix' tf)))
+
+(defn set-transform-transform-inverse
+  [tfi]
+  (let [^js matrix' (.-transformInverse transform-input)]
+    (common/set-matrix matrix' tfi)))
+
+(defn set-transform-vector
+  [vector]
+  (let [^js vector' (.-vector transform-input)]
+    (common/set-point vector' vector)))
+
+(defn set-transform-center
+  [center]
+  (let [^js center' (.-center transform-input)]
+    (common/set-point center' center)))
+
+(defn set-transform-origin
+  [origin]
+  (let [^js origin' (.-origin transform-input)]
+    (common/set-point origin' origin)))
+
+(defn set-transform-should-transform
+  [should-transform]
+  (set! (.-shouldTransform transform-input) should-transform))
+
+(defn set-transform-rotation
+  [rotation]
+  (set! (.-rotation transform-input) rotation))
+
+(defn add-move-modifier
+  [modifier]
+  (let [vector (dm/get-prop modifier :vector)]
+    (set-transform-vector vector)
+    (.addMove instance (dm/get-prop modifier :order))))
+
+(defn add-resize-modifier
+  [modifier]
+  (let [tf     (dm/get-prop modifier :transform)
+        tfi    (dm/get-prop modifier :transform-inverse)
+        vector (dm/get-prop modifier :vector)
+        origin (dm/get-prop modifier :origin)]
+    (set-transform-origin origin)
+    (set-transform-vector vector)
+    (when (some? tf) (set-transform-transform tf))
+    (when (some? tfi) (set-transform-transform-inverse tfi))
+    (set-transform-should-transform ^boolean (or (some? tf) (some? tfi)))
+    (.addResize instance (dm/get-prop modifier :order))))
+
+(defn add-rotation-modifier
+  [modifier]
+  (let [center   (dm/get-prop modifier :center)
+        rotation (dm/get-prop modifier :rotation)]
+    (set-transform-center center)
+    (set-transform-rotation rotation)
+    (.addRotation instance (dm/get-prop modifier :order))))
+
+(defn add-modifier
+  [modifier]
+  (let [type (dm/get-prop modifier :type)]
+    (case type
+      :move (add-move-modifier modifier)
+      :resize (add-resize-modifier modifier)
+      :rotation (add-rotation-modifier modifier))))
+
+(defn modifiers->transform
+  [modifiers]
+  (.reset ^js instance)
+  (run! add-modifier modifiers)
+  (.compute ^js instance)
+  (.-matrix ^js transform-output))
+
+(defn init!
+  "Loads WebAssembly module"
+  []
+  (p/then
+   (wasm/load "wasm/transform.release.wasm")
+   (fn [asm]
+     (js/console.log asm)
+     (set! instance asm)
+     (set! memory asm.memory)
+     (init-proxies asm))))

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -22,6 +22,7 @@
    [app.util.dom :as dom]
    [app.util.object :as obj]
    [app.util.timers :as timers]
+   [app.wasm.resize :as wasm-resize]
    [beicon.core :as rx]
    [cljs.pprint :refer [pprint]]
    [cuerdas.core :as str]
@@ -224,6 +225,13 @@
 
 (defn ^:export dump-buffer []
   (logjs "last-events" @st/last-events)
+  nil)
+
+(defn ^:export dump-resize-wasm []
+  (logjs "wasm-resize-instance" @wasm-resize/instance)
+  (logjs "wasm-resize-memory" @wasm-resize/memory)
+  (logjs "wasm-resize-resize-input" @wasm-resize/resize-input)
+  (logjs "wasm-resize-resize-output" @wasm-resize/resize-output)
   nil)
 
 (defn ^:export get-state [str-path]

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -23,6 +23,7 @@
    [app.util.object :as obj]
    [app.util.timers :as timers]
    [app.wasm.resize :as wasm-resize]
+   [app.wasm.transform :as wasm-transform]
    [beicon.core :as rx]
    [cljs.pprint :refer [pprint]]
    [cuerdas.core :as str]
@@ -232,6 +233,13 @@
   (logjs "wasm-resize-memory" @wasm-resize/memory)
   (logjs "wasm-resize-resize-input" @wasm-resize/resize-input)
   (logjs "wasm-resize-resize-output" @wasm-resize/resize-output)
+  nil)
+
+(defn ^:export dump-transform-wasm []
+  (logjs "wasm-transform-instance" @wasm-transform/instance)
+  (logjs "wasm-transform-memory" @wasm-transform/memory)
+  (logjs "wasm-transform-transform-input" @wasm-transform/transform-input)
+  (logjs "wasm-transform-transform-output" @wasm-transform/transform-output)
   nil)
 
 (defn ^:export get-state [str-path]

--- a/frontend/wasm/.prettierrc
+++ b/frontend/wasm/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/frontend/wasm/Angle.ts
+++ b/frontend/wasm/Angle.ts
@@ -1,0 +1,10 @@
+export const DEG_TO_RAD: f32 = Mathf.PI / 180;
+export const RAD_TO_DEG: f32 = 180 / Mathf.PI;
+
+export function degreesToRadians(degrees: f32): f32 {
+  return degrees * DEG_TO_RAD;
+}
+
+export function radiansToDegrees(radians: f32): f32 {
+  return radians * RAD_TO_DEG;
+}

--- a/frontend/wasm/Interpolation.ts
+++ b/frontend/wasm/Interpolation.ts
@@ -1,0 +1,17 @@
+export function linear(x: f32, a: f32, b: f32): f32 {
+  return (1 - x) * a + x * b;
+}
+
+export function quadratic(x: f32, a: f32, b: f32, c: f32): f32 {
+  return linear(x, linear(x, a, b), linear(x, b, c))
+}
+
+export function cubic(x: f32, a: f32, b: f32, c: f32, d: f32): f32 {
+  return linear(x, quadratic(x, a, b, c), quadratic(x, b, c, d))
+}
+
+export default {
+  linear,
+  quadratic,
+  cubic
+}

--- a/frontend/wasm/Matrix.ts
+++ b/frontend/wasm/Matrix.ts
@@ -1,0 +1,190 @@
+import Point from './Point'
+
+/**
+ * Matrix 2x3
+ *
+ * a c e
+ * b d f
+ */
+@unmanaged
+export default class Matrix {
+  a: f32 = 1
+  b: f32 = 0
+  c: f32 = 0
+  d: f32 = 1
+  e: f32 = 0 // tx
+  f: f32 = 0 // ty
+
+  static multiply(out: Matrix, a: Matrix, b: Matrix): Matrix
+  {
+    return out.set(
+      a.a * b.a + a.c * b.b,
+      a.b * b.a + a.d * b.b,
+      a.a * b.c + a.c * b.d,
+      a.b * b.c + a.d * b.d,
+      a.a * b.e + a.c * b.f + a.e,
+      a.b * b.e + a.d * b.f + a.f
+    )
+  }
+
+  static transform(out: Point, p: Point, m: Matrix): Point {
+    return out.set(
+      p.x * m.a + p.y * m.c + m.e,
+      p.x * m.b + p.y * m.d + m.f
+    )
+  }
+
+  static fromTranslation(point: Point): Matrix {
+    return new Matrix(
+      1, 0, 0, 1, point.x, point.y
+    )
+  }
+
+  constructor(
+    a: f32 = 1,
+    b: f32 = 0,
+    c: f32 = 0,
+    d: f32 = 1,
+    e: f32 = 0,
+    f: f32 = 0
+  ) {
+    this.a = a
+    this.b = b
+    this.c = c
+    this.d = d
+    this.e = e
+    this.f = f
+  }
+
+  @inline
+  set(a: f32, b: f32, c: f32, d: f32, e: f32, f: f32): Matrix
+  {
+    this.a = a
+    this.b = b
+    this.c = c
+    this.d = d
+    this.e = e
+    this.f = f
+    return this
+  }
+
+  setTranslation(point: Point): Matrix {
+    this.e = point.x
+    this.f = point.y
+    return this
+  }
+
+  setNegatedTranslation(point: Point): Matrix {
+    this.e = -point.x
+    this.f = -point.y
+    return this
+  }
+
+  identity(): Matrix {
+    return this.set(1, 0, 0, 1, 0, 0)
+  }
+
+  copy(other: Matrix): Matrix {
+    return this.set(
+      other.a,
+      other.b,
+      other.c,
+      other.d,
+      other.e,
+      other.f
+    )
+  }
+
+  clone(): Matrix {
+    return new Matrix(
+      this.a,
+      this.b,
+      this.c,
+      this.d,
+      this.e,
+      this.f
+    )
+  }
+
+  transform(point: Point, transformed: Point = new Point()): Point {
+    return transformed.set(
+      point.x * this.a + point.y * this.c + this.e,
+      point.x * this.b + point.y * this.d + this.f
+    )
+  }
+
+  determinant(): f32 {
+    return this.a * this.d - this.b * this.c
+  }
+
+  invert(): Matrix|null {
+    const det: f32 = this.determinant()
+    if (!det) {
+      return null
+    }
+    const idet: f32 = 1.0 / det;
+    return this.set(
+      this.d * idet,
+      -this.b * idet,
+      -this.c * idet,
+      this.a * idet,
+      (this.c * this.f - this.d * this.e) * idet,
+      (this.b * this.e - this.a * this.f) * idet
+    )
+  }
+
+  multiply(other: Matrix): Matrix
+  {
+    return this.set(
+      this.a * other.a + this.c * other.b,
+      this.b * other.a + this.d * other.b,
+      this.a * other.c + this.c * other.d,
+      this.b * other.c + this.d * other.d,
+      this.a * other.e + this.c * other.f + this.e,
+      this.b * other.e + this.d * other.f + this.f
+    )
+  }
+
+  rotate(angle: f32): Matrix
+  {
+    const c = Mathf.cos(angle)
+    const s = Mathf.sin(angle)
+    return this.set(
+      this.a * c + this.c * s,
+      this.b * c + this.d * s,
+      this.a * -s + this.c * c,
+      this.b * -s + this.d * c,
+      this.e,
+      this.f
+    )
+  }
+
+  scale(scale: Point): Matrix
+  {
+    return this.set(
+      this.a * scale.x,
+      this.b * scale.x,
+      this.c * scale.y,
+      this.d * scale.y,
+      this.e,
+      this.f
+    )
+  }
+
+  translate(translation: Point): Matrix
+  {
+    return this.set(
+      this.a,
+      this.b,
+      this.c,
+      this.d,
+      this.a * translation.x + this.c * translation.y + this.e,
+      this.b * translation.x + this.d * translation.y + this.f
+    )
+  }
+
+  toString(): string
+  {
+    return `Matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.e}, ${this.f})`
+  }
+}

--- a/frontend/wasm/Modifier.ts
+++ b/frontend/wasm/Modifier.ts
@@ -1,0 +1,45 @@
+import Matrix from './Matrix'
+import Point from './Point'
+import ModifierType from './ModifierType'
+import { degreesToRadians } from './Angle';
+
+@unmanaged
+export default class Modifier {
+  center: Point = new Point();
+  origin: Point = new Point();
+  vector: Point = new Point();
+  transform: Matrix = new Matrix();
+  transformInverse: Matrix = new Matrix();
+  shouldTransform: u32 = 0;
+  rotation: f32 = 0;
+  type: ModifierType = ModifierType.MOVE;
+  order: i32 = 0;
+
+  // Computed matrix
+  matrix: Matrix = new Matrix();
+
+  compute(): Modifier {
+    this.matrix.identity()
+    if (this.type === ModifierType.MOVE) {
+      this.matrix.setTranslation(this.vector)
+    } else if (this.type === ModifierType.RESIZE) {
+      if (this.shouldTransform) {
+        this.origin.transform(this.transformInverse)
+        this.matrix.multiply(this.transform)
+      }
+      this.matrix
+        .translate(this.origin)
+        .scale(this.vector)
+        .translate(this.origin.negate())
+      if (this.shouldTransform) {
+        this.matrix.multiply(this.transformInverse)
+      }
+    } else if (this.type === ModifierType.ROTATION) {
+      this.matrix
+        .translate(this.center)
+        .rotate(this.rotation)
+        .translate(this.center.negate())
+    }
+    return this
+  }
+}

--- a/frontend/wasm/ModifierType.ts
+++ b/frontend/wasm/ModifierType.ts
@@ -1,0 +1,7 @@
+export enum ModifierType {
+  MOVE = 0,
+  RESIZE,
+  ROTATION
+}
+
+export default ModifierType

--- a/frontend/wasm/Point.ts
+++ b/frontend/wasm/Point.ts
@@ -1,0 +1,119 @@
+import Matrix from './Matrix'
+import { clamp } from './Range'
+
+@unmanaged
+export default class Point {
+  x: f32 = 0
+  y: f32 = 0
+
+  constructor(x: f32 = 0, y: f32 = 0) {
+    this.x = x
+    this.y = y
+  }
+
+  get length(): f32 {
+    return Mathf.hypot(this.x, this.y)
+  }
+
+  get lengthSquared(): f32 {
+    return this.x * this.x + this.y * this.y
+  }
+
+  @inline
+  set(x: f32, y: f32): Point {
+    this.x = x
+    this.y = y
+    return this
+  }
+
+  @inline
+  reset(): Point {
+    return this.set(0, 0)
+  }
+
+  polar(angle: f32, length: f32): Point {
+    return this.set(Mathf.cos(angle) * length, Mathf.sin(angle) * length)
+  }
+
+  @inline
+  copy(other: Point): Point {
+    return this.set(other.x, other.y)
+  }
+
+  clone(): Point {
+    return new Point(this.x, this.y)
+  }
+
+  add(other: Point): Point {
+    return this.set(this.x + other.x, this.y + other.y)
+  }
+
+  addScaled(other: Point, scale: f32): Point {
+    return this.set(this.x + other.x * scale, this.y + other.y * scale)
+  }
+
+  subtract(other: Point): Point {
+    return this.set(this.x - other.x, this.y - other.y)
+  }
+
+  multiply(other: Point): Point {
+    return this.set(this.x * other.x, this.y * other.y)
+  }
+
+  divide(other: Point): Point {
+    return this.set(this.x / other.x, this.y / other.y)
+  }
+
+  normalize(): Point {
+    const l: f32 = this.length
+    return this.set(this.x / l, this.y / l)
+  }
+
+  negate(): Point {
+    return this.set(-this.x, -this.y)
+  }
+
+  perpLeft(): Point {
+    return this.set(this.y, -this.x)
+  }
+
+  perpRight(): Point {
+    return this.set(-this.y, this.x)
+  }
+
+  dot(other: Point): f32 {
+    return this.x * other.x + this.y * other.y
+  }
+
+  cross(other: Point): f32 {
+    return this.x * other.y - this.y * other.x
+  }
+
+  rotate(angle: f32): Point {
+    const c: f32 = Mathf.cos(angle)
+    const s: f32 = Mathf.sin(angle)
+    return this.set(c * this.x - s * this.y, s * this.x + c * this.y)
+  }
+
+  scale(scale: f32): Point {
+    return this.set(this.x * scale, this.y * scale)
+  }
+
+  transform(matrix: Matrix): Point {
+    return this.set(
+      this.x * matrix.a + this.y * matrix.c + matrix.e,
+      this.x * matrix.b + this.y * matrix.d + matrix.f
+    )
+  }
+
+  clamp(min: f32 = -Infinity, max: f32 = Infinity): Point {
+    return this.set(
+      clamp(this.x, min, max),
+      clamp(this.y, min, max)
+    )
+  }
+
+  toString(): string {
+    return `Point(${this.x}, ${this.y})`
+  }
+}

--- a/frontend/wasm/Range.ts
+++ b/frontend/wasm/Range.ts
@@ -1,0 +1,15 @@
+export const EPSILON: f32 = 0.001
+
+export function clamp(x: f32, min: f32, max: f32): f32 {
+  if (x < min) return min
+  if (x > max) return max
+  return x
+}
+
+export function from(x: f32, min: f32, max: f32): f32 {
+  return (x - min) / (max - min)
+}
+
+export function almostEqual(a: f32, b: f32, epsilon: f32 = EPSILON): boolean {
+  return Mathf.abs(a - b) <= epsilon * Mathf.max(1.0, Mathf.max(Mathf.abs(a), Mathf.abs(b)))
+}

--- a/frontend/wasm/Rect.ts
+++ b/frontend/wasm/Rect.ts
@@ -1,0 +1,76 @@
+import Point from './Point'
+
+@unmanaged
+export default class Rect {
+  position: Point = new Point()
+  size: Point = new Point()
+
+  constructor(position: Point = new Point(), size: Point = new Point()) {
+    this.position = position
+    this.size = size
+  }
+
+  get left(): f32 {
+    return this.position.x
+  }
+
+  get right(): f32 {
+    return this.position.x + this.size.x
+  }
+
+  get top(): f32 {
+    return this.position.y
+  }
+
+  get bottom(): f32 {
+    return this.position.y + this.size.y
+  }
+
+  get x(): f32 {
+    return this.position.x
+  }
+
+  get y(): f32 {
+    return this.position.y
+  }
+
+  get width(): f32 {
+    return this.size.x
+  }
+
+  get height(): f32 {
+    return this.size.y
+  }
+
+  get centerX(): f32 {
+    return this.position.x + this.size.x / 2
+  }
+
+  get centerY(): f32 {
+    return this.position.y + this.size.y / 2
+  }
+
+  clone(deep: boolean): Rect {
+    return new Rect(
+      deep ? this.position.clone() : this.position,
+      deep ? this.size.clone() : this.size
+    )
+  }
+
+  contains(point: Point): boolean {
+    return point.x > this.left
+        && point.x < this.right
+        && point.y > this.top
+        && point.y < this.bottom
+  }
+
+  intersects(other: Rect): boolean {
+    if (this.left > other.right || this.right < other.left)
+      return false
+
+    if (this.top > other.bottom || this.bottom < other.top)
+      return false
+
+    return true
+  }
+}

--- a/frontend/wasm/ResizeHandler.ts
+++ b/frontend/wasm/ResizeHandler.ts
@@ -1,0 +1,12 @@
+export enum ResizeHandler {
+  RIGHT = 0,
+  BOTTOM_RIGHT,
+  BOTTOM,
+  BOTTOM_LEFT,
+  LEFT,
+  TOP_LEFT,
+  TOP,
+  TOP_RIGHT
+}
+
+export default ResizeHandler

--- a/frontend/wasm/ResizeHandlerMultiplier.ts
+++ b/frontend/wasm/ResizeHandlerMultiplier.ts
@@ -1,0 +1,15 @@
+import Point from './Point'
+import ResizeHandler from './ResizeHandler'
+
+export const ResizeHandlerMultiplier: Array<Point> = [
+  new Point(1, 0), /* [ResizeHandler.RIGHT]: */
+  new Point(1, 1), /* [ResizeHandler.BOTTOM_RIGHT]: */
+  new Point(0, 1), /* [ResizeHandler.BOTTOM]: */
+  new Point(-1, 1), /* [ResizeHandler.BOTTOM_LEFT]: */
+  new Point(-1, 0), /* [ResizeHandler.LEFT]: */
+  new Point(-1, -1), /* [ResizeHandler.TOP_LEFT]: */
+  new Point(0, -1), /* [ResizeHandler.TOP]: */
+  new Point(1, -1), /* [ResizeHandler.TOP_RIGHT]: */
+]
+
+export default ResizeHandlerMultiplier

--- a/frontend/wasm/ResizeInput.ts
+++ b/frontend/wasm/ResizeInput.ts
@@ -1,0 +1,18 @@
+import Matrix from './Matrix'
+import Point from './Point'
+import Rect from './Rect'
+
+@unmanaged
+export default class ResizeInput {
+  rotation: f32 = 0
+  handler: u32 = 0
+  shouldLock: u32 = 0
+  shouldCenter: u32 = 0
+  selRect: Rect = new Rect()
+  start: Point = new Point()
+  current: Point = new Point()
+  snap: Point = new Point()
+  shouldTransform: u32 = 0
+  transform: Matrix = new Matrix()
+  transformInverse: Matrix = new Matrix()
+}

--- a/frontend/wasm/ResizeOutput.ts
+++ b/frontend/wasm/ResizeOutput.ts
@@ -1,0 +1,13 @@
+import Point from './Point'
+import Rect from './Rect'
+
+@unmanaged
+export default class ResizeOutput {
+  origin: Point = new Point()
+  vector: Point = new Point()
+  displacement: Point = new Point()
+
+  toString(): string {
+    return `ResizeOutput(${this.origin}, ${this.vector}, ${this.displacement})`
+  }
+}

--- a/frontend/wasm/TransformInput.ts
+++ b/frontend/wasm/TransformInput.ts
@@ -1,0 +1,14 @@
+import Point from './Point';
+import Matrix from './Matrix';
+
+@unmanaged
+export default class TransformInput {
+  matrix: Matrix = new Matrix();
+  shouldTransform: u32 = 0;
+  transform: Matrix = new Matrix();
+  transformInverse: Matrix = new Matrix();
+  origin: Point = new Point();
+  vector: Point = new Point();
+  center: Point = new Point();
+  rotation: f32 = 0;
+}

--- a/frontend/wasm/TransformOutput.ts
+++ b/frontend/wasm/TransformOutput.ts
@@ -1,0 +1,5 @@
+import Matrix from './Matrix';
+
+export default class TransformOutput {
+  matrix: Matrix = new Matrix();
+}

--- a/frontend/wasm/resize.ts
+++ b/frontend/wasm/resize.ts
@@ -1,0 +1,185 @@
+import Rect from './Rect'
+import Point from './Point'
+import Matrix from './Matrix'
+import ResizeHandler from './ResizeHandler'
+import ResizeHandlerMultiplier from './ResizeHandlerMultiplier'
+import ResizeInput from './ResizeInput'
+import ResizeOutput from './ResizeOutput'
+
+// Input data
+export const resizeInput: ResizeInput = new ResizeInput()
+
+// Output data
+export const resizeOutput: ResizeOutput = new ResizeOutput()
+
+// Handlers classified by its constraints.
+const anyLeft: Array<ResizeHandler> = [
+  ResizeHandler.LEFT,
+  ResizeHandler.TOP_LEFT,
+  ResizeHandler.BOTTOM_LEFT
+]
+const anyRight: Array<ResizeHandler> = [
+  ResizeHandler.RIGHT,
+  ResizeHandler.TOP_RIGHT,
+  ResizeHandler.BOTTOM_RIGHT,
+]
+const anyTop: Array<ResizeHandler> = [
+  ResizeHandler.TOP,
+  ResizeHandler.TOP_RIGHT,
+  ResizeHandler.TOP_LEFT,
+]
+const anyBottom: Array<ResizeHandler> = [
+  ResizeHandler.BOTTOM,
+  ResizeHandler.BOTTOM_RIGHT,
+  ResizeHandler.BOTTOM_LEFT,
+]
+
+// Intermediate values
+const start: Point = new Point()
+const current: Point = new Point()
+const size: Point = new Point()
+const center: Point = new Point()
+const multiplier: Point = new Point()
+const delta: Point = new Point()
+const centerNegatedTransformMatrix: Matrix = new Matrix()
+const centerTransformMatrix: Matrix = new Matrix()
+const transformMatrix: Matrix = new Matrix()
+
+/**
+ * Transform a point along the center of the selection
+ * rectangle.
+ *
+ * @param point
+ * @param matrix
+ */
+function transformPointCenter(point: Point, matrix: Matrix): void
+{
+  transformMatrix
+    .copy(centerTransformMatrix)
+    .multiply(matrix)
+    .multiply(centerNegatedTransformMatrix)
+
+  point
+    .transform(transformMatrix)
+}
+
+/**
+ * Calculate all derived data and transforms vectors
+ * to resize elements.
+ */
+export function resize(): void
+{
+  current.reset()
+  delta.reset()
+
+  size.copy(resizeInput.selRect.size)
+
+  // update center
+  center.set(
+    resizeInput.selRect.centerX,
+    resizeInput.selRect.centerY
+  )
+
+  // create transform matrices.
+  if (resizeInput.shouldTransform) {
+    centerNegatedTransformMatrix
+      .identity()
+      .setNegatedTranslation(center)
+
+    centerTransformMatrix
+      .identity()
+      .setTranslation(center)
+  }
+
+  // update handler origin
+  switch (resizeInput.handler)
+  {
+    case ResizeHandler.RIGHT: resizeOutput.origin.set(resizeInput.selRect.left, resizeInput.selRect.centerY); break
+    case ResizeHandler.BOTTOM: resizeOutput.origin.set(resizeInput.selRect.centerY, resizeInput.selRect.top); break
+    case ResizeHandler.LEFT: resizeOutput.origin.set(resizeInput.selRect.right, resizeInput.selRect.centerY); break
+    case ResizeHandler.TOP: resizeOutput.origin.set(resizeInput.selRect.centerY, resizeInput.selRect.bottom); break
+    case ResizeHandler.TOP_RIGHT: resizeOutput.origin.set(resizeInput.selRect.left, resizeInput.selRect.bottom); break
+    case ResizeHandler.TOP_LEFT: resizeOutput.origin.set(resizeInput.selRect.right, resizeInput.selRect.bottom); break
+    case ResizeHandler.BOTTOM_RIGHT: resizeOutput.origin.set(resizeInput.selRect.left, resizeInput.selRect.top); break
+    case ResizeHandler.BOTTOM_LEFT: resizeOutput.origin.set(resizeInput.selRect.right, resizeInput.selRect.top); break
+  }
+
+  // update handler multiplier
+  multiplier.copy(ResizeHandlerMultiplier[resizeInput.handler])
+
+  // update vector
+  start.copy(resizeInput.start)
+  if (resizeInput.shouldTransform) {
+    transformPointCenter(start, resizeInput.transformInverse)
+  }
+
+  // fix-init-point
+  if (anyLeft.includes(resizeInput.handler)) {
+    start.x = resizeInput.selRect.left
+  }
+
+  if (anyRight.includes(resizeInput.handler)) {
+    start.x = resizeInput.selRect.right
+  }
+
+  if (anyTop.includes(resizeInput.handler)) {
+    start.y = resizeInput.selRect.top
+  }
+
+  if (anyBottom.includes(resizeInput.handler)) {
+    start.y = resizeInput.selRect.bottom
+  }
+
+  current.copy(
+    resizeInput.rotation === 0
+      ? resizeInput.snap
+      : resizeInput.current
+  )
+
+  if (resizeInput.shouldTransform) {
+    transformPointCenter(current, resizeInput.transformInverse)
+  }
+
+  delta.copy(current)
+  delta.subtract(start)
+  delta.multiply(multiplier)
+
+  resizeOutput.vector.copy(size)
+  resizeOutput.vector.add(delta)
+  resizeOutput.vector.divide(size)
+  resizeOutput.vector.clamp(0.001, Infinity) // gpt/no-zeros
+
+  // lock proportions?
+  if (resizeInput.shouldLock) {
+    if (
+      resizeInput.handler === ResizeHandler.LEFT ||
+      resizeInput.handler === ResizeHandler.RIGHT
+    ) {
+      resizeOutput.vector.set(resizeOutput.vector.x, resizeOutput.vector.x)
+    } else if (
+      resizeInput.handler === ResizeHandler.TOP ||
+      resizeInput.handler === ResizeHandler.BOTTOM
+    ) {
+      resizeOutput.vector.set(resizeOutput.vector.y, resizeOutput.vector.y)
+    } else {
+      const v: f32 = f32(Math.max(resizeOutput.vector.x, resizeOutput.vector.y))
+      resizeOutput.vector.set(v, v)
+    }
+  }
+
+  if (resizeInput.shouldCenter) {
+    resizeOutput.displacement
+      .copy(center)
+      .subtract(resizeOutput.origin)
+      .multiply(resizeOutput.vector)
+      .add(resizeOutput.origin)
+      .subtract(center)
+      .multiply(ResizeHandlerMultiplier[ResizeHandler.TOP_LEFT])
+      .transform(resizeInput.transform)
+  }
+
+  if (resizeInput.shouldTransform) {
+    transformPointCenter(resizeOutput.origin, resizeInput.transform)
+  }
+  resizeOutput.origin.add(resizeOutput.displacement)
+}

--- a/frontend/wasm/transform.ts
+++ b/frontend/wasm/transform.ts
@@ -1,0 +1,68 @@
+import Matrix from './Matrix';
+import Point from './Point';
+import { degreesToRadians } from './Angle';
+import TransformInput from './TransformInput';
+import TransformOutput from './TransformOutput';
+import Modifier from './Modifier';
+import ModifierType from './ModifierType';
+
+export const transformInput: TransformInput = new TransformInput();
+export const transformOutput: TransformOutput = new TransformOutput();
+
+const MAX_MODIFIERS = 64;
+
+let modifierIndex: i32 = 0;
+const modifiers: StaticArray<Modifier> = new StaticArray<Modifier>(MAX_MODIFIERS);
+for (let i = 0; i < MAX_MODIFIERS; i++) {
+  modifiers[i] = new Modifier();
+}
+
+const matrix: Matrix = new Matrix();
+
+export function reset(): void
+{
+  modifierIndex = 0;
+}
+
+export function addMove(order: i32): void
+{
+  modifiers[modifierIndex].type = ModifierType.MOVE;
+  modifiers[modifierIndex].vector.copy(transformInput.vector);
+  modifiers[modifierIndex].order = order;
+  modifierIndex++;
+}
+
+export function addResize(order: i32): void
+{
+  modifiers[modifierIndex].type = ModifierType.RESIZE;
+  modifiers[modifierIndex].vector.copy(transformInput.vector);
+  modifiers[modifierIndex].origin.copy(transformInput.origin);
+  modifiers[modifierIndex].transform.copy(transformInput.transform);
+  modifiers[modifierIndex].transformInverse.copy(transformInput.transformInverse);
+  modifiers[modifierIndex].shouldTransform = transformInput.shouldTransform;
+  modifiers[modifierIndex].order = order;
+  modifierIndex++;
+}
+
+export function addRotation(order: i32): void
+{
+  modifiers[modifierIndex].type = ModifierType.ROTATION;
+  modifiers[modifierIndex].center.copy(transformInput.center);
+  modifiers[modifierIndex].rotation = degreesToRadians(transformInput.rotation);
+  modifiers[modifierIndex].order = order;
+  modifierIndex++;
+}
+
+export function compute(): void
+{
+  // modifiers.sort((a, b) => a.order - b.order);
+  matrix.identity()
+  for (let index = 0; index < modifierIndex; index++) {
+    if (modifiers[index].type === ModifierType.MOVE || modifiers[index].type === ModifierType.RESIZE) {
+      Matrix.multiply(matrix, matrix, modifiers[index].compute().matrix)
+    } else if (modifiers[index].type === ModifierType.ROTATION) { // WTF?
+      Matrix.multiply(matrix, modifiers[index].compute().matrix, matrix)
+    }
+  }
+  transformOutput.matrix.copy(matrix)
+}

--- a/frontend/wasm/tsconfig.json
+++ b/frontend/wasm/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../node_modules/assemblyscript/std/assembly.json",
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -400,6 +400,14 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assemblyscript@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.27.1.tgz#d6ba32a3e3030aac04c34bac785ce40d93bb2d2f"
+  integrity sha512-0ZS9ujdoSAjuwc+qdZ4PeZy32wFh3U2GVy7/G2dfDr/5i0jOmWY29AaFsiNxDQ7z6MOeTo9YpNLfIqZ1WWzh8A==
+  dependencies:
+    binaryen "111.0.0-nightly.20230202"
+    long "^5.2.1"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -541,6 +549,11 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+binaryen@111.0.0-nightly.20230202:
+  version "111.0.0-nightly.20230202"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-111.0.0-nightly.20230202.tgz#40899e27447315f1c5fa948e35f365c2b3ca8a58"
+  integrity sha512-aGMDtxmc8zQHzAamyOBvO38n2e/GuXM0dZCJg+IuG2YUQODTqI37XSkAixS8c0wXn2dgLntDMk1VDblKCsy0GA==
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -3312,6 +3325,11 @@ logform@^2.3.2, logform@^2.4.0:
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
+
+long@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.1.tgz#e27595d0083d103d2fa2c20c7699f8e0c92b897f"
+  integrity sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
How to verify it:

Follow these steps with a version of Penpot with and without WebAssembly (try to spend almost the same time doing the same things):
- 1. Enter workspace (open any file, with huge files is easier to see metrics).
- 2. Open DevTools > Options (⋮) > More Tools > JavaScript Profiler.
- 3. Go to JavaScript Profiler > Record (:red_circle:).
- 4. Apply some transformations to complex boards.
- 5. Stop recording.

After that verify that the following times (%) have decreased:
- (garbage collector)
- `app$common$types$modifiers$modifiers__GT_transform` (`app.common.types.modifiers.cljs`: `modifiers->transform`)
- `app$main$data$workspace$transforms$start_resize_$_resize` (`app.main.data.workspace.transforms.cljs`: `start-resize`)

Extra features:
- Now in the console you can write: `debug.dump_resize_wasm()` and `debug.dump_transform_wasm()` to get info about the loaded WebAssembly modules.