### PR TITLE
:bug: Fix SVG text rendering on thumbnails

### DIFF
--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -40,7 +40,7 @@
                      (rx/take 1))]
     ;; renders #svg image
     (if (some? node)
-      (->> (rx/from (js/createImageBitmap node))
+      (->> (rx/from (wapi/create-image-bitmap-with-workaround node))
            (rx/switch-map  #(uw/ask! {:cmd :thumbnails/render-offscreen-canvas} %))
            (rx/map :result))
 

--- a/frontend/src/app/main/ui/workspace/shapes/frame/thumbnail_render.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame/thumbnail_render.cljs
@@ -9,7 +9,6 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.geom.shapes :as gsh]
-   [app.common.math :as mth]
    [app.config :as cf]
    [app.main.data.workspace.thumbnails :as dwt]
    [app.main.refs :as refs]
@@ -17,6 +16,7 @@
    [app.main.ui.hooks :as hooks]
    [app.main.ui.shapes.frame :as frame]
    [app.util.dom :as dom]
+   [app.util.thumbnails :as th]
    [app.util.timers :as ts]
    [app.util.webapi :as wapi]
    [beicon.core :as rx]
@@ -41,16 +41,11 @@
   [rect node style-node]
   (let [{:keys [x y width height]} rect
         viewbox (dm/str x " " y " " width " " height)
-        
+
         ;; Calculate the fixed width and height
-        ;; We don't want to generate thumbnails 
+        ;; We don't want to generate thumbnails
         ;; bigger than 2000px
-        [fixed-width fixed-height]
-        (if (> width height)
-          [(mth/clamp width 250 2000)
-           (/ (* height (mth/clamp width 250 2000)) width)]
-          [(/ (* width (mth/clamp height 250 2000)) height)
-           (mth/clamp height 250 2000)])
+        [fixed-width fixed-height] (th/get-proportional-size width height)
 
         ;; This is way faster than creating a node
         ;; through the DOM API

--- a/frontend/src/app/util/thumbnails.cljs
+++ b/frontend/src/app/util/thumbnails.cljs
@@ -1,0 +1,29 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.util.thumbnails
+  (:require
+   [app.common.math :as mth]))
+
+(def ^:const min-size 250)
+(def ^:const max-size 2000)
+
+(defn get-proportional-size
+  "Returns a proportional size given a width and height and some size constraints."
+  ([width height]
+   (get-proportional-size width height min-size max-size min-size max-size))
+  ([width height min-size max-size]
+   (get-proportional-size width height min-size max-size min-size max-size))
+  ([width height min-width max-width min-height max-height]
+   (let [[fixed-width fixed-height]
+          (if (> width height)
+            [(mth/clamp width min-width max-width)
+             (/ (* height (mth/clamp width min-width max-width)) width)]
+            [(/ (* width (mth/clamp height min-height max-height)) height)
+             (mth/clamp height min-height max-height)])]
+      [fixed-width fixed-height])))
+
+


### PR DESCRIPTION
## Problem

![Screenshot from 2023-07-10 17-25-07](https://github.com/penpot/penpot/assets/478699/b4216933-9ab0-46f3-ba8d-77c6c8f27888)

SVG -> Image -> ImageBitmap doesn't renders text properly when the SVG has a transparent background.

Chromium Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1463435

## Solution:

The problem seems to be on the SVG -> Image -> ImageBitmap renderer part (maybe because it premultiplies alpha on each step?) so if we render first the Image to a OffscreenCanvas/Canvas, the problem disappears and we can still use ImageBitmap.

Taiga Issue: [Taiga #5589](https://tree.taiga.io/project/penpot/issue/5589)