### PR TITLE
:bug: Fix swap in main component with duplicated pages

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -1022,6 +1022,7 @@
                                    (dwlh/generate-sync-library it file-id :colors asset-id library-id state))
                                  (when sync-typographies?
                                    (dwlh/generate-sync-library it file-id :typographies asset-id library-id state))])
+
                file-changes    (reduce
                                 pcb/concat-changes
                                 (-> (pcb/empty-changes it)
@@ -1035,17 +1036,14 @@
 
                changes         (pcb/concat-changes library-changes file-changes)
 
+               find-frames     (fn [change]
+                                 (->> (ch/frames-changed file change)
+                                      (map #(assoc %1 :page-id (:page-id change)))))
 
-               find-frames (fn [change]
-                             (->> (ch/frames-changed file change)
-                                  (map #(assoc %1 :page-id (:page-id change)))))
-
-
-
-               updated-frames (->> changes
-                                   :redo-changes
-                                   (mapcat find-frames)
-                                   distinct)]
+               updated-frames  (->> changes
+                                    :redo-changes
+                                    (mapcat find-frames)
+                                    distinct)]
 
            (log/debug :msg "SYNC-FILE finished" :js/rchanges (log-changes
                                                               (:redo-changes changes)

--- a/frontend/src/app/main/data/workspace/libraries_helpers.cljs
+++ b/frontend/src/app/main/data/workspace/libraries_helpers.cljs
@@ -595,8 +595,14 @@
   instance, and all its children, from the given component."
   [changes libraries container shape-id reset? components-v2]
   (log/debug :msg "Sync shape direct" :shape (str shape-id) :reset? reset?)
-  (let [shape-inst     (ctn/get-shape container shape-id)]
-    (if (ctk/in-component-copy? shape-inst)
+  (let [shape-inst (ctn/get-shape container shape-id)
+        library    (dm/get-in libraries [(:component-file shape-inst) :data])
+        component  (or (ctkl/get-component library (:component-id shape-inst))
+                       (and reset?
+                            (ctkl/get-deleted-component library (:component-id shape-inst))))
+        component-shape (ctn/get-component-shape (:objects container) shape-inst)]
+    (if (and (ctk/in-component-copy? shape-inst)
+             (or (= (:id component) (:component-id component-shape)) reset?)) ; In a normal sync, we don't want to sync remote mains, only near
       (let [redirect-shaperef (partial redirect-shaperef container libraries)
             library    (dm/get-in libraries [(:component-file shape-inst) :data])
             component  (or (ctkl/get-component library (:component-id shape-inst))


### PR DESCRIPTION
This fixes a specific situation when you:
* Have a main component A with a nested copy of B.
* Duplicate the page, generating a copy of A.
* Create a new main C containing the copy of A.
* Duplicate the page again, generating a copy of C.
* In the first page, select the nested copy of B and switch to a copy of D.

The last copy of C becomes invalid, with a shape-ref pointing to the remote main instead of the near one. This is because during sync, as the shape ids are the same for having duplicated pages, the algorythm syncs the switched copy of D directly to the copy inside the copy of C.