### PR TITLE
:sparkles: Set default workers for front-end integration tests to 1

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -17,8 +17,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Opt out of parallel tests by default; can be overriden with --workers */
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
We noticed some **local** flakiness on front-end integration tests in machines that are somewhat old. To ensure a smooth experience to everyone (and also external contributors) we have set the default amount of workers to `1`.

For those with faster machines, this can be easily overridden with `--workers`. For instance, to launch with 4 workers, just run:

```zsh
yarn e2e:test --workers 4
```
