### PR TITLE
:bug: Fix deactivation of show distances when alt-tab is used

### DIFF
--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -149,7 +149,7 @@
     (mf/use-effect
      (mf/deps focus-out)
      (fn []
-       (let [keys [(events/listen globals/document EventType.FOCUSOUT focus-out)]]
+       (let [keys [(events/listen globals/window EventType.BLUR focus-out)]]
          #(doseq [key keys]
             (events/unlistenByKey key)))))
 

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -239,7 +239,7 @@
 
         first-selected-shape (first selected-shapes)
         selecting-first-level-frame? (and one-selected-shape?
-                                       (cph/root-frame? first-selected-shape))
+                                          (cph/root-frame? first-selected-shape))
 
         offset-x (if selecting-first-level-frame?
                    (:x first-selected-shape)
@@ -591,5 +591,4 @@
          [:& grid-layout/editor
           {:zoom zoom
            :objects base-objects
-           :shape (get base-objects edition)}])
-       ]]]))
+           :shape (get base-objects edition)}])]]]))

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -173,8 +173,7 @@
              (->> move-stream
                   (rx/tap #(reset! last-point-ref %))
                   ;; When transforming shapes we stop querying the worker
-                  (rx/merge-map query-point)
-                  ))))]
+                  (rx/merge-map query-point)))))]
 
     ;; Refresh the refs on a value change
     (mf/use-effect


### PR DESCRIPTION
Alt key with a shape selected activates show-distances mode.

If you press Alt+tab, in many window managers the window is switched, and thus the alt keydown event is sent to other app and does not reach Penpot. So, we need to deactivate the mode also on window blur.