### PR TITLE
:bug: Fix layer and component names inputs not having their text selectable on Firefox

### DIFF
--- a/frontend/src/app/main/ui/hooks.cljs
+++ b/frontend/src/app/main/ui/hooks.cljs
@@ -177,8 +177,9 @@
         on-mount
         (fn []
           (let [dom (mf/ref-val ref)]
-            (.setAttribute dom "draggable" true) ;; In firefox it needs to be draggable for problems with event handling.
-                                                 ;; It will stop the drag operation in on-drag-start
+            ;; In firefox it needs to be draggable for problems with event handling.
+            ;; It will stop the drag operation in on-drag-start
+            (.setAttribute dom "draggable" (and draggable? (not disabled)))
 
             ;; Register all events in the (default) bubble mode, so that they
             ;; are captured by the most leaf item. The handler will stop

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -141,14 +141,16 @@
         on-context-menu
         (mf/use-fn
          (mf/deps on-context-menu component-id)
-         (partial on-context-menu component-id))]
+         (partial on-context-menu component-id))
+
+        renaming? (= renaming (:id component))]
 
     [:div {:ref item-ref
            :class (stl/css-case :selected (contains? selected (:id component))
                                 :grid-cell listing-thumbs?
                                 :enum-item (not listing-thumbs?))
            :id (dm/str "component-shape-id-" (:id component))
-           :draggable (not read-only?)
+           :draggable (and (not read-only?) (not renaming?))
            :on-click on-component-click
            :on-double-click on-component-double-click
            :on-context-menu on-context-menu
@@ -160,22 +162,21 @@
      (when (and (some? root-shape)
                 (some? container))
        [:*
-        (let [renaming? (= renaming (:id component))]
-          [:*
-           [:& editable-label
-            {:class (stl/css-case :cell-name listing-thumbs?
-                                  :item-name (not listing-thumbs?)
-                                  :editing renaming?)
-             :value (cfh/merge-path-item (:path component) (:name component))
-             :tooltip (cfh/merge-path-item (:path component) (:name component))
-             :display-value (:name component)
-             :editing renaming?
-             :disable-dbl-click true
-             :on-change do-rename
-             :on-cancel cancel-rename}]
+        [:*
+         [:& editable-label
+          {:class (stl/css-case :cell-name listing-thumbs?
+                                :item-name (not listing-thumbs?)
+                                :editing renaming?)
+           :value (cfh/merge-path-item (:path component) (:name component))
+           :tooltip (cfh/merge-path-item (:path component) (:name component))
+           :display-value (:name component)
+           :editing renaming?
+           :disable-dbl-click true
+           :on-change do-rename
+           :on-cancel cancel-rename}]
 
-           (when ^boolean dragging?
-             [:div {:class (stl/css :dragging)}])])
+         (when ^boolean dragging?
+           [:div {:class (stl/css :dragging)}])]
 
         (when visible?
           [:& cmm/component-item-thumbnail {:file-id file-id


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/6582

> ⚠️ **Verify this in Firefox**, this is a browser-specific bug!

There's a bug in Firefox which makes inputs that have `draggable=true` (or in one of its ancestor elements) not having their text selectable. https://bugzilla.mozilla.org/show_bug.cgi?id=800050

As a workaround, this disables setting that attribute when we are in edit mode for the layer or component name.