### PR TITLE
Fix references when duplicating nested copies

### DIFF
--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -216,14 +216,14 @@
 
     (some find-ref-shape-in-head (ctn/get-parent-heads (:objects container) shape))))
 
-(defn find-original-ref-shape
-  "Recursively call to find-ref-shape until find the original shape of the original component"
-  [file container libraries shape & options]
+(defn advance-shape-ref
+  "Get the shape-ref of the near main of the shape, recursively repeated as many times
+   as the given levels."
+  [file container libraries shape levels & options]
   (let [ref-shape (find-ref-shape file container libraries shape options)]
-    (if (nil? (:shape-ref ref-shape))
-      ref-shape
-      (find-original-ref-shape file container libraries ref-shape options))))
-
+    (if (or (nil? (:shape-ref ref-shape)) (not (pos? levels)))
+      (:id ref-shape)
+      (advance-shape-ref file container libraries ref-shape (dec levels) options))))
 
 (defn find-ref-component
   "Locate the nearest component in the local file or libraries that is referenced by the


### PR DESCRIPTION
This PR fixes this issue https://tree.taiga.io/project/penpot/issue/7240

That was caused by the fix of this one https://tree.taiga.io/project/penpot/issue/7149 in PR https://github.com/penpot/penpot/pull/4254

To correctly fix the old one we need to advance shape-refs only the number of levels necessary in each case. Otherwise they end up attached to the remote main and the syncronization does not work.