### PR TITLE
:bug: Fix comments thread displacing bubbles

### DIFF
--- a/frontend/resources/styles/main/partials/workspace.scss
+++ b/frontend/resources/styles/main/partials/workspace.scss
@@ -152,16 +152,6 @@ $height-palette-max: 80px;
   }
 }
 
-// .workspace-loader {
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-
-//   svg {
-//     fill: $color-gray-50;
-//   }
-// }
-
 .workspace-content {
   background-color: $color-canvas;
   display: flex;
@@ -242,20 +232,22 @@ $height-palette-max: 80px;
 
     .viewport-overlays {
       cursor: initial;
-      height: 100%;
       overflow: hidden;
       pointer-events: none;
       position: absolute;
-      width: 100%;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
       z-index: 10;
 
       .pixel-overlay {
-        height: 100%;
         left: 0;
         pointer-events: initial;
         position: absolute;
         top: 0;
-        width: 100%;
+        right: 0;
+        bottom: 0;
         z-index: 1;
       }
     }

--- a/frontend/src/app/main/ui/comments.scss
+++ b/frontend/src/app/main/ui/comments.scss
@@ -139,11 +139,21 @@
   padding: $s-12;
   border-radius: $br-8;
   background-color: var(--comment-modal-background-color);
+  --translate-x: 0%;
+  --translate-y: 0%;
+  transform: translate(var(--translate-x), var(--translate-y));
   .comments {
     display: flex;
     flex-direction: column;
     gap: $s-24;
   }
+}
+
+.thread-content-left {
+  --translate-x: -100%;
+}
+.thread-content-top {
+  --translate-y: -100%;
 }
 
 // comment-item

--- a/frontend/src/app/main/ui/workspace/viewport/comments.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/comments.cljs
@@ -84,6 +84,7 @@
            (when (seq (dcm/apply-filters local profile [thread]))
              [:& cmt/thread-comments {:thread (update-position positions thread)
                                       :users users
+                                      :viewport {:offset-x pos-x :offset-y pos-y :width (:width vport) :height (:height vport)}
                                       :zoom zoom}])))
 
        (when-let [draft (:comment drawing)]
@@ -91,3 +92,4 @@
                                :on-cancel on-draft-cancel
                                :on-submit on-draft-submit
                                :zoom zoom}])]]]))
+

--- a/frontend/src/app/main/ui/workspace/viewport/comments.scss
+++ b/frontend/src/app/main/ui/workspace/viewport/comments.scss
@@ -15,10 +15,13 @@
   pointer-events: none;
   overflow: hidden;
   user-select: text;
+  position: absolute;
 }
 
 .threads {
   position: absolute;
-  top: $s-0;
-  left: $s-0;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6799 by modifying the threads behavior and changing their positioning depending on the distance to the edges of the viewport (for instance, now comment threads appear in the left if we are too close to the right edge).

<img width="765" alt="Screenshot 2024-03-11 at 10 55 07 AM" src="https://github.com/penpot/penpot/assets/63681/19b0c4c7-5097-46a6-bbf4-5115cdb69cb5">
