### PR TITLE
:bug: Fix pin icon fill in dashboard/projects

### DIFF
--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -305,7 +305,7 @@
 
        [:div {:class (stl/css :project-actions)}
         (when-not (:is-default project)
-          [:> pin-button* {:is-pinned (:is-pinned project) :on-click toggle-pin :tab-index 0}])
+          [:> pin-button* {:class (stl/css :pin-button) :is-pinned (:is-pinned project) :on-click toggle-pin :tab-index 0}])
 
         [:button
          {:class (stl/css :btn-secondary :btn-small :tooltip :tooltip-bottom)

--- a/frontend/src/app/main/ui/dashboard/projects.scss
+++ b/frontend/src/app/main/ui/dashboard/projects.scss
@@ -108,10 +108,7 @@
       opacity: 1;
       margin-left: $s-32;
 
-      svg {
-        fill: $df-primary;
-      }
-      .btn-small {
+      .btn-small:not(.pin-button) {
         height: $s-32;
         margin: 0 $s-8;
         width: $s-32;
@@ -120,6 +117,7 @@
           background: transparent;
         }
         svg {
+          fill: $df-primary;
           height: $s-16;
           width: $s-16;
         }


### PR DESCRIPTION
- :bug: Fix pin button color in dashboard/projects

In the dashboard/projects section the pin button had a fill in the icon, and we don't need it. This is how it looks with this patch:

<img width="431" alt="Screenshot 2024-01-29 at 11 13 45 AM" src="https://github.com/penpot/penpot/assets/63681/8494ff97-1954-457f-8a57-bdef9b851730">

<img width="443" alt="Screenshot 2024-01-29 at 11 14 14 AM" src="https://github.com/penpot/penpot/assets/63681/b270573a-77ea-49d8-94fd-bb7bc79c297e">
