### PR TITLE
:bug: Remove transforming flag and use a global flag

### DIFF
--- a/frontend/src/app/main/data/workspace/shapes.cljs
+++ b/frontend/src/app/main/data/workspace/shapes.cljs
@@ -387,7 +387,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn update-shape-flags
-  [ids {:keys [blocked hidden transforming undo-group] :as flags}]
+  [ids {:keys [blocked hidden undo-group] :as flags}]
   (dm/assert!
    "expected valid coll of uuids"
    (every? uuid? ids))
@@ -403,15 +403,14 @@
             (fn [obj]
               (cond-> obj
                 (boolean? blocked) (assoc :blocked blocked)
-                (boolean? hidden) (assoc :hidden hidden)
-                (boolean? transforming) (assoc :transforming transforming)))
+                (boolean? hidden) (assoc :hidden hidden)))
             objects (wsh/lookup-page-objects state)
             ;; We have change only the hidden behaviour, to hide only the
             ;; selected shape, block behaviour remains the same.
             ids     (if (boolean? blocked)
                       (into ids (->> ids (mapcat #(cfh/get-children-ids objects %))))
                       ids)]
-        (rx/of (dch/update-shapes ids update-fn {:attrs #{:blocked :hidden :transforming} :undo-group undo-group}))))))
+        (rx/of (dch/update-shapes ids update-fn {:attrs #{:blocked :hidden} :undo-group undo-group}))))))
 
 (defn toggle-visibility-selected
   []

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -28,7 +28,6 @@
    [app.main.data.workspace.collapse :as dwc]
    [app.main.data.workspace.modifiers :as dwm]
    [app.main.data.workspace.selection :as dws]
-   [app.main.data.workspace.shapes :as dwsh]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.data.workspace.undo :as dwu]
    [app.main.snap :as snap]
@@ -291,10 +290,10 @@
     ptk/WatchEvent
     (watch [_ _ stream]
       (rx/concat
-       (rx/of (dwsh/update-shape-flags ids {:transforming true}))
+       (rx/of #(assoc-in % [:workspace-local :transform] :move))
        (->> (rx/timer 1000)
             (rx/map (fn []
-                      (dwsh/update-shape-flags ids {:transforming false})))
+                      #(assoc-in % [:workspace-local :transform] nil)))
             (rx/take-until
              (rx/filter (ptk/type? ::trigger-bounding-box-cloaking) stream)))))))
 

--- a/frontend/src/app/main/ui/workspace/viewport/outline.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/outline.cljs
@@ -113,8 +113,7 @@
 (defn- show-outline?
   [shape]
   (and (not (:hidden shape))
-       (not (:blocked shape))
-       (not (:transforming shape))))
+       (not (:blocked shape))))
 
 (mf/defc shape-outlines
   {::mf/wrap-props false}

--- a/frontend/src/app/main/ui/workspace/viewport/selection.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/selection.cljs
@@ -321,7 +321,6 @@
         transform      (gsh/transform-str shape)]
 
     (when (and (some? selrect)
-               (not (:transforming shape))
                (not (or (= transform-type :move)
                         (= transform-type :rotate))))
       [:g.controls {:pointer-events (if ^boolean disable-handlers "none" "visible")}
@@ -356,7 +355,6 @@
                            (and flip-y (not flip-x)))]
 
     (when (and (not ^boolean read-only?)
-               (not (:transforming shape))
                (not (or (= transform-type :move)
                         (= transform-type :rotate))))
 


### PR DESCRIPTION
Fix for bug: https://tree.taiga.io/project/penpot/issue/7418

I've removed the update to the shape because that could cause some unwanted side effects. Also, there was already a mechanism in the workspace for this.