### PR TITLE
:bug: Fix default features for files exported with penpot lib

### DIFF
--- a/frontend/src/app/libs/file_builder.cljs
+++ b/frontend/src/app/libs/file_builder.cljs
@@ -7,6 +7,7 @@
 (ns app.libs.file-builder
   (:require
    [app.common.data :as d]
+   [app.common.features :as cfeat]
    [app.common.files.builder :as fb]
    [app.common.media :as cm]
    [app.common.types.components-list :as ctkl]
@@ -73,7 +74,7 @@
 
         manifest-stream
         (->> files-stream
-             (rx/map #(e/create-manifest (uuid/next) (:id file) :all % false))
+             (rx/map #(e/create-manifest (uuid/next) (:id file) :all % cfeat/default-features))
              (rx/map (fn [a]
                        (vector "manifest.json" a))))
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

Another little change to make the penpot library work outside Penpot to generate export files.

Without this change, you can generate export files, but when you try to import them on Penpot you get an error message about false not being an ISeqable. (screenshot)

If we look at the contents of the manifest we see the false on features:

```json
{"teamId":"e6183edf-bf2e-80bd-8004-3dbd5a552f96","fileId":"e6183edf-bf2e-80bd-8004-3dbd5a528fed","files":{"e6183edf-bf2e-80bd-8004-3dbd5a528fed":{"features":false,"libraries":[],"hasDeletedComponents":false,"hasComponents":false,"name":"Jordi Sala's team library","pagesIndex":{"e6183edf-bf2e-80bd-8004-3dbd5a52ce60":{"name":"Page 1"}},"exportType":"all","pages":["e6183edf-bf2e-80bd-8004-3dbd5a52ce60"],"hasMedia":false,"shared":false,"version":2,"hasTypographies":false,"hasColors":false}}}
```

When a normal file generated and exported on penpot is generating this:

```json
{"teamId":"09bae235-2009-819a-8001-ffe44a74d4d8","fileId":"6f980e07-c478-80d9-8004-3dbfc530c1e8","files":{"6f980e07-c478-80d9-8004-3dbfc530c1e8":{"features":["layout/grid","styles/v2","components/v2","fdata/shape-data-type"],"libraries":[],"hasDeletedComponents":false,"hasComponents":false,"name":"Nuevo Archivo 2","pagesIndex":{"6f980e07-c478-80d9-8004-3dbfc530c1e9":{"name":"Page 1"}},"exportType":"all","pages":["6f980e07-c478-80d9-8004-3dbfc530c1e9"],"hasMedia":false,"shared":false,"version":2,"hasTypographies":false,"hasColors":false}}}
```

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

After this change the file correctly imports on Penpot. **Not sure if we should use default features or simply an empty array**. I guess we should go with the default features since the files generated inside penpot include those features

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

File generated without this change
![image](https://github.com/penpot/penpot/assets/1137485/a0f9e767-f71e-4b28-a910-ace3b9817f6e)

After the change (manifest and screenshot):
![image](https://github.com/penpot/penpot/assets/1137485/7ec8066d-74c6-4472-b65a-977c5b5182ac)

```json
{"teamId":"99b69750-0e8b-80c2-8004-3dbf6afb30af","fileId":"99b69750-0e8b-80c2-8004-3dbf6af84664","files":{"99b69750-0e8b-80c2-8004-3dbf6af84664":{"features":["layout/grid","styles/v2","components/v2","fdata/shape-data-type"],"libraries":[],"hasDeletedComponents":false,"hasComponents":false,"name":"Jordi Sala's team library","pagesIndex":{"99b69750-0e8b-80c2-8004-3dbf6af8bd30":{"name":"Page 1"}},"exportType":"all","pages":["99b69750-0e8b-80c2-8004-3dbf6af8bd30"],"hasMedia":false,"shared":false,"version":2,"hasTypographies":false,"hasColors":false}}}
```