### PR TITLE
Superalex bugfixing 11

### DIFF
--- a/frontend/src/app/main/data/workspace/svg_upload.cljs
+++ b/frontend/src/app/main/data/workspace/svg_upload.cljs
@@ -100,13 +100,13 @@
       (-> (update :svg-attrs dissoc :fill-opacity)
           (update-in [:svg-attrs :style] dissoc :fill-opacity)
           (assoc-in [:fills 0 :fill-opacity] (-> (get-in shape [:svg-attrs :fill-opacity])
-                                                 (d/parse-double))))
+                                                 (d/parse-double 1))))
 
       (get-in shape [:svg-attrs :style :fill-opacity])
       (-> (update-in [:svg-attrs :style] dissoc :fill-opacity)
           (update :svg-attrs dissoc :fill-opacity)
           (assoc-in [:fills 0 :fill-opacity] (-> (get-in shape [:svg-attrs :style :fill-opacity])
-                                                 (d/parse-double)))))))
+                                                 (d/parse-double 1)))))))
 
 (defn setup-stroke [shape]
   (let [stroke-linecap (-> (or (get-in shape [:svg-attrs :stroke-linecap])

--- a/frontend/src/app/util/text_svg_position.cljs
+++ b/frontend/src/app/util/text_svg_position.cljs
@@ -90,27 +90,26 @@
   [shape-id]
   (when (some? shape-id)
     (p/let [text-data (calc-text-node-positions shape-id)]
-      (when (d/not-empty? text-data)
-        (->> text-data
-             (mapv (fn [{:keys [node position text direction]}]
-                     (let [{:keys [x y width height]} position
-                           styles (js/getComputedStyle ^js node)
-                           get    (fn [prop]
-                                    (let [value (.getPropertyValue styles prop)]
-                                      (when (and value (not= value ""))
-                                        value)))]
-                       (d/without-nils
-                        {:x                   x
-                         :y                   (+ y height)
-                         :width               width
-                         :height              height
-                         :direction           direction
-                         :font-family         (str (get "font-family"))
-                         :font-size           (str (get "font-size"))
-                         :font-weight         (str (get "font-weight"))
-                         :text-transform      (str (get "text-transform"))
-                         :text-decoration     (str (get "text-decoration"))
-                         :letter-spacing      (str (get "letter-spacing"))
-                         :font-style          (str (get "font-style"))
-                         :fills               (transit/decode-str (get "--fills"))
-                         :text                text})))))))))
+      (->> text-data
+           (mapv (fn [{:keys [node position text direction]}]
+                   (let [{:keys [x y width height]} position
+                         styles (js/getComputedStyle ^js node)
+                         get    (fn [prop]
+                                  (let [value (.getPropertyValue styles prop)]
+                                    (when (and value (not= value ""))
+                                      value)))]
+                     (d/without-nils
+                       {:x                   x
+                        :y                   (+ y height)
+                        :width               width
+                        :height              height
+                        :direction           direction
+                        :font-family         (str (get "font-family"))
+                        :font-size           (str (get "font-size"))
+                        :font-weight         (str (get "font-weight"))
+                        :text-transform      (str (get "text-transform"))
+                        :text-decoration     (str (get "text-decoration"))
+                        :letter-spacing      (str (get "letter-spacing"))
+                        :font-style          (str (get "font-style"))
+                        :fills               (transit/decode-str (get "--fills"))
+                        :text                text}))))))))


### PR DESCRIPTION
This MR fixes different situations related to svg imports:

![1](https://github.com/penpot/penpot/assets/1579633/1826209e-57d1-463f-b968-78c3a2f7f600)

Also makes the import process more resilient and the position-data in texts safer