### PR TITLE
:bug: Distribute vertical spacing failing for overlapped text

### DIFF
--- a/common/src/app/common/geom/align.cljc
+++ b/common/src/app/common/geom/align.cljc
@@ -69,11 +69,10 @@
   #{:horizontal :vertical})
 
 (defn distribute-space
-  "Distribute equally the space between shapes in the given axis. If
-  there is no space enough, it does nothing. It takes into account
-  the form of the shape and the rotation, what is distributed is
-  the wrapping rectangles of the shapes. If any shape is a group,
-  move also all of its recursive children."
+  "Distribute equally the space between shapes in the given axis.
+  It takes into account the form of the shape and the rotation,
+  what is distributed is the wrapping rectangles of the shapes.
+  If any shape is a group, move also all of its recursive children."
   [shapes axis objects]
   (let [coord (if (= axis :horizontal) :x :y)
         other-coord (if (= axis :horizontal) :y :x)
@@ -87,28 +86,26 @@
         ; The total space between shapes
         space (reduce - (size wrapper-rect) (map size wrapped-shapes))]
 
-    (if (<= space 0)
-      shapes
-      (let [unit-space (/ space (- (count wrapped-shapes) 1))
-            ; Calculate the distance we need to move each shape.
-            ; The new position of each one is the position of the
-            ; previous one plus its size plus the unit space.
-            deltas (loop [shapes' wrapped-shapes
-                          start-pos (coord wrapper-rect)
-                          deltas []]
+    (let [unit-space (/ space (- (count wrapped-shapes) 1))
+          ; Calculate the distance we need to move each shape.
+          ; The new position of each one is the position of the
+          ; previous one plus its size plus the unit space.
+          deltas (loop [shapes' wrapped-shapes
+                        start-pos (coord wrapper-rect)
+                        deltas []]
 
-                     (let [first-shape (first shapes')
-                           delta (- start-pos (coord first-shape))
-                           new-pos (+ start-pos (size first-shape) unit-space)]
+                    (let [first-shape (first shapes')
+                          delta (- start-pos (coord first-shape))
+                          new-pos (+ start-pos (size first-shape) unit-space)]
 
-                       (if (= (count shapes') 1)
-                         (conj deltas delta)
-                         (recur (rest shapes')
-                                new-pos
-                                (conj deltas delta)))))]
+                      (if (= (count shapes') 1)
+                        (conj deltas delta)
+                        (recur (rest shapes')
+                              new-pos
+                              (conj deltas delta)))))]
 
         (mapcat #(recursive-move %1 {coord %2 other-coord 0} objects)
-                sorted-shapes deltas)))))
+                sorted-shapes deltas))))
 
 ;; Adjust to viewport
 


### PR DESCRIPTION
The code was doing what it was designed to, however there is no reason to prevent elements with a bit of overlap to also be equally distributed.

Before:

![image](https://github.com/penpot/penpot/assets/843498/e4967b51-a20d-4f20-be48-da3a5783b738)

Expected (patch):

![image](https://github.com/penpot/penpot/assets/843498/6686a65b-a0ac-4328-b53f-f7881e14aa58)

closes #3141