### PR TITLE
:bug: Fix opacity display when selecting multiple shapes

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layer.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layer.cljs
@@ -23,11 +23,11 @@
 
 (defn opacity->string
   [opacity]
-  (if (= opacity :multiple)
-    ""
+  (if (not= opacity :multiple)
     (dm/str (-> opacity
                 (d/coalesce 1)
-                (* 100)))))
+                (* 100)))
+    :multiple))
 
 (mf/defc layer-menu
   {::mf/wrap-props false}
@@ -39,7 +39,7 @@
         blocked?           (:blocked values)
 
         current-blend-mode (or (:blend-mode values) :normal)
-        current-opacity    (:opacity values)
+        current-opacity    (opacity->string (:opacity values))
 
         state*             (mf/use-state
                             {:selected-blend-mode current-blend-mode
@@ -161,8 +161,8 @@
              :title (tr "workspace.options.opacity")}
        [:span {:class (stl/css :icon)} "%"]
        [:> numeric-input*
-        {:value (opacity->string current-opacity)
-         :placeholder (tr "settings.multiple")
+        {:value current-opacity
+         :placeholder "--"
          :on-change handle-opacity-change
          :min 0
          :max 100


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6925

<img width="451" alt="Screenshot 2024-02-12 at 4 37 46 PM" src="https://github.com/penpot/penpot/assets/63681/1075ec0c-8382-4473-8f84-0388e27301db">

NOTE: we cannot use `Mixed` as placeholder due to lack of space. See [this thread on Mattermost](https://chat.kaleidos.net/kaleidos/pl/nu6m8ujn8bf77q7reify1djq1w) for more context 