### PR TITLE
✨ : Strip extension for uploaded image files

### DIFF
--- a/common/src/app/common/files/builder.cljc
+++ b/common/src/app/common/files/builder.cljc
@@ -746,3 +746,7 @@
           :page-id page-id
           :option :guides
           :value new-guides}))))
+
+(defn strip-image-extension [filename]
+  (let [image-extensions-re #"(\.png)|(\.jpg)|(\.jpeg)|(\.webp)|(\.gif)|(\.svg)$"]
+    (str/replace filename image-extensions-re "")))

--- a/common/test/common_tests/files_builder_test.cljc
+++ b/common/test/common_tests/files_builder_test.cljc
@@ -1,0 +1,26 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.files-builder-test
+  (:require
+   [app.common.files.builder :as builder]
+   [clojure.test :as t]))
+
+(t/deftest test-strip-image-extension
+  (t/testing "removes extension from supported image files"
+    (t/is (= (builder/strip-image-extension "foo.png") "foo"))
+    (t/is (= (builder/strip-image-extension "foo.webp") "foo"))
+    (t/is (= (builder/strip-image-extension "foo.jpg") "foo"))
+    (t/is (= (builder/strip-image-extension "foo.jpeg") "foo"))
+    (t/is (= (builder/strip-image-extension "foo.svg") "foo"))
+    (t/is (= (builder/strip-image-extension "foo.gif") "foo")))
+
+  (t/testing "does not remove extension for unsupported files"
+    (t/is (= (builder/strip-image-extension "foo.txt") "foo.txt"))
+    (t/is (= (builder/strip-image-extension "foo.bmp") "foo.bmp")))
+
+  (t/testing "leaves filename intact when it has no extension"
+    (t/is (= (builder/strip-image-extension "README") "README"))))

--- a/frontend/src/app/main/data/workspace/media.cljs
+++ b/frontend/src/app/main/data/workspace/media.cljs
@@ -8,6 +8,7 @@
   (:require
    [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
+   [app.common.files.builder :as fb]
    [app.common.logging :as log]
    [app.common.math :as mth]
    [app.common.pages.changes-builder :as pcb]
@@ -134,7 +135,7 @@
                  (= (.-type blob) "image/svg+xml")))
 
           (prepare-blob [blob]
-            (let [name (or name (if (dmm/file? blob) (.-name blob) "blob"))]
+            (let [name (or name (if (dmm/file? blob) (fb/strip-image-extension (.-name blob)) "blob"))]
               {:file-id file-id
                :name name
                :is-local local?


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/5485

With this patch newly uploaded images will have their extension removed. They'll look like this (notice the absence of `.png` to the filenames)

<img width="360" alt="Screenshot 2023-11-02 at 5 27 39 PM" src="https://github.com/penpot/penpot/assets/63681/9df75c3e-6982-46bf-899e-a8285dc0a452">