### PR TITLE
:bug: Fix when component has a long name then its icon and '3 dots' m…

### DIFF
--- a/frontend/resources/styles/main/partials/sidebar-element-options.scss
+++ b/frontend/resources/styles/main/partials/sidebar-element-options.scss
@@ -555,6 +555,12 @@
     margin-right: $size-2;
   }
 
+  .component-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+  }
+
   .row-actions {
     margin-left: auto;
     cursor: pointer;

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -224,7 +224,7 @@
          (if main-instance?
            i/component
            i/component-copy)
-         shape-name
+         [:div.component-name shape-name]
          [:div.row-actions
           {:on-click on-menu-click}
           i/actions


### PR DESCRIPTION
…enu are not visible on Design tab

Fixes https://tree.taiga.io/project/penpot/issue/5393