### PR TITLE
:bug: Fix crash on moving a copy in a copy (for a migrated file) (2)

### DIFF
--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -509,6 +509,7 @@
                                           (every? nil?)))]
     (or
       ;;We don't want to change the structure of component copies
+     (ctk/in-component-copy? parent)
      (has-any-copy-parent? objects parent)
       ;; If we are moving something containing a main instance the container can't be part of a component (neither main nor copy)
      (and selected-main-instance? parent-in-component?)


### PR DESCRIPTION
Fixes https://github.com/penpot/penpot/issues/4379