### PR TITLE
:bug: Fix added children detection in fix-touched script

### DIFF
--- a/backend/src/app/srepl/fixes.clj
+++ b/backend/src/app/srepl/fixes.clj
@@ -366,8 +366,8 @@
                                   (let [matches? (fn [[child-id ref-child-id]]
                                                    (let [child (ctn/get-shape page child-id)]
                                                      (= (:shape-ref child) ref-child-id)))
-                                        equal? (every? matches? (d/zip (:shapes shape) (:shapes ref-shape)))]
-                                      (when (and (not equal?) (not (cph/touched-group? shape :shapes)))
+                                        equal? (every? matches? (d/zip-all (:shapes shape) (:shapes ref-shape)))]
+                                      (when (and (not equal?) (not (cph/touched-group? shape :shapes-group)))
                                         (println " -> set touched " (:name shape) (:id shape) :shapes :shapes-group))
                                       (cond-> shape
                                         (and (not equal?) (not (cph/touched-group? shape :shapes-group)))

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -256,6 +256,15 @@
 (defn zip [col1 col2]
   (map vector col1 col2))
 
+(defn zip-all
+  "Return a zip of both collections, extended to the lenght of the longest one,
+   and padding the shorter one with nils as needed."
+  [col1 col2]
+  (let [diff (- (count col1) (count col2))]
+    (cond (pos? diff)  (zip col1 (c/concat col2 (repeat nil)))
+          (neg? diff)  (zip (c/concat col1 (repeat nil)) col2)
+          :else        (zip col1 col2))))
+
 (defn mapm
   "Map over the values of a map"
   ([mfn]


### PR DESCRIPTION
Fixes a condition that ignored the case when a child is added or removed to a copy.