### PR TITLE
:sparkles: Remember last team accross logouts and sessions and fix some weird stuff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Remember last color mode in colorpicker [Taiga #5508](https://tree.taiga.io/project/penpot/issue/5508)
 - Improve layers multiselection behaviour [Github #5741](https://github.com/penpot/penpot/issues/5741)
+- Remember last active team across logouts / sessions [Github #3325](https://github.com/penpot/penpot/issues/3325)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -59,10 +59,11 @@
     ptk/WatchEvent
     (watch [_ state stream]
       (rx/merge
+       ;;fetch teams must be first in case the team doesn't exist
+       (ptk/watch (du/fetch-teams) state stream)
        (ptk/watch (df/load-team-fonts id) state stream)
        (ptk/watch (fetch-projects) state stream)
        (ptk/watch (fetch-team-members) state stream)
-       (ptk/watch (du/fetch-teams) state stream)
        (ptk/watch (du/fetch-users {:team-id id}) state stream)
 
        (let [stoper    (rx/filter (ptk/type? ::finalize) stream)

--- a/frontend/src/app/main/data/users.cljs
+++ b/frontend/src/app/main/data/users.cljs
@@ -125,7 +125,7 @@
   accepting invitation, or third party auth signup or singin."
   [profile]
   (letfn [(get-redirect-event []
-            (let [team-id (:default-team-id profile)
+            (let [team-id (get-current-team-id profile)
                   redirect-url (:redirect-url @storage)]
               (if (some? redirect-url)
                 (do
@@ -247,7 +247,9 @@
 
      ptk/EffectEvent
      (effect [_ _ _]
-       (reset! storage {})
+       ;; We prefer to keek some stuff in the storage like the current-team-id
+       (swap! storage dissoc :redirect-url)
+       (swap! storage dissoc :profile)
        (i18n/reset-locale)))))
 
 (defn logout

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -153,8 +153,10 @@
 
     (hooks/use-shortcuts ::dashboard sc/shortcuts)
 
-    (mf/with-effect [team-id]
-      (st/emit! (dd/initialize {:id team-id}))
+    (mf/with-effect [profile team-id]
+      (when profile
+        ;; When doing logout we must avoid reinitializing the dashboard
+        (st/emit! (dd/initialize {:id team-id})))
       (fn []
         (dd/finalize {:id team-id})))
 

--- a/frontend/src/app/main/ui/dashboard/templates.cljs
+++ b/frontend/src/app/main/ui/dashboard/templates.cljs
@@ -230,8 +230,8 @@
 
         ]
 
-    (mf/with-effect [collapsed]
-      (when-not collapsed
+    (mf/with-effect [profile collapsed]
+      (when (and profile (not collapsed))
         (st/emit! (dd/fetch-builtin-templates))))
 
     [:div.dashboard-templates-section


### PR DESCRIPTION
This PR fixes this: https://tree.taiga.io/project/penpot/issue/5507

It also fixes two more situations:
 - When you logout you have to login twice because of how penpot was managing the redirects and the dashboard initialization (on the logout there was an extra initialization with invalid authentication values)
 - If you change the team id for a non existing one you fall into a loop of redirections