### PR TITLE
:bug: fix modal text color + remove lines in shared library modal

### DIFF
--- a/frontend/src/app/main/data/common.cljs
+++ b/frontend/src/app/main/data/common.cljs
@@ -106,9 +106,8 @@
                                       (:typography-count summary))]
                          (modal/show
                           {:type :confirm
-                           :message ""
                            :title (tr "modals.add-shared-confirm.message" (:name summary))
-                           :hint (if (zero? count) (tr "modals.add-shared-confirm-empty.hint") (tr "modals.add-shared-confirm.hint"))
+                           :message (if (zero? count) (tr "modals.add-shared-confirm-empty.hint") (tr "modals.add-shared-confirm.hint"))
                            :cancel-label (if (zero? count) (tr "labels.cancel") :omit)
                            :accept-label (tr "modals.add-shared-confirm.accept")
                            :accept-style :primary

--- a/frontend/src/app/main/ui/alert.scss
+++ b/frontend/src/app/main/ui/alert.scss
@@ -26,10 +26,7 @@
     .modal-content {
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg,
-      .modal-scd-msg,
-      .modal-hint,
-      .modal-subtitle {
+      .modal-hint {
         @include titleTipography;
       }
     }
@@ -48,4 +45,12 @@
       }
     }
   }
+}
+
+.modal-scd-msg,
+.modal-subtitle,
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }

--- a/frontend/src/app/main/ui/confirm.scss
+++ b/frontend/src/app/main/ui/confirm.scss
@@ -26,11 +26,6 @@
     .modal-content {
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg,
-      .modal-scd-msg,
-      .modal-subtitle {
-        @include titleTipography;
-      }
       .component-list {
         .modal-item-element {
           @include flexRow;
@@ -67,4 +62,11 @@
       }
     }
   }
+}
+
+.modal-scd-msg,
+.modal-subtitle,
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
 }

--- a/frontend/src/app/main/ui/confirm.scss
+++ b/frontend/src/app/main/ui/confirm.scss
@@ -69,4 +69,5 @@
 .modal-msg {
   @include titleTipography;
   color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }

--- a/frontend/src/app/main/ui/dashboard/export.scss
+++ b/frontend/src/app/main/ui/dashboard/export.scss
@@ -25,11 +25,6 @@
     .modal-content {
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg,
-      .modal-scd-msg,
-      .modal-subtitle {
-        @include titleTipography;
-      }
       .export-option {
         @extend .input-checkbox;
         width: 100%;
@@ -66,6 +61,14 @@
       }
     }
   }
+}
+
+.modal-scd-msg,
+.modal-subtitle,
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }
 
 .file-entry {

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -26,11 +26,6 @@
     .modal-content {
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg,
-      .modal-scd-msg,
-      .modal-subtitle {
-        @include titleTipography;
-      }
       .feedback-banner {
         @include flexRow;
         height: $s-32;
@@ -77,6 +72,14 @@
       }
     }
   }
+}
+
+.modal-scd-msg,
+.modal-subtitle,
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }
 
 .file-entry {

--- a/frontend/src/app/main/ui/delete_shared.scss
+++ b/frontend/src/app/main/ui/delete_shared.scss
@@ -26,11 +26,6 @@
     .modal-content {
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg,
-      .modal-scd-msg,
-      .modal-subtitle {
-        @include titleTipography;
-      }
       .modal-hint {
         @extend .modal-hint-base;
       }
@@ -56,4 +51,12 @@
       }
     }
   }
+}
+
+.modal-scd-msg,
+.modal-subtitle,
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }

--- a/frontend/src/app/main/ui/export.scss
+++ b/frontend/src/app/main/ui/export.scss
@@ -89,10 +89,7 @@
     .no-selection {
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg,
-      .modal-scd-msg,
-      .modal-hint,
-      .modal-subtitle {
+      .modal-hint {
         @include titleTipography;
         color: var(--modal-text-foreground-color);
       }
@@ -222,4 +219,12 @@
       }
     }
   }
+}
+
+.modal-scd-msg,
+.modal-subtitle,
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }

--- a/frontend/src/app/main/ui/workspace/nudge.scss
+++ b/frontend/src/app/main/ui/workspace/nudge.scss
@@ -28,9 +28,6 @@
       gap: $s-24;
       @include titleTipography;
       margin-bottom: $s-24;
-      .modal-msg {
-        @include titleTipography;
-      }
       .input-wrapper {
         @extend .input-with-label;
         label {
@@ -39,4 +36,10 @@
       }
     }
   }
+}
+
+.modal-msg {
+  @include titleTipography;
+  color: var(--modal-text-foreground-color);
+  line-height: 1.5;
 }


### PR DESCRIPTION
Fixes wrong UI for the modal of shared libraries.

- Changed the hint text for a message, to remove the borders around the text.
- Actually set the color for the message, since it was barely visible in light theme (note: this affects _all_ modals)

Modal looks like this now:

<img width="503" alt="Screenshot 2023-12-13 at 4 31 04 PM" src="https://github.com/penpot/penpot/assets/63681/6eec60bd-ec85-45f3-aa89-05c0a85ca667">

**Updated PR** with a fix for the message text in all modals. I'm not sure if I missed any, I just looked for the `.modal-msg` class.
