### PR TITLE
:bug: Fix After cancel edit annotation its content is not shown in full view

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -57,7 +57,8 @@
                                 (let [textarea (mf/ref-val textarea-ref)]
                                   (aset textarea "value" annotation)
                                   (reset! editing? false)
-                                  (st/emit! (dw/set-annotations-id-for-create nil))))
+                                  (st/emit! (dw/set-annotations-id-for-create nil))
+                                  (autogrow)))
         save                  (fn [event]
                                 (dom/stop-propagation event)
                                 (let [textarea (mf/ref-val textarea-ref)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6038