### PR TITLE
:sparkles: Show loading message in Libraries modal

### DIFF
--- a/frontend/src/app/main/ui/workspace/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/libraries.cljs
@@ -123,11 +123,12 @@
 
         shared-libraries
         (mf/with-memo [shared-libraries linked-libraries file-id search-term]
-          (->> shared-libraries
-               (remove #(= (:id %) file-id))
-               (remove #(contains? linked-libraries (:id %)))
-               (filter #(matches-search (:name %) search-term))
-               (sort-by (comp str/lower :name))))
+          (when shared-libraries
+            (->> shared-libraries
+                 (remove #(= (:id %) file-id))
+                 (remove #(contains? linked-libraries (:id %)))
+                 (filter #(matches-search (:name %) search-term))
+                 (sort-by (comp str/lower :name)))))
 
         linked-libraries
         (mf/with-memo [linked-libraries]
@@ -275,12 +276,17 @@
                       :on-click link-library}
              i/add-refactor]])]
 
-        [:div {:class (stl/css :section-list-empty)}
-         (if (nil? shared-libraries)
-           i/loader-pencil
-           (if (str/empty? search-term)
+        (when (empty? shared-libraries)
+          [:div {:class (stl/css :section-list-empty)}
+           (cond
+             (nil? shared-libraries)
+             (tr "workspace.libraries.loading")
+
+             (str/empty? search-term)
              (tr "workspace.libraries.no-shared-libraries-available")
-             (tr "workspace.libraries.no-matches-for" search-term)))])]]))
+
+             :else
+             (tr "workspace.libraries.no-matches-for" search-term))]))]]))
 
 (defn- extract-assets
   [file-data library summary?]
@@ -519,4 +525,3 @@
            [:& updates-tab {:file-id file-id
                             :file-data file-data
                             :libraries libraries}]]]]]]]]))
-

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3593,6 +3593,10 @@ msgstr "Search shared libraries"
 msgid "workspace.libraries.shared-libraries"
 msgstr "SHARED LIBRARIES"
 
+#: src/app/main/ui/workspace/libraries.cljs
+msgid "workspace.libraries.loading"
+msgstr "Loading…"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/text.cljs
 msgid "workspace.libraries.text.multiple-typography"
 msgstr "Multiple typographies"


### PR DESCRIPTION
Closes https://tree.taiga.io/project/penpot/us/6702

 https://github.com/penpot/penpot/assets/63681/e042ca09-7db5-4e34-a87e-7b299800ee67

You can check the behavior more easily when running it locally if you enable network throttling in the browser's developer tools.
