### PR TITLE
:bug: Fix layout of assets bar when importing external libraries

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.scss
@@ -9,7 +9,7 @@
 .assets-bar {
   display: grid;
   height: 100%;
-  grid-template-rows: auto 1fr;
+  grid-auto-rows: max-content;
   // TODO: ugly hack :( Fix this! we shouldn't be hardcoding this height
   max-height: calc(100vh - $s-80);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.scss
@@ -6,12 +6,14 @@
 
 @import "refactor/common-refactor.scss";
 .tool-window {
-  margin-block-end: $s-24;
   padding-inline-start: $s-12;
   overflow-y: auto;
   display: grid;
   grid-auto-rows: max-content;
   scrollbar-gutter: stable;
+  &:last-child {
+    margin-block-end: $s-24;
+  }
 }
 
 .file-name {


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6660

<img width="273" alt="Screenshot 2024-01-19 at 2 11 41 PM" src="https://github.com/penpot/penpot/assets/63681/7ea7aeaf-4739-4cb7-88f4-94980359fd20">
