### PR TITLE
⚡ Imposters performance and bugfixing

### DIFF
--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -152,7 +152,7 @@
       (watch [_ state stream]
         (l/dbg :hint "update thumbnail" :object-id object-id :tag tag)
         ;; Send the update to the back-end
-        (->> (get-thumbnail state file-id page-id frame-id {:object-id object-id})
+        (->> (get-thumbnail state file-id page-id frame-id tag)
              (rx/mapcat (fn [uri]
                           (rx/merge
                            (rx/of (assoc-thumbnail object-id uri))

--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -534,14 +534,9 @@
 (defn render-frame
   [objects shape object-id]
   (if (some? shape)
-    (let [shape-id      (dm/get-prop shape :id)
-          fonts         (ff/shape->fonts shape objects)
+    (let [fonts         (ff/shape->fonts shape objects)
 
-          bounds         (if (:show-content shape)
-                           (let [ids      (cfh/get-children-ids objects shape-id)
-                                 children (sequence (keep (d/getf objects)) ids)]
-                             (gsh/shapes->rect (cons shape children)))
-                           (-> shape :points grc/points->rect))
+          bounds         (gsb/get-object-bounds objects shape)
 
           x              (dm/get-prop bounds :x)
           y              (dm/get-prop bounds :y)

--- a/frontend/src/app/main/ui/shapes/shape.cljs
+++ b/frontend/src/app/main/ui/shapes/shape.cljs
@@ -79,9 +79,9 @@
 
         filter-str
         (when (and (or (cfh/group-shape? shape)
-                     (cfh/frame-shape? shape)
-                     (cfh/svg-raw-shape? shape))
-                (not disable-shadows?))
+                       (cfh/frame-shape? shape)
+                       (cfh/svg-raw-shape? shape))
+                   (not disable-shadows?))
           (filters/filter-str filter-id shape))
 
         wrapper-props

--- a/frontend/src/app/main/ui/workspace/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame.cljs
@@ -175,7 +175,7 @@
              :href thumbnail-uri
              :on-load on-load
              :on-error on-error
-             :style {:display (when-not ^boolean thumbnail? "none")}}]
+             :style {:display (when-not (and ^boolean thumbnail? ^boolean thumbnail-uri) "none")}}]
 
            ;; Render border around image when we are debugging
            ;; thumbnails.

--- a/frontend/src/app/main/ui/workspace/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame.cljs
@@ -9,8 +9,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
-   [app.common.geom.rect :as grc]
-   [app.common.geom.shapes :as gsh]
+   [app.common.geom.shapes.bounds :as gsb]
    [app.common.math :as mth]
    [app.common.thumbnails :as thc]
    [app.main.data.workspace.state-helpers :as wsh]
@@ -98,12 +97,7 @@
             container-ref  (mf/use-ref nil)
             content-ref    (mf/use-ref nil)
 
-            ;; FIXME: apply specific rendering optimizations separating to a component
-            bounds         (if (:show-content shape)
-                             (let [ids      (cfh/get-children-ids objects frame-id)
-                                   children (sequence (keep (d/getf objects)) ids)]
-                               (gsh/shapes->rect (cons shape children)))
-                             (-> shape :points grc/points->rect))
+            bounds         (gsb/get-object-bounds objects shape)
 
             x              (dm/get-prop bounds :x)
             y              (dm/get-prop bounds :y)
@@ -156,7 +150,7 @@
 
         (fdm/use-dynamic-modifiers objects (mf/ref-val content-ref) modifiers)
 
-        [:& shape-container {:shape shape}
+        [:& shape-container {:shape shape :disable-shadows? thumbnail?}
          [:g.frame-container
           {:id (dm/str "frame-container-" frame-id)
            :key "frame-container"

--- a/frontend/src/app/main/ui/workspace/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame.cljs
@@ -123,9 +123,12 @@
 
             tries-ref      (mf/use-ref 0)
             imposter-ref   (mf/use-ref nil)
+            imposter-loaded-ref (mf/use-ref false)
             task-ref       (mf/use-ref nil)
 
-            on-load        (mf/use-fn #(mf/set-ref-val! tries-ref 0))
+            on-load        (mf/use-fn (fn []
+                                        (mf/set-ref-val! tries-ref 0)
+                                        (mf/set-ref-val! imposter-loaded-ref true)))
             on-error       (mf/use-fn
                             (fn []
                               (let [current-tries (mf/ref-val tries-ref)
@@ -159,6 +162,15 @@
            :key "frame-container"
            :opacity (when ^boolean hidden? 0)}
 
+           ;; When there is no thumbnail, we generate a empty rect.
+          (when (and (not ^boolean thumbnail-uri) (not (mf/ref-val imposter-loaded-ref)))
+            [:g.frame-placeholder
+             [:rect {:x x
+                     :y y
+                     :width width
+                     :height height
+                     :fill "url(#frame-placeholder-gradient)"}]])
+
           [:g.frame-imposter
            [:image.thumbnail-bitmap
             {:x x
@@ -182,8 +194,7 @@
                      :stroke-width 2}])]
 
           ;; When thumbnail is disabled.
-          (when (or (not ^boolean thumbnail?)
-                    (not ^boolean thumbnail-uri))
+          (when (or (not ^boolean thumbnail?) (not ^boolean thumbnail-uri))
             [:g.frame-content
              {:id (dm/str "frame-content-" frame-id)
               :ref container-ref}

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -316,6 +316,19 @@
                :pointer-events "none"}
        :fill "none"}
 
+      [:defs
+       [:linearGradient {:id "frame-placeholder-gradient"}
+        [:animateTransform
+         {:attributeName "gradientTransform"
+          :type "translate"
+          :from "-1 0"
+          :to "1 0"
+          :dur "2s"
+          :repeatCount "indefinite"}]
+        [:stop {:offset "0%" :stop-color (str "color-mix(in srgb-linear, " background " 90%, #777)") :stop-opacity 1}]
+        [:stop {:offset "50%" :stop-color (str "color-mix(in srgb-linear, " background " 80%, #777)") :stop-opacity 1}]
+        [:stop {:offset "100%" :stop-color (str "color-mix(in srgb-linear, " background " 90%, #777)") :stop-opacity 1}]]]
+
       (when (dbg/enabled? :show-export-metadata)
         [:& use/export-page {:options options}])
 
@@ -329,9 +342,9 @@
       [:& (mf/provider ctx/current-vbox) {:value vbox'}
        [:& (mf/provider use/include-metadata-ctx) {:value (dbg/enabled? :show-export-metadata)}
          ;; Render root shape
-         [:& shapes/root-shape {:key page-id
-                                :objects base-objects
-                                :active-frames @active-frames}]]]]
+        [:& shapes/root-shape {:key page-id
+                               :objects base-objects
+                               :active-frames @active-frames}]]]]
 
      [:svg.viewport-controls
       {:xmlns "http://www.w3.org/2000/svg"


### PR DESCRIPTION
Adds a placeholder the first time a frame imposter is rendered.

Object bounds where calculated wrongly so it doesn't used paddings from filters, strokes, etc.

[Issue Taiga #5653](https://tree.taiga.io/project/penpot/issue/5653)
[Taiga Issue #6006](https://tree.taiga.io/project/penpot/issue/6006)
[Taiga Issue #6250](https://tree.taiga.io/project/penpot/issue/6250)