### PR TITLE
:recycle: Add minor refactor to file migrations

### DIFF
--- a/backend/resources/app/templates/debug.tmpl
+++ b/backend/resources/app/templates/debug.tmpl
@@ -157,7 +157,7 @@ Debug Main Page
       <legend>Reset file version</legend>
       <desc>Allows reset file data version to a specific number/</desc>
 
-      <form method="post" action="/dbg/actions/reset-file-data-version">
+      <form method="post" action="/dbg/actions/reset-file-version">
         <div class="row">
           <input type="text" style="width:300px" name="file-id" placeholder="file-id" />
         </div>

--- a/backend/resources/log4j2-devenv-repl.xml
+++ b/backend/resources/log4j2-devenv-repl.xml
@@ -34,23 +34,19 @@
     <Logger name="app.common.files.migrations" level="debug" />
 
     <Logger name="app.loggers" level="debug" additivity="false">
-      <AppenderRef ref="console" level="info" />
       <AppenderRef ref="main" level="debug" />
     </Logger>
 
     <Logger name="app" level="all" additivity="false">
       <AppenderRef ref="main" level="trace" />
-      <AppenderRef ref="console" level="info" />
     </Logger>
 
     <Logger name="user" level="trace" additivity="false">
       <AppenderRef ref="main" level="trace" />
-      <AppenderRef ref="console" level="info" />
     </Logger>
 
     <Root level="info">
       <AppenderRef ref="main" />
-      <AppenderRef ref="console" level="info" />
     </Root>
   </Loggers>
 </Configuration>

--- a/backend/resources/log4j2-devenv.xml
+++ b/backend/resources/log4j2-devenv.xml
@@ -31,7 +31,7 @@
     <Logger name="app.redis" level="info" />
     <Logger name="app.rpc.rlimit" level="info" />
     <Logger name="app.rpc.climit" level="debug" />
-    <Logger name="app.common.files.migrations" level="info" />
+    <Logger name="app.common.files.migrations" level="trace" />
 
     <Logger name="app.loggers" level="debug" additivity="false">
       <AppenderRef ref="main" level="debug" />

--- a/backend/resources/log4j2.xml
+++ b/backend/resources/log4j2.xml
@@ -11,16 +11,9 @@
     <Logger name="io.lettuce" level="error" />
     <Logger name="com.zaxxer.hikari" level="error" />
     <Logger name="org.postgresql" level="error" />
-
-    <Logger name="app.util" level="info" />
-
-    <Logger name="app.loggers" level="debug" />
-
     <Logger name="app" level="info" additivity="false">
-      <AppenderRef ref="console" />
+      <AppenderRef ref="console" level="info" />
     </Logger>
-
-
     <Root level="info">
       <AppenderRef ref="console" />
     </Root>

--- a/backend/scripts/repl
+++ b/backend/scripts/repl
@@ -68,7 +68,7 @@ export OPTIONS="
        -J-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
        -J-Djdk.attach.allowAttachSelf \
        -J-Dpolyglot.engine.WarnInterpreterOnly=false \
-       -J-Dlog4j2.configurationFile=log4j2-devenv.xml \
+       -J-Dlog4j2.configurationFile=log4j2-devenv-repl.xml \
        -J-XX:+EnableDynamicAgentLoading \
        -J-XX:-OmitStackTraceInFastThrow \
        -J-XX:+UnlockDiagnosticVMOptions \

--- a/backend/scripts/start-dev
+++ b/backend/scripts/start-dev
@@ -28,7 +28,7 @@ export OPTIONS="
        -J-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
        -J-Djdk.attach.allowAttachSelf \
        -J-Dpolyglot.engine.WarnInterpreterOnly=false \
-       -J-Dlog4j2.configurationFile=log4j2.xml \
+       -J-Dlog4j2.configurationFile=log4j2-devenv.xml \
        -J-XX:+EnableDynamicAgentLoading \
        -J-XX:-OmitStackTraceInFastThrow \
        -J-XX:+UnlockDiagnosticVMOptions \

--- a/backend/src/app/features/components_v2.clj
+++ b/backend/src/app/features/components_v2.clj
@@ -1496,6 +1496,13 @@
             fdata (migrate-graphics fdata)]
         (update fdata :options assoc :components-v2 true)))))
 
