### PR TITLE
feature: Hide bounding-box when editing shape.

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -2346,6 +2346,7 @@
 
 ;; Transform
 
+(dm/export dwt/trigger-bounding-box-cloacing)
 (dm/export dwt/start-resize)
 (dm/export dwt/update-dimensions)
 (dm/export dwt/change-orientation)

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -369,7 +369,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn update-shape-flags
-  [ids {:keys [blocked hidden] :as flags}]
+  [ids {:keys [blocked hidden transformed] :as flags}]
   (dm/assert!
    "expected valid coll of uuids"
    (every? uuid? ids))
@@ -385,14 +385,15 @@
             (fn [obj]
               (cond-> obj
                 (boolean? blocked) (assoc :blocked blocked)
-                (boolean? hidden) (assoc :hidden hidden)))
+                (boolean? hidden) (assoc :hidden hidden)
+                (boolean? transformed) (assoc :transformed transformed)))
             objects (wsh/lookup-page-objects state)
             ;; We have change only the hidden behaviour, to hide only the
             ;; selected shape, block behaviour remains the same.
             ids     (if (boolean? blocked)
                       (into ids (->> ids (mapcat #(cfh/get-children-ids objects %))))
                       ids)]
-        (rx/of (dch/update-shapes ids update-fn {:attrs #{:blocked :hidden}}))))))
+        (rx/of (dch/update-shapes ids update-fn {:attrs #{:blocked :hidden :transformed}}))))))
 
 (defn toggle-visibility-selected
   []

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -244,7 +244,7 @@
 
 (defn schedule-bounding-box-reveal
   "Schedule and event to set `shape` `:transformed` flag to `false` in 1 sec.
-   Used to hide bounding-box of shape after changes in sidebar->measures."
+   Used to reveal bounding-box of shape after hiding it in `trigger-bounding-box-cloacing`"
   [ids]
   (dm/assert!
    "expected valid coll of uuids"
@@ -257,7 +257,8 @@
 
 (defn trigger-bounding-box-cloacing
   "Set shapes `:transformed` flag to `true`.
-   Sets bounding-box-cloac-timer to full 1 sec (reset it, if it already exists)."
+   Sets bounding-box-cloac-timer to full 1 sec (reset it, if it already exists).
+   Used to hide bounding-box of shape after changes in sidebar->measures."
   [ids]
   (dm/assert!
    "expected valid coll of uuids"

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -242,7 +242,10 @@
            (rx/of (dwm/apply-modifiers)
                   (finish-transform))))))))
 
-(defn schedule-bounding-box-reveal [ids]
+(defn schedule-bounding-box-reveal
+  "Schedule and event to set `shape` `:transformed` flag to `false` in 1 sec.
+   Used to hide bounding-box of shape after changes in sidebar->measures."
+  [ids]
   (dm/assert!
    "expected valid coll of uuids"
    (every? uuid? ids))
@@ -252,7 +255,10 @@
       (let [task (ts/schedule 1000 #(st/emit! (dwsh/update-shape-flags ids {:transformed false})))]
         (assoc state :bounding-box-cloac-timer task)))))
 
-(defn trigger-bounding-box-cloacing [ids]
+(defn trigger-bounding-box-cloacing
+  "Set shapes `:transformed` flag to `true`.
+   Sets bounding-box-cloac-timer to full 1 sec (reset it, if it already exists)."
+  [ids]
   (dm/assert!
    "expected valid coll of uuids"
    (every? uuid? ids))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -214,6 +214,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
+           (st/emit! (udw/trigger-bounding-box-cloacing ids))
            (st/emit! (udw/update-dimensions ids attr value))))
 
         on-proportion-lock-change
@@ -236,6 +237,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
+           (st/emit! (udw/trigger-bounding-box-cloacing ids))
            (doall (map #(do-position-change %1 %2 value attr) shapes frames))))
 
         ;; ROTATION
@@ -244,6 +246,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value]
+           (st/emit! (udw/trigger-bounding-box-cloacing ids))
            (st/emit! (udw/increase-rotation ids value))))
 
         ;; RADIUS

--- a/frontend/src/app/main/ui/workspace/viewport/outline.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/outline.cljs
@@ -114,7 +114,8 @@
 (defn- show-outline?
   [shape]
   (and (not (:hidden shape))
-       (not (:blocked shape))))
+       (not (:blocked shape))
+       (not (:transformed shape))))
 
 (mf/defc shape-outlines
   {::mf/wrap-props false}

--- a/frontend/src/app/main/ui/workspace/viewport/selection.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/selection.cljs
@@ -278,8 +278,9 @@
 
         selrect (:selrect shape)
         transform (gsh/transform-str shape)]
-
-    (when (not (#{:move :rotate} current-transform))
+    
+    (when (and (not (:transformed shape))
+               (not (#{:move :rotate} current-transform)))
       [:g.controls {:pointer-events (if disable-handlers "none" "visible")}
        ;; Selection rect
        [:& selection-rect {:rect selrect
@@ -310,7 +311,8 @@
                      (mod 360))]
 
     (when (and (not (#{:move :rotate} current-transform))
-               (not workspace-read-only?))
+               (not workspace-read-only?)
+               (not (:transformed shape)))
       [:g.controls {:pointer-events (if disable-handlers "none" "visible")}
        ;; Handlers
        (for [{:keys [type position props]} (handlers-for-selection selrect shape zoom)]


### PR DESCRIPTION
closes #3232

Added behavior for hiding bounding-box of shapes. As described in: https://github.com/penpot/penpot/issues/3232 

Bounding box (`bb`) is being hidden for 1 sec, after any changes in sidebar->measures, made "by hand".

Realized via new flag for shape, indicating it being transformed.
Also: scheduling an updateEvent (`task`) to set shape's `bb` visible after 1 sec.
This `task` schedule resets after each trigger of event, making sure `bb` isn't flickering.