### PR TITLE
:zap: Add performance enhancements for margin-section react component

### DIFF
--- a/frontend/deps.edn
+++ b/frontend/deps.edn
@@ -19,8 +19,8 @@
    :git/url "https://github.com/funcool/beicon.git"}
 
   funcool/rumext
-  {:git/tag "v2.9.4"
-   :git/sha "af08e55"
+  {:git/tag "v2.10"
+   :git/sha "d96ea18"
    :git/url "https://github.com/funcool/rumext.git"}
 
   instaparse/instaparse {:mvn/version "1.4.12"}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -220,11 +220,12 @@
       i/margin-refactor]]))
 
 (mf/defc element-behaviour-horizontal
-  [{:keys [auto? fill? layout-item-sizing on-change] :as props}]
+  {::mf/props :obj}
+  [{:keys [^boolean auto ^boolean fill layout-item-sizing on-change]}]
   [:div {:class (stl/css-case :horizontal-behaviour true
-                              :one-element (and (not fill?) (not auto?))
-                              :two-element (or fill? auto?)
-                              :three-element (and fill? auto?))}
+                              :one-element (and (not fill) (not auto))
+                              :two-element (or fill auto)
+                              :three-element (and fill auto))}
    [:& radio-buttons {:selected  (d/name layout-item-sizing)
                       :on-change on-change
                       :wide      true
@@ -233,12 +234,12 @@
                       :icon  i/fixed-width-refactor
                       :title "Fix width"
                       :id    "behaviour-h-fix"}]
