### PR TITLE
:bug: Fix shortcuts translation error

### DIFF
--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -356,12 +356,14 @@
    :toggle-grid          {:tooltip (ds/meta "'")
                           ;;https://github.com/ccampbell/mousetrap/issues/85
                           :command [(ds/c-mod "'") (ds/c-mod "219")]
+                          :show-command (ds/c-mod "'")
                           :subsections [:main-menu]
                           :fn #(st/emit! (toggle-layout-flag :display-grid))}
 
    :toggle-snap-grid     {:tooltip (ds/meta-shift "'")
                           ;;https://github.com/ccampbell/mousetrap/issues/85
                           :command [(ds/c-mod "shift+'") (ds/c-mod "shift+219")]
+                          :show-command (ds/c-mod "shift+'")
                           :subsections [:main-menu]
                           :fn #(st/emit! (toggle-layout-flag :snap-grid))}
 

--- a/frontend/src/app/main/data/workspace/text/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/text/shortcuts.cljs
@@ -202,24 +202,24 @@
         (st/emit! (dwu/commit-undo-transaction undo-id)))))
 
 (def shortcuts
-  {:text-align-left    {:tooltip (ds/meta (ds/alt "l"))
+  {:text-align-left    {:tooltip (ds/meta (ds/alt "L"))
                         :command (ds/c-mod "alt+l")
                         :subsections [:text-editor]
                         :fn #(update-attrs-when-no-readonly {:text-align "left"})}
-   :text-align-right   {:tooltip (ds/meta (ds/alt "r"))
+   :text-align-right   {:tooltip (ds/meta (ds/alt "R"))
                         :command (ds/c-mod "alt+r")
                         :subsections [:text-editor]
                         :fn #(update-attrs-when-no-readonly {:text-align "right"})}
-   :text-align-center  {:tooltip (ds/meta (ds/alt "t"))
+   :text-align-center  {:tooltip (ds/meta (ds/alt "T"))
                         :command (ds/c-mod "alt+t")
                         :subsections [:text-editor]
                         :fn #(update-attrs-when-no-readonly {:text-align "center"})}
-   :text-align-justify {:tooltip (ds/meta (ds/alt "j"))
+   :text-align-justify {:tooltip (ds/meta (ds/alt "J"))
                         :command (ds/c-mod "alt+j")
                         :subsections [:text-editor]
                         :fn #(update-attrs-when-no-readonly {:text-align "justify"})}
 
-   :underline     {:tooltip (ds/meta "u")
+   :underline     {:tooltip (ds/meta "U")
                    :command (ds/c-mod "u")
                    :subsections [:text-editor]
                    :fn #(update-attrs-when-no-readonly {:text-decoration "toggle-underline"})}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -35,22 +35,22 @@
     ;; --- Align
     [:div.align-icons
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.align-left" (sc/get-tooltip :text-align-left))
+      {:alt (tr "workspace.options.text-options.text-align-left" (sc/get-tooltip :text-align-left))
        :class (dom/classnames :current (= "left" text-align))
        :on-click #(handle-change % "left")}
       i/text-align-left]
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.align-center" (sc/get-tooltip :text-align-center))
+      {:alt (tr "workspace.options.text-options.text-align-center" (sc/get-tooltip :text-align-center))
        :class (dom/classnames :current (= "center" text-align))
        :on-click #(handle-change % "center")}
       i/text-align-center]
      [:span.tooltip.tooltip-bottom
-      {:alt (tr "workspace.options.text-options.align-right" (sc/get-tooltip :text-align-right))
+      {:alt (tr "workspace.options.text-options.text-align-right" (sc/get-tooltip :text-align-right))
        :class (dom/classnames :current (= "right" text-align))
        :on-click #(handle-change % "right")}
       i/text-align-right]
      [:span.tooltip.tooltip-bottom
-      {:alt (tr  "workspace.options.text-options.align-justify" (sc/get-tooltip :text-align-justify))
+      {:alt (tr "workspace.options.text-options.text-align-justify" (sc/get-tooltip :text-align-justify))
        :class (dom/classnames :current (= "justify" text-align))
        :on-click #(handle-change % "justify")}
       i/text-align-justify]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -168,6 +168,10 @@
   ;;   shortcuts.start-editing
   ;;   shortcuts.start-measure
   ;;   shortcuts.stop-measure
+  ;;   shortcuts.text-align-center
+  ;;   shortcuts.text-align-left
+  ;;   shortcuts.text-align-justify
+  ;;   shortcuts.text-align-right
   ;;   shortcuts.thumbnail-set
   ;;   shortcuts.toggle-alignment
   ;;   shortcuts.toggle-assets
@@ -276,7 +280,7 @@
        (for [command-translate sorted-filtered]
          (let [sc-by-translate  (first (filter #(= (:translation (second %)) command-translate) elements))
                [command  comand-info] sc-by-translate
-               content                (:command comand-info)]
+               content                (or (:show-command comand-info)(:command comand-info))]
            [:li {:class (css :shortcuts-name)
                  :key command-translate}
             [:span {:class (css :command-name)}
@@ -288,7 +292,7 @@
        (for [command-translate sorted-filtered]
          (let [sc-by-translate  (first (filter #(= (:translation (second %)) command-translate) elements))
                [command  comand-info] sc-by-translate
-               content                (:command comand-info)]
+               content                (or (:show-command comand-info) (:command comand-info))]
            [:li.shortcut-name {:key command-translate}
             [:span.command-name command-translate]
             [:& shortcuts-keys {:content content

--- a/frontend/translations/ca.po
+++ b/frontend/translations/ca.po
@@ -3619,23 +3619,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Alinea a baix"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Alinea el centre"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Alinea el centre (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justifica (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Alinea a l'esquerra (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinea al centre (%s)"
+msgstr "Alinea al centre"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Alinea a la dreta (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -3684,23 +3684,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Zarovnat dolů"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Zarovnat doprostřed"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Zarovnat doprostřed (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Zarovnat (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Zarovnat vlevo (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Zarovnat na střed (%s)"
+msgstr "Zarovnat na střed"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Zarovnat vpravo (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -4056,23 +4056,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Unten ausrichten"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Zentrieren"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Zentrieren (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Ausrichtung in der Breite (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Linksbündig ausrichten (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "An Mitte ausrichten (%s)"
+msgstr "An Mitte ausrichten"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Rechtsbündig ausrichten (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/el.po
+++ b/frontend/translations/el.po
@@ -1792,23 +1792,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Στοίχιση κάτω"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Ευθυγράμμιση κέντρο"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Ευθυγράμμιση κέντρο (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Δικαιολόγηση (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Στοίχιση αριστερά (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Στοίχιση στο κέντρο (%s)"
+msgstr "Στοίχιση στο κέντρο"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Για ευθυγράμμιση προς τα δεξιά (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2691,6 +2691,18 @@ msgstr "Start measurement"
 msgid "shortcuts.stop-measure"
 msgstr "Stop measurement"
 
+msgid "shortcuts.text-align-center"
+msgstr "Align center"
+
+msgid "shortcuts.text-align-left"
+msgstr "Align left"
+
+msgid "shortcuts.text-align-justify"
+msgstr "Align justify"
+
+msgid "shortcuts.text-align-right"
+msgstr "Align right"
+
 msgid "shortcuts.thumbnail-set"
 msgstr "Set thumbnails"
 
@@ -2775,6 +2787,9 @@ msgstr "Zoom lense increase"
 
 msgid "shortcuts.zoom-selected"
 msgstr "Zoom to selected"
+
+
+
 
 #: src/app/main/ui/dashboard/files.cljs
 msgid "title.dashboard.files"
@@ -4169,23 +4184,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Align bottom"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Align center"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Align center (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justify (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Align left (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Align middle (%s)"
+msgstr "Align middle"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Align right (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2768,6 +2768,18 @@ msgstr "Terminar medida"
 msgid "shortcuts.thumbnail-set"
 msgstr "Activar miniaturas"
 
+msgid "shortcuts.text-align-center"
+msgstr "Alinear al centro"
+
+msgid "shortcuts.text-align-left"
+msgstr "Alinear a la izquierda"
+
+msgid "shortcuts.text-align-justify"
+msgstr "Alinear justificado"
+
+msgid "shortcuts.text-align-right"
+msgstr "Alinear a la derecha"
+
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs
 msgid "shortcuts.title"
 msgstr "Atajos de teclado"
@@ -4273,23 +4285,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Alinear abajo"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Aliniear al centro"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Alinear al centro (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justificar (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Alinear a la izquierda (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinear al centro (%s)"
+msgstr "Alinear al centro"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Alinear a la derecha (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/eu.po
+++ b/frontend/translations/eu.po
@@ -3796,23 +3796,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Lerrokatu behean"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Lerrokatu erdian"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Lerrokatu erdian (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justifikatu (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Lerrokatu ezkerrean (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Lerrokatu erdian (%s)"
+msgstr "Lerrokatu erdian"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Lerrokatu eskuman (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/fa.po
+++ b/frontend/translations/fa.po
@@ -2575,19 +2575,19 @@ msgstr "تراز پایین"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 #, fuzzy
-msgid "workspace.options.text-options.align-center"
-msgstr "تراز در مرکز"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "تراز در مرکز (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "تراز چپ (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "تراز وسط (%s)"
+msgstr "تراز وسط"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "تراز راست (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -3594,23 +3594,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Aligner en bas"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Aligner au centre"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Aligner au centre (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justifier (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Aligner à gauche (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Aligner verticalement au milieu (%s)"
+msgstr "Aligner verticalement au milieu"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Aligner à droite (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -3991,23 +3991,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "יישור לתחתית"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "יישור למרכז"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "יישור למרכז (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "יישור לשני הצדדים (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "יישור שמאלה (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "יישור לאמצע (%s)"
+msgstr "יישור לאמצע"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "יישור ימינה (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/hr.po
+++ b/frontend/translations/hr.po
@@ -3807,24 +3807,24 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Poravnaj dno"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Poravnaj sredinu"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Poravnaj sredinu (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 #, fuzzy
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Složi u blok (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Poravnaj lijevo (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Poravnaj sredinu (%s)"
+msgstr "Poravnaj sredinu"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Poravnaj desno (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -3939,23 +3939,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Paskan ke bawah"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Paskan ke tengah"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Paskan ke tengah (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Rata Kiri Kanan (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Paskan ke kiri (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Paskan ke tengah (%s)"
+msgstr "Paskan ke tengah"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Paskan ke kanan (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -3974,24 +3974,24 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Līdzināt lejā"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Līdzināt uz centru"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Līdzināt uz centru (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
-msgstr "Izlīdzināt"
+msgid "workspace.options.text-options.text-align-justify"
+msgstr "Izlīdzināt (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
-msgstr "Līdzināt pa kreisi"
+msgid "workspace.options.text-options.text-align-left"
+msgstr "Līdzināt pa kreisi (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
 msgstr "Līdzināt pa vidu"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
-msgstr "Līdzināt pa labi"
+msgid "workspace.options.text-options.text-align-right"
+msgstr "Līdzināt pa labi (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-top"

--- a/frontend/translations/pl.po
+++ b/frontend/translations/pl.po
@@ -4003,23 +4003,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Wyrównaj do dołu"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Wyrównaj do środka"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Wyrównaj do środka (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Wyjustuj (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Wyrównaj do lewej (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Wyrównaj do środka (%s)"
+msgstr "Wyrównaj do środka"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Wyrównaj do prawej (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/pt_BR.po
+++ b/frontend/translations/pt_BR.po
@@ -3943,23 +3943,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Alinhar a base"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Alinhar ao centro"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Alinhar ao centro (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justificar (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Alinhar a esquerda (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinhar no meio (%s)"
+msgstr "Alinhar no meio"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Alinhar a direita (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -3793,23 +3793,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Alinhar abaixo"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Alinhar ao centro"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Alinhar ao centro (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justificar (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Alinhar à esquerda (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Alinhar ao meio (%s)"
+msgstr "Alinhar ao meio"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Alinhar à direita (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -3966,23 +3966,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Aliniază jos"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Aliniază centru"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Aliniază centru (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Justifică (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Aliniază la stânga (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Aliniază la mijloc (%s)"
+msgstr "Aliniază la mijloc"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Aliniază la dreapta (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/ru.po
+++ b/frontend/translations/ru.po
@@ -2647,23 +2647,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Выровнять низ"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Выравнивание по центру"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Выравнивание по центру (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "Выравнивание по ширине (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Выравнивание по левому краю (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Выравнивание по центру (%s)"
+msgstr "Выравнивание по центру"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Выравнивание по правому краю (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -4120,23 +4120,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "Alta hizala"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "Ortaya hizala"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "Ortaya hizala (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "İki yana yasla (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "Sola hizala (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "Merkeze hizala (%s)"
+msgstr "Merkeze hizala"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "Sağa hizala (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -3827,23 +3827,23 @@ msgid "workspace.options.text-options.align-bottom"
 msgstr "底部对齐"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "居中对齐"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "居中对齐 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-justify"
+msgid "workspace.options.text-options.text-align-justify"
 msgstr "整理 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-left"
+msgid "workspace.options.text-options.text-align-left"
 msgstr "靠左对齐 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.align-middle"
-msgstr "居中对齐 (%s)"
+msgstr "居中对齐"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-right"
+msgid "workspace.options.text-options.text-align-right"
 msgstr "靠右对齐 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs

--- a/frontend/translations/zh_Hant.po
+++ b/frontend/translations/zh_Hant.po
@@ -2117,8 +2117,8 @@ msgid "workspace.options.stroke.solid"
 msgstr "實線"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
-msgid "workspace.options.text-options.align-center"
-msgstr "置中"
+msgid "workspace.options.text-options.text-align-center"
+msgstr "置中 (%s)"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.options.text-options.direction-ltr"


### PR DESCRIPTION
This PR solve two errors:
Those translations have been added
![Screenshot from 2023-06-15 08-01-25](https://github.com/penpot/penpot/assets/48989967/f439becf-78fb-4a8f-b26e-98a2770402d2)
And those "219" have been deleted
![Screenshot from 2023-06-14 12-29-09](https://github.com/penpot/penpot/assets/48989967/1299fc11-3a3e-440b-a2a3-a9ac56d1d09d)
