### PR TITLE
:bug: Fix previous thumbnail rendered

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/frame/thumbnail_render.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame/thumbnail_render.cljs
@@ -149,6 +149,8 @@
                    loading-fonts?  (some? (dom/query (dm/str "#frame-container-" id " > style[data-loading='true']")))]
                (when (and (not loading-images?)
                           (not loading-fonts?))
+                 (reset! svg-uri* nil)
+                 (reset! bitmap-uri* nil)
                  (generate-thumbnail)
                  (reset! regenerate* false))))))
 


### PR DESCRIPTION
When thumbnail are regenerated and frame doesn't have a fill, the previous thumbnail is shown for a brief moment before being regenerated.