### PR TITLE
:bug: Fix assets dropdown (search bar)

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -178,7 +178,7 @@
          :fixed? true
          :min-width? true
          :top 152
-         :left 64
+         :left 18
          :options options
          :workspace? true}]
        [:button {:class (stl/css :sort-button)


### PR DESCRIPTION
- :bug: Fix positioning of dropdown for assets/types

Fixes https://tree.taiga.io/project/penpot/issue/6571

Now the menu is aligned with its dropdown button:

<img width="349" alt="Screenshot 2024-01-18 at 11 24 57 AM" src="https://github.com/penpot/penpot/assets/63681/723f5b24-a6bf-41d7-9cdd-422c53b434f7">

