### PR TITLE
Fix several invalid :frame-id

### DIFF
--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -255,7 +255,11 @@
                                   (dissoc :component-root)))
 
         [new-root-shape new-shapes updated-shapes]
-        (ctst/clone-object shape nil objects update-new-shape update-original-shape)
+        (ctst/clone-shape shape
+                          nil
+                          objects
+                          :update-new-shape update-new-shape
+                          :update-original-shape update-original-shape)
 
         ;; If frame-id points to a shape inside the component, remap it to the
         ;; corresponding new frame shape. If not, set it to nil.
@@ -339,15 +343,14 @@
                (dissoc :component-root))))
 
          [new-shape new-shapes _]
-         (ctst/clone-object component-shape
-                            frame-id
-                            (if components-v2 (:objects component-page) (:objects component))
-                            update-new-shape
-                            (fn [object _] object)
-                            force-id
-                            keep-ids?
-                            frame-id)
-
+         (ctst/clone-shape component-shape
+                           frame-id
+                           (if components-v2 (:objects component-page) (:objects component))
+                           :update-new-shape update-new-shape
+                           :force-id force-id
+                           :keep-ids? keep-ids?
+                           :frame-id frame-id
+                           :dest-objects (:objects container))
 
          ;; Fix empty parent-id and remap all grid cells to the new ids.
          remap-ids

--- a/common/src/app/common/types/shape_tree.cljc
+++ b/common/src/app/common/types/shape_tree.cljc
@@ -354,21 +354,24 @@
   the order of the children of each parent."
 
   ([object parent-id objects]
-   (clone-object object parent-id objects (fn [object _] object) (fn [object _] object) nil false nil))
+   (clone-object object parent-id objects (fn [object _] object) (fn [object _] object) nil false nil objects))
 
   ([object parent-id objects update-new-object]
-   (clone-object object parent-id objects update-new-object (fn [object _] object) nil false nil))
+   (clone-object object parent-id objects update-new-object (fn [object _] object) nil false nil objects))
 
   ([object parent-id objects update-new-object update-original-object]
-   (clone-object object parent-id objects update-new-object update-original-object nil false nil))
+   (clone-object object parent-id objects update-new-object update-original-object nil false nil objects))
 
   ([object parent-id objects update-new-object update-original-object force-id]
-   (clone-object object parent-id objects update-new-object update-original-object force-id false nil))
+   (clone-object object parent-id objects update-new-object update-original-object force-id false nil objects))
 
   ([object parent-id objects update-new-object update-original-object force-id keep-ids?]
-   (clone-object object parent-id objects update-new-object update-original-object force-id keep-ids? nil))
+   (clone-object object parent-id objects update-new-object update-original-object force-id keep-ids? nil objects))
 
   ([object parent-id objects update-new-object update-original-object force-id keep-ids? frame-id]
+   (clone-object object parent-id objects update-new-object update-original-object force-id keep-ids? frame-id objects))
+
+  ([object parent-id objects update-new-object update-original-object force-id keep-ids? frame-id dest-objects]
    (let [new-id (cond
                   (some? force-id) force-id
                   keep-ids? (:id object)
@@ -378,11 +381,11 @@
          ;; or the parent's frame-id otherwise. Only for the first cloned shapes. In recursive calls
          ;; this is not needed.
          frame-id (cond
-                    (and (nil? frame-id) (cfh/frame-shape? objects parent-id))
+                    (and (nil? frame-id) (cfh/frame-shape? dest-objects parent-id))
                     parent-id
 
                     (nil? frame-id)
-                    (dm/get-in objects [parent-id :frame-id])
+                    (dm/get-in dest-objects [parent-id :frame-id] uuid/zero)
 
                     :else
                     frame-id)]

--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -979,7 +979,11 @@
                            (:id parent-shape)
                            (get component-page :objects)
                            update-new-shape
-                           update-original-shape)
+                           update-original-shape
+                           nil
+                           false
+                           nil
+                           (:objects container))
 
         add-obj-change (fn [changes shape']
                          (update changes :redo-changes conj

--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -98,11 +98,11 @@
                 (gsh/move delta)))
 
             [new-instance-shape new-instance-shapes _]
-            (ctst/clone-object main-instance-shape
-                               (:parent-id main-instance-shape)
-                               (:objects main-instance-page)
-                               update-new-shape
-                               update-original-shape)
+            (ctst/clone-shape main-instance-shape
+                              (:parent-id main-instance-shape)
+                              (:objects main-instance-page)
+                              :update-new-shape update-new-shape
+                              :update-original-shape update-original-shape)
 
             remap-frame
             (fn [shape]
@@ -134,10 +134,9 @@
       (let [component-root (d/seek #(nil? (:parent-id %)) (vals (:objects component)))
 
             [new-component-shape new-component-shapes _]
-            (ctst/clone-object component-root
-                               nil
-                               (get component :objects)
-                               identity)]
+            (ctst/clone-shape component-root
+                              nil
+                              (get component :objects))]
 
         [new-component-shape new-component-shapes nil nil]))))
 
@@ -975,15 +974,12 @@
                                 original-shape)
 
         [_ new-shapes _]
-        (ctst/clone-object component-shape
+        (ctst/clone-shape component-shape
                            (:id parent-shape)
                            (get component-page :objects)
-                           update-new-shape
-                           update-original-shape
-                           nil
-                           false
-                           nil
-                           (:objects container))
+                           :update-new-shape update-new-shape
+                           :update-original-shape update-original-shape
+                           :dest-objects (get container :objects))
 
         add-obj-change (fn [changes shape']
                          (update changes :redo-changes conj
@@ -1041,11 +1037,11 @@
                                   original-shape))
 
         [_new-shape new-shapes updated-shapes]
-        (ctst/clone-object shape
-                           (:id component-parent-shape)
-                           (get page :objects)
-                           update-new-shape
-                           update-original-shape)
+        (ctst/clone-shape shape
+                          (:id component-parent-shape)
+                          (get page :objects)
+                          :update-new-shape update-new-shape
+                          :update-original-shape update-original-shape)
 
         add-obj-change (fn [changes shape']
                          (update changes :redo-changes conj


### PR DESCRIPTION
> WARNING: this is ok, in principle. But since it touches a point very delicated, better to merge it after PIWEEK, when there are people available to revert if something breaks in other place.

Fixes https://tree.taiga.io/project/penpot/issue/6316

And probably other related errors, when adding shapes to a copy, when the copy is in a different page than the main.