### PR TITLE
:tada: Add message for empty state for color and typography palettes

### DIFF
--- a/frontend/src/app/main/ui/workspace/colorpalette.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpalette.cljs
@@ -160,10 +160,16 @@
 
      [:span.left-arrow {:on-click on-left-arrow-click} i/arrow-slide]
      [:div.color-palette-content {:ref container :on-wheel on-scroll}
-      [:div.color-palette-inside {:style {:position "relative"
+     (if (empty? current-colors)
+        [:div.color-palette-empty {:style {:position "absolute"
+                                           :left "50%"
+                                           :top "50%"
+                                           :transform "translate(-50%, -50%)"}} 
+              "There are no Color Styles in your Library yet"]
+        [:div.color-palette-inside {:style {:position "relative"
                                           :right (str (* 66 offset) "px")}}
-       (for [[idx item] (map-indexed vector current-colors)]
-         [:& palette-item {:color item :key idx}])]]
+          (for [[idx item] (map-indexed vector current-colors)]
+            [:& palette-item {:color item :key idx}])])]
 
      [:span.right-arrow {:on-click on-right-arrow-click} i/arrow-slide]]))
 

--- a/frontend/src/app/main/ui/workspace/colorpalette.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpalette.cljs
@@ -165,7 +165,7 @@
                                            :left "50%"
                                            :top "50%"
                                            :transform "translate(-50%, -50%)"}} 
-              "There are no Color Styles in your Library yet"]
+              (tr "workspace.libraries.colors.empty-palette")]
         [:div.color-palette-inside {:style {:position "relative"
                                           :right (str (* 66 offset) "px")}}
           (for [[idx item] (map-indexed vector current-colors)]

--- a/frontend/src/app/main/ui/workspace/textpalette.cljs
+++ b/frontend/src/app/main/ui/workspace/textpalette.cljs
@@ -134,7 +134,7 @@
                                            :left "50%"
                                            :top "50%"
                                            :transform "translate(-50%, -50%)"}} 
-              "There are no Typography Styles in your Library yet"]
+              (tr "workspace.libraries.colors.empty-typography-palette")]
         [:div.color-palette-inside
         (for [[idx item] (map-indexed vector current-typographies)]
           [:& typography-item

--- a/frontend/src/app/main/ui/workspace/textpalette.cljs
+++ b/frontend/src/app/main/ui/workspace/textpalette.cljs
@@ -129,13 +129,19 @@
      [:span.left-arrow {:on-click on-left-arrow-click} i/arrow-slide]
 
      [:div.color-palette-content {:ref container :on-wheel on-wheel}
-      [:div.color-palette-inside
-       (for [[idx item] (map-indexed vector current-typographies)]
-         [:& typography-item
-          {:key idx
-           :file-id file-id
-           :selected-ids selected-ids
-           :typography item}])]]
+     (if (empty? current-typographies)
+        [:div.color-palette-empty {:style {:position "absolute"
+                                           :left "50%"
+                                           :top "50%"
+                                           :transform "translate(-50%, -50%)"}} 
+              "There are no Typography Styles in your Library yet"]
+        [:div.color-palette-inside
+        (for [[idx item] (map-indexed vector current-typographies)]
+          [:& typography-item
+            {:key idx
+            :file-id file-id
+            :selected-ids selected-ids
+            :typography item}])])]
 
      [:span.right-arrow {:on-click on-right-arrow-click} i/arrow-slide]]))
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3132,6 +3132,14 @@ msgstr "HSV"
 msgid "workspace.libraries.colors.recent-colors"
 msgstr "Recent colors"
 
+#: src/app/main/ui/workspace/colorpalette.cljs
+msgid "workspace.libraries.colors.empty-palette"
+msgstr "There are no Color Styles in your Library yet"
+
+#: src/app/main/ui/workspace/textpalette.cljs
+msgid "workspace.libraries.colors.empty-typography-palette"
+msgstr "There are no Typography Styles in your Library yet"
+
 #: src/app/main/ui/workspace/colorpicker.cljs
 msgid "workspace.libraries.colors.rgb-complementary"
 msgstr "RGB Complementary"


### PR DESCRIPTION
🎉  Add message for empty state for color and typography palettes #2522 

* When a user opens the color or font palette, if it's empty, an empty state will be displayed to the user consisting of one of the messages, "There are no Color Styles in your library yet" or "There are no Typography Styles in your library yet" 
