### PR TITLE
:zap: Allow passing overrides to frontend nginx config

### DIFF
--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -50,6 +50,8 @@ http {
     proxy_cache_valid any 48h;
     proxy_cache_key "$host$request_uri";
 
+    include /etc/nginx/overrides.d/*.conf;
+
     server {
         listen 80 default_server;
         server_name _;


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

This allows Docker users to mount an arbitrary number of additional nginx config files at `/etc/nginx/overrides.d` which will then be included in the configuration used. Passed config files take precedence over both the directives in the `http` block. The following `server` block could also be overwritten as the first match takes precedence.

Example in a compose setup:

```yml
  penpot_frontend:
    image: penpotapp/frontend:1.19.1
    networks:
      - penpot
      - penpot_public
    restart: unless-stopped
    volumes:
      - penpot_assets:/opt/data/assets
      - ./logging.conf:/etc/nginx/overrides.d/01logging.conf
    depends_on:
      - penpot_backend
      - penpot_exporter
    environment:
      PENPOT_FLAGS: >-
        disable-registration
        disable-login
        enable-login-with-password
      PENPOT_REDIS_URI: redis://penpot_redis/0
      PENPOT_BACKEND_URI: http://penpot_backend:6060
      PENPOT_EXPORTER_URI: http://penpot_exporter:6061
```

where `logging.conf` looks like

```
access_log off;
```

Users that don't use this feature will not be affected and do not need to change anything.

> Explain the **details** for making this change. What existing problem does the pull request solve?

I would like to disable access logging for the `frontend` container as it is behind another reverse proxy anyways and logs can get quite noisy/heavy. `access_log /dev/stdout` is hard coded in the nginx config, so there is no way of configuring this currently.

----

I am not entirely sure if documentation lives in this repo as well and needs to be updated. In case yes, please lmk and I can do this still.