### PR TITLE
:bug: Fix blur icon + export dropdowns sizes in right sidebar

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.scss
@@ -75,7 +75,6 @@
     .action-btn {
       @extend .button-tertiary;
       box-sizing: border-box;
-      border: $s-1 solid var(--button-tertiary-background-color-rest);
       height: $s-32;
       width: $s-28;
       svg {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.scss
@@ -48,33 +48,10 @@
 }
 
 .element-group {
-  @include flexRow;
-  .input-wrapper {
-    @include flexRow;
-    .format-select {
-      width: $s-60;
-      padding: 0;
-      .dropdown-upwards {
-        bottom: $s-36;
-        width: $s-80;
-        top: unset;
-      }
-    }
-    .size-select {
-      width: $s-60;
-      padding: 0;
-      .dropdown-upwards {
-        bottom: $s-36;
-        top: unset;
-        width: $s-80;
-      }
-    }
-    .suffix-input {
-      @extend .input-element;
-      min-width: $s-92;
-      flex-grow: 1;
-    }
-  }
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  column-gap: $s-4;
+
   .action-btn {
     @extend .button-tertiary;
     height: $s-32;
@@ -83,6 +60,38 @@
       @extend .button-icon;
     }
   }
+}
+
+.input-wrapper {
+  grid-column: span 7;
+  display: grid;
+  grid-template-columns: subgrid;
+}
+
+.format-select {
+  grid-column: span 2;
+  padding: 0;
+
+  .dropdown-upwards {
+    bottom: $s-36;
+    width: $s-80;
+    top: unset;
+  }
+}
+
+.size-select {
+  grid-column: span 2;
+  padding: 0;
+  .dropdown-upwards {
+    bottom: $s-36;
+    top: unset;
+    width: $s-80;
+  }
+}
+
+.suffix-input {
+  grid-column: span 3;
+  @extend .input-element;
 }
 
 .export-btn {


### PR DESCRIPTION
- :bug: fix blur icon changing size on hover
- :bug: fix sizes of dropdowns in the export section

> :warning: This uses CSS Subgrid ([available in major browsers](https://caniuse.com/?search=subgrid) since September). 

**Included fixes**:

The eye icon for Blur does no longer change in size when hovering:

<img width="252" alt="Screenshot 2024-01-03 at 4 34 16 PM" src="https://github.com/penpot/penpot/assets/63681/ce4d6e1c-5a15-49b4-968a-809aec8e6d2d">

<img width="264" alt="Screenshot 2024-01-03 at 4 34 21 PM" src="https://github.com/penpot/penpot/assets/63681/b29ec15e-69d0-4e2f-9991-142b7f106fe2">

The `Export` section now has the right sizes for its elements, and the format dropdown does not need to clip its content.

<img width="285" alt="Screenshot 2024-01-03 at 4 34 06 PM" src="https://github.com/penpot/penpot/assets/63681/81706529-e76a-48a4-9a4c-2449f3a1cc08">


