### PR TITLE
🐛  Color palette sorting

### DIFF
--- a/common/src/app/common/colors.cljc
+++ b/common/src/app/common/colors.cljc
@@ -274,6 +274,13 @@
     (catch #?(:clj Throwable :cljs :default) _cause
       [0 0 0])))
 
+(defn hex->lum
+  [color]
+  (let [[r g b] (hex->rgb color)]
+    (mth/sqrt (+ (* 0.241 r)
+                 (* 0.691 g)
+                 (* 0.068 b)))))
+
 (defn- int->hex
   "Convert integer to hex string"
   [v]
@@ -455,3 +462,19 @@
 
     :else
     [r g (inc b)]))
+
+(defn reduce-range
+  [value range]
+  (/ (mth/floor (* value range)) range))
+
+(defn sort-colors
+  [a b]
+  (let [[ah _ av] (hex->hsv (:color a))
+        [bh _ bv] (hex->hsv (:color b))
+        ah (reduce-range (/ ah 60) 8)
+        bh (reduce-range (/ bh 60) 8)
+        av (/ av 255)
+        bv (/ bv 255)
+        a (+ (* ah 100) (* av 10))
+        b (+ (* bh 100) (* bv 10))]
+    (compare a b)))

--- a/frontend/src/app/main/ui/workspace/colorpicker/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/libraries.cljs
@@ -54,13 +54,7 @@
         get-sorted-colors
         (mf/use-fn
          (fn [colors]
-           (sort (fn [a b]
-                   (let [[ah _ al] (c/hex->hsl (:color a))
-                         [bh _ bl] (c/hex->hsl (:color b))
-                         a (+ (* ah 100) (* al 99))
-                         b (+ (* bh 100) (* bl 99))]
-                     (compare a b)))
-                 (into [] (filter check-valid-color?) colors))))
+           (sort c/sort-colors (into [] (filter check-valid-color?) colors))))
 
         toggle-palette
         (mf/use-fn


### PR DESCRIPTION
[Taiga Issue #7648](https://tree.taiga.io/project/penpot/issue/7648)

Previous version:
![wrong palette](https://github.com/penpot/penpot/assets/478699/285982f2-3b1e-47c1-9de9-d6c6d901042e)

Current version (with this fix):
![Screenshot from 2024-04-30 10-25-57](https://github.com/penpot/penpot/assets/478699/56299b8a-b781-4de0-a6fb-54120d6fe94f)
