### PR TITLE
Fix layers scroll breaking new css system

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -173,7 +173,7 @@
             ;; NOTE: Neither get-parent-at nor get-parent-with-selector
             ;; work if the component template changes, so we need to
             ;; seek for an alternate solution. Maybe use-context?
-            scroll-node (dom/get-parent-with-selector node ".tool-window-content")
+            scroll-node (dom/get-parent-with-data node "scrollContainer")
             parent-node (dom/get-parent-at node 2)
 
             subid

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -506,7 +506,8 @@
        filter-component)
      (if (some? filtered-objects)
        [:*
-        [:div {:class (if new-css-system
+        [:div {:data-scroll-container true
+               :class (if new-css-system
                         (dom/classnames (css :tool-window-content) true)
                         (dom/classnames :tool-window-content true))
                :ref on-render-container  :key "filters"}
@@ -517,6 +518,7 @@
                      :key "lazy-load"
                      :style {:min-height 16}}]]
         [:div {:on-scroll on-scroll
+               :data-scroll-container true
                :class (if new-css-system
                         (dom/classnames (css :tool-window-content) true)
                         (dom/classnames :tool-window-content true))
@@ -526,6 +528,7 @@
                           :filtered? true
                           :parent-size size-parent}]]]
        [:div {:on-scroll on-scroll
+              :data-scroll-container true
               :class (if new-css-system
                        (dom/classnames (css :tool-window-content) true)
                        (dom/classnames :tool-window-content true))

--- a/frontend/src/app/util/dom.cljs
+++ b/frontend/src/app/util/dom.cljs
@@ -151,6 +151,13 @@
         current
         (recur (.-parentElement current) (dec current-count))))))
 
+(defn get-parent-with-data
+  [^js node name]
+  (loop [current node]
+    (if (or (nil? current) (obj/in? (.-dataset current) name))
+      current
+      (recur (.-parentElement current)))))
+
 (defn get-parent-with-selector
   [^js node selector]
   (loop [current node]


### PR DESCRIPTION
When using `features.new_css_system()` the new layer behavior throws an Internal Error.