### PR TITLE
:bug: Fix page item context menu

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 ### :bug: Bugs fixed
 
 - Fix problem with rulers not placing correctly [Taiga #5093](https://tree.taiga.io/project/penpot/issue/5093)
+- Fix page context menu [Taiga #5145](https://tree.taiga.io/project/penpot/issue/5145)
+
+### :arrow_up: Deps updates
 
 ## 1.18.2
 

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1234,6 +1234,7 @@
 
 (s/def ::point gpt/point?)
 
+
 (defn show-context-menu
   [{:keys [position] :as params}]
   (us/verify ::point position)
@@ -1262,9 +1263,19 @@
          (rx/of (show-context-menu
                  (-> params
                      (assoc
+                      :kind :shape
                       :disable-booleans? (or no-bool-shapes? not-group-like?)
                       :disable-flatten? no-bool-shapes?
                       :selected (conj selected (:id shape)))))))))))
+
+(defn show-page-item-context-menu
+  [{:keys [position page] :as params}]
+  (us/verify ::point position)
+  (ptk/reify ::show-page-item-context-menu
+    ptk/WatchEvent
+    (watch [_ _ _]
+           (rx/of (show-context-menu
+                   (-> params (assoc :kind :page :selected (:id page))))))))
 
 (def hide-context-menu
   (ptk/reify ::hide-context-menu
@@ -1989,7 +2000,25 @@
     (update [_ state]
       (assoc-in state [:workspace-local :inspect-expanded] expanded?))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Sitemap
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn start-rename-page-item
+  [id]
+  (ptk/reify ::start-rename-page-item
+    ptk/UpdateEvent
+    (update [_ state]
+      (assoc-in state [:workspace-local :page-item] id))))
+
+(defn stop-rename-page-item
+  []
+  (ptk/reify ::stop-rename-page-item
+    ptk/UpdateEvent
+    (update [_ state]
+      (let [local (-> (:workspace-local state)
+                      (dissoc :page-item))]
+        (assoc state :workspace-local local)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; File Library persistent settings

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -183,6 +183,10 @@
 (def context-menu
   (l/derived :context-menu workspace-local))
 
+;; page item that it is being edited
+(def editing-page-item
+  (l/derived :page-item workspace-local))
+
 (def file-library-listing-thumbs?
   (l/derived :file-library-listing-thumbs workspace-global))
 

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -575,6 +575,30 @@
                        :shortcut (sc/get-tooltip :toggle-focus-mode)
                        :on-click do-toggle-focus-mode}])]))
 
+(mf/defc page-item-context-menu
+  [{:keys [mdata] :as props}]
+  (let [page (:page mdata)
+        deletable? (:deletable? mdata)
+        id (:id page)
+        delete-fn #(st/emit! (dw/delete-page id))
+        do-delete #(st/emit! (modal/show 
+                     {:type :confirm
+                      :title (tr "modals.delete-page.title")
+                      :message (tr "modals.delete-page.body")
+                      :on-accept delete-fn}))
+        do-duplicate #(st/emit! (dw/duplicate-page id))
+        do-rename #(st/emit! (dw/start-rename-page-item id))]
+  
+  [:*
+   (when deletable?
+     [:& menu-entry {:title (tr "workspace.assets.delete")
+                     :on-click do-delete}])
+
+   [:& menu-entry {:title (tr "workspace.assets.rename")
+                   :on-click do-rename}]
+   [:& menu-entry {:title (tr "workspace.assets.duplicate")
+                   :on-click do-duplicate}]]))
+
 (mf/defc context-menu
   []
   (let [mdata (mf/deref menu-ref)
@@ -602,8 +626,9 @@
        :style {:top top :left left}
        :on-context-menu prevent-default}
 
-      (if (contains? mdata :selected)
-        [:& shape-context-menu {:mdata mdata}]
+      (case (:kind mdata)
+        :shape [:& shape-context-menu {:mdata mdata}]
+        :page [:& page-item-context-menu {:mdata mdata}]
         [:& viewport-context-menu {:mdata mdata}])]]))
 
 


### PR DESCRIPTION
Fixes [Taiga #5145](https://tree.taiga.io/project/penpot/issue/5145)

Steps to reproduce:
1. Go to a file with more than one page
2. Open page context menu of on a page with right click
3. Move mouse to next page and right click on it to open the context menu

First context menu should disappear when second menu opens.