### PR TITLE
:tada: Add feature to select full values on click at the design sidebar

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -11,10 +11,14 @@
    [app.main.store :as st]
    [app.main.ui.icons :as i]
    [app.main.ui.workspace.sidebar.options.rows.input-row :refer [input-row]]
+   [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
 (def blur-attrs [:blur])
+
+(defn select-all [event]
+  (dom/select-text! (dom/get-target event)))
 
 (defn create-blur []
   (let [id (uuid/next)]
@@ -82,6 +86,7 @@
      (cond
        has-value?
        [:div.element-set-content
+        {:on-focus select-all}
         [:& input-row {:label "Value"
                        :class "pixels"
                        :min "0"

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -37,6 +37,9 @@
     ""
     (ust/format-precision value 2)))
 
+(defn select-all [event]
+  (dom/select-text! (dom/get-target event)))
+
 (defn- get-next-font
   [{:keys [id] :as current} fonts]
   (if (seq fonts)
@@ -340,6 +343,7 @@
 
 
      [:div.row-flex
+      {:on-focus select-all}
       (let [size-options [8 9 10 11 12 14 16 18 24 36 48 72]
             size-options (if (= font-size :multiple) (into [""] size-options) size-options)]
         [:& editable-select
@@ -390,6 +394,7 @@
         :value (attr->string line-height)
         :placeholder (tr "settings.multiple")
         :on-change #(handle-change % :line-height)
+        :on-focus select-all
         :on-blur on-blur}]]
 
      [:div.input-icon
@@ -403,6 +408,7 @@
         :value (attr->string letter-spacing)
         :placeholder (tr "settings.multiple")
         :on-change #(handle-change % :letter-spacing)
+        :on-focus select-all
         :on-blur on-blur}]]]))
 
 (mf/defc text-transform-options


### PR DESCRIPTION
:tada: Add feature to select full values on click at the design sidebar #2520 

* On clicking a numeric box on the right sidebar (design properties), the whole value will get selected so those values can be easily overwritten
* Feature added to Typography fields(Font size, line height and letter spacing)
* Feature added to Blur value as well
