### PR TITLE
:bug: Fix unexpected exception on consecutive delete files with shift key pressed

### DIFF
--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -86,7 +86,7 @@
   [files selected]
   (let [get-file #(get files %)
         sim-file #(select-keys % [:id :name :project-id :is-shared])
-        xform    (comp (map get-file)
+        xform    (comp (keep get-file)
                        (map sim-file))]
     (->> (into #{} xform selected)
          (d/index-by :id))))
@@ -96,14 +96,15 @@
                ;; we need to this because :dashboard-search-result is a list
                ;; of maps and we need a map of maps (using :id as key).
                (let [files (d/index-by :id (:dashboard-search-result state))]
-                 (dashboard-extract-selected files (dm/get-in state [:dashboard-local :selected-files]))))
+                 (->> (dm/get-in state [:dashboard-local :selected-files])
+                      (dashboard-extract-selected files))))
              st/state))
 
 (def dashboard-selected-files
   (l/derived (fn [state]
-               (dashboard-extract-selected (:dashboard-files state)
-                                           (dm/get-in state [:dashboard-local :selected-files])))
-             st/state =))
+               (->> (dm/get-in state [:dashboard-local :selected-files])
+                    (dashboard-extract-selected (:dashboard-files state))))
+             st/state))
 
 ;; ---- Workspace refs
 

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -218,6 +218,9 @@
   {:wrap [mf/memo]}
   [{:keys [file origin library-view?] :as props}]
   (let [file-id         (:id file)
+
+        ;; FIXME: this breaks react hooks rule, hooks should never to
+        ;; be in a conditional code
         selected-files  (if (= origin :search)
                           (mf/deref refs/dashboard-selected-search)
                           (mf/deref refs/dashboard-selected-files))

--- a/frontend/src/app/main/ui/delete_shared.cljs
+++ b/frontend/src/app/main/ui/delete_shared.cljs
@@ -26,7 +26,7 @@
    ::mf/register-as :delete-shared-libraries
    ::mf/wrap-props false}
   [{:keys [ids on-accept on-cancel accept-style origin count-libraries]}]
-  (let [references*  (mf/use-state {})
+  (let [references*  (mf/use-state nil)
         references   (deref references*)
 
         on-accept    (or on-accept noop)
@@ -78,8 +78,8 @@
 
     (mf/with-effect [ids]
       (->> (rx/from ids)
-           (rx/map #(array-map :file-id %))
-           (rx/mapcat #(rp/cmd! :get-library-file-references %))
+           (rx/filter some?)
+           (rx/mapcat #(rp/cmd! :get-library-file-references {:file-id %}))
            (rx/mapcat identity)
            (rx/map (juxt :id :name))
            (rx/reduce conj [])


### PR DESCRIPTION
If you select N files (using shift key), then delete them and continuing pressing the shift select an other file and proceed to delete it an exception is raised. This is happens because the previous selection is not cleared. This commit fixes that.

