### PR TITLE
:tada: Import/export thumbnails in .penpot files

### DIFF
--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -336,6 +336,14 @@
       (->> (db/exec! conn [sql ids])
            (mapv #(assoc % :file-id id))))))
 
+(defn- get-file-thumbnails
+  "Return all file thumbnails for a given file."
+  [{:keys [::db/pool]} id]
+  (pu/with-open [conn (db/open pool)]
+    (let [sql "SELECT * FROM file_tagged_object_thumbnail WHERE file_id = ?"]
+      (->> (db/exec! conn [sql id])
+           (mapv #(dissoc % :file-id))))))
+
 (def ^:private storage-object-id-xf
   (comp
    (mapcat (juxt :media-id :thumbnail-id))
@@ -511,14 +519,19 @@
 
   (doseq [file-id (-> *state* deref :files)]
     (let [detach? (and (not embed-assets?) (not include-libraries?))
-          file    (cond-> (get-file cfg file-id)
-                    detach?
-                    (-> (ctf/detach-external-references file-id)
-                        (dissoc :libraries))
-                    embed-assets?
-                    (update :data embed-file-assets cfg file-id))
+          thumbnails (get-file-thumbnails cfg file-id)
+          file  (cond-> (get-file cfg file-id)
+                  detach?
+                  (-> (ctf/detach-external-references file-id)
+                      (dissoc :libraries))
 
-          media   (get-file-media cfg file)]
+                  embed-assets?
+                  (update :data embed-file-assets cfg file-id)
+
+                  :always
+                  (assoc :thumbnails thumbnails))
+
+          media (get-file-media cfg file)]
 
       (l/dbg :hint "write penpot file"
              :id file-id
@@ -534,7 +547,8 @@
         (write-obj! file)
         (write-obj! media))
 
-      (vswap! *state* update :sids into storage-object-id-xf media))))
+      (vswap! *state* update :sids into storage-object-id-xf media)
+      (vswap! *state* update :sids into storage-object-id-xf thumbnails))))
 
 (defmethod write-section :v1/rels
   [{:keys [::output ::include-libraries?] :as cfg}]
@@ -676,6 +690,20 @@
          (not (contains? cfeat/*previous* "fdata/pointer-map")))
     (features.fdata/enable-pointer-map)))
 
+(defn- update-thumbnail
+  [thumbnail file-id]
+  (let [thumbnail     (assoc thumbnail :file-id file-id)
+        object-id     (:object-id thumbnail)
+        object-id     (str/replace-first object-id #"^(.*?)/" (str file-id "/"))
+        thumbnail     (assoc thumbnail :object-id object-id)]
+
+    thumbnail))
+
+(defn- update-file-thumbnails
+  [file file-id]
+  (let [thumbnails (:thumbnails file)]
+    (mapv #(update-thumbnail % file-id) thumbnails)))
+
 (defmethod read-section :v1/files
   [{:keys [::db/conn ::input ::project-id ::enabled-features ::timestamp ::overwrite?]}]
 
@@ -688,8 +716,7 @@
 
           features  (-> enabled-features
                         (set/difference cfeat/frontend-only-features)
-                        (set/union (cfeat/check-supported-features! (:features file))))
-          ]
+                        (set/union (cfeat/check-supported-features! (:features file))))]
 
       ;; All features that are enabled and requires explicit migration
       ;; are added to the state for a posterior migration step
@@ -704,6 +731,11 @@
                   :found-id file-id
                   :expected-id expected-file-id
                   :hint "the penpot file seems corrupt, found unexpected uuid (file-id)"))
+
+      (when (contains? file :thumbnails)
+        (let [updated-thumbnails (update-file-thumbnails file file-id')]
+          (vswap! *state* update :thumbnails (fnil into []) updated-thumbnails)
+          (l/dbg :hint "thumbnails updated" :thumbnails (count updated-thumbnails) ::l/sync? true)))
 
       ;; Update index using with media
       (l/dbg :hint "update index with media" ::l/sync? true)
@@ -729,6 +761,7 @@
                          (assoc :project-id project-id)
                          (assoc :created-at timestamp)
                          (assoc :modified-at timestamp)
+                         (dissoc :thumbnails)
                          (update :data (fn [data]
                                          (-> data
                                              (assoc :id file-id')
@@ -837,7 +870,16 @@
                           (assoc :file-id file-id)
                           (d/update-when :media-id lookup-index)
                           (d/update-when :thumbnail-id lookup-index))
-                      {:on-conflict-do-nothing overwrite?}))))))
+                      {:on-conflict-do-nothing overwrite?}))))
+
+    (doseq [item (:thumbnails @*state*)]
+      (l/dbg :hint "inserting file tagged object thumbnail"
+             :file-id (:file-id item)
+             :object-id (:object-id item)
+             ::l/sync? true)
+      (db/insert! conn :file-tagged-object-thumbnail
+                  (update item :media-id lookup-index)
+                  {:on-conflict-do-nothing overwrite?}))))
 
 (defn- lookup-index
   [id]
@@ -979,8 +1021,8 @@
         (l/info :hint "import: terminated"
                 :import-id id
                 :elapsed (dt/format-duration (tp))
-                :error? (some? @cs)
-                )))))
+                :error? (some? @cs))))))
+
 
 ;; --- Command: export-binfile
 


### PR DESCRIPTION
### How to test

- Import file without thumbnails (an old file or a file without any thumbnails)
- Import file with thumbnails
- Export file with thumbnails and import it on a version of Penpot that doesn't read thumbnails (it should work)