### PR TITLE
Fix selectable buttons in light theme + use new icons in project dashboard

### DIFF
--- a/frontend/src/app/main/ui/components/radio_buttons.scss
+++ b/frontend/src/app/main/ui/components/radio_buttons.scss
@@ -14,6 +14,8 @@
 }
 
 .radio-icon {
+  --radio-icon-border-color: var(--radio-btn-border-color);
+
   @include buttonStyle;
   @include flexCenter;
   @include focusRadio;
@@ -21,6 +23,8 @@
   flex-grow: 1;
   border-radius: $s-8;
   box-sizing: border-box;
+  border: $br-2 solid var(--radio-icon-border-color);
+
   input {
     display: none;
   }
@@ -40,8 +44,9 @@
 }
 
 .checked {
+  --radio-icon-border-color: var(--radio-btn-border-color-selected);
+
   background-color: var(--radio-btn-background-color-selected);
-  border-color: var(--radio-btn-border-color-selected);
   svg {
     stroke: var(--radio-btn-foreground-color-selected);
   }

--- a/frontend/src/app/main/ui/components/radio_buttons.scss
+++ b/frontend/src/app/main/ui/components/radio_buttons.scss
@@ -37,20 +37,30 @@
       stroke: var(--radio-btn-foreground-color-selected);
     }
   }
+}
 
-  &.checked {
-    background-color: var(--radio-btn-background-color-selected);
-    border-color: var(--radio-btn-border-color-selected);
-    svg {
-      stroke: var(--radio-btn-foreground-color-selected);
-    }
-    .title-name {
-      color: var(--radio-btn-foreground-color-selected);
-    }
+.checked {
+  background-color: var(--radio-btn-background-color-selected);
+  border-color: var(--radio-btn-border-color-selected);
+  svg {
+    stroke: var(--radio-btn-foreground-color-selected);
   }
+  .title-name {
+    color: var(--radio-btn-foreground-color-selected);
+  }
+}
 
-  &.disabled {
-    cursor: default;
+.disabled {
+  cursor: default;
+  background-color: transparent;
+  border: $s-2 solid transparent;
+  svg {
+    stroke: var(--button-foreground-color-disabled);
+  }
+  .title-name {
+    color: var(--button-foreground-color-disabled);
+  }
+  &:hover {
     background-color: transparent;
     border: $s-2 solid transparent;
     svg {
@@ -58,16 +68,6 @@
     }
     .title-name {
       color: var(--button-foreground-color-disabled);
-    }
-    &:hover {
-      background-color: transparent;
-      border: $s-2 solid transparent;
-      svg {
-        stroke: var(--button-foreground-color-disabled);
-      }
-      .title-name {
-        color: var(--button-foreground-color-disabled);
-      }
     }
   }
 }

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -95,6 +95,9 @@
 
 ;; --- Grid Item Library
 
+(def ^:private menu-icon
+  (i/icon-xref :menu-refactor (stl/css :menu-icon)))
+
 (mf/defc grid-item-library
   {::mf/wrap [mf/memo]}
   [{:keys [file] :as props}]
@@ -381,7 +384,7 @@
                          (when (kbd/enter? event)
                            (dom/stop-propagation event)
                            (on-menu-click event)))}
-         i/actions
+         menu-icon
          (when (and selected? file-menu-open?)
            [:& file-menu {:files (vals selected-files)
                           :show? (:menu-open dashboard-local)

--- a/frontend/src/app/main/ui/dashboard/grid.scss
+++ b/frontend/src/app/main/ui/dashboard/grid.scss
@@ -238,20 +238,20 @@ $thumbnail-default-height: $s-168; // Default width
   margin-right: 0;
   margin-top: $s-20;
   width: 100%;
-
-  svg {
-    fill: $df-secondary;
-    margin-right: 0;
-    height: $s-16;
-    width: $s-16;
-  }
+  --menu-icon-color: var(--button-tertiary-foreground-color-rest);
 
   &:hover,
   &:focus {
-    svg {
-      fill: $da-tertiary;
-    }
+    --menu-icon-color: var(--button-tertiary-foreground-color-hover);
   }
+}
+
+.menu-icon {
+  stroke: var(--menu-icon-color);
+  fill: none;
+  margin-right: 0;
+  height: $s-16;
+  width: $s-16;
 }
 
 .project-th-actions.force-display {

--- a/frontend/src/app/main/ui/dashboard/grid.scss
+++ b/frontend/src/app/main/ui/dashboard/grid.scss
@@ -220,36 +220,36 @@ $thumbnail-default-height: $s-168; // Default width
   span {
     color: $db-secondary;
   }
+}
 
-  .project-th-icon {
-    align-items: center;
-    display: flex;
-    margin-right: $s-8;
-    margin-top: 0;
+.project-th-icon {
+  align-items: center;
+  display: flex;
+  margin-right: $s-8;
+  margin-top: 0;
+}
 
-    &.menu {
-      align-items: flex-end;
-      display: flex;
-      flex-direction: column;
-      height: $s-32;
-      justify-content: center;
-      margin-right: 0;
-      margin-top: $s-20;
-      width: 100%;
+.menu {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  height: $s-32;
+  justify-content: center;
+  margin-right: 0;
+  margin-top: $s-20;
+  width: 100%;
 
-      > svg {
-        fill: $df-secondary;
-        margin-right: 0;
-        height: $s-16;
-        width: $s-16;
-      }
+  svg {
+    fill: $df-secondary;
+    margin-right: 0;
+    height: $s-16;
+    width: $s-16;
+  }
 
-      &:hover,
-      &:focus {
-        > svg {
-          fill: $da-tertiary;
-        }
-      }
+  &:hover,
+  &:focus {
+    svg {
+      fill: $da-tertiary;
     }
   }
 }

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -34,6 +34,9 @@
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
+(def ^:private show-more-icon
+  (i/icon-xref :arrow-refactor (stl/css :show-more-icon)))
+
 (mf/defc header
   {::mf/wrap [mf/memo]}
   []
@@ -314,7 +317,7 @@
           :aria-label (tr "dashboard.new-file")
           :data-test "project-new-file"
           :on-key-down handle-create-click}
-         i/close]
+         i/add-refactor]
 
         [:button
          {:class (stl/css :btn-secondary :btn-small :tooltip :tooltip-bottom)
@@ -323,7 +326,7 @@
           :aria-label  (tr "dashboard.options")
           :data-test "project-options"
           :on-key-down handle-menu-click}
-         i/actions]]]]
+         i/menu-refactor]]]]
 
      [:div {:class (stl/css :grid-container) :ref rowref}
       [:& line-grid
@@ -343,7 +346,7 @@
                         (when (kbd/enter? event)
                           (on-nav)))}
         [:div {:class (stl/css :placeholder-label)} (tr "dashboard.show-all-files")]
