### PR TITLE
:bug: Fix display of mixed measurements +  border-radius input

### DIFF
--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -53,7 +53,7 @@
 
         ;; This `value` represents the previous value and is used as
         ;; initil value for the simple math expression evaluation.
-        value       (d/parse-double value-str default)
+        value       (when (not= :multiple value-str) (d/parse-double value-str default))
 
         ;; We need to store the handle-blur ref so we can call it on unmount
         dirty-ref   (mf/use-ref false)

--- a/frontend/src/app/main/ui/components/numeric_input.cljs
+++ b/frontend/src/app/main/ui/components/numeric_input.cljs
@@ -59,8 +59,7 @@
         dirty-ref   (mf/use-ref false)
 
         ;; Last value input by the user we need to store to save on unmount
-
-        last-value*  (mf/use-var nil)
+        last-value*  (mf/use-var value)
 
         parse-value
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -391,7 +391,7 @@
          [:span {:class (stl/css :icon-text)} "W"]
          [:> numeric-input* {:min 0.01
                              :no-validate true
-                             :placeholder "--"
+                             :placeholder (if (= :multiple (:width values)) (tr "settings.multiple") "--")
                              :on-change on-width-change
                              :disabled disabled-width-sizing?
                              :className (stl/css :numeric-input)
@@ -402,7 +402,7 @@
          [:span {:class (stl/css :icon-text)} "H"]
          [:> numeric-input* {:min 0.01
                              :no-validate true
-                             :placeholder "--"
+                             :placeholder (if (= :multiple (:height values)) (tr "settings.multiple") "--")
                              :on-change on-height-change
                              :disabled disabled-height-sizing?
                              :className (stl/css :numeric-input)
@@ -422,7 +422,7 @@
                :title (tr "workspace.options.x")}
          [:span {:class (stl/css :icon-text)} "X"]
          [:> numeric-input* {:no-validate true
-                             :placeholder "--"
+                             :placeholder (if (= :multiple (:x values)) (tr "settings.multiple") "--")
                              :on-change on-pos-x-change
                              :disabled disabled-position-x?
                              :className (stl/css :numeric-input)
@@ -433,7 +433,7 @@
                :title (tr "workspace.options.y")}
          [:span {:class (stl/css :icon-text)} "Y"]
          [:> numeric-input* {:no-validate true
-                             :placeholder "--"
+                             :placeholder (if (= :multiple (:y values)) (tr "settings.multiple") "--")
                              :disabled disabled-position-y?
                              :on-change on-pos-y-change
                              :className (stl/css :numeric-input)
@@ -450,7 +450,7 @@
              :min 0
              :max 359
              :data-wrap true
-             :placeholder "--"
+             :placeholder (if (= :multiple (:rotation values)) (tr "settings.multiple") "--")
              :on-change on-rotation-change
              :className (stl/css :numeric-input)
              :value (:rotation values)}]])
@@ -464,7 +464,7 @@
                      :title (tr "workspace.options.radius")}
                [:span {:class (stl/css :icon)}  i/corner-radius-refactor]
                [:> numeric-input*
-                {:placeholder "Mixed"
+                {:placeholder (if (= :multiple (:rx values)) (tr "settings.multiple") "--")
                  :ref radius-input-ref
                  :min 0
                  :on-change on-radius-1-change


### PR DESCRIPTION
- :bug: Fix mixed values displays for measurements in the design tab
- :bug: Fix multi radius input being reset to zero on blur

Fixes these tickets:
- https://tree.taiga.io/project/penpot/issue/6872
- https://tree.taiga.io/project/penpot/issue/6917

<img width="1046" alt="Screenshot 2024-02-08 at 1 13 41 PM" src="https://github.com/penpot/penpot/assets/63681/db94c4a2-4092-4215-9dde-26a352597a9d">

