### PR TITLE
:bug: Fix check thumbnails size

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame.cljs
@@ -155,7 +155,8 @@
             task-ref       (mf/use-ref nil)
 
             on-load        (mf/use-fn (fn []
-                                        (check-thumbnail-size (mf/ref-val imposter-ref) bounds file-id page-id frame-id)
+                                        ;; We need to check if this is the culprit of the thumbnail regeneration.
+                                        ;; (check-thumbnail-size (mf/ref-val imposter-ref) bounds file-id page-id frame-id)
                                         (mf/set-ref-val! tries-ref 0)
                                         (reset! imposter-loaded true)))
             on-error       (mf/use-fn


### PR DESCRIPTION
This tries to prevent the regeneration of thumbnails indefinitely by removing the check-thumbnail-size call.