### PR TITLE
:bug: Fix icon for raw svg in layers tab

### DIFF
--- a/frontend/src/app/main/ui/components/shape_icon_refactor.cljs
+++ b/frontend/src/app/main/ui/components/shape_icon_refactor.cljs
@@ -47,7 +47,7 @@
               :exclude      i/boolean-exclude-refactor
               :intersection i/boolean-intersection-refactor
               #_:default    i/boolean-union-refactor)
-      :svg-raw i/path-refactor
+      :svg-raw i/img-refactor
       nil)))
 
 


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6597

As requested by design, now we are using the Image icon (instead of the Path one) for raw SVG in the layers tab.

<img width="281" alt="Screenshot 2024-01-18 at 12 18 35 PM" src="https://github.com/penpot/penpot/assets/63681/572b5989-ce83-412a-82de-d36673b5d697">
