### PR TITLE
:bug: Fix dashboard thumbnails with strokes

### DIFF
--- a/common/src/app/common/geom/shapes/bounds.cljc
+++ b/common/src/app/common/geom/shapes/bounds.cljc
@@ -190,3 +190,8 @@
 
      (get-rect-filter-bounds children-bounds filters blur-value))))
 
+(defn get-frame-bounds
+  ([shape]
+   (get-frame-bounds shape nil))
+  ([shape {:keys [ignore-margin?] :or {ignore-margin? false}}]
+   (get-object-bounds [] shape {:ignore-margin? ignore-margin?})))

--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -28,7 +28,9 @@
    [app.common.types.shape-tree :as ctst]
    [app.common.types.shape.layout :as ctl]
    [app.config :as cfg]
+   [app.main.features :as features]
    [app.main.fonts :as fonts]
+   [app.main.store :as st]
    [app.main.ui.context :as muc]
    [app.main.ui.shapes.bool :as bool]
    [app.main.ui.shapes.circle :as circle]
@@ -44,6 +46,7 @@
    [app.main.ui.shapes.svg-raw :as svg-raw]
    [app.main.ui.shapes.text :as text]
    [app.main.ui.shapes.text.fontfaces :as ff]
+   [app.main.worker :as wrk]
    [app.util.dom :as dom]
    [app.util.http :as http]
    [app.util.strings :as ust]
@@ -668,3 +671,16 @@
      (do
        (l/warn :msg "imposter shape is nil")
        (rx/empty)))))
+
+(defn render-thumbnail
+  [file-id revn]
+  (->> (wrk/ask! {:cmd :thumbnails/generate-for-file
+                  :revn revn
+                  :file-id file-id
+                  :features (features/get-team-enabled-features @st/state)})
+       (rx/mapcat (fn [{:keys [fonts] :as result}]
+                    (->> (fonts/render-font-styles fonts)
+                         (rx/map (fn [styles]
+                                   (assoc result
+                                          :styles styles
+                                          :width 252))))))))

--- a/frontend/src/app/main/ui/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/shapes/frame.cljs
@@ -8,8 +8,8 @@
   (:require
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
-   [app.common.geom.rect :as grc]
    [app.common.geom.shapes :as gsh]
+   [app.common.geom.shapes.bounds :as gsb]
    [app.common.types.shape.layout :as ctl]
    [app.config :as cf]
    [app.main.ui.context :as muc]
@@ -119,7 +119,7 @@
         points   (dm/get-prop shape :points)
 
         bounds   (mf/with-memo [bounds points]
-                   (or bounds (grc/points->rect points)))
+                   (or bounds (gsb/get-frame-bounds shape)))
 
         thumb    (:thumbnail shape)
 


### PR DESCRIPTION
[Taiga Issue #7250](https://tree.taiga.io/project/penpot/issue/7250) Dashboard thumbnails with outside strokes renderer incorrectly
