### PR TITLE
:bug: Fix comments and history toggle

### DIFF
--- a/frontend/src/app/main/data/workspace/comments.cljs
+++ b/frontend/src/app/main/data/workspace/comments.cljs
@@ -60,8 +60,7 @@
       (let [local (:comments-local state)]
         (cond
           (:draft local) (rx/of (dcm/close-thread))
-          (:open local)  (rx/of (dcm/close-thread))
-          :else          (rx/of #(dissoc % :workspace-drawing)))))))
+          (:open local)  (rx/of (dcm/close-thread)))))))
 
 ;; Event responsible of the what should be executed when user clicked
 ;; on the comments layer. An option can be create a new draft thread,

--- a/frontend/src/app/main/data/workspace/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/drawing.cljs
@@ -28,6 +28,10 @@
     ptk/UpdateEvent
     (update [_ state]
       (-> state
+          (update :workspace-layout (fn [workspace-layout]
+                                      (if (= tool :comments)
+                                        (disj workspace-layout :document-history)
+                                        workspace-layout)))
           (update :workspace-drawing assoc :tool tool)
           ;; When changing drawing tool disable "scale text" mode
           ;; automatically, to help users that ignore how this

--- a/frontend/src/app/main/ui/workspace/comments.cljs
+++ b/frontend/src/app/main/ui/workspace/comments.cljs
@@ -92,7 +92,8 @@
          (fn []
            (if from-viewer
              (st/emit! (dcm/update-options {:show-sidebar? false}))
-             (st/emit! :interrupt (dw/deselect-all true)))))
+             (st/emit! (dw/clear-edition-mode)
+                       (dw/deselect-all true)))))
 
         tgroups     (->> threads
                          (dcm/group-threads-by-page))

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -266,7 +266,7 @@
 
         rule-area-size (/ rulers/ruler-area-size zoom)]
 
-    (hooks/setup-dom-events zoom disable-paste in-viewport? workspace-read-only?)
+    (hooks/setup-dom-events zoom disable-paste in-viewport? workspace-read-only? drawing-tool drawing-path?)
     (hooks/setup-viewport-size vport viewport-ref)
     (hooks/setup-cursor cursor alt? mod? space? panning drawing-tool drawing-path? node-editing? z? workspace-read-only?)
     (hooks/setup-keyboard alt? mod? space? z? shift?)


### PR DESCRIPTION
[Taiga Issue #7242](https://tree.taiga.io/project/penpot/issue/7242) History panel doesn't close when click on comments icon