### PR TITLE
:zap: Use subdomain for rasterizer (OOPIF)

### DIFF
--- a/frontend/src/app/main/rasterizer.cljs
+++ b/frontend/src/app/main/rasterizer.cljs
@@ -61,10 +61,19 @@
   [message]
   (.push ^js queue message))
 
+(defn- replace-uris
+  "Replaces URIs for rasterizer ones in styles"
+  [styles]
+  (let [public-uri (str cf/public-uri)
+        rasterizer-uri (str cf/rasterizer-uri)]
+    (if-not (= public-uri rasterizer-uri)
+      (str/replace styles public-uri rasterizer-uri)
+      styles)))
+
 (defn render
   "Renders an SVG"
   [{:keys [data styles width result] :as params}]
-  (let [styles  (d/nilv styles "")
+  (let [styles  (replace-uris (d/nilv styles ""))
         result  (d/nilv result "blob")
         id      (dm/str (uuid/next))
         payload #js {:data data :styles styles :width width :result result}

--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -553,13 +553,15 @@
           [fixed-width
            fixed-height] (th/get-relative-size width height)
 
-          data           (rds/renderToStaticMarkup
-                          (mf/element frame-imposter
-                                      #js {:objects objects
-                                           :frame shape
-                                           :vbox viewbox
-                                           :width width
-                                           :height height}))]
+
+          data           (with-redefs [cfg/public-uri cfg/rasterizer-uri]
+                           (rds/renderToStaticMarkup
+                            (mf/element frame-imposter
+                                        #js {:objects objects
+                                             :frame shape
+                                             :vbox viewbox
+                                             :width width
+                                             :height height})))]
 
       (->> (fonts/render-font-styles-cached fonts)
            (rx/catch (fn [cause]
@@ -567,11 +569,11 @@
                               :cause cause)
                        (rx/empty)))
            (rx/map (fn [styles]
-                     {:id object-id
-                      :data data
-                      :viewbox viewbox
-                      :width fixed-width
-                      :height fixed-height
-                      :styles styles}))))
+                        {:id object-id
+                         :data data
+                         :viewbox viewbox
+                         :width fixed-width
+                         :height fixed-height
+                         :styles styles}))))
     (do (l/warn :msg "imposter shape is nil")
         (rx/empty))))

--- a/frontend/src/app/rasterizer.cljs
+++ b/frontend/src/app/rasterizer.cljs
@@ -221,6 +221,10 @@
             scope   (unchecked-get evdata "scope")]
         (when (and (some? payload)
                    (= scope "penpot/rasterizer"))
+          (log/dbg :hint "received message"
+                   :id id
+                   :payload payload
+                   :scope scope)
           (->> (render payload)
                (rx/subs (partial send-success! id)
                         (partial send-failure! id))))))))


### PR DESCRIPTION
### How to test it (locally)

1. Add a subdomain to `/etc/hosts`

```
127.0.0.1	localhost
127.0.0.1	sub.localhost
```

2. Then add these settings to `frontend/resources/public/js/config.js`:

```javascript
var penpotPublicURI = "http://localhost:3449";
var penpotRasterizerURI = "http://sub.localhost:3449";
```

3. Done!

Now we can check that we have at least one extra thread for the rasterizer iframe in DevTools.

BEFORE (iframe runs in main thread)
![Screenshot from 2023-11-27 15-08-06](https://github.com/penpot/penpot/assets/478699/806c8b31-4cf6-4de5-86f3-3a31d47d034f)


AFTER (iframe now runs in separate thread http:/sub.localhost:3449)
![Screenshot from 2023-11-27 15-09-06](https://github.com/penpot/penpot/assets/478699/652c8af1-2136-4ab8-b660-ae27b2e30781)

