### PR TITLE
:sparkles: Ensure features is always initialized, even after logout

### DIFF
--- a/common/src/app/common/types/components_list.cljc
+++ b/common/src/app/common/types/components_list.cljc
@@ -8,7 +8,7 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
-   [app.common.files.features :as feat]
+   [app.common.files.features :as ffeat]
    [app.common.time :as dt]
    [app.common.types.component :as ctk]))
 
@@ -40,7 +40,7 @@
       (cond-> (update-in fdata [:components id] assoc :main-instance-id main-instance-id :main-instance-page main-instance-page)
         annotation (update-in [:components id] assoc :annotation annotation))
 
-      (let [wrap-object-fn feat/*wrap-with-objects-map-fn*]
+      (let [wrap-object-fn ffeat/*wrap-with-objects-map-fn*]
         (assoc-in fdata [:components id :objects]
                   (->> shapes
                        (d/index-by :id)
@@ -48,7 +48,7 @@
 
 (defn mod-component
   [file-data {:keys [id name path main-instance-id main-instance-page objects annotation]}]
-  (let [wrap-objects-fn feat/*wrap-with-objects-map-fn*]
+  (let [wrap-objects-fn ffeat/*wrap-with-objects-map-fn*]
     (d/update-in-when file-data [:components id]
                       (fn [component]
                         (let [objects (some-> objects wrap-objects-fn)]

--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -82,7 +82,7 @@
       date)))
 
 
-;; --- Globar Config Vars
+;; --- Global Config Vars
 
 (def default-theme  "default")
 (def default-language "en")

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -316,6 +316,7 @@
     ptk/WatchEvent
     (watch [_ _ _]
       (rx/of msg/hide
+             (features/initialize)
              (dcm/retrieve-comment-threads file-id)
              (dwp/initialize-file-persistence file-id)
              (fetch-bundle project-id file-id)))

--- a/frontend/src/app/main/features.cljs
+++ b/frontend/src/app/main/features.cljs
@@ -100,7 +100,7 @@
       ;; environemnt (aka devenv).
       (when *assert*
         ;; By default, all features disabled, except in development
-        ;; environment, that are enabled except components-v2
+        ;; environment, that are enabled except components-v2 and new css
         (->> (rx/from available-features)
              (rx/filter #(not= % :components-v2))
              (rx/filter #(not= % :new-css-system))


### PR DESCRIPTION
This fixes an error:
- Log in with components-v2 enabled.
- Create a file with components.
- Log out and log in again, without reloading the browser.
- Enter the file.

The popup of components-v2 error appears, because in logout the features were removed from the global state and never loaded again.