### PR TITLE
:tada: automatic names for text layers

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -156,7 +156,9 @@
                                                     (apply str)))]
                        (-> shape
                            (assoc :content content)
-                           (assoc :name (subs concatenated-text 0 (min 25 (count concatenated-text))))
+                           (assoc :name (if (> (count concatenated-text) 22)
+                                          (str (subs concatenated-text 0 22) "...")
+                                          concatenated-text))
                            (cond-> new-shape?
                              (assoc :name text))
                            (cond-> (or (some? width) (some? height))

--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -142,9 +142,21 @@
                   (dch/update-shapes
                    [id]
                    (fn [shape]
-                     (let [{:keys [width height]} modifiers]
+                     (let [{:keys [width height]} modifiers
+                           concatenated-text (letfn [(find-text-properties [node]
+                                                       (if (map? node)
+                                                         (if-let [text (get node :text)]
+                                                           [text]
+                                                           (mapcat find-text-properties (vals node)))
+                                                         (if (sequential? node)
+                                                           (mapcat find-text-properties node)
+                                                           [])))]
+                                               (->> content
+                                                    find-text-properties
+                                                    (apply str)))]
                        (-> shape
                            (assoc :content content)
+                           (assoc :name (subs concatenated-text 0 (min 25 (count concatenated-text))))
                            (cond-> new-shape?
                              (assoc :name text))
                            (cond-> (or (some? width) (some? height))


### PR DESCRIPTION
Take up to the first 25 characters of text in a text shape and set it as the name of the layer.