### PR TITLE
:bug: Fix update main when there are swapped copies

### DIFF
--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -166,13 +166,6 @@
     :else
     (get-instance-root objects (get objects (:parent-id shape)))))
 
-(defn get-copy-root
-  "Get the top shape of the copy."
-  [objects shape]
-  (when (:shape-ref shape)
-    (let [parent (cfh/get-parent objects (:id shape))]
-      (or (get-copy-root objects parent) shape))))
-
 (defn inside-component-main?
   "Check if the shape is a component main instance or is inside one."
   [objects shape]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -77,7 +77,11 @@
                 extract (cond-> {:type (:type change)
                                  :raw-change change}
                           shape
-                          (assoc :shape (str prefix (:name shape)))
+                          (assoc :shape (str prefix (:name shape))
+                                 :shape-id (str (:id shape)))
+                          (:obj change)
+                          (assoc :obj (:name (:obj change))
+                                 :obj-id (:id (:obj change)))
                           (:operations change)
                           (assoc :operations (:operations change)))]
             extract))]


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6909
And also the undo operation of update main component, that was broken.