### PR TITLE
:sparkles: Improve performance on websocket notification module

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -15,7 +15,7 @@
  :hooks
  {:analyze-call
   {app.common.data.macros/export hooks.export/export
-   potok.core/reify hooks.export/potok-reify
+   potok.v2.core/reify hooks.export/potok-reify
    app.util.services/defmethod hooks.export/service-defmethod
    app.common.record/defrecord hooks.export/penpot-defrecord
    app.db/with-atomic hooks.export/penpot-with-atomic

--- a/frontend/deps.edn
+++ b/frontend/deps.edn
@@ -6,10 +6,17 @@
   org.clojure/clojure {:mvn/version "1.11.1"}
   binaryage/devtools {:mvn/version "RELEASE"}
   metosin/reitit-core {:mvn/version "0.5.18"}
-
-  funcool/beicon {:mvn/version "2021.07.05-1"}
   funcool/okulary {:mvn/version "2022.04.11-16"}
-  funcool/potok {:mvn/version "2022.12.16-71"}
+
+  funcool/potok2
+  {:git/tag "v2.0"
+   :git/sha "2bb377b"
+   :git/url "https://github.com/funcool/potok.git"}
+
+  funcool/beicon2
+  {:git/tag "v2.0"
+   :git/sha "e7135e0"
+   :git/url "https://github.com/funcool/beicon.git"}
 
   funcool/rumext
   {:git/tag "v2.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "@storybook/react": "^7.5.3",
     "@storybook/react-vite": "^7.5.3",
     "@storybook/testing-library": "^0.2.2",
+    "@types/node": "^20.10.5",
     "animate.css": "^4.1.1",
     "autoprefixer": "^10.4.15",
     "concurrently": "^8.2.2",
@@ -73,6 +74,7 @@
     "sass": "^1.66.1",
     "shadow-cljs": "2.26.2",
     "storybook": "^7.5.3",
+    "typescript": "^5.3.3",
     "vite": "^5.0.2"
   },
   "dependencies": {
@@ -90,7 +92,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-virtualized": "^9.22.3",
-    "rxjs": "~7.8.1",
+    "rxjs": "8.0.0-alpha.13",
     "sax": "^1.2.4",
     "source-map-support": "^0.5.21",
     "tdigest": "^0.1.2",

--- a/frontend/src/app/libs/render.cljs
+++ b/frontend/src/app/libs/render.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.common.uuid :as uuid]
    [app.main.render :as r]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [promesa.core :as p]))
 
 (defn render-page-export
@@ -22,7 +22,7 @@
      (fn [resolve reject]
        (->> (r/render-page data)
             (rx/take 1)
-            (rx/subs resolve reject))) )))
+            (rx/subs! resolve reject))) )))
 
 (defn exports []
   #js {:renderPage render-page-export})

--- a/frontend/src/app/main.cljs
+++ b/frontend/src/app/main.cljs
@@ -28,10 +28,10 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n]
    [app.util.theme :as theme]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [debug]
    [features]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (log/setup! {:app :info})

--- a/frontend/src/app/main/broadcast.cljs
+++ b/frontend/src/app/main/broadcast.cljs
@@ -9,8 +9,8 @@
   (:require
    [app.common.exceptions :as ex]
    [app.common.transit :as t]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defrecord BroadcastMessage [id type data]
   cljs.core/IDeref

--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -14,8 +14,8 @@
    [app.common.uuid :as uuid]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.repo :as rp]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (def ^:private schema:comment-thread
   (sm/define

--- a/frontend/src/app/main/data/common.cljs
+++ b/frontend/src/app/main/data/common.cljs
@@ -14,8 +14,8 @@
    [app.main.features :as features]
    [app.main.repo :as rp]
    [app.util.i18n :refer [tr]]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; SHARE LINK

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -30,9 +30,9 @@
    [app.util.time :as dt]
    [app.util.timers :as tm]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (log/set-level! :warn)
 
@@ -419,7 +419,7 @@
              (rx/map di/validate-file)
              (rx/map prepare)
              (rx/mapcat #(rp/cmd! :update-team-photo %))
-             (rx/do on-success)
+             (rx/tap on-success)
              (rx/map du/fetch-teams)
              (rx/catch on-error))))))
 

--- a/frontend/src/app/main/data/exports.cljs
+++ b/frontend/src/app/main/data/exports.cljs
@@ -15,8 +15,8 @@
    [app.util.dom :as dom]
    [app.util.time :as dt]
    [app.util.websocket :as ws]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (def default-timeout 5000)
 

--- a/frontend/src/app/main/data/fonts.cljs
+++ b/frontend/src/app/main/data/fonts.cljs
@@ -19,9 +19,9 @@
    [app.util.i18n :refer [tr]]
    [app.util.storage :refer [storage]]
    [app.util.webapi :as wa]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; General purpose events & IMPL

--- a/frontend/src/app/main/data/media.cljs
+++ b/frontend/src/app/main/data/media.cljs
@@ -11,7 +11,7 @@
    [app.main.data.messages :as dm]
    [app.main.store :as st]
    [app.util.i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [cuerdas.core :as str]))
 

--- a/frontend/src/app/main/data/messages.cljs
+++ b/frontend/src/app/main/data/messages.cljs
@@ -9,8 +9,8 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.schema :as sm]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (declare hide)
 (declare show)

--- a/frontend/src/app/main/data/modal.cljs
+++ b/frontend/src/app/main/data/modal.cljs
@@ -10,7 +10,7 @@
    [app.common.uuid :as uuid]
    [app.main.store :as st]
    [cljs.core :as c]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defonce components (atom {}))
 

--- a/frontend/src/app/main/data/preview.cljs
+++ b/frontend/src/app/main/data/preview.cljs
@@ -16,10 +16,10 @@
    [app.main.refs :as refs]
    [app.util.code-gen :as cg]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (def style-type "css")
 (def markup-type "html")
