### PR TITLE
:bug: Fix preview of moving a copy of a flex component into its main

### DIFF
--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -511,11 +511,15 @@
                               [(assoc move-vector :x 0) :x]
 
                               :else
-                              [move-vector nil])]
+                              [move-vector nil])
 
-                        (-> (dwm/create-modif-tree ids (ctm/move-modifiers move-vector))
-                            (dwm/build-change-frame-modifiers objects selected target-frame drop-index cell-data)
-                            (dwm/set-modifiers false false {:snap-ignore-axis snap-ignore-axis}))))))
+                            nesting-loop? (some #(cph/components-nesting-loop? objects (:id %) target-frame) shapes)]
+
+                        (cond-> (dwm/create-modif-tree ids (ctm/move-modifiers move-vector))
+                          (not nesting-loop?)
+                          (dwm/build-change-frame-modifiers objects selected target-frame drop-index cell-data)
+                          :always
+                          (dwm/set-modifiers false false {:snap-ignore-axis snap-ignore-axis}))))))
 
               (->> move-stream
                       (rx/with-latest-from ms/mouse-position-alt)


### PR DESCRIPTION
Fixes "Penpot (correctly) doesn't allow me to place a copied component inside its parent component when I drag the copy onto the parent. However, the parent (if it has flex) is creating space for the child, even though it doesn't accept it inside. Visually, it appears as if the copy has entered because the parent has made space for it, but when you check the layers, you realize that it couldn't actually enter."