### PR TITLE
More bugfixes

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -148,6 +148,15 @@
   [objects id]
   (mapv (d/getf objects) (get-children-ids-with-self objects id)))
 
+(defn get-child
+  "Return the child of the given object with the given id (allow that the
+   id may point to the object itself)."
+  [objects id child-id]
+  (let [shape (get objects id)]
+    (if (= id child-id)
+      shape
+      (some #(get-child objects % child-id) (:shapes shape)))))
+
 (defn get-parent
   "Retrieve the parent for the shape-id (if exists)"
   [objects id]

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -168,7 +168,9 @@
     (if (and components-v2 (not (:deleted component)))
       (let [component-page (get-component-page file-data component)]
         (when component-page
-          (ctn/get-shape component-page shape-id)))
+          (cfh/get-child (:objects component-page)
+                         (:main-instance-id component)
+                         shape-id)))
       (dm/get-in component [:objects shape-id]))))
 
 (defn get-ref-shape


### PR DESCRIPTION
We have detected in some files `:shape-ref` that points to a shape that exists in the page, but does not belong to the main component. This is broken, but it was not detected by the validator. For example, this occurs in the file of this issue:

https://tree.taiga.io/project/penpot/issue/6879

This PR enhances the find ref shape function to not resolve the ref in this case, generating a validation error, and then makes the repair function smarter, so it may fix this error in many cases without information loss.