### PR TITLE
:bug: Fix medias not being imported using lib-penpot

### DIFF
--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -157,8 +157,10 @@
 (defn resolve-file-media
   ([media]
    (resolve-file-media media false))
-  ([{:keys [id] :as media} thumbnail?]
-   (dm/str
-    (cond-> (u/join public-uri "assets/by-file-media-id/")
-      (true? thumbnail?) (u/join (dm/str id "/thumbnail"))
-      (false? thumbnail?) (u/join (dm/str id))))))
+  ([{:keys [id data-uri] :as media} thumbnail?]
+   (if data-uri
+     data-uri
+     (dm/str
+      (cond-> (u/join public-uri "assets/by-file-media-id/")
+        (true? thumbnail?) (u/join (dm/str id "/thumbnail"))
+        (false? thumbnail?) (u/join (dm/str id)))))))


### PR DESCRIPTION
This is my first PR to penpot so I'm not really sure if this fix is the correct one. I'm doing this PR just as a starting point.

> Please provide enough information so that others can review your pull request:

Right now we're unable to import images into penpot using the compiled library `lib-penpot` (penpot.js) because in the generated .svg, the href of the media is created using the `resolve-file-media` method which returns a design.penpot.app url of a media not really existing at the moment because it has not been imported yet. So it fails in the import.

> Explain the **details** for making this change. What existing problem does the pull request solve?

In this PR I've modified the `resolve-file-media` method to check if a `data-uri` property is being passed in the media, which would be the href of the image in base64. If this property exists it will return it as the href thus allowing the import to work correctly since penpot will create the media from the base64 correctly.

I'm not sure this is the right fix to do but it's what is working for us at the moment.

You can test this using the main branch of the penpot-exporter plugin: https://github.com/penpot/penpot-exporter-figma-plugin (node 20)

The [penpot.js](https://github.com/penpot/penpot-exporter-figma-plugin/blob/feature/images/ui-src/lib/penpot.js) compiled for this branch has been compiled using this PR. You can try and create a figma file with a simple shape and an image fill. Using the plugin in this branch the export/import will work but using the compiled [penpot.js](https://github.com/penpot/penpot-exporter-figma-plugin/blob/main/ui-src/lib/penpot.js) using staging/develop will fail.