### PR TITLE
:sparkles: Reload imposter on image error

### DIFF
--- a/frontend/src/app/main/ui/workspace/presence.cljs
+++ b/frontend/src/app/main/ui/workspace/presence.cljs
@@ -21,8 +21,8 @@
   [{:keys [session profile index] :as props}]
   (let [profile (assoc profile :color (:color session))]
     [:li {:class (stl/css :session-icon)
-          :style #js {"zIndex" (str (or (+ 1 (* -1 index)) 0)),
-                      "background-color" (:color session)}
+          :style {:z-index (str (or (+ 1 (* -1 index)) 0))
+                  :background-color (:color session)}
           :title (:fullname profile)}
      [:img {:alt (:fullname profile)
             :style {:background-color (:color session)}


### PR DESCRIPTION
### How it works

If an imposter image is broken, it listens to the `on-error` event and schedules a new try to load that image. Every time `on-error` is called, the amount of tries is incremented and also the amount of time to wait to try again.

### How to test it:

1. Open a file with thumbnails/imposters
2. Go to DevTools > Network
3. Change "No throttling" to "Offline"
4. Change page on file
5. Check that images are broken
6. Change "Offline" to "No throttling" and wait to imposters to be shown again.