### PR TITLE
:bug: Fix no visual cue if user want to create anotation with only spaces

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -184,7 +184,7 @@
                      :class (stl/css-case
                              :icon true
                              :icon-tick true
-                             :hidden invalid-text?)}
+                             :invalid invalid-text?)}
                i/tick]
               [:div {:class (stl/css :icon :icon-cross)
                      :title (tr "labels.discard")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -566,6 +566,13 @@
         }
       }
 
+      &.icon-tick.invalid:hover {
+        cursor: default;
+        svg {
+          stroke: var(--icon-foreground);
+        }
+      }
+
       &.icon-cross:hover,
       &.icon-trash:hover {
         svg {


### PR DESCRIPTION
Fixes: 

https://tree.taiga.io/project/penpot/issue/6008