### PR TITLE
:bug: Fix thumbnail rendering flashing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@
 - Fix cannot undo layer styles [Taiga #5676](https://tree.taiga.io/project/penpot/issue/5676)
 - Fix unexpected exception on boolean shapes [Taiga #5685](https://tree.taiga.io/project/penpot/issue/5685)
 - Fix ctrl+z on select not working [Taiga #5677](https://tree.taiga.io/project/penpot/issue/5677)
+- Fix thubmnail rendering flashing [Taiga #5675](https://tree.taiga.io/project/penpot/issue/5675)
 
 ### :arrow_up: Deps updates
 

--- a/frontend/src/app/main/ui/workspace/shapes/frame/thumbnail_render.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame/thumbnail_render.cljs
@@ -96,7 +96,6 @@
         render-frame*     (mf/use-state (not thumbnail-uri))
         debug?            (debug? :thumbnails)
 
-
         on-bitmap-load
         (mf/use-fn
          (fn []
@@ -164,6 +163,8 @@
              (when (not= "false" (dom/get-data image-node "ready"))
                (dom/set-data! image-node "ready" "false")))
            (when-not ^boolean @disable*
+             (reset! svg-uri* nil)
+             (reset! bitmap-uri* nil)
              (reset! render-frame* true)
              (reset! regenerate* true))))
 


### PR DESCRIPTION
### How to reproduce it

1. Open file
2. Create a text (but it happens with any frame without fill)
3. Rotate or scale that element

### Expected behavior

Rotates/scales the element without showing previous "version".

Prevents thumbnail to render bitmap cached copy when modifying node.

[Taiga #5675](https://tree.taiga.io/project/penpot/issue/5675)