### PR TITLE
:tada: Add feature to open project name in new tab from workspace

### DIFF
--- a/frontend/src/app/main/ui/workspace/header.cljs
+++ b/frontend/src/app/main/ui/workspace/header.cljs
@@ -248,8 +248,9 @@
      [:div.btn-icon-dark.btn-small {:on-click #(reset! show-menu? true)} i/actions]
      [:div.project-tree {:alt (tr "workspace.sitemap")}
       [:span.project-name
-       {:on-click #(st/emit! (rt/navigate :dashboard-files {:team-id team-id
-                                                            :project-id (:project-id file)}))}
+       {:on-click #(st/emit! (rt/nav-new-window* {:rname :dashboard-files
+                                                  :path-params {:team-id team-id
+                                                                :project-id (:project-id file)}}))}
        (:name project) " /"]
       (if @editing?
         [:input.file-name


### PR DESCRIPTION
:tada: Add feature to open project name in new tab from workspace #2568 

* With this feature, when a user clicks on Project Name in the workspace header, the list of files in that particular project and team will now be opened in a new tab