### PR TITLE
Add dev deps.edn in the project root

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+;; This file exists to make clojure-lsp serve the whole repository
+{:deps
+ {dev/frontend {:local/root "frontend"}
+  dev/backend {:local/root "backend"}
+  dev/common {:local/root "common"}
+  dev/exporter {:local/root "exporter"}}}


### PR DESCRIPTION
Making clojure-lsp serve the whole repository when opened at the root in, say, Calva.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

In https://github.com/BetterThanTomorrow/calva/issues/2337 it came to my attention that Calva's clojure-lsp services are not in effect if the repository is opened at its root. The way to solve that is to add a deps.edn at the root to help clojure-lsp figure out the class paths and thus which files to analyze.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Only adding a `deps.edn` at the root which references the “sub” projects.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

This only effects development. I could add some screenshots, but don't know if it would bring so much info. 😄 

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

Please let me know if I can clarify this.