### PR TITLE
:bug: Fix error on press escape while renamming a component

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -667,7 +667,7 @@
               (rx/of (update-shape shape-id {:name name})))
 
             ;; Update the component in case if shape is a main instance
-            (when (:main-instance shape)
+            (when (and (string? name) (not (str/blank? name)) (:main-instance shape))
               (when-let [component-id (:component-id shape)]
                 (rx/of (dwl/rename-component component-id name)))))))))))
 


### PR DESCRIPTION
How to test:
1. Create a component
2. Double click on the component on the layers tree
3. Press escape