### PR TITLE
:tada: Implement full-size font selector

### DIFF
--- a/frontend/src/app/main/ui/context.cljs
+++ b/frontend/src/app/main/ui/context.cljs
@@ -29,3 +29,4 @@
 
 (def workspace-read-only? (mf/create-context nil))
 (def is-component?        (mf/create-context false))
+(def sidebar (mf/create-context nil))

--- a/frontend/src/app/main/ui/workspace/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar.cljs
@@ -12,6 +12,7 @@
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.tab-container :refer [tab-container tab-element]]
+   [app.main.ui.context :as muc]
    [app.main.ui.hooks.resize :refer [use-resize-hook]]
    [app.main.ui.workspace.comments :refer [comments-sidebar]]
    [app.main.ui.workspace.left-header :refer [left-header]]
@@ -58,23 +59,23 @@
         on-tab-change
         (mf/use-fn #(st/emit! (dw/go-to-layout %)))]
 
-    [:aside {:ref parent-ref
-             :id "left-sidebar-aside"
-             :data-size (str size)
-             :class (stl/css-case :left-settings-bar true
-                                  :global/two-row   (<= size 300)
-                                  :global/three-row (and (> size 300) (<= size 400))
-                                  :global/four-row  (> size 400))
-             :style #js {"--width" (dm/str size "px")}}
+    [:& (mf/provider muc/sidebar) {:value :left}
+     [:aside {:ref parent-ref
+              :id "left-sidebar-aside"
+              :data-size (str size)
+              :class (stl/css-case :left-settings-bar true
+                                   :global/two-row    (<= size 300)
+                                   :global/three-row  (and (> size 300) (<= size 400))
+                                   :global/four-row  (> size 400))
+              :style #js {"--width" (dm/str size "px")}}
 
-     [:& left-header {:file file :layout layout :project project :page-id page-id
-                      :class (stl/css :left-header)}]
+      [:& left-header {:file file :layout layout :project project :page-id page-id
+                       :class (stl/css :left-header)}]
 
-     [:div {:on-pointer-down on-pointer-down
-            :on-lost-pointer-capture on-lost-pointer-capture
-            :on-pointer-move on-pointer-move
-            :class (stl/css :resize-area)}]
-     [:*
+      [:div {:on-pointer-down on-pointer-down
+             :on-lost-pointer-capture on-lost-pointer-capture
+             :on-pointer-move on-pointer-move
+             :class (stl/css :resize-area)}]
       (cond
         (true? shortcuts?)
         [:& shortcuts-container {:class (stl/css :settings-bar-content)}]
@@ -109,7 +110,6 @@
 
             [:& layers-toolbox {:size-parent size
                                 :size size-pages}]]]
-
 
           (when-not ^boolean mode-inspect?
             [:& tab-element {:id :assets
@@ -159,27 +159,28 @@
             (obj/set! "on-change-section" handle-change-section)
             (obj/set! "on-expand" handle-expand))]
 
-    [:aside {:class (stl/css-case :right-settings-bar true
-                                  :not-expand (not can-be-expanded?)
-                                  :expanded (> size 276))
+    [:& (mf/provider muc/sidebar) {:value :right}
+     [:aside {:class (stl/css-case :right-settings-bar true
+                                   :not-expand (not can-be-expanded?)
+                                   :expanded (> size 276))
 
-             :id "right-sidebar-aside"
-             :data-size (str size)
-             :style #js {"--width" (when can-be-expanded? (dm/str size "px"))}}
-     (when can-be-expanded?
-       [:div {:class (stl/css :resize-area)
-              :on-pointer-down on-pointer-down
-              :on-lost-pointer-capture on-lost-pointer-capture
-              :on-pointer-move on-pointer-move}])
-     [:& right-header {:file file :layout layout :page-id page-id}]
+              :id "right-sidebar-aside"
+              :data-size (str size)
+              :style #js {"--width" (when can-be-expanded? (dm/str size "px"))}}
+      (when can-be-expanded?
+        [:div {:class (stl/css :resize-area)
+               :on-pointer-down on-pointer-down
+               :on-lost-pointer-capture on-lost-pointer-capture
+               :on-pointer-move on-pointer-move}])
+      [:& right-header {:file file :layout layout :page-id page-id}]
 
-     [:div {:class (stl/css :settings-bar-inside)}
-      (cond
-        (true? is-comments?)
-        [:& comments-sidebar]
+      [:div {:class (stl/css :settings-bar-inside)}
+       (cond
+         (true? is-comments?)
+         [:& comments-sidebar]
 
-        (true? is-history?)
-        [:& history-toolbox]
+         (true? is-history?)
+         [:& history-toolbox]
 
-        :else
-        [:> options-toolbox props])]]))
+         :else
+         [:> options-toolbox props])]]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/file_library.scss
@@ -14,6 +14,7 @@
   &:last-child {
     margin-block-end: $s-24;
   }
+  height: 100%;
 }
 
 .file-name {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.scss
@@ -247,8 +247,10 @@
 
 .text-options {
   @include flexColumn;
-  position: relative;
   margin-bottom: $s-8;
+  &:not(.text-options-full-size) {
+    position: relative;
+  }
   .font-option {
     @include titleTipography;
     @extend .asset-element;
@@ -342,71 +344,99 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
   height: 100%;
   width: 100%;
   z-index: $z-index-3;
+}
 
-  .font-selector-dropdown {
+.show-recent {
+  border-radius: $br-8 $br-8 0 0;
+  background: var(--dropdown-background-color);
+  border: $s-1 solid var(--color-background-quaternary);
+  border-block-end: none;
+}
+
+.font-selector-dropdown {
+  width: 100%;
+  &:not(.font-selector-dropdown-full-size) {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
     height: 100%;
-    .header {
-      display: flex;
-      flex-direction: column;
-      position: relative;
-      margin-bottom: $s-2;
-      background-color: var(--dropdown-background-color);
-      .title {
-        @include tabTitleTipography;
-        margin: 9px 17px;
-        color: var(--title-foreground-color);
-      }
+  }
+  .header {
+    display: grid;
+    row-gap: $s-2;
+    .title {
+      @include tabTitleTipography;
+      color: var(--title-foreground-color);
+      margin: 0;
+      padding: $s-12;
     }
-    .fonts-list {
-      @include menuShadow;
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      flex: 1 1 auto;
-      min-height: 100%;
-      width: 100%;
-      height: 100%;
-      padding: $s-2;
-      border-radius: $br-8;
-      background-color: var(--dropdown-background-color);
-    }
-    .font-wrapper {
-      padding-bottom: $s-4;
-      cursor: pointer;
-      .font-item {
-        @extend .asset-element;
-        margin-bottom: $s-4;
-        border-radius: $br-8;
-        display: flex;
-        .icon {
-          @include flexCenter;
-          height: $s-28;
-          width: $s-28;
-          svg {
-            @extend .button-icon-small;
-            stroke: var(--icon-foreground);
-          }
-        }
-        &.selected {
-          color: var(--assets-item-name-foreground-color-hover);
-          .icon {
-            svg {
-              stroke: var(--assets-item-name-foreground-color-hover);
-            }
-          }
-        }
+  }
 
-        .label {
-          @include titleTipography;
-          flex-grow: 1;
+  .font-wrapper {
+    padding-bottom: $s-4;
+    cursor: pointer;
+    .font-item {
+      @extend .asset-element;
+      margin-bottom: $s-4;
+      border-radius: $br-8;
+      display: flex;
+      .icon {
+        @include flexCenter;
+        height: $s-28;
+        width: $s-28;
+        svg {
+          @extend .button-icon-small;
+          stroke: var(--icon-foreground);
         }
+      }
+      &.selected {
+        color: var(--assets-item-name-foreground-color-hover);
+        .icon {
+          svg {
+            stroke: var(--assets-item-name-foreground-color-hover);
+          }
+        }
+      }
+
+      .label {
+        @include titleTipography;
+        flex-grow: 1;
       }
     }
   }
+}
+
+.font-selector-dropdown-full-size {
+  height: calc(100vh - 48px); // TODO: ugly hack :( Find a workaround for this.
+  display: grid;
+  grid-template-rows: auto 1fr;
+  padding: $s-2 $s-12 $s-12 $s-12;
+}
+
+.fonts-list {
+  @include menuShadow;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 100%;
+  width: 100%;
+  height: 100%;
+  padding: $s-2;
+  border-radius: $br-8;
+  background-color: var(--dropdown-background-color);
+  overflow: hidden;
+  &:not(.fonts-list-full-size) {
+    margin-block-start: $s-2;
+  }
+}
+
+.fonts-list-full-size {
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border: $s-1 solid var(--color-background-quaternary);
 }


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/task/6685

- :tada: Implement full-size font selector
- :bug: Fix assets bar not being tall enough (and thus typography dropdown clipped) in some ocasions

When we click on a font selector dropdown that _does not belong to a typography_ now we get a full-size font selector. The other font selector dropdowns stay the same.

<img width="1344" alt="Screenshot 2024-01-23 at 4 43 32 PM" src="https://github.com/penpot/penpot/assets/63681/7245d676-bcd6-4493-9356-7b50035598f2">
