### PR TITLE
:bug: Fix problem with absolutes inside grid

### DIFF
--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -358,13 +358,13 @@
 
 (defn changed-attrs
   "Returns the list of attributes that will change when `update-fn` is applied"
-  [object update-fn {:keys [attrs]}]
+  [object objects update-fn {:keys [attrs]}]
   (let [changed?
         (fn [old new attr]
           (let [old-val (get old attr)
                 new-val (get new attr)]
             (not= old-val new-val)))
-        new-obj (update-fn object)]
+        new-obj (update-fn object objects)]
     (when-not (= object new-obj)
       (let [attrs (or attrs (d/concat-set (keys object) (keys new-obj)))]
         (filter (partial changed? object new-obj) attrs)))))
@@ -412,7 +412,7 @@
          update-shape
          (fn [changes id]
            (let [old-obj (get objects id)
-                 new-obj (update-fn old-obj)]
+                 new-obj (update-fn old-obj objects)]
              (if (= old-obj new-obj)
                changes
                (let [[rops uops] (-> (or attrs (d/concat-set (keys old-obj) (keys new-obj)))

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -872,10 +872,10 @@
           (pcb/update-shapes [parent-id] #(ctl/add-children-to-index % ids objects to-index)))
 
         (pcb/update-shapes parents
-                           (fn [parent]
+                           (fn [parent objects]
                              (cond-> parent
                                (ctl/grid-layout? parent)
-                               (ctl/assign-cells))))
+                               (ctl/assign-cells objects))))
 
         (pcb/reorder-grid-children parents)
 

--- a/frontend/src/app/main/data/workspace/changes.cljs
+++ b/frontend/src/app/main/data/workspace/changes.cljs
@@ -70,7 +70,7 @@
              update-layout-ids
              (->> ids
                   (map (d/getf objects))
-                  (filter #(some update-layout-attr? (pcb/changed-attrs % update-fn {:attrs attrs})))
+                  (filter #(some update-layout-attr? (pcb/changed-attrs % objects update-fn {:attrs attrs})))
                   (map :id))
 
              changes   (reduce

--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -182,10 +182,10 @@
              (-> changes
                  (pcb/update-shapes
                   [(:parent-id first-shape)]
-                  (fn [shape]
+                  (fn [shape objects]
                     (-> shape
                         (ctl/push-into-cell [(:id first-shape)] row column)
-                        (ctl/assign-cells))))
+                        (ctl/assign-cells objects))))
                  (pcb/reorder-grid-children [(:parent-id first-shape)])))
            changes)
 

--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -191,14 +191,14 @@
         ;; Temporary remove the children when moving them
         frame (-> frame
                   (update :shapes #(d/removev ids %))
-                  (ctl/assign-cells))
+                  (ctl/assign-cells objects))
 
         ids (->> ids (remove #(ctl/position-absolute? objects %)))
         frame (-> frame
                   (update :shapes d/concat-vec ids)
                   (cond-> (some? cell)
                     (ctl/push-into-cell ids row column))
-                  (ctl/assign-cells))]
+                  (ctl/assign-cells objects))]
 
     (-> modifiers
         (ctm/change-property :layout-grid-rows (:layout-grid-rows frame))

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -498,7 +498,8 @@
            changes (-> (pcb/add-object changes new-obj {:ignore-touched (and duplicating-component? child?)})
                        (pcb/amend-last-change #(assoc % :old-id (:id obj)))
                        (cond-> (ctl/grid-layout? objects (:parent-id obj))
-                         (-> (pcb/update-shapes [(:parent-id obj)] (fn [shape] (-> shape ctl/assign-cells ctl/check-deassigned-cells)))
+                         (-> (pcb/update-shapes [(:parent-id obj)] ctl/assign-cells)
+                             (pcb/update-shapes [(:parent-id obj)] ctl/check-deassigned-cells)
                              (pcb/reorder-grid-children [(:parent-id obj)]))))
 
            changes (cond-> changes

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -629,7 +629,7 @@
                 (-> changes
                     (pcb/update-shapes [(:id parent)] (fn [shape] (-> shape
                                                                       (assoc :layout-grid-cells layout-grid-cells)
-                                                                      (ctl/assign-cells))))
+                                                                      (ctl/assign-cells objects))))
                     (pcb/reorder-grid-children [(:id parent)]))))
 
             changes

--- a/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/grid_layout_editor.cljs
@@ -196,13 +196,13 @@
   {::mf/wrap-props false}
   [props]
   (let [shape (unchecked-get props "shape")
-
         x (unchecked-get props "x")
         y (unchecked-get props "y")
         width (unchecked-get props "width")
         height (unchecked-get props "height")
         handler (unchecked-get props "handler")
 
+        objects (mf/deref refs/workspace-page-objects)
         {cell-id :id} (unchecked-get props "cell")
         {:keys [row column row-span column-span]} (get-in shape [:layout-grid-cells cell-id])
 
@@ -237,7 +237,7 @@
 
                  shape
                  (-> (ctl/resize-cell-area shape row column new-row new-column new-row-span new-column-span)
-                     (ctl/assign-cells))
+                     (ctl/assign-cells objects))
 
                  modifiers
                  (-> (ctm/empty)


### PR DESCRIPTION
The current version of the grid was using the hidden and absolutes to allocate cells. This caused the problem of having more columns/rows than expected.