### PR TITLE
Prepare builder for figma exporter

### DIFF
--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -240,7 +240,6 @@
   (when-not ^boolean (-validate s value)
     (let [hint    (d/nilv dm/*assert-context* "check error")
           explain (-explain s value)]
-      (println (humanize-explain explain))
       (throw (ex-info hint {:type :assertion
                             :code :data-validation
                             :hint hint

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -240,6 +240,7 @@
   (when-not ^boolean (-validate s value)
     (let [hint    (d/nilv dm/*assert-context* "check error")
           explain (-explain s value)]
+      (println (humanize-explain explain))
       (throw (ex-info hint {:type :assertion
                             :code :data-validation
                             :hint hint

--- a/frontend/src/app/libs/file_builder.cljs
+++ b/frontend/src/app/libs/file_builder.cljs
@@ -249,8 +249,17 @@
   (deleteObject [_ id]
     (set! file (fb/delete-object file (uuid/uuid id))))
 
+  (getId [_]
+    (:id file))
+
+  (getCurrentPageId [_]
+    (:current-page-id file))
+
   (asMap [_]
     (clj->js file))
+
+  (newId [_]
+    (uuid/next))
 
   (export [_]
     (->> (export-file file)
@@ -261,7 +270,8 @@
                 (dom/trigger-download (:name file) export-blob))))))))
 
 (defn create-file-export [^string name]
-  (File. (fb/create-file name)))
+  (binding [cfeat/*current* cfeat/default-features]
+    (File. (fb/create-file name))))
 
 (defn exports []
   #js {:createFile    create-file-export})


### PR DESCRIPTION
Enhance file-builder to work better with components-v2 when called from the lib-penpot javascript library (in particular from the figma exporter plugin).