### PR TITLE
:bug: Fix selected text not being visible

### DIFF
--- a/frontend/resources/styles/common/refactor/basic-rules.scss
+++ b/frontend/resources/styles/common/refactor/basic-rules.scss
@@ -29,7 +29,8 @@
   }
 
   ::selection {
-    background-color: var(--color-accent-primary-muted);
+    background: var(--text-editor-selection-background-color);
+    color: var(--text-editor-selection-foreground-color);
   }
 }
 

--- a/frontend/resources/styles/common/refactor/color-defs.scss
+++ b/frontend/resources/styles/common/refactor/color-defs.scss
@@ -27,6 +27,7 @@
   --da-secondary: #bb97d8;
   --da-tertiary: #00d1b8;
   --da-tertiary-10: #{color.change(#00d1b8, $alpha: 0.1)};
+  --da-tertiary-70: #{color.change(#00d1b8, $alpha: 0.7)};
   --da-quaternary: #ff6fe0;
 
   // LIGHT
@@ -50,6 +51,7 @@
   --la-secondary: #1345aa;
   --la-tertiary: #8c33eb;
   --la-tertiary-10: #{color.change(#8c33eb, $alpha: 0.1)};
+  --la-tertiary-70: #{color.change(#8c33eb, $alpha: 0.7)};
   --la-quaternary: #ff6fe0;
 
   // STATUS COLOR

--- a/frontend/resources/styles/common/refactor/design-tokens.scss
+++ b/frontend/resources/styles/common/refactor/design-tokens.scss
@@ -357,6 +357,10 @@
   --viewer-thumbnails-control-foreground-color: var(--color-foreground-secondary);
   --viewer-thumbnail-border-color: var(--color-accent-primary);
   --viewer-thumbnail-background-color-selected: var(--color-accent-primary-muted);
+
+  // TEXT SELECTION
+  --text-editor-selection-background-color: var(--da-tertiary-70);
+  --text-editor-selection-foreground-color: var(--app-white);
 }
 
 #app {
@@ -383,4 +387,6 @@
 
   --assets-item-name-background-color: var(--color-background-primary);
   --assets-item-name-foreground-color: var(--color-foreground-primary);
+
+  --text-editor-selection-background-color: var(--la-tertiary-70);
 }


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6828

Now the text is visible when you select it.

<img width="511" alt="Screenshot 2024-01-31 at 3 32 22 PM" src="https://github.com/penpot/penpot/assets/63681/8406a535-e752-419c-af32-3289926b1be7">

There's one caveat, though. Since the selection background is now semi-transparent, there's a faux drop shadow effect  (see screenshot below) caused by the original text being rendered underneath the selection (which is a `<span>` that gets generated). Not sure how to get rid off it, though, I guess we'd need to modify the text editor itself.

<img width="561" alt="Screenshot 2024-01-31 at 3 19 25 PM" src="https://github.com/penpot/penpot/assets/63681/7fa4fc88-c90e-451a-b14a-7591ad7fd694">

An easy workaround would be to make the background fully opaque.


