### PR TITLE
:bug: Bug fixing

### DIFF
--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -353,9 +353,12 @@
           (-> state
               (assoc-in [:workspace-global :picking-color?] true)
               (assoc ::md/modal {:id (random-uuid)
-                                 :data {:color colors/black :opacity 1}
                                  :type :colorpicker
-                                 :props {:on-change handle-change-color}
+                                 :props {:data {:color colors/black
+                                                :opacity 1}
+                                         :disable-opacity false
+                                         :disable-gradient false
+                                         :on-change handle-change-color}
                                  :allow-click-outside true})))))))
 
 (defn color-att->text

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
@@ -319,7 +319,8 @@
          [:div.interactions-element.separator
           [:span.element-set-subtitle.wide (tr "workspace.options.interaction-trigger")]
           [:select.input-select
-           {:value (str (:event-type interaction))
+           {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+            :value (str (:event-type interaction))
             :on-change change-event-type}
            (for [[value name] (event-type-names)]
              (when-not (and (= value :after-delay)
@@ -342,7 +343,8 @@
          [:div.interactions-element.separator
           [:span.element-set-subtitle.wide (tr "workspace.options.interaction-action")]
           [:select.input-select
-           {:value (str (:action-type interaction))
+           {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+            :value (str (:action-type interaction))
             :on-change change-action-type}
            (for [[value name] (action-type-names)]
              [:option {:key (dm/str "action-" value)
@@ -353,7 +355,8 @@
            [:div.interactions-element
             [:span.element-set-subtitle.wide (tr "workspace.options.interaction-destination")]
             [:select.input-select
-             {:value (str (:destination interaction))
+             {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+              :value (str (:destination interaction))
               :on-change change-destination}
              (if (= (:action-type interaction) :close-overlay)
                [:option {:value ""} (tr "workspace.options.interaction-self")]
@@ -390,7 +393,8 @@
             [:div.interactions-element
              [:span.element-set-subtitle.wide (tr "workspace.options.interaction-relative-to")]
              [:select.input-select
-              {:value (str (:position-relative-to interaction))
+              {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+               :value (str (:position-relative-to interaction))
                :on-change change-position-relative-to}
               (when (not= (:overlay-pos-type interaction) :manual)
                 [:*
@@ -405,7 +409,8 @@
             [:div.interactions-element
              [:span.element-set-subtitle.wide (tr "workspace.options.interaction-position")]
              [:select.input-select
-              {:value (str (:overlay-pos-type interaction))
+              {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+               :value (str (:overlay-pos-type interaction))
                :on-change (partial change-overlay-pos-type (:id shape))}
               (for [[value name] (overlay-pos-type-names)]
                 [:option {:value (str value)} name])]]
@@ -467,7 +472,8 @@
              [:div.interactions-element.separator
               [:span.element-set-subtitle.wide (tr "workspace.options.interaction-animation")]
               [:select.input-select
-               {:value (str (-> interaction :animation :animation-type))
+               {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+                :value (str (-> interaction :animation :animation-type))
                 :on-change change-animation-type}
                [:option {:value ""} (tr "workspace.options.interaction-animation-none")]
                (for [[value name] (animation-type-names interaction)]
@@ -529,7 +535,8 @@
                [:div.interactions-element
                 [:span.element-set-subtitle.wide (tr "workspace.options.interaction-easing")]
                 [:select.input-select
-                 {:value (str (-> interaction :animation :easing))
+                 {:data-mousetrap-dont-stop true ;; makes mousetrap to not stop at this element
+                  :value (str (-> interaction :animation :easing))
                   :on-change change-easing}
                  (for [[value name] (easing-names)]
                    [:option {:value (str value)} name])]


### PR DESCRIPTION
[Issue #5552](https://tree.taiga.io/project/penpot/issue/5552)

### How to reproduce it

1. Open an empty file
2. Open assets
4. Open color palette (select File Library instead of recent colors)
5. Press 'I' key to open color picker
6. Select (File library instead of recent colors)
7. Click '+' in color picker to add current color (#000000)

### Expected behavior

Color should appear on Color assets and Color palette with name #000000.

### Issue

Color appeared in Colors (assets) with an empty name and didn't appear in the Color palette.

[Issue #5677](https://tree.taiga.io/project/penpot/issue/5677)

### How to reproduce it

1. Create two boards
2. Go to prototype tab
3. Link the two boards
4. Click 3 dots in interactions
5. Change any select value
6. Press Ctrl+Z

### Expected behavior

Previous value should be restored

### Issue

Nothing happens