### PR TITLE
:bug: Fix add flow option in contextual menu for frames

### DIFF
--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -349,7 +349,7 @@
 (mf/defc context-menu-prototype
   [{:keys [shapes]}]
   (let [options         (mf/deref refs/workspace-page-options)
-        options-mode    (mf/deref refs/options-mode)
+        options-mode    (mf/deref refs/options-mode-global)
         do-add-flow     #(st/emit! (dwi/add-flow-selected-frame))
         do-remove-flow  #(st/emit! (dwi/remove-flow (:id %)))
         flows           (:flows options)


### PR DESCRIPTION
This option disappeared in a previous refactor

![1](https://github.com/penpot/penpot/assets/1579633/70f5fb4c-dc99-4139-bfe1-68d984bc6b8e)
