### PR TITLE
:bug: Fix rasterizer using wrong sizes

### DIFF
--- a/frontend/src/app/rasterizer.cljs
+++ b/frontend/src/app/rasterizer.cljs
@@ -58,7 +58,7 @@
   "Returns the adjusted size of an SVG."
   [width height max]
   (let [ratio (/ width height)]
-    (if (> width height)
+    (if (< width height)
       [max (* max (/ 1 ratio))]
       [(* max ratio) max])))
 


### PR DESCRIPTION
[Taiga Issue #7120](https://tree.taiga.io/project/penpot/issue/7120) Conflict with the copies, their thumbnails and their appearance
