### PR TITLE
:bug: Fix ellipsis on color row

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
@@ -21,6 +21,7 @@
   --detach-icon-foreground-color: none;
 
   display: grid;
+  flex: 1;
   grid-template-columns: 1fr auto;
   align-items: center;
   gap: $s-2;
@@ -42,10 +43,15 @@
   @extend .input-element;
   flex-grow: 1;
   width: 100%;
+  min-width: 0;
   border-radius: $br-8 0 0 $br-8;
   padding: 0;
   margin-inline-end: 0;
   gap: $s-4;
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   input {
     padding: 0;
   }


### PR DESCRIPTION
This bug fixes: https://tree.taiga.io/project/penpot/issue/6971

It also fixes a (new non-reported) bug: when the name of the colour is short, it does not fill all the available space.
