### PR TITLE
:sparkles: Add change theme shortcut on help section

### DIFF
--- a/frontend/src/app/main/data/dashboard/shortcuts.cljs
+++ b/frontend/src/app/main/data/dashboard/shortcuts.cljs
@@ -32,9 +32,10 @@
                         :subsections [:general-dashboard]
                         :fn #(st/emit! (dd/create-element))}
 
-   :toggle-light-dark    {:tooltip (ds/meta (ds/alt "Q"))
-                          :command (ds/c-mod "alt+q")
-                          :fn #(st/emit! (du/toggle-theme))}})
+   :toggle-theme    {:tooltip (ds/meta (ds/alt "M"))
+                     :command (ds/c-mod "alt+m")
+                     :subsections [:general-dashboard]
+                     :fn #(st/emit! (du/toggle-theme))}})
 
 (defn get-tooltip [shortcut]
   (assert (contains? shortcuts shortcut) (str shortcut))

--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -551,9 +551,10 @@
 
 
    ;; THEME
-   :toggle-light-dark    {:tooltip (ds/meta (ds/alt "Q"))
-                          :command (ds/c-mod "alt+q")
-                          :fn #(st/emit! (du/toggle-theme))}})
+   :toggle-theme    {:tooltip (ds/meta (ds/alt "M"))
+                     :command (ds/c-mod "alt+m")
+                     :subsections [:basics]
+                     :fn #(st/emit! (du/toggle-theme))}})
 
 (def opacity-shortcuts
   (into {} (->>

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2976,6 +2976,9 @@ msgstr "Snap to guides"
 msgid "shortcuts.toggle-textpalette"
 msgstr "Toggle text palette"
 
+msgid "shortcuts.toggle-theme"
+msgstr "Change theme"
+
 msgid "shortcuts.toggle-visibility"
 msgstr "Show / Hide"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3022,6 +3022,9 @@ msgstr "Alinear a las guias"
 msgid "shortcuts.toggle-textpalette"
 msgstr "Mostrar/ocultar paleta de textos"
 
+msgid "shortcuts.toggle-theme"
+msgstr "Cambiar tema"
+
 msgid "shortcuts.toggle-visibility"
 msgstr "Mostrar/ocultar elemento"
 


### PR DESCRIPTION
This PR will fix this [ task 6646](https://tree.taiga.io/project/penpot/task/6646). Add change theme shortchut
