### PR TITLE
Fix annotation textarea steals focus and prevents deleting a component with keyboard

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -139,7 +139,7 @@
           {:ref textarea-ref
            :id "annotation-textarea"
            :data-debug annotation
-           :auto-focus true
+           :auto-focus (or @editing? creating?)
            :maxLength 300
            :on-input autogrow
            :default-value annotation


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6366