### PR TITLE
:sparkles: Remove storybook dependency on Gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@
 /frontend/package-lock.json
 /frontend/resources/fonts/experiments
 /frontend/resources/public/*
+/frontend/storybook-static/
 /frontend/target/
 /other/
 /scripts/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,9 +33,9 @@
     "watch": "node ./scripts/watch.js",
     "e2e:server": "node ./scripts/e2e-server.js",
     "e2e:test": "playwright test",
-    "storybook:compile": "gulp template:storybook && clojure -M:dev:shadow-cljs compile storybook",
-    "storybook:watch": "npm run storybook:compile && concurrently \"clojure -M:dev:shadow-cljs watch storybook\" \"storybook dev -p 6006\"",
-    "storybook:build": "npm run storybook:compile && storybook build"
+    "storybook:compile": "yarn run compile && clojure -M:dev:shadow-cljs compile storybook",
+    "storybook:watch": "yarn run storybook:compile && concurrently \"clojure -M:dev:shadow-cljs watch storybook\" \"storybook dev -p 6006\" \"yarn run watch\"",
+    "storybook:build": "yarn run storybook:compile && storybook build"
   },
   "devDependencies": {
     "@playwright/test": "1.42.1",


### PR DESCRIPTION
Closes https://tree.taiga.io/project/penpot/task/7845

To try this out:

1. ⚠️ **Stop the jobs of watching the assets and shadow cljs** (these are in tabs `0` and `1` of the tmux session in the dev env)
2. Create a new tab (`Ctrl + b c`) and run the storybook related commands there.

To do a build (to then been copied somewhere else or served from an HTTP server):

```zsh
yarn run storybook:build
```

To start watch mode (use this while developing components):

```zsh
yarn run storybook:watch
```
