### PR TITLE
:bug: Fix search bar being wider when recent-fonts is nil

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -103,7 +103,7 @@
         fonts          (mf/use-memo (mf/deps @state) #(filter-fonts @state @fonts/fonts))
         recent-fonts   (mf/deref refs/workspace-recent-fonts)
 
-        full-size? (boolean (and full-size recent-fonts show-recent))
+        full-size? (boolean (and full-size show-recent))
 
         select-next
         (mf/use-fn


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6874

<img width="290" alt="Screenshot 2024-02-06 at 1 49 48 PM" src="https://github.com/penpot/penpot/assets/63681/b527b4cf-3dc0-424e-a96d-b86e58ede56e">
