### PR TITLE
:bug: Fix opacity field size

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
@@ -20,15 +20,13 @@
 .color-info {
   --detach-icon-foreground-color: none;
 
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: $s-2;
   border-radius: $s-8;
   background-color: var(--input-details-color);
   height: $s-32;
-  width: 100%;
-  flex-grow: 1;
-  min-width: 0;
 
   &:hover {
     --detach-icon-foreground-color: var(--input-foreground-color-active);


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6858

See [Penpot design file](https://design.penpot.dev/#/workspace/de2ad733-15fa-81f5-8003-c3b0958e1a27/867aea81-33c7-8057-8003-c9eb729c01ac?page-id=1c8349c5-b4fd-806d-8003-c9ebaac7e97b) for reference.

<img width="377" alt="Screenshot 2024-02-19 at 4 22 09 PM" src="https://github.com/penpot/penpot/assets/63681/f3cea0a4-88bf-47bd-9a67-0114bf7b0439">
