### PR TITLE
:bug: Fix wrong margins for the give feedback page

### DIFF
--- a/frontend/src/app/main/ui/settings/profile.scss
+++ b/frontend/src/app/main/ui/settings/profile.scss
@@ -20,16 +20,15 @@
   display: flex;
   justify-content: center;
   flex-direction: column;
-  max-width: $s-368;
+  max-width: $s-500;
   margin-bottom: $s-32;
   width: $s-580;
-  margin: $s-80 auto auto $s-120;
+  margin: $s-80 auto $s-120 auto;
   justify-content: center;
 
   form {
     display: flex;
     flex-direction: column;
-    width: $s-500;
 
     .btn-secondary {
       width: 100%;


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6754

I can't find a design file for this, so I'm assuming someone got confused with the order of the `margin` shorthand.

<img width="1164" alt="Screenshot 2024-02-28 at 12 59 53 PM" src="https://github.com/penpot/penpot/assets/63681/e61de500-3364-49b5-a892-f4957f1d70f6">