+(defn- fix-version
+  [file]
+  (let [file (fmg/fix-version file)]
+    (if (> (:version file) 22)
+      (assoc file :version 22)
+      file)))
+
 (defn- get-file
   [system id]
   (binding [pmap/*load-fn* (partial fdata/load-pointer system id)]
@@ -1506,10 +1513,7 @@
         (update :data assoc :id id)
         (update :data fdata/process-pointers deref)
         (update :data fdata/process-objects (partial into {}))
-        (update :data (fn [data]
-                        (if (> (:version data) 22)
-                          (assoc data :version 22)
-                          data)))
+        (fix-version)
         (fmg/migrate-file))))
 
 (defn get-team

--- a/backend/src/app/http/debug.clj
+++ b/backend/src/app/http/debug.clj
@@ -393,7 +393,7 @@
          ::rres/body    (str/ffmt "PROFILE '%' ACTIVATED" (:email profile))}))))
 
 
-(defn- reset-file-data-version
+(defn- reset-file-version
   [cfg {:keys [params] :as request}]
   (let [file-id (some-> params :file-id d/parse-uuid)
         version (some-> params :version d/parse-integer)]
@@ -413,7 +413,7 @@
                 :code :invalid-version
                 :hint "provided invalid version"))
 
-    (db/tx-run! cfg srepl/process-file! file-id #(update % :data assoc :version version))
+    (db/tx-run! cfg srepl/process-file! file-id #(assoc % :version version))
 
     {::rres/status  200
      ::rres/headers {"content-type" "text/plain"}
@@ -486,8 +486,8 @@
     ["/error" {:handler (partial error-list-handler cfg)}]
     ["/actions/resend-email-verification"
      {:handler (partial resend-email-notification cfg)}]
-    ["/actions/reset-file-data-version"
-     {:handler (partial reset-file-data-version cfg)}]
+    ["/actions/reset-file-version"
+     {:handler (partial reset-file-version cfg)}]
     ["/file/export" {:handler (partial export-handler cfg)}]
     ["/file/import" {:handler (partial import-handler cfg)}]
     ["/file/data" {:handler (partial file-data-handler cfg)}]

--- a/backend/src/app/migrations.clj
+++ b/backend/src/app/migrations.clj
@@ -373,7 +373,10 @@
     :fn (mg/resource "app/migrations/sql/0117-mod-file-object-thumbnail-table.sql")}
 
    {:name "0118-mod-task-table"
-    :fn (mg/resource "app/migrations/sql/0118-mod-task-table.sql")}])
+    :fn (mg/resource "app/migrations/sql/0118-mod-task-table.sql")}
+
+   {:name "0119-mod-file-table"
+    :fn (mg/resource "app/migrations/sql/0119-mod-file-table.sql")}])
 
 (defn apply-migrations!
   [pool name migrations]

--- a/backend/src/app/migrations/sql/0119-mod-file-table.sql
+++ b/backend/src/app/migrations/sql/0119-mod-file-table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file
+  ADD COLUMN version integer NULL;

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -71,19 +71,14 @@
       data     (assoc :data (blob/decode data)))))
 
 (defn check-version!
-  [{:keys [data] :as file}]
-  (dm/assert!
-   "expect data to be decoded"
-   (map? data))
-
-  (let [version (:version data 0)]
+  [file]
+  (let [version (:version file)]
     (when (> version fmg/version)
       (ex/raise :type :restriction
                 :code :file-version-not-supported
                 :hint "file version is greated that the maximum"
                 :file-version version
                 :max-version fmg/version))
-
     file))
 
 ;; --- FILE PERMISSIONS
@@ -252,6 +247,7 @@
 
       (db/update! conn :file
                   {:data (blob/encode (:data file))
+                   :version (:version file)
                    :features (db/create-array conn "text" (:features file))}
                   {:id id})
 

--- a/backend/src/app/rpc/commands/files_create.clj
+++ b/backend/src/app/rpc/commands/files_create.clj
@@ -9,6 +9,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.features :as cfeat]
+   [app.common.files.defaults :refer [version]]
    [app.common.schema :as sm]
    [app.common.types.file :as ctf]
    [app.common.uuid :as uuid]
@@ -61,6 +62,7 @@
                     :name name
                     :revn revn
                     :is-shared is-shared
+                    :version version
                     :data data
                     :features features
                     :ignore-sync-until ignore-sync-until

--- a/backend/src/app/srepl/helpers.clj
+++ b/backend/src/app/srepl/helpers.clj
@@ -66,6 +66,7 @@
     (db/update! conn :file
                 {:revn (:revn file)
                  :data (:data file)
+                 :version (:version file)
                  :features (:features file)
                  :deleted-at (:deleted-at file)
                  :created-at (:created-at file)

--- a/backend/src/app/tasks/file_gc.clj
+++ b/backend/src/app/tasks/file_gc.clj
@@ -62,6 +62,8 @@
 
     (db/update! conn :file
                 {:has-media-trimmed true
+                 :features (:features file)
+                 :version (:version file)
                  :data (:data file)}
                 {:id id})))
 
@@ -82,6 +84,7 @@
   "SELECT f.id,
           f.data,
           f.revn,
+          f.version,
           f.features,
           f.modified_at
      FROM file AS f
@@ -175,7 +178,7 @@
 
 
 (def ^:private sql:get-files-for-library
-  "SELECT f.id, f.data, f.modified_at, f.features
+  "SELECT f.id, f.data, f.modified_at, f.features, f.version
      FROM file AS f
      LEFT JOIN file_library_rel AS fl ON (fl.file_id = f.id)
     WHERE fl.library_file_id = ?

--- a/backend/test/backend_tests/rpc_file_thumbnails_test.clj
+++ b/backend/test/backend_tests/rpc_file_thumbnails_test.clj
@@ -82,7 +82,6 @@
       (t/is (nil? (:error out)))
       (t/is (map? (:result out))))
 
-
     ;; run the task again
     (let [res (th/run-task! "storage-gc-touched" {:min-age 0})]
       (t/is (= 2 (:freeze res))))

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -9,7 +9,6 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.features :as cfeat]
-   [app.common.files.defaults :refer [version]]
    [app.common.files.helpers :as cfh]
    [app.common.geom.point :as gpt]
    [app.common.geom.shapes :as gsh]
@@ -70,8 +69,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def empty-file-data
-  {:version version
-   :pages []
+  {:pages []
    :pages-index {}})
 
 (defn make-file-data
@@ -82,7 +80,7 @@
    (let [page (when (some? page-id)
                 (ctp/make-empty-page page-id "Page 1"))]
 
-     (cond-> (assoc empty-file-data :id file-id :version version)
+     (cond-> (assoc empty-file-data :id file-id)
        (some? page-id)
        (ctpl/add-page page)
 

--- a/common/test/common_tests/files_migrations_test.cljc
+++ b/common/test/common_tests/files_migrations_test.cljc
@@ -7,10 +7,41 @@
 (ns common-tests.files-migrations-test
   (:require
    [app.common.data :as d]
-   [app.common.files.migrations :as cpm]
+   [app.common.files.migrations :as cfm]
+   [app.common.pprint :as pp]
    [app.common.uuid :as uuid]
-   [clojure.pprint :refer [pprint]]
    [clojure.test :as t]))
+
+(t/deftest test-generic-migration-subsystem-1
+  (let [migrations [{:id 1 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 2 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 3 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 4 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 5 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 6 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 7 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 8 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 9 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 10 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 11 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 12 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}
+                    {:id 13 :migrate-up (comp inc inc) :migrate-down (comp dec dec)}]]
+
+    (t/testing "migrate up 1"
+      (let [result (cfm/migrate-data 0 migrations 0 2)]
+        (t/is (= result 4))))
+
+    (t/testing "migrate up 2"
+      (let [result (cfm/migrate-data 0 migrations 0 20)]
+        (t/is (= result 26))))
+
+    (t/testing "migrate down 1"
+      (let [result (cfm/migrate-data 12 migrations 6 3)]
+        (t/is (= result 6))))
+
+    (t/testing "migrate down 2"
+      (let [result (cfm/migrate-data 12 migrations 6 0)]
+        (t/is (= result 0))))))
 
 (t/deftest test-migration-8-1
   (let [page-id (uuid/custom 0 0)
@@ -34,16 +65,11 @@
                  {:type :path :id (uuid/custom 1 5)}]
 
         data    {:pages-index {page-id {:objects (d/index-by :id objects)}}
-                 :components {}
-                 :version 7}
+                 :components {}}
 
-        res     (cpm/migrate-data data 8)]
+        res     (cfm/migrate-data data cfm/migrations 7 8)]
 
-    ;; (pprint data)
-    ;; (pprint res)
-
-    (t/is (= (dissoc data :version)
-             (dissoc res :version)))))
+    (t/is (= data res))))
 
 (t/deftest test-migration-8-2
   (let [page-id (uuid/custom 0 0)
@@ -67,8 +93,7 @@
                  {:type :path :id (uuid/custom 1 5)}]
 
         data    {:pages-index {page-id {:objects (d/index-by :id objects)}}
-                 :components {}
-                 :version 7}
+                 :components {}}
 
         expect   (-> data
                      (update-in [:pages-index page-id :objects] dissoc
@@ -80,10 +105,9 @@
                                   (let [id (uuid/custom 1 2)]
                                     (into [] (remove #(= id %)) shapes)))))
 
-        res     (cpm/migrate-data data 8)]
+        res     (cfm/migrate-data data cfm/migrations 7 8)]
 
     ;; (pprint res)
     ;; (pprint expect)
 
-    (t/is (= (dissoc expect :version)
-             (dissoc res :version)))))
+    (t/is (= expect res))))

--- a/frontend/src/app/main/ui/auth/verify_token.cljs
+++ b/frontend/src/app/main/ui/auth/verify_token.cljs
@@ -25,7 +25,7 @@
 (defmethod handle-token :verify-email
   [data]
   (let [msg (tr "dashboard.notifications.email-verified-successfully")]
-    (ts/schedule 100 #(st/emit! (dm/success msg)))
+    (ts/schedule 1000 #(st/emit! (dm/success msg)))
     (st/emit! (du/login-from-token data))))
 
 (defmethod handle-token :change-email


### PR DESCRIPTION
Relevant changes:

- Add the ability to create migration in both directions, defaulting
  to identity if not provided
- Move the version attribute to file table column for to make it more
  accessible (previously it was on data blob)
- Reduce db update operations on file-update rpc method

Also fixes this issue:
- https://tree.taiga.io/project/penpot/issue/6509