### PR TITLE
:bug: Correctly initialize geometry when creating a new group

### DIFF
--- a/frontend/src/app/main/data/workspace/groups.cljs
+++ b/frontend/src/app/main/data/workspace/groups.cljs
@@ -91,6 +91,10 @@
                                     :name gname
                                     :shapes (mapv :id shapes)
                                     :selrect selrect
+                                    :x (:x selrect)
+                                    :y (:y selrect)
+                                    :width (:width selrect)
+                                    :height (:height selrect)
                                     :parent-id parent-id
                                     :frame-id frame-id
                                     :index group-idx})


### PR DESCRIPTION
This was the cause of new components not visible in asset tabs in components-v1, until resized.