### PR TITLE
:bug: Fix opening the swap panel on a copy of a deleted component fails

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -224,11 +224,10 @@
                               (cfh/join-path (if (not every-same-file?)
                                                ""
                                                (find-common-path [] 0))))
-
         filters*            (mf/use-state
                              {:term ""
                               :file-id file-id
-                              :path path
+                              :path (or path "")
                               :listing-thumbs? false})
 
         filters             (deref filters*)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6481