### PR TITLE
🐛 Fix docker compose version.

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -1,5 +1,5 @@
 ---
-version: "3.5"
+version: "3.8"
 
 networks:
   penpot:


### PR DESCRIPTION
Hi,

**Details About The PR** :

- Current situation : docker-compose.yaml: version is obsolete, this contribution will fix this problem.
- And will allow users to run the solution on their local machines/servers without any issue.
-  Closes #4545

After changing the version [Tested on my local machine ]: 

![image](https://github.com/penpot/penpot/assets/82835348/2488505a-e4be-43f7-a494-feba8908737f)