-        [:div {:class (stl/css :placeholder-icon)} i/arrow-down]])]))
+        show-more-icon])]))
 
 
 (def recent-files-ref

--- a/frontend/src/app/main/ui/dashboard/projects.scss
+++ b/frontend/src/app/main/ui/dashboard/projects.scss
@@ -115,9 +115,11 @@
 }
 
 .show-more {
-  align-items: center;
-  color: $df-secondary;
   display: flex;
+  align-items: center;
+  column-gap: $s-12;
+
+  color: $df-secondary;
   font-size: $fs-14;
   justify-content: space-between;
   cursor: pointer;
@@ -129,20 +131,14 @@
 
   &:hover {
     color: $da-tertiary;
-    svg {
-      fill: $da-tertiary;
-    }
   }
 }
 
-.placeholder-icon {
-  transform: rotate(-90deg);
-  margin-left: $s-12;
-  svg {
-    height: $s-16;
-    width: $s-16;
-    fill: $df-secondary;
-  }
+.show-more-icon {
+  height: $s-16;
+  width: $s-16;
+  fill: none;
+  stroke: currentColor;
 }
 
 .team-hero {

--- a/frontend/src/app/main/ui/dashboard/projects.scss
+++ b/frontend/src/app/main/ui/dashboard/projects.scss
@@ -51,31 +51,6 @@
       min-height: $s-32;
       margin-left: $s-8;
     }
-    .show-more {
-      align-items: center;
-      color: $df-secondary;
-      display: flex;
-      font-size: $fs-14;
-      justify-content: space-between;
-      cursor: pointer;
-      background-color: transparent;
-      border: none;
-      .placeholder-icon {
-        transform: rotate(-90deg);
-        margin-left: $s-12;
-        svg {
-          height: $s-16;
-          width: $s-16;
-          fill: $df-secondary;
-        }
-      }
-      &:hover {
-        color: $da-tertiary;
-        svg {
-          fill: $da-tertiary;
-        }
-      }
-    }
 
     .btn-secondary {
       border: none;
@@ -137,34 +112,36 @@
       opacity: 1;
     }
   }
+}
 