-    (when fill?
+    (when fill
       [:& radio-button {:value "fill"
                         :icon  i/fill-content-refactor
                         :title "Width 100%"
                         :id    "behaviour-h-fill"}])
-    (when auto?
+    (when auto
       [:& radio-button {:value "auto"
                         :icon  i/hug-content-refactor
                         :title "Fit content"
@@ -281,8 +282,8 @@
            on-change-behaviour-v-refactor] :as props}]
   [:div {:class (stl/css-case :behaviour-menu true
                               :wrap (and fill? auto?))}
-   [:& element-behaviour-horizontal {:auto? auto?
-                                     :fill? fill?
+   [:& element-behaviour-horizontal {:auto auto?
+                                     :fill fill?
                                      :layout-item-sizing layout-item-h-sizing
                                      :on-change on-change-behaviour-h-refactor}]
    [:& element-behaviour-vertical {:auto? auto?

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -246,11 +246,12 @@
                         :id    "behaviour-h-auto"}])]])
 
 (mf/defc element-behaviour-vertical
-  [{:keys [auto? fill? layout-item-sizing on-change] :as props}]
+  {::mf/props :obj}
+  [{:keys [^boolean auto ^boolean fill layout-item-sizing on-change]}]
   [:div {:class (stl/css-case :vertical-behaviour true
-                              :one-element (and (not fill?) (not auto?))
-                              :two-element (or fill? auto?)
-                              :three-element (and fill? auto?))}
+                              :one-element (and (not fill) (not auto))
+                              :two-element (or fill auto)
+                              :three-element (and fill auto))}
    [:& radio-buttons {:selected  (d/name layout-item-sizing)
                       :on-change on-change
                       :wide      true
@@ -260,13 +261,13 @@
                       :icon-class (stl/css :rotated)
                       :title      "Fix height"
                       :id         "behaviour-v-fix"}]
-    (when fill?
+    (when fill
       [:& radio-button {:value      "fill"
                         :icon       i/fill-content-refactor
                         :icon-class (stl/css :rotated)
                         :title      "Height 100%"
                         :id         "behaviour-v-fill"}])
-    (when auto?
+    (when auto
       [:& radio-button {:value      "auto"
                         :icon       i/hug-content-refactor
                         :icon-class (stl/css :rotated)
@@ -286,8 +287,8 @@
                                      :fill fill?
                                      :layout-item-sizing layout-item-h-sizing
                                      :on-change on-change-behaviour-h-refactor}]
-   [:& element-behaviour-vertical {:auto? auto?
-                                   :fill? fill?
+   [:& element-behaviour-vertical {:auto auto?
+                                   :fill fill?
                                    :layout-item-sizing layout-item-v-sizing
                                    :on-change on-change-behaviour-v-refactor}]])
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -221,76 +221,94 @@
 
 (mf/defc element-behaviour-horizontal
   {::mf/props :obj}
-  [{:keys [^boolean auto ^boolean fill layout-item-sizing on-change]}]
+  [{:keys [^boolean is-auto ^boolean has-fill item-sizing on-change]}]
   [:div {:class (stl/css-case :horizontal-behaviour true
-                              :one-element (and (not fill) (not auto))
-                              :two-element (or fill auto)
-                              :three-element (and fill auto))}
-   [:& radio-buttons {:selected  (d/name layout-item-sizing)
-                      :on-change on-change
-                      :wide      true
-                      :name      "flex-behaviour-h"}
-    [:& radio-button {:value "fix"
-                      :icon  i/fixed-width-refactor
-                      :title "Fix width"
-                      :id    "behaviour-h-fix"}]
-    (when fill
-      [:& radio-button {:value "fill"
-                        :icon  i/fill-content-refactor
-                        :title "Width 100%"
-                        :id    "behaviour-h-fill"}])
-    (when auto
-      [:& radio-button {:value "auto"
-                        :icon  i/hug-content-refactor
-                        :title "Fit content"
-                        :id    "behaviour-h-auto"}])]])
+                              :one-element (and (not has-fill) (not is-auto))
+                              :two-element (or has-fill is-auto)
+                              :three-element (and has-fill is-auto))}
+   [:& radio-buttons
+    {:selected  (d/name item-sizing)
+     :on-change on-change
+     :wide      true
+     :name      "flex-behaviour-h"}
+
+    [:& radio-button
+     {:value "fix"
+      :icon  i/fixed-width-refactor
+      :title "Fix width"
+      :id    "behaviour-h-fix"}]
+
+    (when has-fill
+      [:& radio-button
+       {:value "fill"
+        :icon  i/fill-content-refactor
+        :title "Width 100%"
+        :id    "behaviour-h-fill"}])
+    (when is-auto
+      [:& radio-button
+       {:value "auto"
+        :icon  i/hug-content-refactor
+        :title "Fit content"
+        :id    "behaviour-h-auto"}])]])
 
 (mf/defc element-behaviour-vertical
   {::mf/props :obj}
-  [{:keys [^boolean auto ^boolean fill layout-item-sizing on-change]}]
+  [{:keys [^boolean is-auto ^boolean has-fill item-sizing on-change]}]
   [:div {:class (stl/css-case :vertical-behaviour true
-                              :one-element (and (not fill) (not auto))
-                              :two-element (or fill auto)
-                              :three-element (and fill auto))}
-   [:& radio-buttons {:selected  (d/name layout-item-sizing)
-                      :on-change on-change
-                      :wide      true
-                      :name      "flex-behaviour-v"}
-    [:& radio-button {:value      "fix"
-                      :icon       i/fixed-width-refactor
-                      :icon-class (stl/css :rotated)
-                      :title      "Fix height"
-                      :id         "behaviour-v-fix"}]
-    (when fill
-      [:& radio-button {:value      "fill"
-                        :icon       i/fill-content-refactor
-                        :icon-class (stl/css :rotated)
-                        :title      "Height 100%"
-                        :id         "behaviour-v-fill"}])
-    (when auto
-      [:& radio-button {:value      "auto"
-                        :icon       i/hug-content-refactor
-                        :icon-class (stl/css :rotated)
-                        :title      "Fit content"
-                        :id         "behaviour-v-auto"}])]])
+                              :one-element (and (not has-fill) (not is-auto))
+                              :two-element (or has-fill is-auto)
+                              :three-element (and has-fill is-auto))}
+   [:& radio-buttons
+    {:selected  (d/name item-sizing)
+     :on-change on-change
+     :wide      true
+     :name      "flex-behaviour-v"}
+
+    [:& radio-button
+     {:value      "fix"
+      :icon       i/fixed-width-refactor
+      :icon-class (stl/css :rotated)
+      :title      "Fix height"
+      :id         "behaviour-v-fix"}]
+
+    (when has-fill
+      [:& radio-button
+       {:value      "fill"
+        :icon       i/fill-content-refactor
+        :icon-class (stl/css :rotated)
+        :title      "Height 100%"
+        :id         "behaviour-v-fill"}])
+    (when is-auto
+      [:& radio-button
+       {:value      "auto"
+        :icon       i/hug-content-refactor
+        :icon-class (stl/css :rotated)
+        :title      "Fit content"
+        :id         "behaviour-v-auto"}])]])
 
 (mf/defc element-behaviour
-  {::mf/props :obj}
-  [{:keys [^boolean auto ^boolean fill
-           layout-item-h-sizing
-           layout-item-v-sizing
-           on-change-behaviour-h-refactor
-           on-change-behaviour-v-refactor]}]
-  [:div {:class (stl/css-case :behaviour-menu true
-                              :wrap (and fill auto))}
-   [:& element-behaviour-horizontal {:auto auto
-                                     :fill fill
-                                     :layout-item-sizing layout-item-h-sizing
-                                     :on-change on-change-behaviour-h-refactor}]
-   [:& element-behaviour-vertical {:auto auto
-                                   :fill fill
-                                   :layout-item-sizing layout-item-v-sizing
-                                   :on-change on-change-behaviour-v-refactor}]])
+  {::mf/props :obj
+   ::mf/private true}
+  [{:keys [^boolean is-auto
+           ^boolean has-fill
+           item-h-sizing
+           item-v-sizing
+           on-h-change
+           on-v-change]}]
+  [:div {:class (stl/css-case
+                 :behaviour-menu true
+                 :wrap (and has-fill is-auto))}
+
+   [:& element-behaviour-horizontal
+    {:is-auto is-auto
+     :has-fill has-fill
+     :item-sizing item-h-sizing
+     :on-change on-h-change}]
+   [:& element-behaviour-vertical
+    {:is-auto is-auto
+     :has-fill has-fill
+     :item-sizing item-v-sizing
+     :on-change on-v-change}]])
 
 (mf/defc align-self-row
   {::mf/props :obj}
@@ -323,27 +341,29 @@
            ^boolean is-flex-layout?
            ^boolean is-grid-layout?]}]
 
