### PR TITLE
:bug: Fix icon not being shown when asset category had a zero count

### DIFF
--- a/frontend/src/app/main/ui/components/title_bar.cljs
+++ b/frontend/src/app/main/ui/components/title_bar.cljs
@@ -13,7 +13,7 @@
 
 (mf/defc title-bar
   {::mf/wrap-props false}
-  [{:keys [collapsable collapsed on-collapsed title children on-btn-click btn-children class all-clickable]}]
+  [{:keys [collapsable collapsed on-collapsed title children on-btn-click btn-children class all-clickable add-icon-gap]}]
   (let [klass (dm/str (stl/css :title-bar) " " class)]
     [:div {:class klass}
      (if ^boolean collapsable
@@ -33,7 +33,7 @@
                      :on-click on-collapsed}
             i/arrow-refactor]
            [:div {:class (stl/css :title)} title]])]
-       [:div {:class (stl/css :title-only)} title])
+       [:div {:class (stl/css-case :title-only true :title-only-icon-gap add-icon-gap)} title])
      children
      (when (some? on-btn-click)
        [:button {:class (stl/css :title-button)

--- a/frontend/src/app/main/ui/components/title_bar.scss
+++ b/frontend/src/app/main/ui/components/title_bar.scss
@@ -14,20 +14,6 @@
   width: 100%;
   min-height: $s-32;
   background-color: var(--title-background-color);
-  .title,
-  .title-only {
-    @include tabTitleTipography;
-    display: flex;
-    align-items: center;
-    flex-grow: 1;
-    height: 100%;
-    min-height: $s-32;
-    color: var(--title-foreground-color);
-    overflow: hidden;
-  }
-  .title-only {
-    margin-left: $s-8;
-  }
 
   .title-wrapper {
     display: flex;
@@ -108,4 +94,25 @@
       stroke: var(--icon-foreground);
     }
   }
+}
+
+.title,
+.title-only {
+  @include tabTitleTipography;
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  height: 100%;
+  min-height: $s-32;
+  color: var(--title-foreground-color);
+  overflow: hidden;
+}
+
+.title-only {
+  --title-bar-title-margin: #{$s-8};
+  margin-inline-start: var(--title-bar-title-margin);
+}
+
+.title-only-icon-gap {
+  --title-bar-title-margin: #{$s-12};
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -166,6 +166,7 @@
        :collapsed     (not open?)
        :all-clickable true
        :on-collapsed  on-collapsed
+       :add-icon-gap  (= 0 assets-count)
        :class         (stl/css-case :title-spacing open?)
        :title         title}
       buttons]

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.scss
@@ -21,8 +21,8 @@
     @include flexCenter;
     height: $s-16;
     width: $s-16;
-    color: transparent;
     fill: none;
+    stroke: currentColor;
   }
 }
 


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6957

<img width="276" alt="Screenshot 2024-02-13 at 3 22 35 PM" src="https://github.com/penpot/penpot/assets/63681/1bd594b5-0659-4fdf-99f5-bdaa18c2347b">

Also fixed the alignment of icons, this was how it was looking before:

<img width="263" alt="Screenshot 2024-02-13 at 3 10 14 PM" src="https://github.com/penpot/penpot/assets/63681/bab4502f-7870-4750-bad1-71eafff0d8d5">