-  .show-more {
-    align-items: center;
-    color: $df-secondary;
-    display: flex;
-    font-size: $fs-14;
-    justify-content: space-between;
-    cursor: pointer;
-    background-color: transparent;
-    border: none;
-    position: absolute;
-    top: $s-8;
-    right: $s-52;
-    .placeholder-icon {
-      transform: rotate(-90deg);
-      margin-left: $s-8;
-      svg {
-        height: $s-16;
-        width: $s-16;
-        fill: $df-secondary;
-      }
+.show-more {
+  align-items: center;
+  color: $df-secondary;
+  display: flex;
+  font-size: $fs-14;
+  justify-content: space-between;
+  cursor: pointer;
+  background-color: transparent;
+  border: none;
+  position: absolute;
+  top: $s-8;
+  right: $s-52;
+
+  &:hover {
+    color: $da-tertiary;
+    svg {
+      fill: $da-tertiary;
     }
-    &:hover {
-      color: $da-tertiary;
-      svg {
-        fill: $da-tertiary;
-      }
-    }
+  }
+}
+
+.placeholder-icon {
+  transform: rotate(-90deg);
+  margin-left: $s-12;
+  svg {
+    height: $s-16;
+    width: $s-16;
+    fill: $df-secondary;
   }
 }
 

--- a/frontend/src/app/main/ui/workspace/top_toolbar.cljs
+++ b/frontend/src/app/main/ui/workspace/top_toolbar.cljs
@@ -53,7 +53,8 @@
      [:button
       {:title (tr "workspace.toolbar.image" (sc/get-tooltip :insert-image))
        :aria-label (tr "workspace.toolbar.image" (sc/get-tooltip :insert-image))
-       :on-click on-click}
+       :on-click on-click
+       :class (stl/css :main-toolbar-options-button)}
       i/img-refactor
       [:& file-uploader
        {:input-id "image-upload"
@@ -114,7 +115,8 @@
          [:button
           {:title (tr "workspace.toolbar.move"  (sc/get-tooltip :move))
            :aria-label (tr "workspace.toolbar.move"  (sc/get-tooltip :move))
-           :class (stl/css-case :selected (and (nil? selected-drawtool)
+           :class (stl/css-case :main-toolbar-options-button true
+                                :selected (and (nil? selected-drawtool)
                                                (not edition)))
            :on-click interrupt}
           i/move-refactor]]
@@ -123,7 +125,7 @@
           [:button
            {:title (tr "workspace.toolbar.frame" (sc/get-tooltip :draw-frame))
             :aria-label (tr "workspace.toolbar.frame" (sc/get-tooltip :draw-frame))
-            :class  (stl/css-case :selected (= selected-drawtool :frame))
+            :class  (stl/css-case :main-toolbar-options-button true :selected (= selected-drawtool :frame))
             :on-click select-drawtool
             :data-tool "frame"
             :data-test "artboard-btn"}
@@ -132,7 +134,7 @@
           [:button
            {:title (tr "workspace.toolbar.rect" (sc/get-tooltip :draw-rect))
             :aria-label (tr "workspace.toolbar.rect" (sc/get-tooltip :draw-rect))
-            :class (stl/css-case :selected (= selected-drawtool :rect))
+            :class (stl/css-case :main-toolbar-options-button true :selected (= selected-drawtool :rect))
             :on-click select-drawtool
             :data-tool "rect"
             :data-test "rect-btn"}
@@ -141,7 +143,7 @@
           [:button
            {:title (tr "workspace.toolbar.ellipse" (sc/get-tooltip :draw-ellipse))
             :aria-label (tr "workspace.toolbar.ellipse" (sc/get-tooltip :draw-ellipse))
-            :class (stl/css-case :selected (= selected-drawtool :circle))
+            :class (stl/css-case :main-toolbar-options-button true :selected (= selected-drawtool :circle))
             :on-click select-drawtool
             :data-tool "circle"
             :data-test "ellipse-btn"}
@@ -150,7 +152,7 @@
           [:button
            {:title (tr "workspace.toolbar.text" (sc/get-tooltip :draw-text))
             :aria-label (tr "workspace.toolbar.text" (sc/get-tooltip :draw-text))
-            :class (stl/css-case :selected (= selected-drawtool :text))
+            :class (stl/css-case :main-toolbar-options-button true :selected (= selected-drawtool :text))
             :on-click select-drawtool
             :data-tool "text"}
            i/text-refactor]]
@@ -161,7 +163,7 @@
           [:button
            {:title  (tr "workspace.toolbar.curve" (sc/get-tooltip :draw-curve))
             :aria-label (tr "workspace.toolbar.curve" (sc/get-tooltip :draw-curve))
-            :class (stl/css-case :selected (= selected-drawtool :curve))
+            :class (stl/css-case :main-toolbar-options-button true :selected (= selected-drawtool :curve))
             :on-click select-drawtool
             :data-tool "curve"
             :data-test "curve-btn"}
@@ -170,7 +172,7 @@
           [:button
            {:title (tr "workspace.toolbar.path" (sc/get-tooltip :draw-path))
             :aria-label (tr "workspace.toolbar.path" (sc/get-tooltip :draw-path))
-            :class (stl/css-case :selected (= selected-drawtool :path))
+            :class (stl/css-case :main-toolbar-options-button true :selected (= selected-drawtool :path))
             :on-click select-drawtool
             :data-tool "path"
             :data-test "path-btn"}
@@ -180,7 +182,7 @@
            [:li
             [:button
              {:title "Debugging tool"
-              :class (stl/css-case :selected (contains? layout :debug-panel))
+              :class (stl/css-case :main-toolbar-options-button true :selected (contains? layout :debug-panel))
               :on-click toggle-debug-panel}
              i/bug-refactor]])]]
 

--- a/frontend/src/app/main/ui/workspace/top_toolbar.scss
+++ b/frontend/src/app/main/ui/workspace/top_toolbar.scss
@@ -48,25 +48,25 @@
   transition: opacity 0.3s ease;
   li {
     position: relative;
+  }
+}
 
-    button {
-      @extend .button-tertiary;
-      height: $s-36;
-      width: $s-36;
-      flex-shrink: 0;
-      border-radius: $s-8;
-      border: none;
-      margin: 0 $s-2;
+.main-toolbar-options-button {
+  @extend .button-tertiary;
+  height: $s-36;
+  width: $s-36;
+  flex-shrink: 0;
+  border-radius: $s-8;
+  border: none;
+  margin: 0 $s-2;
 
-      svg {
-        @extend .button-icon;
-        stroke: var(--color-foreground-secondary);
-      }
+  svg {
+    @extend .button-icon;
+    stroke: var(--color-foreground-secondary);
+  }
 
-      &.selected {
-        @extend .button-icon-selected;
-      }
-    }
+  &.selected {
+    @extend .button-icon-selected;
   }
 }
 

--- a/frontend/src/app/main/ui/workspace/top_toolbar.scss
+++ b/frontend/src/app/main/ui/workspace/top_toolbar.scss
@@ -57,7 +57,6 @@
   width: $s-36;
   flex-shrink: 0;
   border-radius: $s-8;
-  border: none;
   margin: 0 $s-2;
 
   svg {


### PR DESCRIPTION
Fixes:
- https://tree.taiga.io/project/penpot/issue/7065
- https://tree.taiga.io/project/penpot/issue/7069

Main toolbar:

<img width="520" alt="Screenshot 2024-02-28 at 4 24 28 PM" src="https://github.com/penpot/penpot/assets/63681/8925e260-588c-49ad-be13-70c0580a0342">

<img width="541" alt="Screenshot 2024-02-28 at 4 24 32 PM" src="https://github.com/penpot/penpot/assets/63681/049571ff-9a0b-492a-9859-a257b29219df">

Radio buttons:

<img width="296" alt="Screenshot 2024-02-28 at 3 50 02 PM" src="https://github.com/penpot/penpot/assets/63681/157c1950-1b0f-437b-a0b6-f56f2fe4f79a">

<img width="288" alt="Screenshot 2024-02-28 at 3 54 02 PM" src="https://github.com/penpot/penpot/assets/63681/e1db1006-a86a-42f5-a353-9ad078a20002">

Project grid in the dashboard:

<img width="1130" alt="Screenshot 2024-02-28 at 5 04 32 PM" src="https://github.com/penpot/penpot/assets/63681/3fab5093-1e79-4822-9310-80e7a7890f1e">

<img width="1129" alt="Screenshot 2024-02-28 at 5 04 43 PM" src="https://github.com/penpot/penpot/assets/63681/f8ed22e4-20bc-4aed-a56e-c8d9a4460a73">


- :lipstick: remove nesting in radio-button scss
- :bug: Fix style of radio buttons in light theme
- :lipstick: Remove nesting of mail toolbar buttons css
- :bug: Fix css for mail toolbar button
- :lipstick: Unnest css selectors for the 'show all files' in the dashboard
- :bug: Use new icons for dashboard/projects
- :lipstick: Remove nesting in css for project grid menu icon
- :bug: Use new icon for menu action in project grid