-  (let [selection-parents-ref (mf/use-memo (mf/deps ids) #(refs/parents-by-ids ids))
-        selection-parents     (mf/deref selection-parents-ref)
+  (let [selection-parents* (mf/use-memo (mf/deps ids) #(refs/parents-by-ids ids))
+        selection-parents  (mf/deref selection-parents*)
 
-        is-absolute?          (:layout-item-absolute values)
+        ^boolean
+        is-absolute?       (:layout-item-absolute values)
 
-        is-col?               (every? ctl/col? selection-parents)
+        ^boolean
+        is-col?            (every? ctl/col? selection-parents)
 
-        is-layout-child?      (and is-layout-child? (not is-absolute?))
+        ^boolean
+        is-layout-child?   (and is-layout-child? (not is-absolute?))
 
-        state*                (mf/use-state true)
-        open?                 (deref state*)
+        state*             (mf/use-state true)
+        open?              (deref state*)
 
-        toggle-content        (mf/use-fn #(swap! state* not))
-        has-content?          (or ^boolean is-layout-child?
-                                  ^boolean is-flex-parent?
-                                  ^boolean is-grid-parent?
-                                  ^boolean is-layout-container?)
+        toggle-content     (mf/use-fn #(swap! state* not))
+        has-content?       (or is-layout-child?
+                               is-flex-parent?
+                               is-grid-parent?
+                               is-layout-container?)
 
         ;; Align self
-
-        align-self           (:layout-item-align-self values)
+        align-self         (:layout-item-align-self values)
 
         title
         (cond
@@ -401,21 +421,6 @@
              (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {prop val}})))))
 
         ;; Behaviour
-
-        on-change-behaviour
-        (mf/use-fn
-         (mf/deps ids)
-         (fn [event]
-           (let [value (-> (dom/get-current-target event)
-                           (dom/get-data "value")
-                           (keyword))
-                 dir (-> (dom/get-current-target event)
-                         (dom/get-data "direction")
-                         (keyword))]
-             (if (= dir :h)
-               (st/emit! (dwsl/update-layout-child ids {:layout-item-h-sizing value}))
-               (st/emit! (dwsl/update-layout-child ids {:layout-item-v-sizing value}))))))
-
         on-change-behaviour-h
         (mf/use-fn
          (mf/deps ids)
@@ -481,7 +486,7 @@
             [:span {:class (stl/css :icon-text)}
              "Z"]
             [:> numeric-input*
-             {:className (stl/css :numeric-input)
+             {:class (stl/css :numeric-input)
               :placeholder "--"
               :on-focus #(dom/select-target %)
               :on-change #(on-change-z-index %)
@@ -489,13 +494,12 @@
               :value (:layout-item-z-index values)}]]])
 
         [:div {:class (stl/css :row)}
-         [:& element-behaviour {:fill is-layout-child?
-                                :auto is-layout-container?
-                                :layout-item-v-sizing (or (:layout-item-v-sizing values) :fix)
-                                :layout-item-h-sizing (or (:layout-item-h-sizing values) :fix)
-                                :on-change-behaviour-h-refactor on-change-behaviour-h
-                                :on-change-behaviour-v-refactor on-change-behaviour-v
-                                :on-change on-change-behaviour}]]
+         [:& element-behaviour {:has-fill is-layout-child?
+                                :is-auto is-layout-container?
+                                :item-v-sizing (:layout-item-v-sizing values)
+                                :item-h-sizing (:layout-item-h-sizing values)
+                                :on-h-change on-change-behaviour-h
+                                :on-v-change on-change-behaviour-v}]]
 
         (when (and is-layout-child? is-flex-parent?)
           [:div {:class (stl/css :row)}
@@ -519,10 +523,9 @@
                [:div {:class (stl/css :layout-item-min-w)
                       :title (tr "workspace.options.layout-item.layout-item-min-w")}
 
-                [:span {:class (stl/css :icon-text)}
-                 "MIN W"]
+                [:span {:class (stl/css :icon-text)} "MIN W"]
                 [:> numeric-input*
-                 {:className (stl/css :numeric-input)
+                 {:class (stl/css :numeric-input)
                   :no-validate true
                   :min 0
                   :data-wrap true
@@ -536,7 +539,7 @@
                       :title (tr "workspace.options.layout-item.layout-item-max-w")}
                 [:span {:class (stl/css :icon-text)} "MAX W"]
                 [:> numeric-input*
-                 {:className (stl/css :numeric-input)
+                 {:class (stl/css :numeric-input)
                   :no-validate true
                   :min 0
                   :data-wrap true
@@ -550,10 +553,9 @@
                [:div {:class (stl/css :layout-item-min-h)
                       :title (tr "workspace.options.layout-item.layout-item-min-h")}
 
-                [:span {:class (stl/css :icon-text)}
-                 "MIN H"]
+                [:span {:class (stl/css :icon-text)} "MIN H"]
                 [:> numeric-input*
-                 {:className (stl/css :numeric-input)
+                 {:class (stl/css :numeric-input)
                   :no-validate true
                   :min 0
                   :data-wrap true
@@ -566,10 +568,9 @@
                [:div {:class (stl/css :layout-item-max-h)
                       :title (tr "workspace.options.layout-item.layout-item-max-h")}
 
-                [:span {:class (stl/css :icon-text)}
-                 "MAX H"]
+                [:span {:class (stl/css :icon-text)} "MAX H"]
                 [:> numeric-input*
-                 {:className (stl/css :numeric-input)
+                 {:class (stl/css :numeric-input)
                   :no-validate true
                   :min 0
                   :data-wrap true

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -20,7 +20,8 @@
    [app.main.ui.workspace.sidebar.options.menus.layout-container :refer [get-layout-flex-icon]]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
-   [rumext.v2 :as mf]))
+   [rumext.v2 :as mf]
+   [rumext.v2.props :as-alias mf.props]))
 
 (def layout-item-attrs
   [:layout-item-margin      ;; {:m1 0 :m2 0 :m3 0 :m4 0}
@@ -185,7 +186,7 @@
 (mf/defc margin-section
   {::mf/props :obj
    ::mf/private true
-   ::mf/expected-props #{:margin :type :on-type-change :on-change}}
+   ::mf.props/expect #{:margin :type :on-type-change :on-change}}
   [{:keys [type on-type-change] :as props}]
   (let [type       (d/nilv type :simple)
         on-blur    (mf/use-fn #(select-margins false false false false))
@@ -330,7 +331,7 @@
                      :id    "align-self-end"}]])
 
 (mf/defc layout-item-menu
-  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "is-layout-child?" "is-grid-parent?" "is-flex-parent?"]))]
+  {::mf/memo #{:ids :values :type :is-layout-child? :is-grid-parent :is-flex-parent?}
    ::mf/props :obj}
   [{:keys [ids values
            ^boolean is-layout-child?

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -293,21 +293,22 @@
                                    :on-change on-change-behaviour-v-refactor}]])
 
 (mf/defc align-self-row
-  [{:keys [is-col? align-self on-change] :as props}]
+  {::mf/props :obj}
+  [{:keys [^boolean is-col align-self on-change]}]
   [:& radio-buttons {:selected (d/name align-self)
                      :on-change on-change
                      :name "flex-align-self"
                      :allow-empty true}
    [:& radio-button {:value "start"
-                     :icon  (get-layout-flex-icon :align-self :start is-col?)
+                     :icon  (get-layout-flex-icon :align-self :start is-col)
                      :title "Align self start"
                      :id     "align-self-start"}]
    [:& radio-button {:value "center"
-                     :icon  (get-layout-flex-icon :align-self :center is-col?)
+                     :icon  (get-layout-flex-icon :align-self :center is-col)
                      :title "Align self center"
                      :id    "align-self-center"}]
    [:& radio-button {:value "end"
-                     :icon  (get-layout-flex-icon :align-self :end is-col?)
+                     :icon  (get-layout-flex-icon :align-self :end is-col)
                      :title "Align self end"
                      :id    "align-self-end"}]])
 
@@ -478,7 +479,7 @@
 
         (when (and is-layout-child? is-flex-parent?)
           [:div {:class (stl/css :row)}
-           [:& align-self-row {:is-col? is-col?
+           [:& align-self-row {:is-col is-col?
                                :align-self align-self
                                :on-change set-align-self}]])
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -275,20 +275,20 @@
                         :id         "behaviour-v-auto"}])]])
 
 (mf/defc element-behaviour
-  [{:keys [auto?
-           fill?
+  {::mf/props :obj}
+  [{:keys [^boolean auto ^boolean fill
            layout-item-h-sizing
            layout-item-v-sizing
            on-change-behaviour-h-refactor
-           on-change-behaviour-v-refactor] :as props}]
+           on-change-behaviour-v-refactor]}]
   [:div {:class (stl/css-case :behaviour-menu true
-                              :wrap (and fill? auto?))}
-   [:& element-behaviour-horizontal {:auto auto?
-                                     :fill fill?
+                              :wrap (and fill auto))}
+   [:& element-behaviour-horizontal {:auto auto
+                                     :fill fill
                                      :layout-item-sizing layout-item-h-sizing
                                      :on-change on-change-behaviour-h-refactor}]
-   [:& element-behaviour-vertical {:auto auto?
-                                   :fill fill?
+   [:& element-behaviour-vertical {:auto auto
+                                   :fill fill
                                    :layout-item-sizing layout-item-v-sizing
                                    :on-change on-change-behaviour-v-refactor}]])
 
@@ -468,8 +468,8 @@
               :value (:layout-item-z-index values)}]]])
 
         [:div {:class (stl/css :row)}
-         [:& element-behaviour {:fill? is-layout-child?
-                                :auto? is-layout-container?
+         [:& element-behaviour {:fill is-layout-child?
+                                :auto is-layout-container?
                                 :layout-item-v-sizing (or (:layout-item-v-sizing values) :fix)
                                 :layout-item-h-sizing (or (:layout-item-h-sizing values) :fix)
                                 :on-change-behaviour-h-refactor on-change-behaviour-h

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_item.cljs
@@ -313,36 +313,52 @@
                      :id    "align-self-end"}]])
 
 (mf/defc layout-item-menu
-  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "is-layout-child?" "is-grid-parent?" "is-flex-parent?"]))]}
-  [{:keys [ids values is-layout-child? is-layout-container? is-grid-parent? is-flex-parent? is-flex-layout? is-grid-layout?] :as props}]
+  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "is-layout-child?" "is-grid-parent?" "is-flex-parent?"]))]
+   ::mf/props :obj}
+  [{:keys [ids values
+           ^boolean is-layout-child?
+           ^boolean is-layout-container?
+           ^boolean is-grid-parent?
+           ^boolean is-flex-parent?
+           ^boolean is-flex-layout?
+           ^boolean is-grid-layout?]}]
 
   (let [selection-parents-ref (mf/use-memo (mf/deps ids) #(refs/parents-by-ids ids))
         selection-parents     (mf/deref selection-parents-ref)
 
         is-absolute?          (:layout-item-absolute values)
 
-        is-col? (every? ctl/col? selection-parents)
+        is-col?               (every? ctl/col? selection-parents)
 
-        is-layout-child? (and is-layout-child? (not is-absolute?))
+        is-layout-child?      (and is-layout-child? (not is-absolute?))
 
-        state*                 (mf/use-state true)
-        open?                  (deref state*)
-        toggle-content         (mf/use-fn #(swap! state* not))
-        has-content?           (or is-layout-child? is-flex-parent? is-grid-parent? is-layout-container?)
+        state*                (mf/use-state true)
+        open?                 (deref state*)
+
+        toggle-content        (mf/use-fn #(swap! state* not))
+        has-content?          (or ^boolean is-layout-child?
+                                  ^boolean is-flex-parent?
+                                  ^boolean is-grid-parent?
+                                  ^boolean is-layout-container?)
 
         ;; Align self
 
-        align-self         (:layout-item-align-self values)
+        align-self           (:layout-item-align-self values)
 
         title
         (cond
-          (and is-layout-container? (not is-layout-child?) is-flex-layout?)
+          (and is-layout-container?
+               is-flex-layout?
+               (not is-layout-child?))
           "Flex board"
 
-          (and is-layout-container? (not is-layout-child?) is-grid-layout?)
+          (and is-layout-container?
+               is-grid-layout?
+               (not is-layout-child?))
           "Grid board"
 
-          (and is-layout-container? (not is-layout-child?))
+          (and is-layout-container?
+               (not is-layout-child?))
           "Layout board"
 
           is-flex-parent?
@@ -365,20 +381,24 @@
         ;; Margin
 
         on-change-margin-type
-        (fn [type]
-          (st/emit! (dwsl/update-layout-child ids {:layout-item-margin-type type})))
+        (mf/use-fn
+         (mf/deps ids)
+         (fn [type]
+           (st/emit! (dwsl/update-layout-child ids {:layout-item-margin-type type}))))
 
         on-margin-change
-        (fn [type prop val]
-          (cond
-            (and (= type :simple) (= prop :m1))
-            (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {:m1 val :m3 val}}))
+        (mf/use-fn
+         (mf/deps ids)
+         (fn [type prop val]
+           (cond
+             (and (= type :simple) (= prop :m1))
+             (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {:m1 val :m3 val}}))
 
-            (and (= type :simple) (= prop :m2))
-            (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {:m2 val :m4 val}}))
+             (and (= type :simple) (= prop :m2))
+             (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {:m2 val :m4 val}}))
 
-            :else
-            (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {prop val}}))))
+             :else
+             (st/emit! (dwsl/update-layout-child ids {:layout-item-margin {prop val}})))))
 
         ;; Behaviour
 


