### PR TITLE
:sparkles: Improve connection errors handling on workspace save operation

### DIFF
--- a/frontend/src/app/main/data/workspace/persistence.cljs
+++ b/frontend/src/app/main/data/workspace/persistence.cljs
@@ -182,11 +182,19 @@
 
                              (rx/of (shapes-changes-persisted-finished))))))
              (rx/catch (fn [cause]
-                         (rx/concat
-                          (if (= :authentication (:type cause))
-                            (rx/empty)
-                            (rx/of (rt/assign-exception cause)))
-                          (rx/throw cause)))))))))
+                         (cond
+                           (= :authentication (:type cause))
+                           (rx/throw cause)
+
+                           (instance? js/TypeError cause)
+                           (->> (rx/timer 2000)
+                                (rx/map (fn [_]
+                                          (persist-changes file-id file-revn changes pending-commits))))
+
+                           :else
+                           (rx/concat
+                            (rx/of (rt/assign-exception cause))
+                            (rx/throw cause))))))))))
 
 ;; Event to be thrown after the changes have been persisted
 (defn shapes-changes-persisted-finished

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -66,7 +66,8 @@
 
 (defmethod ptk/handle-error :default
   [error]
-  (ts/schedule #(st/emit! (rt/assign-exception (::instance error))))
+  (when-let [cause (::instance error)]
+    (ts/schedule #(st/emit! (rt/assign-exception cause))))
   (print-group! "Unhandled Error"
                 (fn []
                   (print-trace! error)

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -142,6 +142,7 @@
 
     (mf/with-effect [theme]
       (dom/set-html-theme-color theme))
+
     [:& (mf/provider ctx/current-route) {:value route}
      [:& (mf/provider ctx/current-profile) {:value profile}
       (if edata


### PR DESCRIPTION
How to test:
- Go to workspace
- Open devtools and set network to offline
- try to modify the file

Expected result:
the file will wait the connection for save instead of raising an exception