### PR TITLE
:bug: Fix cropped imposters

### DIFF
--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -534,14 +534,9 @@
 (defn render-frame
   [objects shape object-id]
   (if (some? shape)
-    (let [shape-id      (dm/get-prop shape :id)
-          fonts         (ff/shape->fonts shape objects)
+    (let [fonts         (ff/shape->fonts shape objects)
 
-          bounds         (if (:show-content shape)
-                           (let [ids      (cfh/get-children-ids objects shape-id)
-                                 children (sequence (keep (d/getf objects)) ids)]
-                             (gsh/shapes->rect (cons shape children)))
-                           (-> shape :points grc/points->rect))
+          bounds         (gsb/get-object-bounds objects shape)
 
           x              (dm/get-prop bounds :x)
           y              (dm/get-prop bounds :y)

--- a/frontend/src/app/main/ui/shapes/shape.cljs
+++ b/frontend/src/app/main/ui/shapes/shape.cljs
@@ -79,9 +79,9 @@
 
         filter-str
         (when (and (or (cfh/group-shape? shape)
-                     (cfh/frame-shape? shape)
-                     (cfh/svg-raw-shape? shape))
-                (not disable-shadows?))
+                       (cfh/frame-shape? shape)
+                       (cfh/svg-raw-shape? shape))
+                   (not disable-shadows?))
           (filters/filter-str filter-id shape))
 
         wrapper-props

--- a/frontend/src/app/main/ui/workspace/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame.cljs
@@ -9,8 +9,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
-   [app.common.geom.rect :as grc]
-   [app.common.geom.shapes :as gsh]
+   [app.common.geom.shapes.bounds :as gsb]
    [app.common.math :as mth]
    [app.common.thumbnails :as thc]
    [app.main.data.workspace.state-helpers :as wsh]
@@ -99,11 +98,14 @@
             content-ref    (mf/use-ref nil)
 
             ;; FIXME: apply specific rendering optimizations separating to a component
-            bounds         (if (:show-content shape)
-                             (let [ids      (cfh/get-children-ids objects frame-id)
-                                   children (sequence (keep (d/getf objects)) ids)]
-                               (gsh/shapes->rect (cons shape children)))
-                             (-> shape :points grc/points->rect))
+            ;; bounds         (if (:show-content shape)
+            ;;                  (gsb/get-object-bounds objects shape)
+            ;;                  #_ (let [ids      (cfh/get-children-ids objects frame-id)
+            ;;                        children (sequence (keep (d/getf objects)) ids)]
+            ;;                    (gsh/shapes->rect (cons shape children)))
+            ;;                  (-> shape :points grc/points->rect))
+
+            bounds         (gsb/get-object-bounds objects shape)
 
             x              (dm/get-prop bounds :x)
             y              (dm/get-prop bounds :y)
@@ -153,7 +155,7 @@
 
         (fdm/use-dynamic-modifiers objects (mf/ref-val content-ref) modifiers)
 
-        [:& shape-container {:shape shape}
+        [:& shape-container {:shape shape :disable-shadows? thumbnail?}
          [:g.frame-container
           {:id (dm/str "frame-container-" frame-id)
            :key "frame-container"


### PR DESCRIPTION
Object bounds where calculated wrongly so it doesn't used paddings from filters, strokes, etc.

[Taiga Issue #6006](https://tree.taiga.io/project/penpot/issue/6006)