### PR TITLE
:bug: Avoid setting touched in parent when swapping components

### DIFF
--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -326,7 +326,9 @@
            (some? index)
            (assoc :index index)
            (:component-swap options)
-           (assoc :component-swap true))
+           (assoc :component-swap true)
+           (:ignore-touched options)
+           (assoc :ignore-touched true))
 
          mk-undo-change
          (fn [undo-changes shape]
@@ -450,10 +452,11 @@
          add-redo-change
          (fn [change-set id]
            (conj change-set
-                 {:type :del-obj
-                  :page-id page-id
-                  :ignore-touched ignore-touched
-                  :id id}))
+                 (cond-> {:type :del-obj
+                          :page-id page-id
+                          :id id}
+                   ignore-touched
+                   (assoc :ignore-touched true))))
 
          add-undo-change-shape
          (fn [change-set id]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -898,7 +898,8 @@
                 (pcb/update-shapes [(:id new-shape)] #(d/patch-object % keep-props-values))
 
                 ;; We need to set the same index as the original shape
-                (pcb/change-parent (:parent-id shape) [new-shape] index {:component-swap true}))]
+                (pcb/change-parent (:parent-id shape) [new-shape] index {:component-swap true
+                                                                         :ignore-touched true}))]
 
         ;; First delete so we don't break the grid layout cells
         (rx/of (dch/commit-changes changes)


### PR DESCRIPTION
Implements https://tree.taiga.io/project/penpot/task/6794