### PR TITLE
:recycle: Refactor svg to data-uri code

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/pixel_overlay.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/pixel_overlay.cljs
@@ -7,7 +7,6 @@
 (ns app.main.ui.workspace.viewport.pixel-overlay
   (:require
    [app.common.data :as d]
-   [app.common.data.macros :as dm]
    [app.common.pages.helpers :as cph]
    [app.common.uuid :as uuid]
    [app.main.data.modal :as modal]
@@ -50,13 +49,7 @@
   [svg]
   (let [svg-clone (.cloneNode svg true)]
     (->> (resolve-svg-images! svg-clone)
-         (rx/map (fn [_]
-                   (let [xml (-> (js/XMLSerializer.)
-                                 (.serializeToString ^js svg-clone)
-                                 (js/encodeURIComponent)
-                                 (js/unescape)
-                                 (js/btoa))]
-                     (dm/str "data:image/svg+xml;base64," xml)))))))
+         (rx/map (fn [_] (dom/svg-node->data-uri svg-clone))))))
 
 (defn format-viewbox [vbox]
   (str/join " " [(:x vbox 0)

--- a/frontend/src/app/util/dom.cljs
+++ b/frontend/src/app/util/dom.cljs
@@ -410,14 +410,19 @@
     (->  (js/XMLSerializer.)
          (.serializeToString node))))
 
-(defn svg->data-uri
-  [svg]
-  (assert (string? svg))
-  (let [b64 (-> svg
-                js/encodeURIComponent
-                js/unescape
+(defn str->data-uri
+  [str type]
+  (assert (string? str))
+  (let [b64 (-> str
                 js/btoa)]
-    (dm/str "data:image/svg+xml;base64," b64)))
+    (dm/str "data:" type ";base64," b64)))
+
+(defn svg-node->data-uri
+  [svg-node]
+  (let [xml  (-> (js/XMLSerializer.)
+                 (.serializeToString svg-node))
+        data-uri (str->data-uri xml "image/svg+xml")]
+    data-uri))
 
 (defn set-property! [^js node property value]
   (when (some? node)


### PR DESCRIPTION
Removes an unnecessary step that encodes text using `encodeURIComponent` and then decodes it using `unescape` (obsolete).

### How to test

1. Change background color with the color picker tool.
2. <canvas> image of the color picker dialog should be rendered without problems.
