### PR TITLE
:bug: When duplicating a main component from the assets tab, the new …

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -134,7 +134,7 @@
 
       (let [main-instance-page  (ctf/get-component-page library-data component)
             main-instance-shape (ctf/get-component-root library-data component)
-            position            (gpt/point (:x main-instance-shape) (:y main-instance-shape))
+            position            (gpt/point (+ (:x main-instance-shape) (:width main-instance-shape) 50) (:y main-instance-shape))
             options             (if components-v2 {:main-instance? true} {})
 
             [new-instance-shape new-instance-shapes]


### PR DESCRIPTION
…component should be next to it.
