### PR TITLE
:bug: Fix comment reply menu

### DIFF
--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -67,6 +67,7 @@
             (update :comment-threads assoc id (dissoc thread :comment))
             (update-in [:workspace-data :pages-index page-id :options :comment-threads-position] assoc id position)
             (update :comments-local assoc :open id)
+            (update :comments-local assoc :options nil)
             (update :comments-local dissoc :draft)
             (update :workspace-drawing dissoc :comment)
             (update-in [:comments id] assoc (:id comment) comment))))
@@ -120,6 +121,7 @@
             (update :comment-threads assoc id (dissoc thread :comment))
             (update-in [:viewer :pages page-id :options :comment-threads-position] assoc id position)
             (update :comments-local assoc :open id)
+            (update :comments-local assoc :options nil)
             (update :comments-local dissoc :draft)
             (update :workspace-drawing dissoc :comment)
             (update-in [:comments id] assoc (:id comment) comment))))
@@ -427,6 +429,7 @@
     (update [_ state]
       (-> state
           (update :comments-local assoc :open id)
+          (update :comments-local assoc :options nil)
           (update :workspace-drawing dissoc :comment)))))
 
 (defn close-thread
@@ -435,7 +438,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (-> state
-          (update :comments-local dissoc :open :draft)
+          (update :comments-local dissoc :open :draft :options)
           (update :workspace-drawing dissoc :comment)))))
 
 (defn update-filters
@@ -490,6 +493,19 @@
           (d/update-in-when [:workspace-drawing :comment] merge data)
           (d/update-in-when [:comments-local :draft] merge data)))))
 
+(defn toggle-comment-options
+  [comment]
+  (ptk/reify ::toggle-comment-options
+    ptk/UpdateEvent
+    (update [_ state]
+      (update-in state [:comments-local :options] #(if (=  (:id comment) %) nil (:id comment))))))
+
+(defn hide-comment-options
+  []
+  (ptk/reify ::hide-comment-options
+    ptk/UpdateEvent
+    (update [_ state]
+      (update-in state [:comments-local :options] (constantly nil)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helpers

--- a/frontend/src/app/main/ui/comments.scss
+++ b/frontend/src/app/main/ui/comments.scss
@@ -238,6 +238,7 @@
     margin-bottom: $s-8;
     padding: $s-8;
     color: var(--input-foreground-color-active);
+    resize: vertical;
     &:focus {
       border: $s-1 solid var(--input-border-color-active);
       outline: none;

--- a/frontend/src/app/main/ui/comments.scss
+++ b/frontend/src/app/main/ui/comments.scss
@@ -216,7 +216,8 @@
   .comment-options-dropdown {
     @extend .dropdown-wrapper;
     position: absolute;
-    width: $s-120;
+    width: fit-content;
+    max-width: $s-200;
     right: 0;
     left: unset;
     .context-menu-option {


### PR DESCRIPTION
[Taiga Issue # 7335](https://tree.taiga.io/project/penpot/issue/7335) Comment reply menu is not autoclosing after user opens menu of another reply
