### PR TITLE
:bug: Fix deleted pages comments shown in right sidebar

### DIFF
--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -279,8 +279,9 @@
                  (assoc-in (conj path :position) (:position comment-thread))
                  (assoc-in (conj path :frame-id) (:frame-id comment-thread))))))
            (fetched [[users comments] state]
-             (let [pages (get-in state [:workspace-data :pages-index])
-                   comments (filter #(some? (get pages (:page-id %))) comments)
+             (let [pages (-> (get-in state [:workspace-data :pages])
+                             set)
+                   comments (filter #(contains? pages (:page-id %)) comments)
                    state (-> state
                              (assoc :comment-threads (d/index-by :id comments))
                              (update :current-file-comments-users merge (d/index-by :id users)))]


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/5648

In the first implementation I was using pages-index but it's not enough when removing a page.