@@ -80,7 +80,7 @@
              (rx/merge-map fonts/fetch-font-css)
              (rx/reduce conj [])
              (rx/map #(str/join "\n" %))
-             (rx/subs
+             (rx/subs!
               (fn [fontfaces-css]
                 (let [style-code
                       (dm/str

--- a/frontend/src/app/main/data/shortcuts.cljs
+++ b/frontend/src/app/main/data/shortcuts.cljs
@@ -13,7 +13,7 @@
    [app.common.schema :as sm]
    [app.config :as cf]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (log/set-level! :warn)
 

--- a/frontend/src/app/main/data/users.cljs
+++ b/frontend/src/app/main/data/users.cljs
@@ -21,8 +21,8 @@
    [app.util.i18n :as i18n]
    [app.util.router :as rt]
    [app.util.storage :refer [storage]]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; --- SCHEMAS
 
@@ -434,7 +434,7 @@
              (rx/map di/validate-file)
              (rx/map prepare)
              (rx/mapcat #(rp/cmd! :update-profile-photo %))
-             (rx/do on-success)
+             (rx/tap on-success)
              (rx/map (constantly (fetch-profile)))
              (rx/catch on-error))))))
 

--- a/frontend/src/app/main/data/viewer.cljs
+++ b/frontend/src/app/main/data/viewer.cljs
@@ -21,8 +21,8 @@
    [app.main.repo :as rp]
    [app.util.globals :as ug]
    [app.util.router :as rt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; --- Local State Initialization
 

--- a/frontend/src/app/main/data/websocket.cljs
+++ b/frontend/src/app/main/data/websocket.cljs
@@ -44,7 +44,7 @@
   (ptk/reify ::initialize
     ptk/WatchEvent
     (watch [_ state stream]
-      (l/trace :hint "event:initialize" :fn "watch")
+      (l/trace :hint "initialize" :fn "watch")
       (let [sid (:session-id state)
             uri (prepare-uri {:session-id sid})
             ws  (ws/create uri)]

--- a/frontend/src/app/main/data/websocket.cljs
+++ b/frontend/src/app/main/data/websocket.cljs
@@ -11,8 +11,8 @@
    [app.common.uri :as u]
    [app.config :as cf]
    [app.util.websocket :as ws]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (l/set-level! :error)
 

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -78,10 +78,10 @@
    [app.util.router :as rt]
    [app.util.timers :as tm]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (def default-workspace-local {:zoom 1})
 
@@ -444,7 +444,7 @@
             uris  (into #{} xform (wsh/lookup-page-objects state page-id))]
 
         (->> (rx/from uris)
-             (rx/subs #(http/fetch-data-uri % false)))))))
+             (rx/subs! #(http/fetch-data-uri % false)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Workspace Page CRUD

--- a/frontend/src/app/main/data/workspace/bool.cljs
+++ b/frontend/src/app/main/data/workspace/bool.cljs
@@ -18,9 +18,9 @@
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn selected-shapes-idx
   [state]

--- a/frontend/src/app/main/data/workspace/changes.cljs
+++ b/frontend/src/app/main/data/workspace/changes.cljs
@@ -20,8 +20,8 @@
    [app.main.data.workspace.undo :as dwu]
    [app.main.store :as st]
    [app.main.worker :as uw]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; Change this to :info :debug or :trace to debug this module
 (log/set-level! :warn)

--- a/frontend/src/app/main/data/workspace/collapse.cljs
+++ b/frontend/src/app/main/data/workspace/collapse.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.common.files.helpers :as cfh]
    [app.common.uuid :as uuid]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 ;; --- Shape attrs (Layers Sidebar)
 

--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -23,8 +23,8 @@
    [app.main.data.workspace.undo :as dwu]
    [app.util.color :as uc]
    [app.util.storage :refer [storage]]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; A set of keys that are used for shared state identifiers
 (def ^:const colorpicker-selected-broadcast-key ::colorpicker-selected)
@@ -353,7 +353,7 @@
            ;; Stream that updates the stroke/width and stops if `esc` pressed
            (->> sub
                 (rx/take-until stop?)
-                (rx/flat-map update-events))
+                (rx/merge-map update-events))
 
            ;; Hide the modal if the stop event is emitted
            (->> stop?

--- a/frontend/src/app/main/data/workspace/comments.cljs
+++ b/frontend/src/app/main/data/workspace/comments.cljs
@@ -22,8 +22,8 @@
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
    [app.util.router :as rt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (declare handle-interrupt)
 (declare handle-comment-layer-click)

--- a/frontend/src/app/main/data/workspace/common.cljs
+++ b/frontend/src/app/main/data/workspace/common.cljs
@@ -13,8 +13,8 @@
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
    [app.util.router :as rt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; Change this to :info :debug or :trace to debug this module
 (log/set-level! :warn)

--- a/frontend/src/app/main/data/workspace/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/drawing.cljs
@@ -14,8 +14,8 @@
    [app.main.data.workspace.drawing.common :as common]
    [app.main.data.workspace.drawing.curve :as curve]
    [app.main.data.workspace.path :as path]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (declare start-drawing)
 (declare handle-drawing)

--- a/frontend/src/app/main/data/workspace/drawing/box.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/box.cljs
@@ -24,6 +24,7 @@
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.snap :as snap]
    [app.main.streams :as ms]
+   [app.util.array :as array]
    [app.util.mouse :as mse]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
@@ -128,12 +129,11 @@
 
                (->> ms/mouse-position
                     (rx/filter #(> (gpt/distance % initial) (/ 2 zoom)))
-                    (rx/with-latest vector ms/mouse-position-shift)
-                    (rx/with-latest conj ms/mouse-position-mod)
+                    (rx/with-latest-from ms/mouse-position-shift ms/mouse-position-mod)
                     (rx/switch-map
                      (fn [[point :as current]]
                        (->> (snap/closest-snap-point page-id [shape] objects layout zoom focus point)
-                            (rx/map #(conj current %)))))
+                            (rx/map (partial array/conj current)))))
                     (rx/map
                      (fn [[_ shift? mod? point]]
                        #(update-drawing % initial (cond-> point snap-pixel? (gpt/round-step snap-prec)) shift? mod?)))))

--- a/frontend/src/app/main/data/workspace/drawing/box.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/box.cljs
@@ -25,8 +25,8 @@
    [app.main.snap :as snap]
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn adjust-ratio
   [point initial]

--- a/frontend/src/app/main/data/workspace/drawing/common.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/common.cljs
@@ -16,8 +16,8 @@
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
    [app.main.worker :as uw]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn clear-drawing
   []

--- a/frontend/src/app/main/data/workspace/drawing/curve.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/curve.cljs
@@ -23,8 +23,8 @@
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
    [app.util.path.simplify-curve :as ups]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (def simplify-tolerance 0.3)
 

--- a/frontend/src/app/main/data/workspace/edition.cljs
+++ b/frontend/src/app/main/data/workspace/edition.cljs
@@ -10,8 +10,8 @@
    [app.common.types.shape.layout :as ctl]
    [app.main.data.workspace.common :as dwc]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn interrupt? [e] (= e :interrupt))
 

--- a/frontend/src/app/main/data/workspace/fix_bool_contents.cljs
+++ b/frontend/src/app/main/data/workspace/fix_bool_contents.cljs
@@ -10,8 +10,8 @@
    [app.common.geom.shapes :as gsh]
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; This event will update the file so the boolean data has a pre-generated path data
 ;; to increase performance.

--- a/frontend/src/app/main/data/workspace/fix_broken_shapes.cljs
+++ b/frontend/src/app/main/data/workspace/fix_broken_shapes.cljs
@@ -7,8 +7,8 @@
 (ns app.main.data.workspace.fix-broken-shapes
   (:require
    [app.main.data.workspace.changes :as dch]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn- generate-broken-link-changes
   [attr {:keys [objects id] :as container}]

--- a/frontend/src/app/main/data/workspace/fix_deleted_fonts.cljs
+++ b/frontend/src/app/main/data/workspace/fix_deleted_fonts.cljs
@@ -12,8 +12,8 @@
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.fonts :as fonts]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; This event will update the file so the texts with non existing custom fonts try to be fixed.
 ;; This can happen when:

--- a/frontend/src/app/main/data/workspace/grid.cljs
+++ b/frontend/src/app/main/data/workspace/grid.cljs
@@ -12,8 +12,8 @@
    [app.common.files.changes-builder :as pcb]
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Grid

--- a/frontend/src/app/main/data/workspace/grid_layout/editor.cljs
+++ b/frontend/src/app/main/data/workspace/grid_layout/editor.cljs
@@ -9,7 +9,7 @@
    [app.common.geom.rect :as grc]
    [app.common.types.shape.layout :as ctl]
    [app.main.data.workspace.state-helpers :as wsh]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn hover-grid-cell
   [grid-id cell-id add-to-set]

--- a/frontend/src/app/main/data/workspace/grid_layout/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/grid_layout/shortcuts.cljs
@@ -10,8 +10,8 @@
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.common :as dwc]
    [app.main.store :as st]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Shortcuts

--- a/frontend/src/app/main/data/workspace/groups.cljs
+++ b/frontend/src/app/main/data/workspace/groups.cljs
@@ -19,8 +19,8 @@
    [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn shapes-for-grouping
   [objects selected]

--- a/frontend/src/app/main/data/workspace/guides.cljs
+++ b/frontend/src/app/main/data/workspace/guides.cljs
@@ -13,8 +13,8 @@
    [app.common.types.page :as ctp]
    [app.main.data.workspace.changes :as dwc]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn make-update-guide [guide]
   (fn [other]

--- a/frontend/src/app/main/data/workspace/highlight.cljs
+++ b/frontend/src/app/main/data/workspace/highlight.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.common.data.macros :as dm]
    [clojure.set :as set]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 ;; --- Manage shape's highlight status
 

--- a/frontend/src/app/main/data/workspace/interactions.cljs
+++ b/frontend/src/app/main/data/workspace/interactions.cljs
@@ -20,8 +20,8 @@
    [app.main.data.workspace.undo :as dwu]
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; --- Flows
 

--- a/frontend/src/app/main/data/workspace/layers.cljs
+++ b/frontend/src/app/main/data/workspace/layers.cljs
@@ -11,9 +11,9 @@
    [app.common.math :as mth]
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 ;; -- Opacity ----------------------------------------------------------
 

--- a/frontend/src/app/main/data/workspace/layout.cljs
+++ b/frontend/src/app/main/data/workspace/layout.cljs
@@ -10,7 +10,7 @@
    [app.common.data.macros :as dm]
    [app.util.storage :refer [storage]]
    [clojure.set :as set]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (def valid-flags
   #{:sitemap

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -45,9 +45,9 @@
    [app.util.i18n :refer [tr]]
    [app.util.router :as rt]
    [app.util.time :as dt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 ;; Change this to :info :debug or :trace to debug this module, or :warn to reset to default
 (log/set-level! :warn)

--- a/frontend/src/app/main/data/workspace/media.cljs
+++ b/frontend/src/app/main/data/workspace/media.cljs
@@ -30,9 +30,9 @@
    [app.main.store :as st]
    [app.util.http :as http]
    [app.util.i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [promesa.core :as p]
    [tubax.core :as tubax]))
 
@@ -122,13 +122,13 @@
      (->> (rx/from uris)
           (rx/filter (comp not svg-url?))
           (rx/mapcat upload)
-          (rx/do on-image))
+          (rx/tap on-image))
 
      (->> (rx/from uris)
           (rx/filter svg-url?)
           (rx/merge-map (partial fetch-svg name))
           (rx/merge-map svg->clj)
-          (rx/do on-svg)))))
+          (rx/tap on-svg)))))
 
 (defn- process-blobs
   [{:keys [file-id local? name blobs force-media on-image on-svg]}]
@@ -154,14 +154,14 @@
           (rx/filter (comp not svg-blob?))
           (rx/map prepare-blob)
           (rx/mapcat #(rp/cmd! :upload-file-media-object %))
-          (rx/do on-image))
+          (rx/tap on-image))
 
      (->> (rx/from blobs)
           (rx/map dmm/validate-file)
           (rx/filter svg-blob?)
           (rx/merge-map extract-content)
           (rx/merge-map svg->clj)
-          (rx/do on-svg)))))
+          (rx/tap on-svg)))))
 
 (defn handle-media-error [error on-error]
   (if (ex/ex-info? error)
@@ -278,7 +278,7 @@
              (rx/map dmm/validate-file)
              (rx/map prepare)
              (rx/mapcat #(rp/cmd! :upload-file-media-object %))
-             (rx/do on-upload-success)
+             (rx/tap on-upload-success)
              (rx/catch handle-media-error))))))
 
 ;; --- Upload File Media objects
