### PR TITLE
:recycle: Refactor thumbnails persistence

### DIFF
--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -91,8 +91,8 @@
 
 (defn clear-thumbnail
   ([file-id page-id frame-id tag]
-   (clear-thumbnail file-id (thc/fmt-object-id file-id page-id frame-id tag)))
-  ([file-id object-id]
+   (clear-thumbnail (thc/fmt-object-id file-id page-id frame-id tag)))
+  ([object-id]
    (let [emit-rpc? (volatile! false)]
      (ptk/reify ::clear-thumbnail
        cljs.core/IDeref
@@ -108,14 +108,7 @@
                (tm/schedule-on-idle (partial wapi/revoke-uri uri))
                (update state :workspace-thumbnails dissoc object-id))
 
-             state)))
-
-     ptk/WatchEvent
-     (watch [_ _ _]
-       (when ^boolean @emit-rpc?
-         (->> (rp/cmd! :delete-file-object-thumbnail {:file-id file-id :object-id object-id})
-              (rx/catch rx/empty)
-              (rx/ignore))))))))
+             state)))))))
 
 (defn- assoc-thumbnail
   [object-id uri]
@@ -171,7 +164,7 @@
                                                            :object-id object-id
                                                            :media blob
                                                            :tag (or tag "frame")}]
-                                               (rp/cmd! :create-file-object-thumbnail params))))
+                                               (rp/cmd! :upsert-file-object-thumbnail params))))
                                 (rx/catch rx/empty)
                                 (rx/ignore)))))
              (rx/catch (fn [cause]

--- a/frontend/src/app/main/repo.cljs
+++ b/frontend/src/app/main/repo.cljs
@@ -47,8 +47,9 @@
 (def default-options
   {:update-file {:query-params [:id]}
    :get-raw-file {:rename-to :get-file :raw-transit? true}
-   :upsert-file-object-thumbnail {:query-params [:file-id :object-id]}
-   :create-file-object-thumbnail {:query-params [:file-id :object-id]
+   :upsert-file-object-thumbnail {:query-params [:file-id :object-id :tag]
+                                  :form-data? true}
+   :create-file-object-thumbnail {:query-params [:file-id :object-id :tag]
                                   :form-data? true}
 
    :create-file-thumbnail


### PR DESCRIPTION
Reduces the amount of RPC calls to create and delete file-object-thumbnails.