### PR TITLE
:sparkles: Sort interaction destinations by label

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
@@ -380,7 +380,8 @@
                                {:value "" :label (tr "workspace.options.interaction-none")})]
         destination-options
         (mf/with-memo [frames-opts default-opts]
-          (d/concat-vec default-opts frames-opts))
+          (let [sorted-frames-opts (sort-by :label frames-opts)]
+            (d/concat-vec default-opts sorted-frames-opts)))
 
         shape-parents-opts (get-shared-frames-options shape-parents)
 


### PR DESCRIPTION
Now this dropdown is sorted by frame name
![image](https://github.com/penpot/penpot/assets/478699/984bc2cd-eefe-476d-9cad-de1a5f996ba7)
