### PR TITLE
:paperclip: Add script to find missing mf/use-fn

### DIFF
--- a/frontend/scripts/find-mf-use-fn.sh
+++ b/frontend/scripts/find-mf-use-fn.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+echo -e "\x1B[0;41mmf/use-fn\x1B[0m\n"
+
+#
+# Get count of expressions
+#
+FN_COUNT=$(egrep -rn ":on-.*?\s+\(fn" src/app/main/ui | wc -l)
+PARTIAL_COUNT=$(egrep -rn ":on-.*?\s+\(partial" src/app/main/ui | wc -l)
+AFN_COUNT=$(egrep -rn ":on-.*?\s+#\(" src/app/main/ui | wc -l)
+
+#
+# Show counts
+#
+echo -e ":on-.*? (fn \x1B[0;31m" $FN_COUNT "\x1B[0m"
+echo -e ":on-.*? (partial \x1B[0;31m" $PARTIAL_COUNT "\x1B[0m"
+echo -e ":on-.*? #(\x1B[0;31m" $AFN_COUNT "\x1B[0m\n"
+
+echo -e "total: \x1B[0;31m" $((FN_COUNT + PARTIAL_COUNT + AFN_COUNT)) "\x1B[0m\n"
+
+# Show summary or show file list
+if [[ $1 == "-s" ]]; then
+  #
+  # Files with handlers that don't use mf/use-fn
+  #
+  egrep -rn ":on-.*?\s+#?\((fn|partial)" src/app/main/ui | egrep -o "src/app/.*?\.cljs:" | uniq
+else
+  #
+  # List files with lines
+  #
+  egrep -rn ":on-.*?\s+#?\((fn|partial)" src/app/main/ui | egrep -o "src/app/.*?\.cljs:([0-9]+)"
+fi


### PR DESCRIPTION
Adds a script to find missing `mf/use-fn` on React Components.

### Why?

When a component has a `:on-<event>` prop and that prop value doesn't uses the `mf/use-fn` function, the function passed to that prop is "recreated" on every re-render of that component.

NOTE: This script isn't perfect and it can probably miss some props, but it's better than nothing.