### PR TITLE
:bug: Distribute fix enabled when two elements were selected

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1014,7 +1014,7 @@
 (defn can-distribute? [selected]
   (cond
     (empty? selected) false
-    (< (count selected) 2) false
+    (< (count selected) 3) false
     :else true))
 
 (defn distribute-objects


### PR DESCRIPTION
The distribute operations only make sense when there are at least 3 selected elements. Unlike the alignment ones which indeed should be enabled if there are at least two elements selected.

Current behavior:

![image](https://github.com/penpot/penpot/assets/843498/338121d4-822c-4b47-b88f-6659a5dc2943)

Expected (patch) behavior:

![image](https://github.com/penpot/penpot/assets/843498/6b059642-93eb-499f-8f4e-bcd1025ed112)
