### PR TITLE
:sparkles: Add file object thumbnail deduplication mechanism

### DIFF
--- a/backend/src/app/migrations.clj
+++ b/backend/src/app/migrations.clj
@@ -335,6 +335,10 @@
 
    {:name "0106-mod-team-table"
     :fn (mg/resource "app/migrations/sql/0106-mod-team-table.sql")}
+
+   {:name "0107-mod-file-tagged-object-thumbnail-table"
+    :fn (mg/resource "app/migrations/sql/0107-mod-file-tagged-object-thumbnail-table.sql")}
+
    ])
 
 (defn apply-migrations!

--- a/backend/src/app/migrations/sql/0107-mod-file-tagged-object-thumbnail-table.sql
+++ b/backend/src/app/migrations/sql/0107-mod-file-tagged-object-thumbnail-table.sql
@@ -1,0 +1,2 @@
+CREATE INDEX file_tagged_object_thumbnail__media_id__idx
+    ON file_tagged_object_thumbnail (media_id);

--- a/backend/src/app/rpc/commands/files_thumbnails.clj
+++ b/backend/src/app/rpc/commands/files_thumbnails.clj
@@ -249,7 +249,8 @@
                   (sto/wrap-with-hash hash))
         media (sto/put-object! storage
                                {::sto/content data
-                                ::sto/deduplicate? false
+                                ::sto/deduplicate? true
+                                ::sto/touched-at (dt/now)
                                 :content-type mtype
                                 :bucket "file-object-thumbnail"})]
 
@@ -292,7 +293,7 @@
                                           :object-id object-id}
                                          {::db/for-update? true})]
 
-    (sto/del-object! storage media-id)
+    (sto/touch-object! storage media-id)
     (db/delete! conn :file-tagged-object-thumbnail
                 {:file-id file-id
                  :object-id object-id})

--- a/backend/test/backend_tests/storage_test.clj
+++ b/backend/test/backend_tests/storage_test.clj
@@ -309,7 +309,7 @@
       (let [res (db/exec-one! th/*pool* ["select count(*) from storage_object where deleted_at is null"])]
         (t/is (= 2 (:count res)))))
 
-    ;; now we proceed to manually delete all team_font_variant
+    ;; now we proceed to manually delete all file_media_object
     (db/exec-one! th/*pool* ["delete from file_media_object"])
 
     ;; run the touched gc task

--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -164,7 +164,7 @@
                                                            :object-id object-id
                                                            :media blob
                                                            :tag (or tag "frame")}]
-                                               (rp/cmd! :upsert-file-object-thumbnail params))))
+                                               (rp/cmd! :create-file-object-thumbnail params))))
                                 (rx/catch rx/empty)
                                 (rx/ignore)))))
              (rx/catch (fn [cause]

--- a/frontend/src/app/main/repo.cljs
+++ b/frontend/src/app/main/repo.cljs
@@ -47,10 +47,10 @@
 (def default-options
   {:update-file {:query-params [:id]}
    :get-raw-file {:rename-to :get-file :raw-transit? true}
-   :upsert-file-object-thumbnail {:query-params [:file-id :object-id :tag]
-                                  :form-data? true}
-   :create-file-object-thumbnail {:query-params [:file-id :object-id :tag]
-                                  :form-data? true}
+
+   :create-file-object-thumbnail
+   {:query-params [:file-id :object-id :tag]
+    :form-data? true}
 
    :create-file-thumbnail
    {:query-params [:file-id :revn]


### PR DESCRIPTION
- avoid storing repeated thumbnails on template imports, 
- increasing the speed of importation because no additional IO is performed for thumbnails