@@ -423,7 +423,7 @@
                            :timeout nil
                            :tag :media-loading}))
          (->> (rp/cmd! :clone-file-media-object params)
-              (rx/do on-success)
+              (rx/tap on-success)
               (rx/catch on-error)
               (rx/finalize #(st/emit! (msg/hide-tag :media-loading)))))))))
 

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -27,8 +27,8 @@
    [app.main.data.workspace.guides :as-alias dwg]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; -- temporary modifiers -------------------------------------------
 

--- a/frontend/src/app/main/data/workspace/notifications.cljs
+++ b/frontend/src/app/main/data/workspace/notifications.cljs
@@ -19,6 +19,7 @@
    [app.util.globals :refer [global]]
    [app.util.mouse :as mse]
    [app.util.object :as obj]
+   [app.util.rxops :as rxs]
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
    [clojure.set :as set]
@@ -82,7 +83,7 @@
                              ;; position changes.
                              (->> stream
                                   (rx/filter mse/pointer-event?)
-                                  (rx/sample 50)
+                                  (rx/pipe (rxs/throttle 100))
                                   (rx/map #(handle-pointer-send file-id (:pt %)))))
 
                             (rx/take-until stoper))]

--- a/frontend/src/app/main/data/workspace/notifications.cljs
+++ b/frontend/src/app/main/data/workspace/notifications.cljs
@@ -20,9 +20,9 @@
    [app.util.mouse :as mse]
    [app.util.object :as obj]
    [app.util.time :as dt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (declare process-message)
 (declare handle-presence)

--- a/frontend/src/app/main/data/workspace/path/changes.cljs
+++ b/frontend/src/app/main/data/workspace/path/changes.cljs
@@ -13,8 +13,8 @@
    [app.main.data.workspace.path.helpers :as helpers]
    [app.main.data.workspace.path.state :as st]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn generate-path-changes
   "Generates changes to update the new content of the shape"

--- a/frontend/src/app/main/data/workspace/path/common.cljs
+++ b/frontend/src/app/main/data/workspace/path/common.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.common.schema :as sm]
    [app.main.data.workspace.path.state :as st]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (def valid-commands
   #{:move-to

--- a/frontend/src/app/main/data/workspace/path/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/path/drawing.cljs
@@ -27,8 +27,8 @@
    [app.main.data.workspace.path.undo :as undo]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (declare change-edit-mode)
 

--- a/frontend/src/app/main/data/workspace/path/edition.cljs
+++ b/frontend/src/app/main/data/workspace/path/edition.cljs
@@ -28,8 +28,8 @@
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
    [app.util.path.tools :as upt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn modify-handler [id index prefix dx dy match-opposite?]
   (ptk/reify ::modify-handler

--- a/frontend/src/app/main/data/workspace/path/helpers.cljs
+++ b/frontend/src/app/main/data/workspace/path/helpers.cljs
@@ -15,7 +15,7 @@
    [app.common.svg.path.subpath :as ups]
    [app.main.data.workspace.path.common :as common]
    [app.util.mouse :as mse]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn end-path-event?
   [event]

--- a/frontend/src/app/main/data/workspace/path/selection.cljs
+++ b/frontend/src/app/main/data/workspace/path/selection.cljs
@@ -14,8 +14,8 @@
    [app.main.data.workspace.path.state :as st]
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn path-pointer-enter [position]
   (ptk/reify ::path-pointer-enter

--- a/frontend/src/app/main/data/workspace/path/shapes_to_path.cljs
+++ b/frontend/src/app/main/data/workspace/path/shapes_to_path.cljs
@@ -12,8 +12,8 @@
    [app.common.types.container :as ctn]
    [app.main.data.workspace.changes :as dch]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn convert-selected-to-path []
   (ptk/reify ::convert-selected-to-path

--- a/frontend/src/app/main/data/workspace/path/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/path/shortcuts.cljs
@@ -10,8 +10,8 @@
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.path :as drp]
    [app.main.store :as st]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Shortcuts

--- a/frontend/src/app/main/data/workspace/path/streams.cljs
+++ b/frontend/src/app/main/data/workspace/path/streams.cljs
@@ -15,9 +15,9 @@
    [app.main.store :as st]
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [okulary.core :as l]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defonce drag-threshold 5)
 

--- a/frontend/src/app/main/data/workspace/path/streams.cljs
+++ b/frontend/src/app/main/data/workspace/path/streams.cljs
@@ -115,7 +115,6 @@
 
 (defn move-handler-stream
   [start-point node handler opposite points]
-
   (let [zoom (get-in @st/state [:workspace-local :zoom] 1)
         ranges (snap/create-ranges points)
         d-pos (/ snap/snap-path-accuracy zoom)
@@ -145,16 +144,20 @@
                 (let [snap (snap/get-snap-delta [handler] ranges d-pos)]
                   (merge position (gpt/add position snap)))))
             position))]
+
     (->> ms/mouse-position
          (rx/map to-pixel-snap)
-         (rx/with-latest merge (->> ms/mouse-position-shift (rx/map #(hash-map :shift? %))))
-         (rx/with-latest merge (->> ms/mouse-position-alt (rx/map #(hash-map :alt? %))))
+         (rx/with-latest-from
+           (fn [position shift? alt?]
+             (assoc position :shift? shift? :alt? alt?))
+           ms/mouse-position-shift
+           ms/mouse-position-alt)
          (rx/with-latest-from (snap-toggled-stream))
          (rx/map check-path-snap))))
 
 (defn position-stream
-  []
-  (let [zoom (get-in @st/state [:workspace-local :zoom] 1)
+  [state]
+  (let [zoom (get-in state [:workspace-local :zoom] 1)
         d-pos (/ snap/snap-path-accuracy zoom)
         get-content #(pst/get-path % :content)
 
@@ -169,12 +172,14 @@
 
     (->> ms/mouse-position
          (rx/map to-pixel-snap)
-         (rx/with-latest vector ranges-stream)
-         (rx/with-latest-from (snap-toggled-stream))
-         (rx/map (fn [[[position ranges] snap-toggled]]
+         (rx/with-latest-from ranges-stream (snap-toggled-stream))
+         (rx/map (fn [[position ranges snap-toggled]]
                    (if snap-toggled
                      (let [snap (snap/get-snap-delta [position] ranges d-pos)]
                        (gpt/add position snap))
                      position)))
-         (rx/with-latest merge (->> ms/mouse-position-shift (rx/map #(hash-map :shift? %))))
-         (rx/with-latest merge (->> ms/mouse-position-alt (rx/map #(hash-map :alt? %)))))))
+         (rx/with-latest-from
+           (fn [position shift? alt?]
+             (assoc position :shift? shift? :alt? alt?))
+           ms/mouse-position-shift
+           ms/mouse-position-alt))))

--- a/frontend/src/app/main/data/workspace/path/tools.cljs
+++ b/frontend/src/app/main/data/workspace/path/tools.cljs
@@ -14,8 +14,8 @@
    [app.main.data.workspace.path.state :as st]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.util.path.tools :as upt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn process-path-tool
   "Generic function that executes path transformations with the content and selected nodes"

--- a/frontend/src/app/main/data/workspace/path/undo.cljs
+++ b/frontend/src/app/main/data/workspace/path/undo.cljs
@@ -12,9 +12,9 @@
    [app.main.data.workspace.path.changes :as changes]
    [app.main.data.workspace.path.state :as st]
    [app.main.store :as store]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [okulary.core :as l]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn undo-event?
   [event]

--- a/frontend/src/app/main/data/workspace/persistence.cljs
+++ b/frontend/src/app/main/data/workspace/persistence.cljs
@@ -18,9 +18,9 @@
    [app.main.store :as st]
    [app.util.router :as rt]
    [app.util.time :as dt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [okulary.core :as l]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (log/set-level! :info)
 

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -36,10 +36,11 @@
    [app.main.streams :as ms]
    [app.main.worker :as uw]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
+   [beicon.v2.operators :as rxo]
    [clojure.set :as set]
    [linked.set :as lks]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn interrupt?
   [e]
@@ -111,8 +112,8 @@
 
           (->> selrect-stream
                (rx/buffer-time 100)
-               (rx/map #(last %))
-               (rx/dedupe)
+               (rx/map last)
+               (rx/pipe (rxo/distinct-contiguous))
                (rx/map #(select-shapes-by-current-selrect preserve? ignore-groups?))))
 
          (->> (rx/of (update-selrect nil))

--- a/frontend/src/app/main/data/workspace/shape_layout.cljs
+++ b/frontend/src/app/main/data/workspace/shape_layout.cljs
@@ -24,8 +24,8 @@
    [app.main.data.workspace.shapes :as dws]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (def layout-keys
   [:layout

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -24,8 +24,8 @@
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
    [app.main.features :as features]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn add-shape
   ([shape]

--- a/frontend/src/app/main/data/workspace/specialized_panel.cljs
+++ b/frontend/src/app/main/data/workspace/specialized_panel.cljs
@@ -9,8 +9,8 @@
    [app.common.data :as d]
    [app.main.data.workspace.common :as-alias dwc]
    [app.main.data.workspace.state-helpers :as wsh]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn interrupt? [e] (or (= e :interrupt) (= e ::interrupt)))
 

--- a/frontend/src/app/main/data/workspace/svg_upload.cljs
+++ b/frontend/src/app/main/data/workspace/svg_upload.cljs
@@ -19,9 +19,9 @@
    [app.main.data.workspace.undo :as dwu]
    [app.main.repo :as rp]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn extract-name [href]
   (let [query-idx (str/last-index-of href "?")

--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -29,9 +29,9 @@
    [app.util.router :as rt]
    [app.util.text-editor :as ted]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 ;; -- Attrs
 

--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -24,8 +24,8 @@
    [app.util.time :as tp]
    [app.util.timers :as tm]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (l/set-level! :info)
 
@@ -246,7 +246,7 @@
                        (rx/filter dch/commit-changes?)
                        (rx/observe-on :async)
                        (rx/with-latest-from workspace-data-s)
-                       (rx/flat-map (partial extract-frame-changes page-id))
+                       (rx/merge-map (partial extract-frame-changes page-id))
                        (rx/tap #(l/trc :hint "inconming change" :origin "local" :frame-id (dm/str %))))
 
                   ;; NOTIFICATIONS CHANGES
@@ -254,7 +254,7 @@
                        (rx/filter (ptk/type? ::wnt/handle-file-change))
                        (rx/observe-on :async)
                        (rx/with-latest-from workspace-data-s)
-                       (rx/flat-map (partial extract-frame-changes page-id))
+                       (rx/merge-map (partial extract-frame-changes page-id))
                        (rx/tap #(l/trc :hint "inconming change" :origin "notifications" :frame-id (dm/str %))))
 
                   ;; PERSISTENCE CHANGES

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -35,8 +35,8 @@
    [app.util.dom :as dom]
    [app.util.keyboard :as kbd]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 ;; -- Helpers --------------------------------------------------------
 

--- a/frontend/src/app/main/data/workspace/undo.cljs
+++ b/frontend/src/app/main/data/workspace/undo.cljs
@@ -12,8 +12,8 @@
    [app.common.logging :as log]
    [app.common.schema :as sm]
    [app.util.time :as dt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (def discard-transaction-time-millis (* 20 1000))
 

--- a/frontend/src/app/main/data/workspace/viewport.cljs
+++ b/frontend/src/app/main/data/workspace/viewport.cljs
@@ -16,8 +16,8 @@
    [app.common.math :as mth]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn initialize-viewport
   [{:keys [width height] :as size}]

--- a/frontend/src/app/main/data/workspace/zoom.cljs
+++ b/frontend/src/app/main/data/workspace/zoom.cljs
@@ -15,8 +15,8 @@
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
-   [potok.core :as ptk]))
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]))
 
 (defn- impl-update-zoom
   [{:keys [vbox] :as local} center zoom]

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -20,7 +20,7 @@
    [app.util.storage :refer [storage]]
    [app.util.timers :as ts]
    [cuerdas.core :as str]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (defn- print-data!
   [data]

--- a/frontend/src/app/main/features.cljs
+++ b/frontend/src/app/main/features.cljs
@@ -12,11 +12,11 @@
    [app.common.logging :as log]
    [app.config :as cf]
    [app.main.store :as st]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
    [cuerdas.core :as str]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (log/set-level! :trace)

--- a/frontend/src/app/main/features/pointer_map.cljs
+++ b/frontend/src/app/main/features/pointer_map.cljs
@@ -9,7 +9,7 @@
   (:require
    [app.common.transit :as t]
    [app.main.repo :as rp]
-   [beicon.core :as rx]))
+   [beicon.v2.core :as rx]))
 
 (defn resolve-file
   [{:keys [id data] :as file}]

--- a/frontend/src/app/main/fonts.cljs
+++ b/frontend/src/app/main/fonts.cljs
@@ -17,7 +17,7 @@
    [app.util.globals :as globals]
    [app.util.http :as http]
    [app.util.object :as obj]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
    [cuerdas.core :as str]
    [lambdaisland.uri :as u]
@@ -144,7 +144,7 @@
       (->> (fetch-gfont-css url)
            (rx/map process-gfont-css)
            (rx/tap #(on-loaded id))
-           (rx/subs (partial add-font-css! id)))
+           (rx/subs! (partial add-font-css! id)))
       nil)))
 
 ;; --- LOADER: CUSTOM

--- a/frontend/src/app/main/rasterizer.cljs
+++ b/frontend/src/app/main/rasterizer.cljs
@@ -18,7 +18,7 @@
    [app.config :as cf]
    [app.util.dom :as dom]
    [app.util.http :as http]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]))
 
 (defonce ready? false)
@@ -123,18 +123,18 @@
                      (log/err :hint "rasterizer iframe blocked by adblocker" :origin origin :cause cause)
                      (rx/of false)))
 
-         (rx/subs (fn [allowed?]
-                    (if allowed?
-                      (do
-                        (dom/append-child! js/document.body iframe)
-                        (set! instance iframe))
+         (rx/subs! (fn [allowed?]
+                     (if allowed?
+                       (do
+                         (dom/append-child! js/document.body iframe)
+                         (set! instance iframe))
 
-                      (let [new-origin (dm/str (assoc cf/public-uri :path "/rasterizer.html"))]
-                        (log/warn :hint "fallback to main domain" :origin new-origin)
+                       (let [new-origin (dm/str (assoc cf/public-uri :path "/rasterizer.html"))]
+                         (log/warn :hint "fallback to main domain" :origin new-origin)
 
-                        (dom/set-attribute! iframe "src" new-origin)
-                        (dom/append-child! js/document.body iframe)
+                         (dom/set-attribute! iframe "src" new-origin)
+                         (dom/append-child! js/document.body iframe)
 
-                        (set! origin new-origin)
-                        (set! cf/rasterizer-uri cf/public-uri)
-                        (set! instance iframe))))))))
+                         (set! origin new-origin)
+                         (set! cf/rasterizer-uri cf/public-uri)
+                         (set! instance iframe))))))))

--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -48,7 +48,7 @@
    [app.util.strings :as ust]
    [app.util.thumbnails :as th]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
@@ -550,7 +550,7 @@
                     (mapcat get-image-data))]
     (->> (rx/from images)
          (rx/map #(cfg/resolve-file-media %))
-         (rx/flat-map http/fetch-data-uri))))
+         (rx/merge-map http/fetch-data-uri))))
 
 (defn populate-fonts-cache [objects]
   (let [texts (->> objects
@@ -561,10 +561,10 @@
     (->> (rx/from texts)
          (rx/map fonts/get-content-fonts)
          (rx/reduce set/union #{})
-         (rx/flat-map identity)
-         (rx/flat-map fonts/fetch-font-css)
-         (rx/flat-map fonts/extract-fontface-urls)
-         (rx/flat-map http/fetch-data-uri))))
+         (rx/merge-map identity)
+         (rx/merge-map fonts/fetch-font-css)
+         (rx/merge-map fonts/extract-fontface-urls)
+         (rx/merge-map http/fetch-data-uri))))
 
 (defn render-page
   [data]

--- a/frontend/src/app/main/repo.cljs
+++ b/frontend/src/app/main/repo.cljs
@@ -12,7 +12,7 @@
    [app.config :as cf]
    [app.util.http :as http]
    [app.util.sse :as sse]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]))
 
 (defn handle-response

--- a/frontend/src/app/main/snap.cljs
+++ b/frontend/src/app/main/snap.cljs
@@ -19,7 +19,7 @@
    [app.main.refs :as refs]
    [app.main.worker :as uw]
    [app.util.range-tree :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]))
 
 (def ^:const snap-accuracy 10)

--- a/frontend/src/app/main/store.cljs
+++ b/frontend/src/app/main/store.cljs
@@ -9,9 +9,10 @@
    [app.common.logging :as log]
    [app.util.object :as obj]
    [app.util.timers :as tm]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
+   [beicon.v2.operators :as rxo]
    [okulary.core :as l]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (log/set-level! :info)
 
@@ -65,7 +66,7 @@
           (->> stream
                (rx/filter (ptk/type? :app.main.data.workspace.changes/commit-changes))
                (rx/map #(-> % deref :hint-origin str))
-               (rx/dedupe))
+               (rx/pipe (rxo/distinct-contiguous)))
           (->> stream
                (rx/map ptk/type)
                (rx/filter #(contains? allowed %))
@@ -75,7 +76,7 @@
                       (> (count buffer) 20)
                       (pop)))
                   #queue [])
-         (rx/subs #(reset! buffer (vec %))))
+         (rx/subs! #(reset! buffer (vec %))))
     buffer))
 
 (defn emit!

--- a/frontend/src/app/main/streams.cljs
+++ b/frontend/src/app/main/streams.cljs
@@ -12,7 +12,8 @@
    [app.util.globals :as globals]
    [app.util.keyboard :as kbd]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]))
