### PR TITLE
:bug: Fix comments not being visible on View mode

### DIFF
--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -418,8 +418,7 @@
              :id (str "thread-" thread-id)
              :style {:left (str pos-x "px")
                      :top (str pos-y "px")
-                     :max-height max-height
-                     :overflow-y "scroll"}
+                     :max-height max-height}
              :on-click dom/stop-propagation}
 
        [:div {:class (stl/css :comments)}

--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -356,7 +356,8 @@
   (l/derived (l/in [:comments thread-id]) st/state))
 
 (defn- offset-position [position viewport zoom bubble-margin]
-  (let [base-x (+ (* (:x position) zoom) (:offset-x viewport))
+  (let [viewport (or viewport {:offset-x 0 :offset-y 0 :width 0 :height 0})
+        base-x (+ (* (:x position) zoom) (:offset-x viewport))
         base-y (+ (* (:y position) zoom) (:offset-y viewport))
         w (:width viewport)
         h (:height viewport)
@@ -381,7 +382,7 @@
                        (some? position-modifier)
                        (gpt/transform position-modifier))
 
-        max-height   (int (* (:height viewport) 0.75))
+        max-height   (when (some? viewport) (int (* (:height viewport) 0.75)))
                           ;; We should probably look for a better way of doing this.
         bubble-margin {:x 24 :y 0}
         pos          (offset-position base-pos viewport zoom bubble-margin)

--- a/frontend/src/app/main/ui/comments.scss
+++ b/frontend/src/app/main/ui/comments.scss
@@ -142,10 +142,14 @@
 // thread-content
 .thread-content {
   position: absolute;
-  pointer-events: auto;
-  user-select: text;
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
   width: $s-284;
   padding: $s-12;
+  padding-inline-end: 0;
+
+  pointer-events: auto;
+  user-select: text;
   border-radius: $br-8;
   border: $s-2 solid var(--modal-border-color);
   background-color: var(--comment-modal-background-color);


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/7338

- :bug: Fix comments padding
- :bug: Fix comments not being visible on view mode

Note that this doesn't change the comments positioning in the view mode, we did this in https://tree.taiga.io/project/penpot/issue/6799 but only for the workspace. I'll create [another ticket](https://tree.taiga.io/project/penpot/issue/7346) to handle this, since it's not trivial and fixing comments not appearing is kind of urgent.

<img width="569" alt="Screenshot 2024-04-02 at 2 58 12 PM" src="https://github.com/penpot/penpot/assets/63681/ed8ec42e-1ffa-4f77-bf98-663626969e05">
