### PR TITLE
:bug: Fix when duplicating a main component all internal shapes are m…

### DIFF
--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -269,7 +269,8 @@
 
          update-new-shape
          (fn [new-shape original-shape]
-           (let [new-name (:name new-shape)]
+           (let [new-name (:name new-shape)
+                 main-instance? (and main-instance? (ctk/instance-root? new-shape))] ; Only the instance root can be a main instance
 
              (when (nil? (:parent-id original-shape))
                (vswap! unames conj new-name))


### PR DESCRIPTION
…arked as :main-instance
