### PR TITLE
:tada: Add feature to set line-height to auto as 1.2

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -378,10 +378,7 @@
 
         handle-change
         (fn [value attr]
-          (let [new-values (case attr
-                            :line-height (assoc values :line-height (if (or (str/empty? value) (nil? value)) 1.2 value))
-                            :spacing-options (assoc values :letter-spacing value))]
-            (on-change new-values)))]
+          (on-change {attr (str value)}))]
 
     [:div.spacing-options
      [:div.input-icon
@@ -392,6 +389,7 @@
        {:min -200
         :max 200
         :step 0.1
+        :default "1.2"
         :value (attr->string line-height)
         :placeholder (tr "settings.multiple")
         :nillable line-height-nillable

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -374,9 +374,14 @@
         line-height (or line-height "1.2")
         letter-spacing (or letter-spacing "0")
 
+        line-height-nillable (if (= (str line-height) "1.2") false true)
+
         handle-change
         (fn [value attr]
-          (on-change {attr (str value)}))]
+          (let [new-values (case attr
+                            :line-height (assoc values :line-height (if (or (str/empty? value) (nil? value)) 1.2 value))
+                            :spacing-options (assoc values :letter-spacing value))]
+            (on-change new-values)))]
 
     [:div.spacing-options
      [:div.input-icon
@@ -389,6 +394,7 @@
         :step 0.1
         :value (attr->string line-height)
         :placeholder (tr "settings.multiple")
+        :nillable line-height-nillable
         :on-change #(handle-change % :line-height)
         :on-blur on-blur}]]
 


### PR DESCRIPTION
:tada: Add feature to set line-height to auto as 1.2 #2518 

* With this feature, deleting the value at the line height will leave it with the value "1.2"
* Hence, the value that will be applied and shown at the handoff is "line-height: 1.2"