### PR DESCRIPTION
This PR adds:
- `layout-item-menu` component and subcomponents basic performance enhancements
- update **rumext**

The rumext update mainly improves existing idioms and adding new ones:

1. A concise way for declare memoization with correct (& automatic) props naming/transformation
```diff
 (mf/defc layout-item-menu
-  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "is-layout-child?" "is-grid-parent?" "is-flex-parent?"]))]
+  {::mf/memo #{:ids :values :type :is-layout-child? :is-grid-parent :is-flex-parent?}
    ::mf/props :obj}
   [{:keys [ids values
            ^boolean is-layout-child?
```

2. Add props documentation (or simple predicate checking):

```diff
 (mf/defc margin-section
   {::mf/props :obj
    ::mf/private true
-   ::mf/expected-props #{:margin :type :on-type-change :on-change}}
+   ::mf.props/expect #{:margin :type :on-type-change :on-change}}
   [{:keys [type on-type-change] :as props}]
   (let [type       (d/nilv type :simple)
         on-blur    (mf/use-fn #(select-margins false false false false))
```
In this example we use simple existence checking, but if you provide a map of prop -> predicate, the props will be checked using that predicates.

Also adds the ability to set `:private` flag (not very well enforced by cljs compiler)

3. Add the ability to use native ECMAScript destructuring facilities for extract all the not destructured props in a separated objects:

```clojure
(mf/defc label
  "test docstring"
  {::mf/props :obj}
  [{:keys [name] :& props}]
  ;; This asserts are just for documentation
  (assert (object? props) "expect js plain object")
  (assert (string? name) "expect string")

  ;; props contains all passed props except name
  [:> :label props name])
```