### PR TITLE
:sparkles:  Add anidation constraints for components

### DIFF
--- a/common/src/app/common/files/repair.cljc
+++ b/common/src/app/common/files/repair.cljc
@@ -326,7 +326,8 @@
     (log/dbg :hint "repairing shape :nested-main-not-allowed" :id (:id shape) :name (:name shape) :page-id page-id)
     (-> (pcb/empty-changes nil page-id)
         (pcb/with-file-data file-data)
-        (pcb/update-shapes [(:id shape)] repair-shape))))
+        (pcb/update-shapes [(:id shape)] repair-shape)
+        (pcb/change-parent uuid/zero [shape] nil {:component-swap true}))))
 
 (defmethod repair-error :root-copy-not-allowed
   [_ {:keys [shape page-id] :as error} file-data _]

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -393,7 +393,8 @@
                   (check-shape-copy-root-top shape file page libraries)))
 
               (if (ctk/main-instance? shape)
-                (if (= context :not-component)
+                ;; mains can't be nested into mains
+                (if (or (= context :not-component) (= context :main-top))
                   (report-error :nested-main-not-allowed
                                 "Nested main component only allowed inside other component"
                                 shape file page)

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -422,13 +422,13 @@
   (let [components-v2              (features/use-feature "components/v2")
         single?                    (= (count shapes) 1)
         objects                    (deref refs/workspace-page-objects)
-        any-in-copy?               (some true? (map #(ctn/has-any-copy-parent? objects %) shapes))
+        can-make-component         (every? true? (map #(ctn/valid-shape-for-component? objects %) shapes))
         heads                      (filter ctk/instance-head? shapes)
         components-menu-entries    (cmm/generate-components-menu-entries heads components-v2)
         do-add-component           #(st/emit! (dwl/add-component))
         do-add-multiple-components #(st/emit! (dwl/add-multiple-components))]
     [:*
-     (when-not any-in-copy? ;; We don't want to change the structure of component copies
+     (when can-make-component ;; We don't want to change the structure of component copies
        [:*
         [:& menu-separator]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -10,7 +10,6 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
-   [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
    [app.common.types.shape.layout :as ctl]
    [app.common.uuid :as uuid]
@@ -261,7 +260,7 @@
 
         on-drop
         (mf/use-fn
-         (mf/deps id index objects expanded?)
+         (mf/deps id index objects expanded? selected)
          (fn [side _data]
            (let [shape (get objects id)
 
@@ -276,6 +275,8 @@
                    :else
                    (cfh/get-parent-id objects id))
 
+                 [parent-id _] (ctn/find-valid-parent-and-frame-ids parent-id objects (map #(get objects %) selected))
+
                  parent    (get objects parent-id)
 
                  to-index  (cond
@@ -283,9 +284,7 @@
                              (and expanded? (= side :bot) (d/not-empty? (:shapes shape))) (count (:shapes parent))
                              (= side :top) (inc index)
                              :else index)]
-
-             (when-not (ctk/in-component-copy? parent) ;; We don't want to change the structure of component copies
-               (st/emit! (dw/relocate-selected-shapes parent-id to-index))))))
+             (st/emit! (dw/relocate-selected-shapes parent-id to-index)))))
 
         on-hold
         (mf/use-fn


### PR DESCRIPTION
The only allowed situations for anidated components is copies inside main, the rest is not allowed (copies inside copies, main inside mains, mains inside copies...)

- Create component shouldn't produce any invalid situations, test ctrl+k and right click with:
  - Selecting shapes
  - Selecting nested shapes
  - Selecting components (mains and instances)
  - Selecting children of components (mains and instances)
  - Selecting parents of components (mains and instances)

- Copy + paste must generate only valid situations. Test copying shapes/instances/mains to the different situations listed for creation
- Drag & drop in workspace must generate only valid situations. Test copying shapes/instances/mains to the different situations listed for creation
- Drag & drop in layers must generate only valid situations. Test copying shapes/instances/mains to the different situations listed for creation

This should solve the following issues
- https://tree.taiga.io/project/penpot/issue/6293 (this situation is not allowed now)
- https://tree.taiga.io/project/penpot/issue/6387
- https://tree.taiga.io/project/penpot/issue/6478

Document with test cases: https://docs.google.com/spreadsheets/d/1rRGw3x07SsY91_D4yuTfPsBtvW2rZan2cAHPlspNrpU/edit?usp=sharing
