### PR TITLE
:bug: Fix incorrect style for asset libraries titles

### DIFF
--- a/frontend/resources/styles/main/partials/sidebar.scss
+++ b/frontend/resources/styles/main/partials/sidebar.scss
@@ -85,6 +85,15 @@
           }
         }
 
+        span.library-title {
+          color: $color-gray-10;
+          font-size: $fs14;
+          max-width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
         .tool-window-bar-icon {
           height: 21px;
           display: flex;

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -2100,11 +2100,11 @@
 
      (if local?
        [:*
-        [:span file-name " (" (tr "workspace.assets.local-library") ")"]
+        [:span.library-title file-name " (" (tr "workspace.assets.local-library") ")"]
         (when shared?
           [:span.tool-badge (tr "workspace.assets.shared")])]
        [:*
-        [:span file-name]
+        [:span.library-title file-name]
         [:span.tool-link.tooltip.tooltip-left {:alt "Open library file"}
          [:a {:href (str "#" url)
               :target "_blank"


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/5626