### PR TITLE
:sparkles: Add set of events for hiding and revealing bounding box for selected shape while transforming

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -2304,6 +2304,7 @@
 
 ;; Transform
 
+(dm/export dwt/trigger-bounding-box-cloaking)
 (dm/export dwt/start-resize)
 (dm/export dwt/update-dimensions)
 (dm/export dwt/change-orientation)

--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -369,7 +369,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn update-shape-flags
-  [ids {:keys [blocked hidden] :as flags}]
+  [ids {:keys [blocked hidden transforming] :as flags}]
   (dm/assert!
    "expected valid coll of uuids"
    (every? uuid? ids))
@@ -385,14 +385,15 @@
             (fn [obj]
               (cond-> obj
                 (boolean? blocked) (assoc :blocked blocked)
-                (boolean? hidden) (assoc :hidden hidden)))
+                (boolean? hidden) (assoc :hidden hidden)
+                (boolean? transforming) (assoc :transforming transforming)))
             objects (wsh/lookup-page-objects state)
             ;; We have change only the hidden behaviour, to hide only the
             ;; selected shape, block behaviour remains the same.
             ids     (if (boolean? blocked)
                       (into ids (->> ids (mapcat #(cfh/get-children-ids objects %))))
                       ids)]
-        (rx/of (dch/update-shapes ids update-fn {:attrs #{:blocked :hidden}}))))))
+        (rx/of (dch/update-shapes ids update-fn {:attrs #{:blocked :hidden :transforming}}))))))
 
 (defn toggle-visibility-selected
   []

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -214,7 +214,8 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
-           (st/emit! (udw/update-dimensions ids attr value))))
+           (st/emit! (udw/trigger-bounding-box-cloaking ids)
+                     (udw/update-dimensions ids attr value))))
 
         on-proportion-lock-change
         (mf/use-fn
@@ -236,6 +237,7 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value attr]
+           (st/emit! (udw/trigger-bounding-box-cloaking ids))
            (doall (map #(do-position-change %1 %2 value attr) shapes frames))))
 
         ;; ROTATION
@@ -244,7 +246,8 @@
         (mf/use-fn
          (mf/deps ids)
          (fn [value]
-           (st/emit! (udw/increase-rotation ids value))))
+           (st/emit! (udw/trigger-bounding-box-cloaking ids)
+                     (udw/increase-rotation ids value))))
 
         ;; RADIUS
 

--- a/frontend/src/app/main/ui/workspace/viewport/outline.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/outline.cljs
@@ -114,7 +114,8 @@
 (defn- show-outline?
   [shape]
   (and (not (:hidden shape))
-       (not (:blocked shape))))
+       (not (:blocked shape))
+       (not (:transforming shape))))
 
 (mf/defc shape-outlines
   {::mf/wrap-props false}

--- a/frontend/src/app/main/ui/workspace/viewport/selection.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/selection.cljs
@@ -279,7 +279,8 @@
         selrect (:selrect shape)
         transform (gsh/transform-str shape)]
 
-    (when (not (#{:move :rotate} current-transform))
+    (when (and (not (:transforming shape))
+               (not (#{:move :rotate} current-transform)))
       [:g.controls {:pointer-events (if disable-handlers "none" "visible")}
        ;; Selection rect
        [:& selection-rect {:rect selrect
@@ -310,7 +311,8 @@
                      (mod 360))]
 
     (when (and (not (#{:move :rotate} current-transform))
-               (not workspace-read-only?))
+               (not workspace-read-only?)
+               (not (:transforming shape)))
       [:g.controls {:pointer-events (if disable-handlers "none" "visible")}
        ;; Handlers
        (for [{:keys [type position props]} (handlers-for-selection selrect shape zoom)]


### PR DESCRIPTION
Replaces: https://github.com/penpot/penpot/pull/3930
Closes #3232

Added behavior for hiding bounding-box of shapes. As described in: https://github.com/penpot/penpot/issues/3232 