### PR TITLE
:bug: Fix wrong icon for SVG

### DIFF
--- a/frontend/src/app/main/ui/components/shape_icon_refactor.cljs
+++ b/frontend/src/app/main/ui/components/shape_icon_refactor.cljs
@@ -47,7 +47,7 @@
               :exclude      i/boolean-exclude-refactor
               :intersection i/boolean-intersection-refactor
               #_:default    i/boolean-union-refactor)
-      :svg-raw i/file-svg
+      :svg-raw i/path-refactor
       nil)))
 
 


### PR DESCRIPTION
The icon in the layers for SVG was broken, and Design asked to use the path icon instead.

<img width="242" alt="Screenshot 2024-01-08 at 4 42 29 PM" src="https://github.com/penpot/penpot/assets/63681/4b690ad3-e932-4a2a-9bf4-ad6d515b2446">
