### PR TITLE
:bug: Fix Crash on moving a frame with copy outside a component

### DIFF
--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -910,6 +910,11 @@
                  (mapcat #(cfh/get-children-with-self objects (:id %)))
                  (map :id))
 
+            child-heads
+            (->> moving-shapes-ids
+                 (mapcat #(ctn/get-child-heads objects %))
+                 (map :id))
+
             changes
             (-> (pcb/empty-changes it page-id)
                 (pcb/with-objects objects)
@@ -921,10 +926,7 @@
                   (pcb/update-shapes moving-shapes-children-ids #(dissoc % :component-root)))
                 ;; Add component-root property when moving a component outside a component
                 (cond-> (not (ctn/get-instance-root objects frame))
-                  (pcb/update-shapes moving-shapes-ids (fn [shape]
-                                                         (if (ctk/instance-head? shape)
-                                                           (assoc shape :component-root true)
-                                                           shape))))
+                  (pcb/update-shapes child-heads #(assoc % :component-root true)))
                 (pcb/update-shapes moving-shapes-ids #(cond-> % (cfh/frame-shape? %) (assoc :hide-in-viewer true)))
                 (pcb/update-shapes shape-ids-to-detach ctk/detach-shape)
                 (pcb/change-parent frame-id moving-shapes drop-index)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/7302