### PR TITLE
🐛  Fix position of image grid on onboarding

### DIFF
--- a/frontend/src/app/main/ui/components/forms.cljs
+++ b/frontend/src/app/main/ui/components/forms.cljs
@@ -239,6 +239,7 @@
   (let [form          (or (unchecked-get props "form")
                           (mf/use-ctx form-ctx))
         name          (unchecked-get props "name")
+        image         (unchecked-get props "image")
 
         current-value (or (dm/get-in @form [:data name] "")
                           (unchecked-get props "value"))
@@ -260,7 +261,9 @@
 
              (when (fn? on-change)
                (on-change name value)))))]
-    [:div {:class (dm/str class " " (stl/css :custom-radio))}
+    [:div {:class (if image
+                    class
+                    (dm/str class " " (stl/css :custom-radio)))}
      (for [{:keys [image icon value label area]} options]
        (let [image?   (some? image)
              icon?    (some? icon)

--- a/frontend/src/app/main/ui/onboarding/questions.cljs
+++ b/frontend/src/app/main/ui/onboarding/questions.cljs
@@ -167,6 +167,7 @@
                                       {:label (tr "questions.never-used-one")  :area "image6" :value "never-used-a-tool" :icon i/curve}
                                       {:label (tr "questions.other") :value "other" :area "other"}]
                             :name :experience-design-tool
+                            :image true
                             :class (stl/css :image-radio)
                             :on-change on-design-tool-change}]
 


### PR DESCRIPTION

![1 (4)](https://github.com/penpot/penpot/assets/48989967/f5263e0d-c765-4177-8989-666f2cab37aa)

Fix this image grid to be centered.