+   [beicon.v2.core :as rx]
+   [beicon.v2.operators :as rxo]))
 
 ;; --- User Events
 
@@ -33,23 +34,23 @@
         ob  (->> pointer
                  (rx/filter #(= :viewport (mse/get-pointer-source %)))
                  (rx/map mse/get-pointer-position))]
-    (rx/subscribe-with ob sub)
+    (rx/sub! ob sub)
     sub))
 
 (defonce mouse-position-ctrl
   (let [sub (rx/behavior-subject nil)
         ob  (->> pointer
                  (rx/map mse/get-pointer-ctrl-mod)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce mouse-position-meta
   (let [sub (rx/behavior-subject nil)
         ob  (->> pointer
                  (rx/map mse/get-pointer-meta-mod)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce mouse-position-mod
@@ -61,16 +62,16 @@
   (let [sub (rx/behavior-subject nil)
         ob  (->> pointer
                  (rx/map mse/get-pointer-shift-mod)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce mouse-position-alt
   (let [sub (rx/behavior-subject nil)
         ob  (->> pointer
                  (rx/map mse/get-pointer-alt-mod)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce ^:private window-blur
@@ -93,8 +94,8 @@
                  ;; registering the key pressed but on blurring the
                  ;; window (unfocus) the key down is never arrived.
                  (rx/merge window-blur)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce keyboard-ctrl
@@ -107,8 +108,8 @@
                  ;; registering the key pressed but on blurring the
                  ;; window (unfocus) the key down is never arrived.
                  (rx/merge window-blur)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce keyboard-meta
@@ -121,8 +122,8 @@
                  ;; registering the key pressed but on blurring the
                  ;; window (unfocus) the key down is never arrived.
                  (rx/merge window-blur)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))
 
 (defonce keyboard-mod
@@ -136,6 +137,6 @@
                  (rx/filter kbd/space?)
                  (rx/filter (complement kbd/editing-event?))
                  (rx/map kbd/key-down-event?)
-                 (rx/dedupe))]
-    (rx/subscribe-with ob sub)
+                 (rx/pipe (rxo/distinct-contiguous)))]
+    (rx/sub! ob sub)
     sub))

--- a/frontend/src/app/main/ui/auth/login.cljs
+++ b/frontend/src/app/main/ui/auth/login.cljs
@@ -25,7 +25,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.keyboard :as k]
    [app.util.router :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [rumext.v2 :as mf]))
 
@@ -40,7 +40,7 @@
   [event provider params]
   (dom/prevent-default event)
   (->> (rp/cmd! :login-with-oidc (assoc params :provider provider))
-       (rx/subs (fn [{:keys [redirect-uri] :as rsp}]
+       (rx/subs! (fn [{:keys [redirect-uri] :as rsp}]
                   (if redirect-uri
                     (.replace js/location redirect-uri)
                     (log/error :hint "unexpected response from OIDC method"
@@ -60,7 +60,7 @@
   (dom/stop-propagation event)
   (let [{:keys [on-error]} (meta params)]
     (->> (rp/cmd! :login-with-ldap params)
-         (rx/subs (fn [profile]
+         (rx/subs! (fn [profile]
                     (if-let [token (:invitation-token profile)]
                       (st/emit! (rt/nav :auth-verify-token {} {:token token}))
                       (st/emit! (du/login-from-token {:profile profile}))))

--- a/frontend/src/app/main/ui/auth/recovery_request.cljs
+++ b/frontend/src/app/main/ui/auth/recovery_request.cljs
@@ -18,7 +18,7 @@
    [app.main.ui.icons :as i]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/app/main/ui/auth/register.cljs
+++ b/frontend/src/app/main/ui/auth/register.cljs
@@ -22,7 +22,7 @@
    [app.main.ui.messages :as msgs]
    [app.util.i18n :refer [tr tr-html]]
    [app.util.router :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [rumext.v2 :as mf]))
 
@@ -109,7 +109,7 @@
              (->> (rp/cmd! :prepare-register-profile cdata)
                   (rx/map #(merge % params))
                   (rx/finalize #(reset! submitted? false))
-                  (rx/subs
+                  (rx/subs!
                    on-success
                    (partial handle-prepare-register-error form))))))]
 
@@ -303,7 +303,7 @@
            (let [params (:clean-data @form)]
              (->> (rp/cmd! :register-profile params)
                   (rx/finalize #(reset! submitted? false))
-                  (rx/subs on-success
+                  (rx/subs! on-success
                            (partial handle-register-error form))))))]
 
     (if new-css-system
@@ -375,7 +375,7 @@
         [:div {:class (stl/css :link-entry :go-back)}
          [:& lk/link {:action  #(st/emit! (rt/nav :auth-register {} {}))}
           (tr "labels.go-back")]]]]
-      
+
       ;; OLD
       [:div.form-container
        [:h1 {:data-test "register-title"} (tr "auth.register-title")]

--- a/frontend/src/app/main/ui/auth/verify_token.cljs
+++ b/frontend/src/app/main/ui/auth/verify_token.cljs
@@ -18,7 +18,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (defmulti handle-token (fn [token] (:iss token)))
@@ -69,7 +69,7 @@
     (mf/with-effect []
       (dom/set-html-title (tr "title.default"))
       (->> (rp/cmd! :verify-token {:token token})
-           (rx/subs
+           (rx/subs!
             (fn [tdata]
               (handle-token tdata))
             (fn [{:keys [type code] :as error}]

--- a/frontend/src/app/main/ui/components/copy_button.cljs
+++ b/frontend/src/app/main/ui/components/copy_button.cljs
@@ -12,7 +12,7 @@
    [app.main.ui.icons :as i]
    [app.util.timers :as timers]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (mf/defc copy-button [{:keys [data on-copied children class]}]

--- a/frontend/src/app/main/ui/dashboard/comments.cljs
+++ b/frontend/src/app/main/ui/dashboard/comments.cljs
@@ -19,7 +19,7 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc comments-icon

--- a/frontend/src/app/main/ui/dashboard/export.cljs
+++ b/frontend/src/app/main/ui/dashboard/export.cljs
@@ -16,7 +16,7 @@
    [app.main.worker :as uw]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (def ^:const options [:all :merge :detach])
@@ -101,8 +101,9 @@
                   :features features
                   :export-type selected
                   :files files})
-                (rx/delay-emit 1000)
-                (rx/subs
+                (rx/mapcat #(->> (rx/of %)
+                                 (rx/delay 1000)))
+                (rx/subs!
                  (fn [msg]
                    (cond
                      (= :error (:type msg))

--- a/frontend/src/app/main/ui/dashboard/file_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/file_menu.cljs
@@ -18,8 +18,8 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
-   [beicon.core :as rx]
-   [potok.core :as ptk]
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (defn get-project-name
@@ -195,7 +195,7 @@
        (when show?
          (->> (rp/cmd! :get-all-projects)
               (rx/map group-by-team)
-              (rx/subs #(when (mf/ref-val mounted-ref)
+              (rx/subs! #(when (mf/ref-val mounted-ref)
                           (reset! teams %)))))))
 
     (when current-team

--- a/frontend/src/app/main/ui/dashboard/fonts.cljs
+++ b/frontend/src/app/main/ui/dashboard/fonts.cljs
@@ -20,7 +20,7 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -75,7 +75,7 @@
          (mf/deps team installed-fonts)
          (fn [blobs]
            (->> (df/process-upload blobs (:id team))
-                (rx/subs (fn [result]
+                (rx/subs! (fn [result]
                            (swap! fonts df/merge-and-group-fonts installed-fonts result))
                          (fn [error]
                            (js/console.error "error" error))))))
@@ -87,7 +87,7 @@
            (swap! uploading conj (:id item))
            (->> (rp/cmd! :create-font-variant item)
                 (rx/delay-at-least 2000)
-                (rx/subs (fn [font]
+                (rx/subs! (fn [font]
                            (swap! fonts dissoc (:id item))
                            (swap! uploading disj (:id item))
                            (st/emit! (df/add-font font)))

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -35,7 +35,7 @@
    [app.util.keyboard :as kbd]
    [app.util.time :as dt]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -75,7 +75,7 @@
     (mf/with-effect [file-id revn visible? thumbnail-uri]
       (when (and visible? (not thumbnail-uri))
         (->> (ask-for-thumbnail file-id revn)
-             (rx/subs (fn [url]
+             (rx/subs! (fn [url]
                         (st/emit! (dd/set-file-thumbnail file-id url)))
                       (fn [cause]
                         (log/error :hint "unable to render thumbnail"

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -25,9 +25,9 @@
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (log/set-level! :debug)
@@ -319,9 +319,9 @@
            (->> (uw/ask-many!
                  {:cmd :analyze-import
                   :files files})
-                (rx/delay-emit emit-delay)
+                (rx/mapcat #(rx/delay emit-delay (rx/of %)))
                 (rx/filter some?)
-                (rx/subs
+                (rx/subs!
                  (fn [{:keys [uri data error type] :as msg}]
                    (if (some? error)
                      (swap! state update :files set-analyze-error uri)
@@ -337,7 +337,7 @@
                   :project-id project-id
                   :files files
                   :features @features/features-ref})
-                (rx/subs
+                (rx/subs!
                  (fn [{:keys [file-id status message errors] :as msg}]
                    (swap! state update :files update-status file-id status message errors))))))
 

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -31,7 +31,7 @@
    [app.util.time :as dt]
    [cuerdas.core :as str]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc header

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -33,10 +33,10 @@
    [app.util.object :as obj]
    [app.util.router :as rt]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [goog.functions :as f]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc sidebar-project

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -27,7 +27,7 @@
    [app.main.ui.icons :as i]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))

--- a/frontend/src/app/main/ui/dashboard/team_form.cljs
+++ b/frontend/src/app/main/ui/dashboard/team_form.cljs
@@ -17,7 +17,7 @@
    [app.main.ui.icons :as i]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/app/main/ui/dashboard/templates.cljs
+++ b/frontend/src/app/main/ui/dashboard/templates.cljs
@@ -23,7 +23,7 @@
    [app.util.keyboard :as kbd]
    [app.util.router :as rt]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (def builtin-templates

--- a/frontend/src/app/main/ui/delete_shared.cljs
+++ b/frontend/src/app/main/ui/delete_shared.cljs
@@ -16,7 +16,7 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as k]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [goog.events :as events]
    [rumext.v2 :as mf]))
 
@@ -85,7 +85,7 @@
            (rx/mapcat identity)
            (rx/map (juxt :id :name))
            (rx/reduce conj [])
-           (rx/subs #(reset! references* %))))
+           (rx/subs! #(reset! references* %))))
 
     (mf/with-effect [accept-fn]
       (letfn [(on-keydown [event]

--- a/frontend/src/app/main/ui/onboarding.cljs
+++ b/frontend/src/app/main/ui/onboarding.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.onboarding.templates]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.timers :as tm]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 ;; --- ONBOARDING LIGHTBOX

--- a/frontend/src/app/main/ui/onboarding/team_choice.cljs
+++ b/frontend/src/app/main/ui/onboarding/team_choice.cljs
@@ -21,7 +21,7 @@
    [app.util.router :as rt]
    [app.util.timers :as tm]
    [cljs.spec.alpha :as s]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (s/def ::name ::us/not-empty-string)

--- a/frontend/src/app/main/ui/onboarding/templates.cljs
+++ b/frontend/src/app/main/ui/onboarding/templates.cljs
@@ -16,7 +16,7 @@
    [app.util.http :as http]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (mf/defc template-item
@@ -39,7 +39,7 @@
         (fn []
           (reset! downloading? true)
           (->> (http/send! {:method :get :uri link :response-type :blob :mode :no-cors})
-               (rx/subs (fn [{:keys [body] :as response}]
+               (rx/subs! (fn [{:keys [body] :as response}]
                           (open-import-modal {:name name :uri (wapi/create-uri body)}))
                         (fn [error]
                           (js/console.log "error" error))

--- a/frontend/src/app/main/ui/routes.cljs
+++ b/frontend/src/app/main/ui/routes.cljs
@@ -14,9 +14,9 @@
    [app.main.repo :as rp]
    [app.main.store :as st]
    [app.util.router :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (s/def ::page-id ::us/uuid)
 (s/def ::file-id ::us/uuid)
@@ -112,7 +112,7 @@
       ;; some race conditions that causes unexpected redirects on
       ;; invitations workflows (and probably other cases).
       (->> (rp/cmd! :get-profile)
-           (rx/subs (fn [{:keys [id] :as profile}]
+           (rx/subs! (fn [{:keys [id] :as profile}]
                       (cond
                         (= id uuid/zero)
                         (st/emit! (rt/nav :auth-login))

--- a/frontend/src/app/main/ui/settings/change_email.cljs
+++ b/frontend/src/app/main/ui/settings/change_email.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.icons :as i]
    [app.main.ui.messages :as msgs]
    [app.util.i18n :as i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/app/main/ui/settings/delete_account.cljs
+++ b/frontend/src/app/main/ui/settings/delete_account.cljs
@@ -15,7 +15,7 @@
    [app.main.ui.icons :as i]
    [app.main.ui.messages :as msgs]
    [app.util.i18n :as i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (defn on-error

--- a/frontend/src/app/main/ui/settings/feedback.cljs
+++ b/frontend/src/app/main/ui/settings/feedback.cljs
@@ -17,7 +17,7 @@
    [app.main.ui.context :as ctx]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.spec.alpha :as s]
    [rumext.v2 :as mf]))
 
@@ -60,7 +60,7 @@
            (reset! loading true)
            (let [data (:clean-data @form)]
              (->> (rp/cmd! :send-user-feedback data)
-                  (rx/subs on-succes on-error)))))]
+                  (rx/subs! on-succes on-error)))))]
 
     (if new-css-system
       [:& fm/form {:class (stl/css :feedback-form)

--- a/frontend/src/app/main/ui/settings/sidebar.cljs
+++ b/frontend/src/app/main/ui/settings/sidebar.cljs
@@ -18,7 +18,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
    [app.util.router :as rt]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc sidebar-content

--- a/frontend/src/app/main/ui/shapes/embed.cljs
+++ b/frontend/src/app/main/ui/shapes/embed.cljs
@@ -8,7 +8,7 @@
   (:require
    [app.main.ui.hooks :as hooks]
    [app.util.http :as http]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (def context (mf/create-context false))
@@ -37,7 +37,7 @@
                       (rx/filter some?)
                       (url-mapping)
                       (rx/reduce conj {})
-                      (rx/subs (fn [data]
+                      (rx/subs! (fn [data]
                                  (when-not (= data (mf/ref-val uri-data))
                                    (mf/set-ref-val! uri-data data)
                                    (reset! state inc)))))]

--- a/frontend/src/app/main/ui/shapes/text/fontfaces.cljs
+++ b/frontend/src/app/main/ui/shapes/text/fontfaces.cljs
@@ -10,7 +10,7 @@
    [app.common.files.helpers :as cfh]
    [app.main.fonts :as fonts]
    [app.util.object :as obj]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
@@ -28,7 +28,7 @@
              (->> (rx/from fonts)
                   (rx/merge-map fonts/fetch-font-css)
                   (rx/reduce conj [])
-                  (rx/subs
+                  (rx/subs!
                    (fn [result]
                      (let [css (str/join "\n" result)]
                        (when-not (= (mf/ref-val fonts-css-ref) css)

--- a/frontend/src/app/main/ui/viewer/inspect/code.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/code.cljs
@@ -30,9 +30,9 @@
    [app.util.dom :as dom]
    [app.util.http :as http]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (def embed-images? true)
@@ -224,7 +224,7 @@
      #(->> (rx/from fonts)
            (rx/merge-map fonts/fetch-font-css)
            (rx/reduce conj [])
-           (rx/subs
+           (rx/subs!
             (fn [result]
               (let [css (str/join "\n" result)]
                 (reset! fontfaces-css* css))))))
@@ -237,7 +237,7 @@
               (->> (http/fetch-data-uri uri true)
                    (rx/catch (fn [_] (rx/of (hash-map uri uri)))))))
            (rx/reduce conj {})
-           (rx/subs
+           (rx/subs!
             (fn [result]
               (reset! images-data* result)))))
 

--- a/frontend/src/app/main/ui/viewer/share_link.cljs
+++ b/frontend/src/app/main/ui/viewer/share_link.cljs
@@ -24,7 +24,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
    [app.util.webapi :as wapi]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (log/set-level! :warn)

--- a/frontend/src/app/main/ui/workspace/header.cljs
+++ b/frontend/src/app/main/ui/workspace/header.cljs
@@ -31,10 +31,10 @@
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
    [app.util.router :as rt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (def ref:workspace-persistence
@@ -393,12 +393,12 @@
                                             :num-files 1}))
 
            (->> (rx/of file)
-                (rx/flat-map
+                (rx/merge-map
                  (fn [file]
                    (->> (rp/cmd! :has-file-libraries {:file-id (:id file)})
                         (rx/map #(assoc file :has-libraries? %)))))
                 (rx/reduce conj [])
-                (rx/subs
+                (rx/subs!
                  (fn [files]
                    (modal/show!
                     {:type :export

--- a/frontend/src/app/main/ui/workspace/left_header.cljs
+++ b/frontend/src/app/main/ui/workspace/left_header.cljs
@@ -31,7 +31,7 @@
    [app.util.keyboard :as kbd]
    [app.util.router :as rt]
    [cuerdas.core :as str]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 ;; --- Header menu and submenus

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
@@ -30,7 +30,7 @@
    [app.util.keyboard :as kbd]
    [cuerdas.core :as str]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc color-item

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -33,7 +33,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [cuerdas.core :as str]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (def drag-data* (atom {:local? false}))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/graphics.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/graphics.cljs
@@ -31,7 +31,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [cuerdas.core :as str]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc graphics-item

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -28,7 +28,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.keyboard :as kbd]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [okulary.core :as l]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -46,7 +46,7 @@
    [app.main.ui.workspace.viewport.viewport-ref :refer [create-viewport-ref]]
    [app.main.ui.workspace.viewport.widgets :as widgets]
    [app.util.debug :as dbg]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 ;; --- Viewport

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -30,7 +30,7 @@
    [app.util.object :as obj]
    [app.util.timers :as timers]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
@@ -17,7 +17,7 @@
    [app.main.store :as st]
    [app.util.dom :as dom]
    [app.util.mouse :as mse]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -157,7 +157,7 @@
                        (rx/filter mse/pointer-event?)
                        (rx/filter #(= :viewport (mse/get-pointer-source %)))
                        (rx/map mse/get-pointer-position)
-                       (rx/subs
+                       (rx/subs!
                         (fn [pt]
                           (case @moving-point
                             :from-p  (when on-change-start (on-change-start pt))

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -32,7 +32,8 @@
    [app.util.dom :as dom]
    [app.util.globals :as globals]
    [app.util.keyboard :as kbd]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
+   [beicon.v2.operators :as rxo]
    [goog.events :as events]
    [rumext.v2 :as mf])
   (:import goog.events.EventType))
@@ -112,7 +113,7 @@
                                 ^boolean (kbd/underscore? kevent)
                                 ^boolean (kbd/equals? kevent)
                                 ^boolean (kbd/plus? kevent))))
-               (rx/dedupe)))
+               (rx/pipe (rxo/distinct-contiguous))))
 
         kbd-shift-s
         (mf/with-memo []
@@ -120,7 +121,7 @@
                (rx/filter kbd/shift-key?)
                (rx/filter (complement kbd/editing-event?))
                (rx/map kbd/key-down-event?)
-               (rx/dedupe)))
+               (rx/pipe (rxo/distinct-contiguous))))
 
         kbd-z-s
         (mf/with-memo []
@@ -128,7 +129,7 @@
                (rx/filter kbd/z?)
                (rx/filter (complement kbd/editing-event?))
                (rx/map kbd/key-down-event?)
-               (rx/dedupe)))]
+               (rx/pipe (rxo/distinct-contiguous))))]
 
     (hooks/use-stream ms/keyboard-alt (partial reset! alt*))
     (hooks/use-stream ms/keyboard-space (partial reset! space*))

--- a/frontend/src/app/main/ui/workspace/viewport/pixel_overlay.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/pixel_overlay.cljs
@@ -18,7 +18,7 @@
    [app.util.dom :as dom]
    [app.util.keyboard :as kbd]
    [app.util.object :as obj]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [goog.events :as events]
    [rumext.v2 :as mf])
   (:import goog.events.EventType))
@@ -144,7 +144,7 @@
                             (assoc result
                                    :styles styles)))
                   (rx/mapcat thr/render-node)
-                  (rx/subs (fn [image-bitmap]
+                  (rx/subs! (fn [image-bitmap]
                              (.drawImage canvas-context image-bitmap 0 0)
                              (let [width (unchecked-get canvas "width")
                                    height (unchecked-get canvas "height")
@@ -168,7 +168,7 @@
      (fn []
        (let [sub (->> update-str
                       (rx/debounce 10)
-                      (rx/subs handle-draw-picker-canvas))]
+                      (rx/subs! handle-draw-picker-canvas))]
          #(rx/dispose! sub))))
 
     (mf/use-effect

--- a/frontend/src/app/main/ui/workspace/viewport/presence.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/presence.cljs
@@ -9,7 +9,7 @@
    [app.main.refs :as refs]
    [app.util.time :as dt]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/app/main/ui/workspace/viewport/snap_distances.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/snap_distances.cljs
@@ -15,7 +15,7 @@
    [app.main.refs :as refs]
    [app.main.snap :as ams]
    [app.main.ui.formats :as fmt]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [clojure.set :as set]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
@@ -256,7 +256,7 @@
                      ;; know it is a static value and will not go to
                      ;; change
                      (rx/switch-map (partial query-worker page-id coord))
-                     (rx/subs (fn [[lt-shapes gt-shapes]]
+                     (rx/subs! (fn [[lt-shapes gt-shapes]]
                                 (reset! lt-shapes* lt-shapes)
                                 (reset! gt-shapes* gt-shapes))))]
         ;; On unmount dispose

--- a/frontend/src/app/main/ui/workspace/viewport/snap_points.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/snap_points.cljs
@@ -13,7 +13,7 @@
    [app.common.geom.snap :as sp]
    [app.common.types.shape.layout :as ctl]
    [app.main.snap :as snap]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (def ^:private line-color "var(--color-snap)")
@@ -56,12 +56,12 @@
         frame-id  (snap/snap-frame-id shapes)]
 
     (->> (rx/of bounds)
-         (rx/flat-map
+         (rx/merge-map
           (fn [bounds]
             (->> (sp/rect->snap-points bounds)
                  (map #(vector frame-id %)))))
 
-         (rx/flat-map
+         (rx/merge-map
           (fn [[frame-id point]]
             (->> (snap/get-snap-points page-id frame-id remove-snap? zoom point coord)
                  (rx/map #(mapcat second %))
@@ -124,7 +124,7 @@
                        (fn [result]
                          (apply d/concat-vec (seq result))))
 
-                      (rx/subs
+                      (rx/subs!
                        (fn [data]
                          (let [rs (filter (fn [[_ snaps _]] (> (count snaps) 0)) data)]
                            (reset! state rs)))))]

--- a/frontend/src/app/rasterizer.cljs
+++ b/frontend/src/app/rasterizer.cljs
@@ -17,7 +17,7 @@
    [app.util.http :as http]
    [app.util.object :as obj]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]))
 
 (log/set-level! :info)
@@ -229,7 +229,7 @@
         (when (and (some? payload)
                    (= scope "penpot/rasterizer"))
           (->> (render payload)
-               (rx/subs (partial send-success! id)
+               (rx/subs! (partial send-success! id)
                         (partial send-failure! id))))))))
 
 (defn- listen

--- a/frontend/src/app/render.cljs
+++ b/frontend/src/app/render.cljs
@@ -21,11 +21,11 @@
    [app.main.store :as st]
    [app.util.dom :as dom]
    [app.util.globals :as glob]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [garden.core :refer [css]]
    [okulary.core :as l]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (log/setup! {:app :info})

--- a/frontend/src/app/util/array.cljs
+++ b/frontend/src/app/util/array.cljs
@@ -6,10 +6,15 @@
 
 (ns app.util.array
   "A collection of helpers for work with javascript arrays."
-  (:refer-clojure :exclude [conj!]))
+  (:refer-clojure :exclude [conj! conj]))
+
+(defn conj
+  "A conj like function for js arrays."
+  [a v]
+  (js* "[...~{}, ~{}]" a v))
 
 (defn conj!
-  "A conj like function for js arrays."
+  "A conj! like function for js arrays."
   [a v]
   (.push ^js a v)
   a)

--- a/frontend/src/app/util/cache.cljs
+++ b/frontend/src/app/util/cache.cljs
@@ -7,7 +7,7 @@
 (ns app.util.cache
   (:require
    [app.util.time :as dt]
-   [beicon.core :as rx]))
+   [beicon.v2.core :as rx]))
 
 (defonce cache (atom {}))
 (defonce pending (atom {}))

--- a/frontend/src/app/util/http.cljs
+++ b/frontend/src/app/util/http.cljs
@@ -15,7 +15,7 @@
    [app.util.globals :as globals]
    [app.util.time :as dt]
    [app.util.webapi :as wapi]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [promesa.core :as p]))
 
@@ -58,7 +58,7 @@
     :or {mode :cors
          headers {}
          credentials "same-origin"}}]
-  (rx/Observable.create
+  (rx/create
    (fn [subscriber]
      (let [controller    (js/AbortController.)
            signal        (.-signal ^js controller)
@@ -172,7 +172,7 @@
   (p/create
    (fn [resolve reject]
      (->> (rx/take 1 observable)
-          (rx/subs resolve reject)))))
+          (rx/subs! resolve reject)))))
 
 (defn fetch-data-uri
   ([uri]

--- a/frontend/src/app/util/router.cljs
+++ b/frontend/src/app/util/router.cljs
@@ -12,9 +12,9 @@
    [app.util.browser-history :as bhistory]
    [app.util.dom :as dom]
    [app.util.timers :as ts]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [goog.events :as e]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [reitit.core :as r]))
 
 ;; --- Router API
@@ -159,4 +159,4 @@
                                (bhistory/disable! history)
                                (e/unlistenByKey key)))))
               (rx/take-until stoper)
-              (rx/subs #(on-change router %)))))))
+              (rx/subs! #(on-change router %)))))))

--- a/frontend/src/app/util/rxops.cljs
+++ b/frontend/src/app/util/rxops.cljs
@@ -1,0 +1,72 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.util.rxops
+  (:require
+   [beicon.v2.core :as rx]))
+
+(defn- throttle-fn
+  [delay f]
+  (let [state
+        #js {:lastExecTime 0
+             :timeoutId nil
+             :context nil
+             :args nil}
+
+        execute-fn
+        (fn []
+          (let [context (.-context ^js state)
+                args    (.-args ^js state)]
+            (.apply f context args)
+            (set! (.-lastExecTime state) (js/Date.now))
+            (set! (.-timeoutId state) nil)))
+
+        wrapped-fn
+        (fn []
+          (let [ctime (js/Date.now)
+                ltime (.-lastExecTime ^js state)
+                args  (js-arguments)]
+
+            (this-as this
+              (set! (.-context state) this)
+              (set! (.-args state) args))
+
+            (let [timeout-id (.-timeoutId state)]
+              (if (>= (- ctime ltime) delay)
+                (do
+                  (when ^boolean timeout-id
+                    (js/clearTimeout timeout-id)
+                    (set! (.-timeoutId state) nil))
+                  (execute-fn))
+
+                (when-not ^boolean timeout-id
+                  (set! (.-timeoutId state)
+                        (js/setTimeout execute-fn (- delay ctime ltime))))))))]
+
+    (specify! wrapped-fn
+      rx/IDisposable
+      (-dispose [_]
+        (js/clearTimeout (.-timeoutId state))
+        (set! (.-lastExecTime state) 0)
+        (set! (.-timeoutId state) nil)))))
+
+
+(defn throttle
+  "High performance rxjs throttle operation. It does not saturates the
+  macro-task queue of the js runtime on long burst of mouse
+  movements."
+  [delay]
+  (fn [source]
+    (rx/create
+     (fn [subs]
+       (let [next-fn  (throttle-fn delay (partial rx/push! subs))
+             error-fn (fn [cause]
+                        (rx/dispose! next-fn)
+                        (rx/error! subs cause))
+             end-fn   (fn []
+                        (rx/dispose! next-fn)
+                        (rx/end! subs))]
+         (rx/sub! source next-fn error-fn end-fn))))))

--- a/frontend/src/app/util/sse.cljs
+++ b/frontend/src/app/util/sse.cljs
@@ -7,7 +7,7 @@
 (ns app.util.sse
   (:require
    ["eventsource-parser/stream" :as sse]
-   [beicon.core :as rx]))
+   [beicon.v2.core :as rx]))
 
 (defn create-stream
   [^js/ReadableStream stream]

--- a/frontend/src/app/util/theme.cljs
+++ b/frontend/src/app/util/theme.cljs
@@ -11,7 +11,7 @@
    [app.config :as cfg]
    [app.util.dom :as dom]
    [app.util.storage :refer [storage]]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
 (defonce theme (get @storage ::theme cfg/default-theme))

--- a/frontend/src/app/util/timers.cljs
+++ b/frontend/src/app/util/timers.cljs
@@ -7,7 +7,7 @@
 (ns app.util.timers
   (:require
    [app.common.data :as d]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [promesa.core :as p]))
 
 (defn schedule

--- a/frontend/src/app/util/webapi.cljs
+++ b/frontend/src/app/util/webapi.cljs
@@ -11,7 +11,7 @@
    [app.common.exceptions :as ex]
    [app.common.logging :as log]
    [app.util.object :as obj]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [promesa.core :as p]))
 
@@ -247,7 +247,7 @@
                   (fn [blob]
                     (->> (read-file-as-data-url blob)
                          (rx/catch (fn [err] (reject err)))
-                         (rx/subs (fn [result] (resolve result)))))))
+                         (rx/subs! (fn [result] (resolve result)))))))
 
        (catch :default e (reject e))))))
 

--- a/frontend/src/app/util/websocket.cljs
+++ b/frontend/src/app/util/websocket.cljs
@@ -8,7 +8,7 @@
   "A interface to webworkers exposed functionality."
   (:require
    [app.common.transit :as t]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [goog.events :as ev])
   (:import
    goog.net.WebSocket

--- a/frontend/src/app/util/worker.cljs
+++ b/frontend/src/app/util/worker.cljs
@@ -10,7 +10,7 @@
    [app.common.uuid :as uuid]
    [app.util.object :as obj]
    [app.worker.messages :as wm]
-   [beicon.core :as rx]))
+   [beicon.v2.core :as rx]))
 
 (declare handle-response)
 (defrecord Worker [instance stream])

--- a/frontend/src/app/util/zip.cljs
+++ b/frontend/src/app/util/zip.cljs
@@ -9,7 +9,7 @@
   (:require
    ["jszip" :as zip]
    [app.util.http :as http]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [promesa.core :as p]))
 
 (defn compress-files
@@ -29,7 +29,7 @@
          :response-type :blob
          :method :get})
        (rx/map :body)
-       (rx/flat-map zip/loadAsync)))
+       (rx/merge-map zip/loadAsync)))
 
 (defn- process-file
   [entry path type]
@@ -65,4 +65,4 @@
     (.forEach zip get-file)
 
     (->> (rx/from (p/all @promises))
-         (rx/flat-map identity))))
+         (rx/merge-map identity))))

--- a/frontend/src/app/worker.cljs
+++ b/frontend/src/app/worker.cljs
@@ -17,7 +17,7 @@
    [app.worker.selection]
    [app.worker.snaps]
    [app.worker.thumbnails]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [promesa.core :as p]))
 
 (log/setup! {:app :info})
@@ -130,7 +130,7 @@
          ;; 1ms debounce, after 1ms without messages will process the buffer
          (rx/debounce 1)
 
-         (rx/subs (fn [[messages dropped last]]
+         (rx/subs! (fn [[messages dropped last]]
                     ;; Send back the dropped messages replies
                     (doseq [msg dropped]
                       (drop-message msg))

--- a/frontend/src/app/worker/import.cljs
+++ b/frontend/src/app/worker/import.cljs
@@ -26,7 +26,7 @@
    [app.util.webapi :as wapi]
    [app.util.zip :as uz]
    [app.worker.impl :as impl]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [tubax.core :as tubax]))
 
@@ -147,7 +147,7 @@
         libraries (->> context :libraries (mapv resolve))]
     (->> (rx/from libraries)
          (rx/map #(hash-map :file-id file-id :library-id %))
-         (rx/flat-map (partial rp/cmd! :link-file-to-library)))))
+         (rx/merge-map (partial rp/cmd! :link-file-to-library)))))
 
 (defn send-changes
   "Creates batches of changes to be sent to the backend"
@@ -197,7 +197,7 @@
            :content blob
            :is-local true}))
        (rx/tap #(progress! context :upload-media name))
-       (rx/flat-map #(rp/cmd! :upload-file-media-object %))))
+       (rx/merge-map #(rp/cmd! :upload-file-media-object %))))
 
 (defn resolve-text-content [node context]
   (let [resolve (:resolve context)]
@@ -408,7 +408,7 @@
              (rx/reduce conj {}))]
 
     (->> pre-process-images
-         (rx/flat-map
+         (rx/merge-map
           (fn  [pre-proc]
             (->> (rx/from nodes)
                  (rx/filter cip/shape?)
@@ -510,7 +510,7 @@
                             (assoc :id (resolve id)))]
               (fb/add-library-color file color)))]
       (->> (get-file context :colors)
-           (rx/flat-map (comp d/kebab-keys cip/string->uuid))
+           (rx/merge-map (comp d/kebab-keys cip/string->uuid))
            (rx/reduce add-color file)))
 
     (rx/of file)))
@@ -520,7 +520,7 @@
   (if (:has-typographies context)
     (let [resolve (:resolve context)]
       (->> (get-file context :typographies)
-           (rx/flat-map (comp d/kebab-keys cip/string->uuid))
+           (rx/merge-map (comp d/kebab-keys cip/string->uuid))
            (rx/map (fn [[id typography]]
                      (-> typography
                          (d/kebab-keys)
@@ -534,7 +534,7 @@
   (if (:has-media context)
     (let [resolve (:resolve context)]
       (->> (get-file context :media-list)
-           (rx/flat-map (comp d/kebab-keys cip/string->uuid))
+           (rx/merge-map (comp d/kebab-keys cip/string->uuid))
            (rx/mapcat
             (fn [[id media]]
               (let [media (assoc media :id (resolve id))]
@@ -562,7 +562,7 @@
                              (filter #(= :symbol (:tag %)))))]
 
       (->> (get-file context :components)
-           (rx/flat-map split-components)
+           (rx/merge-map split-components)
            (rx/concat-reduce (partial import-component context) file)))
     (rx/of file)))
 
@@ -574,7 +574,7 @@
                              (filter #(= :symbol (:tag %)))))]
 
       (->> (get-file context :deleted-components)
-           (rx/flat-map split-components)
+           (rx/merge-map split-components)
            (rx/concat-reduce (partial import-deleted-component context) file)))
     (rx/of file)))
 
@@ -585,18 +585,18 @@
         context (assoc context :progress progress-str)]
     [progress-str
      (->> (rx/of file)
-          (rx/flat-map (partial process-pages context))
+          (rx/merge-map (partial process-pages context))
           (rx/tap #(progress! context :process-colors))
-          (rx/flat-map (partial process-library-colors context))
+          (rx/merge-map (partial process-library-colors context))
           (rx/tap #(progress! context :process-typographies))
-          (rx/flat-map (partial process-library-typographies context))
+          (rx/merge-map (partial process-library-typographies context))
           (rx/tap #(progress! context :process-media))
-          (rx/flat-map (partial process-library-media context))
+          (rx/merge-map (partial process-library-media context))
           (rx/tap #(progress! context :process-components))
-          (rx/flat-map (partial process-library-components context))
+          (rx/merge-map (partial process-library-components context))
           (rx/tap #(progress! context :process-deleted-components))
-          (rx/flat-map (partial process-deleted-components context))
-          (rx/flat-map (partial send-changes context))
+          (rx/merge-map (partial process-deleted-components context))
+          (rx/merge-map (partial send-changes context))
           (rx/tap #(rx/end! progress-str)))]))
 
 (defn create-files
@@ -606,13 +606,13 @@
     (rx/concat
      (->> (rx/from files)
           (rx/map #(merge context %))
-          (rx/flat-map (fn [context]
+          (rx/merge-map (fn [context]
                          (->> (create-file context features)
                               (rx/map #(vector % (first (get data (:file-id context)))))))))
 
      (->> (rx/from files)
           (rx/map #(merge context %))
-          (rx/flat-map link-file-libraries)
+          (rx/merge-map link-file-libraries)
           (rx/ignore)))))
 
 (defn parse-mtype [ba]
@@ -627,7 +627,7 @@
   [{:keys [files]}]
 
   (->> (rx/from files)
-       (rx/flat-map
+       (rx/merge-map
         (fn [file]
           (let [st (->> (http/send!
                          {:uri (:uri file)
@@ -642,8 +642,8 @@
             (->> (rx/merge
                   (->> st
                        (rx/filter (fn [data] (= "application/zip" (:type data))))
-                       (rx/flat-map #(zip/loadAsync (:body %)))
-                       (rx/flat-map #(get-file {:zip %} :manifest))
+                       (rx/merge-map #(zip/loadAsync (:body %)))
+                       (rx/merge-map #(get-file {:zip %} :manifest))
                        (rx/map (comp d/kebab-keys cip/string->uuid))
                        (rx/map #(hash-map :uri (:uri file) :data % :type "application/zip")))
                   (->> st
@@ -677,7 +677,7 @@
 
     (rx/merge
      (->> (create-files context zip-files)
-          (rx/flat-map
+          (rx/merge-map
            (fn [[file data]]
              (->> (uz/load-from-url (:uri data))
                   (rx/map #(-> context (assoc :zip %) (merge data)))
@@ -703,7 +703,7 @@
                                       :error-data (ex-data cause)})))))))
 
      (->> (rx/from binary-files)
-          (rx/flat-map
+          (rx/merge-map
            (fn [data]
              (->> (http/send!
                    {:uri (:uri data)

--- a/frontend/src/app/worker/thumbnails.cljs
+++ b/frontend/src/app/worker/thumbnails.cljs
@@ -15,7 +15,7 @@
    [app.main.render :as render]
    [app.util.http :as http]
    [app.worker.impl :as impl]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [okulary.core :as l]
    [rumext.v2 :as mf]))
 

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -34,10 +34,10 @@
    [app.util.http :as http]
    [app.util.object :as obj]
    [app.util.timers :as timers]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.pprint :refer [pprint]]
    [cuerdas.core :as str]
-   [potok.core :as ptk]
+   [potok.v2.core :as ptk]
    [promesa.core :as p]))
 
 (l/set-level! :debug)
@@ -289,7 +289,7 @@
          (rx/filter ptk/event?)
          (rx/filter (fn [s] (and (dbg/enabled? :events)
                                  (not (debug-exclude-events (ptk/type s))))))
-         (rx/subs #(println "[stream]: " (ptk/repr-event %))))))
+         (rx/subs! #(println "[stream]: " (ptk/repr-event %))))))
 
 (defn ^:export apply-changes
   "Takes a Transit JSON changes"
@@ -432,7 +432,7 @@
 
 
          (->> (rp/cmd! :update-file params)
-              (rx/subs (fn [_]
+              (rx/subs! (fn [_]
                          (when reload?
                            (dom/reload-current-window)))
                        (fn [cause]
@@ -463,7 +463,7 @@
                       :query {:file-id file-id}})
          (rx/map http/conditional-decode-transit)
          (rx/mapcat rp/handle-response)
-         (rx/subs (fn [result]
+         (rx/subs! (fn [result]
                     (let [result (map (fn [row]
                                         (update row :id str))
                                       result)]
@@ -481,7 +481,7 @@
                       :body (http/transit-data {:file-id file-id :label label})})
          (rx/map http/conditional-decode-transit)
          (rx/mapcat rp/handle-response)
-         (rx/subs (fn [{:keys [id]}]
+         (rx/subs! (fn [{:keys [id]}]
                     (println "Snapshot saved:" (str id)))
                   (fn [cause]
                     (js/console.log "EE:" cause))))))
@@ -496,7 +496,7 @@
                         :body (http/transit-data {:file-id file-id :id id})})
            (rx/map http/conditional-decode-transit)
            (rx/mapcat rp/handle-response)
-           (rx/subs (fn [_]
+           (rx/subs! (fn [_]
                       (println "Snapshot restored " id)
                       #_(.reload js/location))
                     (fn [cause]

--- a/frontend/test/frontend_tests/helpers_shapes_test.cljs
+++ b/frontend/test/frontend_tests/helpers_shapes_test.cljs
@@ -10,7 +10,7 @@
    [app.common.data :as d]
    [app.common.geom.point :as gpt]
    [app.main.data.workspace.libraries :as dwl]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.pprint :refer [pprint]]
    [cljs.test :as t :include-macros true]
    [clojure.stacktrace :as stk]
@@ -18,7 +18,7 @@
    [frontend-tests.helpers.libraries :as thl]
    [frontend-tests.helpers.pages :as thp]
    [linked.core :as lks]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (t/use-fixtures :each
   {:before thp/reset-idmap!})

--- a/frontend/test/frontend_tests/state_components_sync_test.cljs
+++ b/frontend/test/frontend_tests/state_components_sync_test.cljs
@@ -17,7 +17,7 @@
    [frontend-tests.helpers.events :as the]
    [frontend-tests.helpers.libraries :as thl]
    [frontend-tests.helpers.pages :as thp]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (t/use-fixtures :each
   {:before thp/reset-idmap!})

--- a/frontend/test/frontend_tests/state_components_test.cljs
+++ b/frontend/test/frontend_tests/state_components_test.cljs
@@ -13,7 +13,7 @@
    [frontend-tests.helpers.libraries :as thl]
    [frontend-tests.helpers.pages :as thp]
    [linked.core :as lks]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (t/use-fixtures :each
   {:before thp/reset-idmap!})

--- a/frontend/test/frontend_tests/test_helpers_shapes.cljs
+++ b/frontend/test/frontend_tests/test_helpers_shapes.cljs
@@ -7,12 +7,12 @@
    [app.test-helpers.events :as the]
    [app.test-helpers.libraries :as thl]
    [app.test-helpers.pages :as thp]
-   [beicon.core :as rx]
+   [beicon.v2.core :as rx]
    [cljs.pprint :refer [pprint]]
    [cljs.test :as t :include-macros true]
    [clojure.stacktrace :as stk]
    [linked.core :as lks]
-   [potok.core :as ptk]))
+   [potok.v2.core :as ptk]))
 
 (t/use-fixtures :each
   {:before thp/reset-idmap!})

--- a/frontend/vendor/beicon/impl/rxjs.cljs
+++ b/frontend/vendor/beicon/impl/rxjs.cljs
@@ -1,4 +1,0 @@
-(ns beicon.impl.rxjs
-  (:require ["rxjs" :as rx]))
-
-(goog/exportSymbol "rxjsMain" rx)

--- a/frontend/vendor/beicon/impl/rxjs_operators.cljs
+++ b/frontend/vendor/beicon/impl/rxjs_operators.cljs
@@ -1,4 +1,0 @@
-(ns beicon.impl.rxjs-operators
-  (:require ["rxjs/operators" :as rxop]))
-
-(goog/exportSymbol "rxjsOperators" rxop)

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4018,6 +4018,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^20.10.5":
+  version: 20.10.5
+  resolution: "@types/node@npm:20.10.5"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: be30609aae0bfe492097815f166ccc07f465220cb604647fa4e5ec05a1d16c012a41b82b5f11ecfe2485cbb479d4d20384b95b809ca0bcff6d94d5bbafa645bb
+  languageName: node
+  linkType: hard
+
 "@types/normalize-package-data@npm:^2.4.0":
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
@@ -7580,6 +7589,7 @@ __metadata:
     "@storybook/react": "npm:^7.5.3"
     "@storybook/react-vite": "npm:^7.5.3"
     "@storybook/testing-library": "npm:^0.2.2"
+    "@types/node": "npm:^20.10.5"
     animate.css: "npm:^4.1.1"
     autoprefixer: "npm:^10.4.15"
     concurrently: "npm:^8.2.2"
@@ -7618,13 +7628,14 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-virtualized: "npm:^9.22.3"
     rimraf: "npm:^5.0.1"
-    rxjs: "npm:~7.8.1"
+    rxjs: "npm:8.0.0-alpha.13"
     sass: "npm:^1.66.1"
     sax: "npm:^1.2.4"
     shadow-cljs: "npm:2.26.2"
     source-map-support: "npm:^0.5.21"
     storybook: "npm:^7.5.3"
     tdigest: "npm:^0.1.2"
+    typescript: "npm:^5.3.3"
     ua-parser-js: "npm:^1.0.32"
     vite: "npm:^5.0.2"
     xregexp: "npm:^5.1.1"
@@ -12516,7 +12527,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.8.1, rxjs@npm:~7.8.1":
+"rxjs@npm:8.0.0-alpha.13":
+  version: 8.0.0-alpha.13
+  resolution: "rxjs@npm:8.0.0-alpha.13"
+  peerDependencies:
+    "@types/node": ^20.6.3
+    typescript: ^5.2.2
+  checksum: d3d8a395e7b92158d621d686b819aa5be480f5c17155f695506b9a70a32af886962d23d4040a1d1611d815abe0ba0fd4929b3687da75a62a03a1e90e5b616464
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -13919,6 +13940,26 @@ __metadata:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 6005cb31df50eef8b1f3c780eb71a17925f3038a100d82f9406ac2ad1de5eb59f8e6decbdc145b3a1f8e5836e17b0c0002fb698b9fe2516b8f9f9ff602d36412
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "typescript@npm:5.3.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: e33cef99d82573624fc0f854a2980322714986bc35b9cb4d1ce736ed182aeab78e2cb32b385efa493b2a976ef52c53e20d6c6918312353a91850e2b76f1ea44f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
+  version: 5.3.3
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 1d0a5f4ce496c42caa9a30e659c467c5686eae15d54b027ee7866744952547f1be1262f2d40de911618c242b510029d51d43ff605dba8fb740ec85ca2d3f9500
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR started as a quick bug fix and ended up with a beicon library refactor for allow easy way to plug-in custom operators.
Then, I have implemented a custom `throttle` operator that does not saturates the js runtime macro-task queue, so with this fix the bursts of mouse movement does not interrupt pointer position reporting to other peers.