### PR TITLE
:sparkles: Board grids are now synced with components

### DIFF
--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -63,6 +63,7 @@
    :constraints-v           :constraints-group
    :fixed-scroll            :constraints-group
    :exports                 :exports-group
+   :grids                   :grids-group
 
    :layout                  :layout-container
    :layout-align-content    :layout-container


### PR DESCRIPTION
Implements https://tree.taiga.io/project/penpot/issue/5363