### PR TITLE
:bug: Fix touched on adding shapes to a component copy and undo

### DIFF
--- a/common/src/app/common/types/shape_tree.cljc
+++ b/common/src/app/common/types/shape_tree.cljc
@@ -39,9 +39,7 @@
           (-> parent
               (update :shapes update-parent-shapes)
               (update :shapes d/vec-without-nils)
-              (cond-> (and (:shape-ref parent)
-                           (not= (:id parent) frame-id)
-                           (not ignore-touched))
+              (cond-> (and (ctk/in-component-copy? parent) (not ignore-touched))
                 (-> (update :touched cph/set-touched-group :shapes-group)
                     (dissoc :remote-synced?)))))
 

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -487,7 +487,8 @@
       (let [page      (wsh/lookup-page state)
             libraries (wsh/get-libraries state)
 
-            changes   (pcb/empty-changes it (:id page))
+            changes   (-> (pcb/empty-changes it (:id page))
+                          (pcb/with-objects (:objects page)))
 
             [new-shape changes]
             (dwlh/generate-instantiate-component changes

--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -228,6 +228,7 @@
                         (assoc :parent-id parent-id))
          changes      (-> (or changes (pcb/empty-changes it))
                           (pcb/with-page page)
+                          (pcb/with-objects (:objects page))
                           (pcb/with-library-data library-data))
          changes      (cond-> (pcb/add-object changes first-shape {:ignore-touched true})
                         (some? old-id) (pcb/amend-last-change #(assoc % :old-id old-id))) ; on copy/paste old id is used later to reorder the paster layers

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -433,7 +433,7 @@
                            (gsh/move delta)
                            (d/update-when :interactions #(ctsi/remap-interactions % ids-map objects)))
 
-           changes (-> (pcb/add-object changes new-obj {:ignore-touched true})
+           changes (-> (pcb/add-object changes new-obj)
                        (pcb/amend-last-change #(assoc % :old-id (:id obj))))
 
            changes (cond-> changes

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -108,7 +108,8 @@
              objects  (wsh/lookup-page-objects state page-id)
              selected (wsh/lookup-selected state)
 
-             changes  (pcb/empty-changes it page-id)
+             changes  (-> (pcb/empty-changes it page-id)
+                          (pcb/with-objects objects))
 
              [shape changes]
              (prepare-add-shape changes attrs objects selected)
@@ -433,7 +434,8 @@
              selected (wsh/lookup-selected state)
              selected (cph/clean-loops objects selected)
 
-             changes  (pcb/empty-changes it page-id)
+             changes  (-> (pcb/empty-changes it page-id)
+                          (pcb/with-objects objects))
 
              [frame-shape changes]
              (prepare-create-artboard-from-selection changes

--- a/frontend/test/frontend_tests/helpers/pages.cljs
+++ b/frontend/test/frontend_tests/helpers/pages.cljs
@@ -154,7 +154,8 @@
    (let [page      (current-page state)
          libraries (wsh/get-libraries state)
 
-         changes   (pcb/empty-changes nil (:id page))
+         changes   (-> (pcb/empty-changes nil (:id page))
+                       (pcb/with-objects (:objects page)))
 
          [new-shape changes]
          (dwlh/generate-instantiate-component changes


### PR DESCRIPTION
Fixes "Si copio y pego una shape en una copia, no se marca como modificada. Así que cualquier cambio en el componente original borra la shape que hubieras pegado"

and some other cases