### PR TITLE
:fire: Replace spec usage on RPC methods with schema

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -4,6 +4,7 @@
  :remove-consecutive-blank-lines? false
  :extra-indents {rumext.v2/fnc [[:inner 0]]
                  cljs.test/async [[:inner 0]]
+                 app.common.schema/register! [[:inner 0] [:inner 1]]
                  promesa.exec/thread [[:inner 0]]
                  specify! [[:inner 0] [:inner 1]]}
  }

--- a/backend/resources/app/templates/api-doc-entry.tmpl
+++ b/backend/resources/app/templates/api-doc-entry.tmpl
@@ -20,9 +20,16 @@
           <span>WEBHOOK</span>
         </span>
       {% endif %}
+
       {% if item.params-schema-js %}
         <span class="tag">
           <span>SCHEMA</span>
+        </span>
+      {% endif %}
+
+      {% if item.spec %}
+        <span class="tag">
+          <span>SPEC</span>
         </span>
       {% endif %}
 

--- a/backend/src/app/http/client.clj
+++ b/backend/src/app/http/client.clj
@@ -54,9 +54,10 @@
   "A convencience toplevel function for gradual migration to a new API
   convention."
   ([cfg-or-client request]
-   (let [client (resolve-client cfg-or-client)]
+   (let [client  (resolve-client cfg-or-client)
+         request (update request :uri str)]
      (send! client request {:sync? true})))
   ([cfg-or-client request options]
-   (let [client (resolve-client cfg-or-client)]
+   (let [client  (resolve-client cfg-or-client)
+         request (update request :uri str)]
      (send! client request (merge {:sync? true} options)))))
-

--- a/backend/src/app/media.clj
+++ b/backend/src/app/media.clj
@@ -47,7 +47,7 @@
   (s/keys :req-un [::path]
           :opt-un [::mtype]))
 
-(sm/def! ::fs/path
+(sm/register! ::fs/path
   {:type ::fs/path
    :pred fs/path?
    :type-properties
@@ -59,7 +59,7 @@
     ::oapi/format "unix-path"
     ::oapi/decode fs/path}})
 
-(sm/def! ::upload
+(sm/register! ::upload
   [:map {:title "Upload"}
    [:filename :string]
    [:size :int]

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -30,9 +30,10 @@
 
 ;; --- Command: export-binfile
 
-(def ^:private schema:export-binfile
+(def ^:private
+  schema:export-binfile
   [:map {:title "export-binfile"}
-   [:name :string]
+   [:name [:string {:max 250}]]
    [:file-id ::sm/uuid]
    [:include-libraries :boolean]
    [:embed-assets :boolean]])
@@ -74,9 +75,10 @@
                 {:id project-id})
     result))
 
-(def ^:private schema:import-binfile
+(def ^:private
+  schema:import-binfile
   [:map {:title "import-binfile"}
-   [:name :string]
+   [:name [:string {:max 250}]]
    [:project-id ::sm/uuid]
    [:file ::media/upload]])
 

--- a/backend/src/app/rpc/commands/comments.clj
+++ b/backend/src/app/rpc/commands/comments.clj
@@ -292,7 +292,7 @@
   [:map {:title "create-comment-thread"}
    [:file-id ::sm/uuid]
    [:position ::gpt/point]
-   [:content :string]
+   [:content [:string {:max 250}]]
    [:page-id ::sm/uuid]
    [:frame-id ::sm/uuid]
    [:share-id {:optional true} [:maybe ::sm/uuid]]])
@@ -418,7 +418,7 @@
   schema:create-comment
   [:map {:title "create-comment"}
    [:thread-id ::sm/uuid]
-   [:content :string]
+   [:content [:string {:max 250}]]
    [:share-id {:optional true} [:maybe ::sm/uuid]]])
 
 (sv/defmethod ::create-comment
@@ -477,7 +477,7 @@
   schema:update-comment
   [:map {:title "update-comment"}
    [:id ::sm/uuid]
-   [:content :string]
+   [:content [:string {:max 250}]]
    [:share-id {:optional true} [:maybe ::sm/uuid]]])
 
 (sv/defmethod ::update-comment

--- a/backend/src/app/rpc/commands/demo.clj
+++ b/backend/src/app/rpc/commands/demo.clj
@@ -18,10 +18,7 @@
    [app.util.services :as sv]
    [app.util.time :as dt]
    [buddy.core.codecs :as bc]
-   [buddy.core.nonce :as bn]
-   [clojure.spec.alpha :as s]))
-
-(s/def ::create-demo-profile any?)
+   [buddy.core.nonce :as bn]))
 
 (sv/defmethod ::create-demo-profile
   "A command that is responsible of creating a demo purpose

--- a/backend/src/app/rpc/commands/feedback.clj
+++ b/backend/src/app/rpc/commands/feedback.clj
@@ -8,29 +8,25 @@
   "A general purpose feedback module."
   (:require
    [app.common.exceptions :as ex]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.config :as cf]
    [app.db :as db]
    [app.email :as eml]
    [app.rpc :as-alias rpc]
    [app.rpc.commands.profile :as profile]
    [app.rpc.doc :as-alias doc]
-   [app.util.services :as sv]
-   [clojure.spec.alpha :as s]))
+   [app.util.services :as sv]))
 
 (declare ^:private send-feedback!)
 
-(s/def ::content ::us/string)
-(s/def ::from    ::us/email)
-(s/def ::subject ::us/string)
-
-(s/def ::send-user-feedback
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::subject
-                   ::content]))
+(def ^:private schema:send-user-feedback
+  [:map {:title "send-user-feedback"}
+   [:subject :string]
+   [:content :string]])
 
 (sv/defmethod ::send-user-feedback
-  {::doc/added "1.18"}
+  {::doc/added "1.18"
+   ::sm/params schema:send-user-feedback}
   [{:keys [::db/pool]} {:keys [::rpc/profile-id] :as params}]
   (when-not (contains? cf/flags :user-feedback)
     (ex/raise :type :restriction

--- a/backend/src/app/rpc/commands/feedback.clj
+++ b/backend/src/app/rpc/commands/feedback.clj
@@ -21,8 +21,8 @@
 
 (def ^:private schema:send-user-feedback
   [:map {:title "send-user-feedback"}
-   [:subject :string]
-   [:content :string]])
+   [:subject [:string {:max 250}]]
+   [:content [:string {:max 250}]]])
 
 (sv/defmethod ::send-user-feedback
   {::doc/added "1.18"

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -15,7 +15,6 @@
    [app.common.logging :as l]
    [app.common.schema :as sm]
    [app.common.schema.desc-js-like :as-alias smdj]
-   [app.common.spec :as us]
    [app.common.types.components-list :as ctkl]
    [app.common.types.file :as ctf]
    [app.config :as cf]
@@ -36,7 +35,6 @@
    [app.util.services :as sv]
    [app.util.time :as dt]
    [app.worker :as wrk]
-   [clojure.spec.alpha :as s]
    [cuerdas.core :as str]))
 
 ;; --- FEATURES
@@ -45,18 +43,6 @@
   [media-id]
   (when media-id
     (str (cf/get :public-uri) "/assets/by-id/" media-id)))
-
-;; --- SPECS
-
-(s/def ::features ::us/set-of-strings)
-(s/def ::file-id ::us/uuid)
-(s/def ::frame-id ::us/uuid)
-(s/def ::id ::us/uuid)
-(s/def ::is-shared ::us/boolean)
-(s/def ::name ::us/string)
-(s/def ::project-id ::us/uuid)
-(s/def ::search-term ::us/string)
-(s/def ::team-id ::us/uuid)
 
 ;; --- HELPERS
 
@@ -1047,14 +1033,16 @@
               {:id file-id}
               {::db/return-keys true}))
 
-(s/def ::ignore-file-library-sync-status
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::file-id ::date]))
+(def ^:private schema:ignore-file-library-sync-status
+  [:map {:title "ignore-file-library-sync-status"}
+   [:file-id ::sm/uuid]
+   [:date ::dt/duration]])
 
 ;; TODO: improve naming
 (sv/defmethod ::ignore-file-library-sync-status
   "Ignore updates in linked files"
-  {::doc/added "1.17"}
+  {::doc/added "1.17"
+   ::sm/params schema:ignore-file-library-sync-status}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
   (db/with-atomic [conn pool]
     (check-edition-permissions! conn profile-id file-id)

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -177,7 +177,7 @@
      [:features ::cfeat/features]
      [:has-media-trimmed :boolean]
      [:comment-thread-seqn {:min 0} :int]
-     [:name :string]
+     [:name [:string {:max 250}]]
      [:revn {:min 0} :int]
      [:modified-at ::dt/instant]
      [:is-shared :boolean]
@@ -747,19 +747,19 @@
    [:map {:title "RenameFileEvent"}
     [:id ::sm/uuid]
     [:project-id ::sm/uuid]
-    [:name :string]
+    [:name [:string {:max 250}]]
     [:created-at ::dt/instant]
     [:modified-at ::dt/instant]]
 
    ::sm/params
    [:map {:title "RenameFileParams"}
-    [:name {:min 1} :string]
+    [:name [:string {:min 1 :max 250}]]
     [:id ::sm/uuid]]
 
    ::sm/result
    [:map {:title "SimplifiedFile"}
     [:id ::sm/uuid]
-    [:name :string]
+    [:name [:string {:max 250}]]
     [:created-at ::dt/instant]
     [:modified-at ::dt/instant]]}
 

--- a/backend/src/app/rpc/commands/files_create.clj
+++ b/backend/src/app/rpc/commands/files_create.clj
@@ -88,7 +88,7 @@
 
 (def ^:private schema:create-file
   [:map {:title "create-file"}
-   [:name :string]
+   [:name [:string {:max 250}]]
    [:project-id ::sm/uuid]
    [:id {:optional true} ::sm/uuid]
    [:is-shared {:optional true} :boolean]

--- a/backend/src/app/rpc/commands/files_share.clj
+++ b/backend/src/app/rpc/commands/files_share.clj
@@ -22,8 +22,8 @@
 (def ^:private schema:create-share-link
   [:map {:title "create-share-link"}
    [:file-id ::sm/uuid]
-   [:who-comment :string]
-   [:who-inspect :string]
+   [:who-comment [:string {:max 250}]]
+   [:who-inspect [:string {:max 250}]]
    [:pages [:set ::sm/uuid]]])
 
 (sv/defmethod ::create-share-link

--- a/backend/src/app/rpc/commands/files_share.clj
+++ b/backend/src/app/rpc/commands/files_share.clj
@@ -7,29 +7,24 @@
 (ns app.rpc.commands.files-share
   "Share link related rpc mutation methods."
   (:require
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.common.uuid :as uuid]
    [app.db :as db]
    [app.rpc :as-alias rpc]
    [app.rpc.commands.files :as files]
    [app.rpc.doc :as-alias doc]
-   [app.util.services :as sv]
-   [clojure.spec.alpha :as s]))
-
-;; --- Helpers & Specs
-
-(s/def ::file-id ::us/uuid)
-(s/def ::who-comment ::us/string)
-(s/def ::who-inspect ::us/string)
-(s/def ::pages (s/every ::us/uuid :kind set?))
+   [app.util.services :as sv]))
 
 ;; --- MUTATION: Create Share Link
 
 (declare create-share-link)
 
-(s/def ::create-share-link
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::file-id ::who-comment ::who-inspect ::pages]))
+(def ^:private schema:create-share-link
+  [:map {:title "create-share-link"}
+   [:file-id ::sm/uuid]
+   [:who-comment :string]
+   [:who-inspect :string]
+   [:pages [:set ::sm/uuid]]])
 
 (sv/defmethod ::create-share-link
   "Creates a share-link object.
@@ -37,7 +32,8 @@
   Share links are resources that allows external users access to specific
   pages of a file with specific permissions (who-comment and who-inspect)."
   {::doc/added "1.18"
-   ::doc/module :files}
+   ::doc/module :files
+   ::sm/params schema:create-share-link}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
   (db/with-atomic [conn pool]
     (files/check-edition-permissions! conn profile-id file-id)
@@ -58,13 +54,14 @@
 
 ;; --- MUTATION: Delete Share Link
 
-(s/def ::delete-share-link
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::us/id]))
+(def ^:private schema:delete-share-link
+  [:map {:title "delete-share-link"}
+   [:id ::sm/uuid]])
 
 (sv/defmethod ::delete-share-link
   {::doc/added "1.18"
-   ::doc/module ::files}
+   ::doc/module ::files
+   ::sm/params schema:delete-share-link}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id id] :as params}]
   (db/with-atomic [conn pool]
     (let [slink (db/get-by-id conn :share-link id)]

--- a/backend/src/app/rpc/commands/files_temp.clj
+++ b/backend/src/app/rpc/commands/files_temp.clj
@@ -35,7 +35,7 @@
 
 (def ^:private schema:create-temp-file
   [:map {:title "create-temp-file"}
-   [:name :string]
+   [:name [:string {:max 250}]]
    [:project-id ::sm/uuid]
    [:id {:optional true} ::sm/uuid]
    [:is-shared :boolean]

--- a/backend/src/app/rpc/commands/files_thumbnails.clj
+++ b/backend/src/app/rpc/commands/files_thumbnails.clj
@@ -85,8 +85,8 @@
    ::doc/module :files
    ::sm/params [:map {:title "get-file-object-thumbnails"}
                 [:file-id ::sm/uuid]
-                [:tag {:optional true} :string]]
-   ::sm/result [:map-of :string :string]}
+                [:tag {:optional true} [:string {:max 50}]]]
+   ::sm/result [:map-of [:string {:max 250}] [:string {:max 250}]]}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id tag] :as params}]
   (dm/with-open [conn (db/open pool)]
     (files/check-read-permissions! conn profile-id file-id)
@@ -275,9 +275,9 @@
   schema:create-file-object-thumbnail
   [:map {:title "create-file-object-thumbnail"}
    [:file-id ::sm/uuid]
-   [:object-id :string]
+   [:object-id [:string {:max 250}]]
    [:media ::media/upload]
-   [:tag {:optional true} :string]])
+   [:tag {:optional true} [:string {:max 50}]]])
 
 (sv/defmethod ::create-file-object-thumbnail
   {::doc/added "1.19"
@@ -316,7 +316,7 @@
 (def ^:private schema:delete-file-object-thumbnail
   [:map {:title "delete-file-object-thumbnail"}
    [:file-id ::sm/uuid]
-   [:object-id :string]])
+   [:object-id [:string {:max 250}]]])
 
 (sv/defmethod ::delete-file-object-thumbnail
   {::doc/added "1.19"

--- a/backend/src/app/rpc/commands/files_thumbnails.clj
+++ b/backend/src/app/rpc/commands/files_thumbnails.clj
@@ -33,7 +33,6 @@
    [app.util.pointer-map :as pmap]
    [app.util.services :as sv]
    [app.util.time :as dt]
-   [clojure.spec.alpha :as s]
    [cuerdas.core :as str]))
 
 ;; --- FEATURES
@@ -314,13 +313,15 @@
                  :object-id object-id
                  :tag tag})))
 
-(s/def ::delete-file-object-thumbnail
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::file-id ::object-id]))
+(def ^:private schema:delete-file-object-thumbnail
+  [:map {:title "delete-file-object-thumbnail"}
+   [:file-id ::sm/uuid]
+   [:object-id :string]])
 
 (sv/defmethod ::delete-file-object-thumbnail
   {::doc/added "1.19"
    ::doc/module :files
+   ::sm/params schema:delete-file-object-thumbnail
    ::audit/skip true}
   [cfg {:keys [::rpc/profile-id file-id object-id]}]
   (files/check-edition-permissions! cfg profile-id file-id)

--- a/backend/src/app/rpc/commands/files_update.clj
+++ b/backend/src/app/rpc/commands/files_update.clj
@@ -51,7 +51,7 @@
     [:vector [:map
               [:changes [:vector ::cpc/change]]
               [:hint-origin {:optional true} :keyword]
-              [:hint-events {:optional true} [:vector :string]]]]]
+              [:hint-events {:optional true} [:vector [:string {:max 250}]]]]]]
    [:skip-validate {:optional true} :boolean]])
 
 (def ^:private

--- a/backend/src/app/rpc/commands/ldap.clj
+++ b/backend/src/app/rpc/commands/ldap.clj
@@ -8,7 +8,7 @@
   (:require
    [app.auth.ldap :as ldap]
    [app.common.exceptions :as ex]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.db :as db]
    [app.http.session :as session]
    [app.loggers.audit :as-alias audit]
@@ -19,27 +19,25 @@
    [app.rpc.helpers :as rph]
    [app.setup :as-alias setup]
    [app.tokens :as tokens]
-   [app.util.services :as sv]
-   [clojure.spec.alpha :as s]))
+   [app.util.services :as sv]))
 
 ;; --- COMMAND: login-with-ldap
 
 (declare login-or-register)
 
-(s/def ::email ::us/email)
-(s/def ::password ::us/string)
-(s/def ::invitation-token ::us/string)
-
-(s/def ::login-with-ldap
-  (s/keys :req-un [::email ::password]
-          :opt-un [::invitation-token]))
+(def schema:login-with-ldap
+  [:map {:title "login-with-ldap"}
+   [:email ::sm/email]
+   [:password auth/schema:password]
+   [:invitation-token {:optional true} auth/schema:token]])
 
 (sv/defmethod ::login-with-ldap
   "Performs the authentication using LDAP backend. Only works if LDAP
   is properly configured and enabled with `login-with-ldap` flag."
   {::rpc/auth false
    ::doc/added "1.15"
-   ::doc/module :auth}
+   ::doc/module :auth
+   ::sm/params schema:login-with-ldap}
   [{:keys [::setup/props ::ldap/provider] :as cfg} params]
   (when-not provider
     (ex/raise :type :restriction

--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -91,7 +91,7 @@
   (sm/define
     [:map {:title "duplicate-file"}
      [:file-id ::sm/uuid]
-     [:name {:optional true} :string]]))
+     [:name {:optional true} [:string {:max 250}]]]))
 
 (sv/defmethod ::duplicate-file
   "Duplicate a single file in the same team."
@@ -153,7 +153,7 @@
   (sm/define
     [:map {:title "duplicate-project"}
      [:project-id ::sm/uuid]
-     [:name {:optional true} :string]]))
+     [:name {:optional true} [:string {:max 250}]]]))
 
 (sv/defmethod ::duplicate-project
   "Duplicate an entire project with all the files"

--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -9,7 +9,7 @@
    [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.media :as cm]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.db :as db]
@@ -25,7 +25,6 @@
    [app.util.services :as sv]
    [app.util.time :as dt]
    [app.worker :as-alias wrk]
-   [clojure.spec.alpha :as s]
    [cuerdas.core :as str]
    [datoteka.io :as io]
    [promesa.exec :as px]))
@@ -39,25 +38,21 @@
    :quality 85
    :format :jpeg})
 
-(s/def ::id ::us/uuid)
-(s/def ::name ::us/string)
-(s/def ::file-id ::us/uuid)
-(s/def ::team-id ::us/uuid)
-
 ;; --- Create File Media object (upload)
 
 (declare create-file-media-object)
 
-(s/def ::content ::media/upload)
-(s/def ::is-local ::us/boolean)
-
-(s/def ::upload-file-media-object
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::file-id ::is-local ::name ::content]
-          :opt-un [::id]))
+(def ^:private schema:upload-file-media-object
+  [:map {:title "upload-file-media-object"}
+   [:id {:optional true} ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:is-local :boolean]
+   [:name :string]
+   [:content ::media/upload]])
 
 (sv/defmethod ::upload-file-media-object
   {::doc/added "1.17"
+   ::sm/params schema:upload-file-media-object
    ::climit/id [[:process-image/by-profile ::rpc/profile-id]
                 [:process-image/global]]}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id content] :as params}]
@@ -176,14 +171,17 @@
 
 (declare ^:private create-file-media-object-from-url)
 
-(s/def ::create-file-media-object-from-url
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::file-id ::is-local ::url]
-          :opt-un [::id ::name]))
+(def ^:private schema:create-file-media-object-from-url
+  [:map {:title "create-file-media-object-from-url"}
+   [:file-id ::sm/uuid]
+   [:is-local :boolean]
+   [:url ::sm/uri]
+   [:id {:optional true} ::sm/uuid]
+   [:name {:optional true} :string]])
 
 (sv/defmethod ::create-file-media-object-from-url
   {::doc/added "1.17"
-   ::doc/deprecated "1.19"}
+   ::sm/params schema:create-file-media-object-from-url}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
   (let [cfg (update cfg ::sto/storage media/configure-assets-storage)]
     (files/check-edition-permissions! pool profile-id file-id)
@@ -255,12 +253,15 @@
 
 (declare clone-file-media-object)
 
-(s/def ::clone-file-media-object
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::file-id ::is-local ::id]))
+(def ^:private schema:clone-file-media-object
+  [:map {:title "clone-file-media-object"}
+   [:file-id ::sm/uuid]
+   [:is-local :boolean]
+   [:id ::sm/uuid]])
 
 (sv/defmethod ::clone-file-media-object
-  {::doc/added "1.17"}
+  {::doc/added "1.17"
+   ::sm/params schema:clone-file-media-object}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
   (db/with-atomic [conn pool]
     (files/check-edition-permissions! conn profile-id file-id)

--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -47,7 +47,7 @@
    [:id {:optional true} ::sm/uuid]
    [:file-id ::sm/uuid]
    [:is-local :boolean]
-   [:name :string]
+   [:name [:string {:max 250}]]
    [:content ::media/upload]])
 
 (sv/defmethod ::upload-file-media-object
@@ -177,7 +177,7 @@
    [:is-local :boolean]
    [:url ::sm/uri]
    [:id {:optional true} ::sm/uuid]
-   [:name {:optional true} :string]])
+   [:name {:optional true} [:string {:max 250}]]])
 
 (sv/defmethod ::create-file-media-object-from-url
   {::doc/added "1.17"

--- a/backend/src/app/rpc/commands/search.clj
+++ b/backend/src/app/rpc/commands/search.clj
@@ -6,13 +6,12 @@
 
 (ns app.rpc.commands.search
   (:require
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.db :as db]
    [app.rpc :as-alias rpc]
    [app.rpc.commands.files :refer [resolve-public-uri]]
    [app.rpc.doc :as-alias doc]
-   [app.util.services :as sv]
-   [clojure.spec.alpha :as s]))
+   [app.util.services :as sv]))
 
 (def ^:private sql:search-files
   "with projects as (
@@ -65,16 +64,14 @@
                      (assoc :thumbnail-uri (resolve-public-uri media-id)))
                  (dissoc row :media-id))))))
 
-(s/def ::team-id ::us/uuid)
-(s/def ::search-files ::us/string)
-
-(s/def ::search-files
-  (s/keys :req [::rpc/profile-id]
-          :req-un [::team-id]
-          :opt-un [::search-term]))
+(def ^:private schema:search-files
+  [:map {:title "search-files"}
+   [:team-id ::sm/uuid]
+   [:search-term {:optional true} :string]])
 
 (sv/defmethod ::search-files
   {::doc/added "1.17"
-   ::doc/module :files}
+   ::doc/module :files
+   ::sm/params schema:search-files}
   [{:keys [::db/pool]} {:keys [::rpc/profile-id team-id search-term]}]
   (some->> search-term (search-files pool profile-id team-id)))

--- a/backend/src/app/rpc/commands/teams.clj
+++ b/backend/src/app/rpc/commands/teams.clj
@@ -873,7 +873,7 @@
 
 (def ^:private schema:create-team-with-invitations
   [:map {:title "create-team-with-invitations"}
-   [:name :string]
+   [:name [:string {:max 250}]]
    [:features {:optional true} ::cfeat/features]
    [:id {:optional true} ::sm/uuid]
    [:emails ::sm/set-of-emails]

--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -29,7 +29,7 @@
 
 (def ^:private schema:verify-token
   [:map {:title "verify-token"}
-   [:token :string]])
+   [:token [:string {:max 1000}]]])
 
 (sv/defmethod ::verify-token
   {::rpc/auth false

--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -7,7 +7,7 @@
 (ns app.rpc.commands.verify-token
   (:require
    [app.common.exceptions :as ex]
-   [app.common.spec :as us]
+   [app.common.schema :as sm]
    [app.db :as db]
    [app.db.sql :as-alias sql]
    [app.http.session :as session]
@@ -23,21 +23,19 @@
    [app.tokens :as tokens]
    [app.tokens.spec.team-invitation :as-alias spec.team-invitation]
    [app.util.services :as sv]
-   [clojure.spec.alpha :as s]))
-
-(s/def ::iss keyword?)
-(s/def ::exp ::us/inst)
+   [app.util.time :as dt]))
 
 (defmulti process-token (fn [_ _ claims] (:iss claims)))
 
-(s/def ::verify-token
-  (s/keys :req-un [::token]
-          :opt [::rpc/profile-id]))
+(def ^:private schema:verify-token
+  [:map {:title "verify-token"}
+   [:token :string]])
 
 (sv/defmethod ::verify-token
   {::rpc/auth false
    ::doc/added "1.15"
-   ::doc/module :auth}
+   ::doc/module :auth
+   ::sm/params schema:verify-token}
   [{:keys [::db/pool] :as cfg} {:keys [token] :as params}]
   (db/with-atomic [conn pool]
     (let [claims (tokens/verify (::setup/props cfg) {:token token})
@@ -131,26 +129,28 @@
 
     (assoc member :is-active true)))
 
-(s/def ::spec.team-invitation/profile-id ::us/uuid)
-(s/def ::spec.team-invitation/role ::us/keyword)
-(s/def ::spec.team-invitation/team-id ::us/uuid)
-(s/def ::spec.team-invitation/member-email ::us/email)
-(s/def ::spec.team-invitation/member-id (s/nilable ::us/uuid))
+(def schema:team-invitation-claims
+  [:map {:title "TeamInvitationClaims"}
+   [:iss :keyword]
+   [:exp ::dt/instant]
+   [:profile-id ::sm/uuid]
+   [:role teams/schema:role]
+   [:team-id ::sm/uuid]
+   [:member-email ::sm/email]
+   [:member-id {:optional true} ::sm/uuid]])
 
-(s/def ::team-invitation-claims
-  (s/keys :req-un [::iss ::exp
-                   ::spec.team-invitation/profile-id
-                   ::spec.team-invitation/role
-                   ::spec.team-invitation/team-id
-                   ::spec.team-invitation/member-email]
-          :opt-un [::spec.team-invitation/member-id]))
+(def valid-team-invitation-claims?
+  (sm/lazy-validator schema:team-invitation-claims))
 
 (defmethod process-token :team-invitation
   [{:keys [conn] :as cfg}
    {:keys [::rpc/profile-id token] :as params}
    {:keys [member-id team-id member-email] :as claims}]
 
-  (us/verify! ::team-invitation-claims claims)
+  (when-not (valid-team-invitation-claims? claims)
+    (ex/raise :type :validation
+              :code :invalid-invitation-token
+              :hint "invitation token contains unexpected data"))
 
   (let [invitation (db/get* conn :team-invitation
                             {:team-id team-id :email-to member-email})

--- a/backend/src/app/rpc/commands/viewer.clj
+++ b/backend/src/app/rpc/commands/viewer.clj
@@ -98,7 +98,7 @@
                               (assoc ::perms perms)
                               (assoc :profile-id profile-id))]
 
-                  ;; When we have neither profile nor share, we just return a not
+               ;; When we have neither profile nor share, we just return a not
                ;; found response to the user.
                (when-not perms
                  (ex/raise :type :not-found

--- a/backend/src/app/rpc/permissions.clj
+++ b/backend/src/app/rpc/permissions.clj
@@ -12,7 +12,7 @@
    [app.common.spec :as us]
    [clojure.spec.alpha :as s]))
 
-(sm/def! ::permissions
+(sm/register! ::permissions
   [:map {:title "Permissions"}
    [:type {:gen/elements [:membership :share-link]} :keyword]
    [:is-owner :boolean]

--- a/backend/src/app/util/time.clj
+++ b/backend/src/app/util/time.clj
@@ -368,7 +368,7 @@
   (let [p1 (System/nanoTime)]
     #(duration {:nanos (- (System/nanoTime) p1)})))
 
-(sm/def! ::instant
+(sm/register! ::instant
   {:type ::instant
    :pred instant?
    :type-properties
@@ -379,7 +379,7 @@
     ::oapi/type "string"
     ::oapi/format "iso"}})
 
-(sm/def! ::duration
+(sm/register! ::duration
   {:type :durations
    :pred duration?
    :type-properties

--- a/backend/test/backend_tests/helpers.clj
+++ b/backend/test/backend_tests/helpers.clj
@@ -104,10 +104,10 @@
                      (dissoc :app.srepl/server
                              :app.http/server
                              :app.http/router
-                             :app.auth.oidc/google-provider
-                             :app.auth.oidc/gitlab-provider
-                             :app.auth.oidc/github-provider
-                             :app.auth.oidc/generic-provider
+                             :app.auth.oidc.providers/google
+                             :app.auth.oidc.providers/gitlab
+                             :app.auth.oidc.providers/github
+                             :app.auth.oidc.providers/generic
                              :app.setup/templates
                              :app.auth.oidc/routes
                              :app.worker/monitor

--- a/backend/test/backend_tests/rpc_webhooks_test.clj
+++ b/backend/test/backend_tests/rpc_webhooks_test.clj
@@ -39,6 +39,8 @@
           (t/is (nil? (:error out)))
           (t/is (= 1 (:call-count @http-mock)))
 
+          ;; (th/print-result! out)
+
           (let [result (:result out)]
             (t/is (contains? result :id))
             (t/is (contains? result :team-id))

--- a/common/src/app/common/features.cljc
+++ b/common/src/app/common/features.cljc
@@ -84,7 +84,7 @@
         "plugins/runtime"}
       (into frontend-only-features)))
 
-(sm/def! ::features
+(sm/register! ::features
   [:schema
    {:title "FileFeatures"
     ::smdj/inline true

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -33,25 +33,24 @@
 
 (def ^:private
   schema:operation
-  (sm/define
-    [:multi {:dispatch :type :title "Operation" ::smd/simplified true}
-     [:set
-      [:map {:title "SetOperation"}
-       [:type [:= :set]]
-       [:attr :keyword]
-       [:val :any]
-       [:ignore-touched {:optional true} :boolean]
-       [:ignore-geometry {:optional true} :boolean]]]
-     [:set-touched
-      [:map {:title "SetTouchedOperation"}
-       [:type [:= :set-touched]]
-       [:touched [:maybe [:set :keyword]]]]]
-     [:set-remote-synced
-      [:map {:title "SetRemoteSyncedOperation"}
-       [:type [:= :set-remote-synced]]
-       [:remote-synced {:optional true} [:maybe :boolean]]]]]))
+  [:multi {:dispatch :type :title "Operation" ::smd/simplified true}
+   [:set
+    [:map {:title "SetOperation"}
+     [:type [:= :set]]
+     [:attr :keyword]
+     [:val :any]
+     [:ignore-touched {:optional true} :boolean]
+     [:ignore-geometry {:optional true} :boolean]]]
+   [:set-touched
+    [:map {:title "SetTouchedOperation"}
+     [:type [:= :set-touched]]
+     [:touched [:maybe [:set :keyword]]]]]
+   [:set-remote-synced
+    [:map {:title "SetRemoteSyncedOperation"}
+     [:type [:= :set-remote-synced]]
+     [:remote-synced {:optional true} [:maybe :boolean]]]]])
 
-(sm/define! ::change
+(sm/register! ::change
   [:schema
    [:multi {:dispatch :type :title "Change" ::smd/simplified true}
     [:set-option
@@ -246,7 +245,7 @@
       [:type [:= :del-typography]]
       [:id ::sm/uuid]]]]])
 
-(sm/define! ::changes
+(sm/register! ::changes
   [:sequential {:gen/max 2} ::change])
 
 (def check-change!

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -24,7 +24,7 @@
 
 ;; Auxiliary functions to help create a set of changes (undo + redo)
 
-(sm/define! ::changes
+(sm/register! ::changes
   [:map {:title "changes"}
    [:redo-changes vector?]
    [:undo-changes seq?]

--- a/common/src/app/common/geom/matrix.cljc
+++ b/common/src/app/common/geom/matrix.cljc
@@ -90,7 +90,7 @@
   (sm/lazy-validator
    [:and [:fn matrix?] schema:matrix-attrs]))
 
-(sm/def! ::matrix
+(sm/register! ::matrix
   (letfn [(decode [o]
             (if (map? o)
               (map->Matrix o)

--- a/common/src/app/common/geom/point.cljc
+++ b/common/src/app/common/geom/point.cljc
@@ -61,7 +61,7 @@
   (sm/lazy-validator
    [:and [:fn point?] schema:point-attrs]))
 
-(sm/def! ::point
+(sm/register! ::point
   (letfn [(decode [p]
             (if (map? p)
               (map->Point p)

--- a/common/src/app/common/geom/rect.cljc
+++ b/common/src/app/common/geom/rect.cljc
@@ -80,7 +80,7 @@
    [:x2 ::sm/safe-number]
    [:y2 ::sm/safe-number]])
 
-(sm/define! ::rect
+(sm/register! ::rect
   [:and
    {:gen/gen (->> (sg/tuple (sg/small-double)
                             (sg/small-double)

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -844,7 +844,11 @@
     :gen/gen (sg/uri)
     ::oapi/type "string"
     ::oapi/format "uri"
-    ::oapi/decode (comp u/uri str/trim)}})
+    ::oapi/decode
+    (fn [val]
+      (if (u/uri? val)
+        val
+        (-> val str/trim u/uri)))}})
 
 (register! ::text
   {:type :string

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -75,7 +75,8 @@
     (-explain s value)
     (m/explain s value default-options)))
 
-(defn humanize
+(defn simplify
+  "Given an explain data structure, return a simplified version of it"
   [exp]
   (me/humanize exp))
 
@@ -86,10 +87,12 @@
    (mg/generate (schema s) o)))
 
 (defn form
+  "Returns a readable form of the schema"
   [s]
   (m/form s default-options))
 
 (defn merge
+  "Merge two schemas"
   [& items]
   (apply mu/merge (map schema items)))
 
@@ -102,6 +105,7 @@
   (m/deref s))
 
 (defn error-values
+  "Get error values form explain data structure"
   [exp]
   (malli.error/error-value exp {:malli.error/mask-valid-values '...}))
 
@@ -138,18 +142,6 @@
       :decoders coders
       :encoders coders})))
 
-(defn validator
-  [s]
-  (if (lazy-schema? s)
-    (-get-validator s)
-    (-> s schema m/validator)))
-
-(defn explainer
-  [s]
-  (if (lazy-schema? s)
-    (-get-explainer s)
-    (-> s schema m/explainer)))
-
 (defn encode
   ([s val transformer]
    (m/encode s val default-options transformer))
@@ -163,6 +155,18 @@
    (m/decode s val default-options transformer))
   ([s val options transformer]
    (m/decode s val options transformer)))
+
+(defn validator
+  [s]
+  (if (lazy-schema? s)
+    (-get-validator s)
+    (-> s schema m/validator)))
+
+(defn explainer
+  [s]
+  (if (lazy-schema? s)
+    (-get-explainer s)
+    (-> s schema m/explainer)))
 
 (defn encoder
   ([s]
@@ -201,6 +205,7 @@
      (fn [v] (@vfn v)))))
 
 (defn humanize-explain
+  "Returns a string representation of the explain data structure"
   [{:keys [schema errors value]} & {:keys [length level]}]
   (let [errors (mapv #(update % :schema form) errors)]
     (with-out-str
@@ -212,7 +217,6 @@
       (println (pp/pprint-str value {:width 160
                                      :level (d/nilv level 8)
                                      :length (d/nilv length 12)})))))
-
 
 (defmethod v/-format ::schemaless-explain
   [_ {:keys [schema] :as explanation} printer]
@@ -353,15 +357,8 @@
 
 (defn register! [type s]
   (let [s (if (map? s) (simple-schema s) s)]
-    (swap! sr/registry assoc type s)))
-
-(defn def! [type s]
-  (register! type s)
-  nil)
-
-(defn define! [id s]
-  (register! id s)
-  nil)
+    (swap! sr/registry assoc type s)
+    nil))
 
 (defn define
   "Create ans instance of ILazySchema"
@@ -435,8 +432,8 @@
 
 ;; --- BUILTIN SCHEMAS
 
-(define! :merge (mu/-merge))
-(define! :union (mu/-union))
+(register! :merge (mu/-merge))
+(register! :union (mu/-union))
 
 (def uuid-rx
   #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
@@ -447,7 +444,7 @@
     (some->> (re-matches uuid-rx s) uuid/uuid)
     s))
 
-(define! ::uuid
+(register! ::uuid
   {:type ::uuid
    :pred uuid?
    :type-properties
@@ -472,7 +469,7 @@
   (and (string? s)
        (re-seq email-re s)))
 
-(define! ::email
+(register! ::email
   {:type :string
    :pred email-string?
    :property-pred
@@ -501,7 +498,7 @@
 
 ;; NOTE: this is general purpose set spec and should be used over the other
 
-(define! ::set
+(register! ::set
   {:type :set
    :min 0
    :max 1
@@ -557,7 +554,7 @@
                            (into #{} xform v)))}}))})
 
 
-(define! ::vec
+(register! ::vec
   {:type :vector
    :min 0
    :max 1
@@ -614,7 +611,7 @@
                            (into [] xform v)))}}))})
 
 
-(define! ::set-of-strings
+(register! ::set-of-strings
   {:type ::set-of-strings
    :pred #(and (set? %) (every? string? %))
    :type-properties
@@ -630,7 +627,7 @@
                     (let [v (if (string? v) (str/split v #"[\s,]+") v)]
                       (into #{} non-empty-strings-xf v)))}})
 
-(define! ::set-of-keywords
+(register! ::set-of-keywords
   {:type ::set-of-keywords
    :pred #(and (set? %) (every? keyword? %))
    :type-properties
@@ -646,7 +643,7 @@
                     (let [v (if (string? v) (str/split v #"[\s,]+") v)]
                       (into #{} (comp non-empty-strings-xf (map keyword)) v)))}})
 
-(define! ::set-of-emails
+(register! ::set-of-emails
   {:type ::set-of-emails
    :pred #(and (set? %) (every? string? %))
    :type-properties
@@ -662,7 +659,7 @@
                (let [v (if (string? v) (str/split v #"[\s,]+") v)]
                  (into #{} (keep parse-email) v)))}})
 
-(define! ::set-of-uuid
+(register! ::set-of-uuid
   {:type ::set-of-uuid
    :pred #(and (set? %) (every? uuid? %))
    :type-properties
@@ -678,7 +675,7 @@
                     (let [v (if (string? v) (str/split v #"[\s,]+") v)]
                       (into #{} (keep parse-uuid) v)))}})
 
-(define! ::coll-of-uuid
+(register! ::coll-of-uuid
   {:type ::set-of-uuid
    :pred (partial every? uuid?)
    :type-properties
@@ -694,7 +691,7 @@
                     (let [v (if (string? v) (str/split v #"[\s,]+") v)]
                       (into [] (keep parse-uuid) v)))}})
 
-(define! ::one-of
+(register! ::one-of
   {:type ::one-of
    :min 1
    :max 1
@@ -717,7 +714,7 @@
 ;; Integer/MIN_VALUE
 (def min-safe-int -2147483648)
 
-(define! ::safe-int
+(register! ::safe-int
   {:type ::safe-int
    :pred #(and (int? %) (>= max-safe-int %) (>= % min-safe-int))
    :type-properties
@@ -732,7 +729,7 @@
                       (parse-long s)
                       s))}})
 
-(define! ::safe-number
+(register! ::safe-number
   {:type ::safe-number
    :pred #(and (number? %) (>= max-safe-int %) (>= % min-safe-int))
    :type-properties
@@ -748,7 +745,7 @@
                       (parse-double s)
                       s))}})
 
-(define! ::safe-double
+(register! ::safe-double
   {:type ::safe-double
    :pred #(and (double? %) (>= max-safe-int %) (>= % min-safe-int))
    :type-properties
@@ -763,7 +760,7 @@
                       (parse-double s)
                       s))}})
 
-(define! ::contains-any
+(register! ::contains-any
   {:type ::contains-any
    :min 1
    :max 1
@@ -781,7 +778,7 @@
                  {:title "contains"
                   :description "contains predicate"}}))})
 
-(define! ::inst
+(register! ::inst
   {:type ::inst
    :pred inst?
    :type-properties
@@ -793,12 +790,12 @@
     ::oapi/type "number"
     ::oapi/format "int64"}})
 
-(define! ::fn
+(register! ::fn
   [:schema fn?])
 
 ;; FIXME: deprecated, replace with ::text
 
-(define! ::word-string
+(register! ::word-string
   {:type ::word-string
    :pred #(and (string? %) (not (str/blank? %)))
    :property-pred (m/-min-max-pred count)
@@ -810,7 +807,7 @@
     ::oapi/type "string"
     ::oapi/format "string"}})
 
-(define! ::uri
+(register! ::uri
   {:type ::uri
    :pred u/uri?
    :property-pred
@@ -849,7 +846,7 @@
     ::oapi/format "uri"
     ::oapi/decode (comp u/uri str/trim)}})
 
-(define! ::text
+(register! ::text
   {:type :string
    :pred #(and (string? %) (not (str/blank? %)))
    :property-pred
@@ -891,7 +888,7 @@
                (str/blank? value))
           "errors.field-not-all-whitespace")))}})
 
-(define! ::password
+(register! ::password
   {:type :string
    :pred
    (fn [value]
@@ -908,7 +905,7 @@
 
 
 ;; FIXME: this should not be here
-(define! ::plugin-data
+(register! ::plugin-data
   [:map-of {:gen/max 5} :string :string])
 
 ;; ---- PREDICATES

--- a/common/src/app/common/types/color.cljc
+++ b/common/src/app/common/types/color.cljc
@@ -37,7 +37,7 @@
             (.. g (toString 16) (padStart 2 "0"))
             (.. b (toString 16) (padStart 2 "0"))))))
 
-(sm/define! ::rgb-color
+(sm/register! ::rgb-color
   {:type ::rgb-color
    :pred #(and (string? %) (some? (re-matches rgb-color-re %)))
    :type-properties
@@ -49,7 +49,7 @@
     ::oapi/type "integer"
     ::oapi/format "int64"}})
 
-(sm/define! ::image-color
+(sm/register! ::image-color
   [:map {:title "ImageColor"}
    [:name {:optional true} :string]
    [:width :int]
@@ -58,7 +58,7 @@
    [:id ::sm/uuid]
    [:keep-aspect-ratio {:optional true} :boolean]])
 
-(sm/define! ::gradient
+(sm/register! ::gradient
   [:map {:title "Gradient"}
    [:type [::sm/one-of #{:linear :radial}]]
    [:start-x ::sm/safe-number]
@@ -73,7 +73,7 @@
       [:opacity {:optional true} [:maybe ::sm/safe-number]]
       [:offset ::sm/safe-number]]]]])
 
-(sm/define! ::color
+(sm/register! ::color
   [:and
    [:map {:title "Color"}
     [:id {:optional true} ::sm/uuid]
@@ -91,7 +91,7 @@
      [:map-of {:gen/max 5} :keyword ::sm/plugin-data]]]
    [::sm/contains-any {:strict true} [:color :gradient :image]]])
 
-(sm/define! ::recent-color
+(sm/register! ::recent-color
   [:and
    [:map {:title "RecentColor"}
     [:opacity {:optional true} [:maybe ::sm/safe-number]]

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -26,7 +26,7 @@
 (def valid-container-types
   #{:page :component})
 
-(sm/define! ::container
+(sm/register! ::container
   [:map
    [:id ::sm/uuid]
    [:type {:optional true}

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -34,7 +34,7 @@
 ;; SCHEMA
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(sm/define! ::media-object
+(sm/register! ::media-object
   [:map {:title "FileMediaObject"}
    [:id ::sm/uuid]
    [:name :string]
@@ -43,7 +43,7 @@
    [:mtype :string]
    [:path {:optional true} [:maybe :string]]])
 
-(sm/define! ::data
+(sm/register! ::data
   [:map {:title "FileData"}
    [:pages [:vector ::sm/uuid]]
    [:pages-index

--- a/common/src/app/common/types/grid.cljc
+++ b/common/src/app/common/types/grid.cljc
@@ -13,12 +13,12 @@
 ;; SCHEMA
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(sm/def! ::grid-color
+(sm/register! ::grid-color
   [:map {:title "PageGridColor"}
    [:color ::ctc/rgb-color]
    [:opacity ::sm/safe-number]])
 
-(sm/def! ::column-params
+(sm/register! ::column-params
   [:map
    [:color ::grid-color]
    [:type {:optional true} [::sm/one-of #{:stretch :left :center :right}]]
@@ -27,12 +27,12 @@
    [:item-length {:optional true} [:maybe ::sm/safe-number]]
    [:gutter {:optional true} [:maybe ::sm/safe-number]]])
 
-(sm/def! ::square-params
+(sm/register! ::square-params
   [:map
    [:size {:optional true} [:maybe ::sm/safe-number]]
    [:color ::grid-color]])
 
-(sm/def! ::grid
+(sm/register! ::grid
   [:multi {:dispatch :type}
    [:column
     [:map
@@ -52,7 +52,7 @@
      [:display :boolean]
      [:params ::square-params]]]])
 
-(sm/def! ::saved-grids
+(sm/register! ::saved-grids
   [:map {:title "PageGrid"}
    [:square {:optional true} ::square-params]
    [:row {:optional true} ::column-params]

--- a/common/src/app/common/types/page.cljc
+++ b/common/src/app/common/types/page.cljc
@@ -17,20 +17,20 @@
 ;; SCHEMAS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(sm/define! ::flow
+(sm/register! ::flow
   [:map {:title "PageFlow"}
    [:id ::sm/uuid]
    [:name :string]
    [:starting-frame ::sm/uuid]])
 
-(sm/define! ::guide
+(sm/register! ::guide
   [:map {:title "PageGuide"}
    [:id ::sm/uuid]
    [:axis [::sm/one-of #{:x :y}]]
    [:position ::sm/safe-number]
    [:frame-id {:optional true} [:maybe ::sm/uuid]]])
 
-(sm/define! ::page
+(sm/register! ::page
   [:map {:title "FilePage"}
    [:id ::sm/uuid]
    [:name :string]

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -85,10 +85,10 @@
     :exclude
     :intersection})
 
-(sm/define! ::points
+(sm/register! ::points
   [:vector {:gen/max 4 :gen/min 4} ::gpt/point])
 
-(sm/define! ::fill
+(sm/register! ::fill
   [:map {:title "Fill"}
    [:fill-color {:optional true} ::ctc/rgb-color]
    [:fill-opacity {:optional true} ::sm/safe-number]
@@ -97,7 +97,7 @@
    [:fill-color-ref-id {:optional true} [:maybe ::sm/uuid]]
    [:fill-image {:optional true} ::ctc/image-color]])
 
-(sm/define! ::stroke
+(sm/register! ::stroke
   [:map {:title "Stroke"}
    [:stroke-color {:optional true} :string]
    [:stroke-color-ref-file {:optional true} ::sm/uuid]
@@ -115,7 +115,7 @@
    [:stroke-color-gradient {:optional true} ::ctc/gradient]
    [:stroke-image {:optional true} ::ctc/image-color]])
 
-(sm/define! ::shape-base-attrs
+(sm/register! ::shape-base-attrs
   [:map {:title "ShapeMinimalRecord"}
    [:id ::sm/uuid]
    [:name :string]
@@ -127,14 +127,14 @@
    [:parent-id ::sm/uuid]
    [:frame-id ::sm/uuid]])
 
-(sm/define! ::shape-geom-attrs
+(sm/register! ::shape-geom-attrs
   [:map {:title "ShapeGeometryAttrs"}
    [:x ::sm/safe-number]
    [:y ::sm/safe-number]
    [:width ::sm/safe-number]
    [:height ::sm/safe-number]])
 
-(sm/define! ::shape-attrs
+(sm/register! ::shape-attrs
   [:map {:title "ShapeAttrs"}
    [:name {:optional true} :string]
    [:component-id {:optional true}  ::sm/uuid]
@@ -190,12 +190,12 @@
    [:plugin-data {:optional true}
     [:map-of {:gen/max 5} :keyword ::sm/plugin-data]]])
 
-(sm/define! ::group-attrs
+(sm/register! ::group-attrs
   [:map {:title "GroupAttrs"}
    [:type [:= :group]]
    [:shapes [:vector {:gen/max 10 :gen/min 1} ::sm/uuid]]])
 
-(sm/define! ::frame-attrs
+(sm/register! ::frame-attrs
   [:map {:title "FrameAttrs"}
    [:type [:= :frame]]
    [:shapes [:vector {:gen/max 10 :gen/min 1} ::sm/uuid]]
@@ -203,7 +203,7 @@
    [:show-content {:optional true} :boolean]
    [:hide-in-viewer {:optional true} :boolean]])
 
-(sm/define! ::bool-attrs
+(sm/register! ::bool-attrs
   [:map {:title "BoolAttrs"}
    [:type [:= :bool]]
    [:shapes [:vector {:gen/max 10 :gen/min 1} ::sm/uuid]]
@@ -223,19 +223,19 @@
        [:maybe
         [:map-of {:gen/max 5} :keyword ::sm/safe-number]]]]]]])
 
-(sm/define! ::rect-attrs
+(sm/register! ::rect-attrs
   [:map {:title "RectAttrs"}
    [:type [:= :rect]]])
 
-(sm/define! ::circle-attrs
+(sm/register! ::circle-attrs
   [:map {:title "CircleAttrs"}
    [:type [:= :circle]]])
 
-(sm/define! ::svg-raw-attrs
+(sm/register! ::svg-raw-attrs
   [:map {:title "SvgRawAttrs"}
    [:type [:= :svg-raw]]])
 
-(sm/define! ::image-attrs
+(sm/register! ::image-attrs
   [:map {:title "ImageAttrs"}
    [:type [:= :image]]
    [:metadata
@@ -245,17 +245,17 @@
      [:mtype {:optional true} [:maybe :string]]
      [:id ::sm/uuid]]]])
 
-(sm/define! ::path-attrs
+(sm/register! ::path-attrs
   [:map {:title "PathAttrs"}
    [:type [:= :path]]
    [:content ::ctsp/content]])
 
-(sm/define! ::text-attrs
+(sm/register! ::text-attrs
   [:map {:title "TextAttrs"}
    [:type [:= :text]]
    [:content {:optional true} [:maybe ::ctsx/content]]])
 
-(sm/define! ::shape-map
+(sm/register! ::shape-map
   [:multi {:dispatch :type :title "Shape"}
    [:group
     [:and {:title "GroupShape"}
@@ -327,7 +327,7 @@
      ::text-attrs
      ::ctsl/layout-child-attrs]]])
 
-(sm/define! ::shape
+(sm/register! ::shape
   [:and
    {:title "Shape"
     :gen/gen (->> (sg/generator ::shape-base-attrs)

--- a/common/src/app/common/types/shape/blur.cljc
+++ b/common/src/app/common/types/shape/blur.cljc
@@ -26,7 +26,7 @@
 ;; SCHEMA
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(sm/def! ::blur
+(sm/register! ::blur
   [:map {:title "Blur"}
    [:id ::sm/uuid]
    [:type [:= :layer-blur]]

--- a/common/src/app/common/types/shape/export.cljc
+++ b/common/src/app/common/types/shape/export.cljc
@@ -12,6 +12,6 @@
 
 (sm/register! ::export
   [:map {:title "ShapeExport"}
-   [:type :keyword]
+   [:type [::sm/one-of export-types]]
    [:scale ::sm/safe-number]
    [:suffix :string]])

--- a/common/src/app/common/types/shape/export.cljc
+++ b/common/src/app/common/types/shape/export.cljc
@@ -10,7 +10,7 @@
 
 (def export-types #{:png :jpeg :svg :pdf})
 
-(sm/def! ::export
+(sm/register! ::export
   [:map {:title "ShapeExport"}
    [:type :keyword]
    [:scale ::sm/safe-number]

--- a/common/src/app/common/types/shape/interactions.cljc
+++ b/common/src/app/common/types/shape/interactions.cljc
@@ -71,7 +71,7 @@
 (def animation-types
   #{:dissolve :slide :push})
 
-(sm/define! ::animation
+(sm/register! ::animation
   [:multi {:dispatch :animation-type :title "Animation"}
    [:dissolve
     [:map {:title "AnimationDisolve"}
@@ -96,7 +96,7 @@
 (def check-animation!
   (sm/check-fn ::animation))
 
-(sm/define! ::interaction
+(sm/register! ::interaction
   [:multi {:dispatch :action-type}
    [:navigate
     [:map

--- a/common/src/app/common/types/shape/layout.cljc
+++ b/common/src/app/common/types/shape/layout.cljc
@@ -87,7 +87,7 @@
    :layout-item-absolute
    :layout-item-z-index])
 
-(sm/def! ::layout-attrs
+(sm/register! ::layout-attrs
   [:map {:title "LayoutAttrs"}
    [:layout {:optional true} [::sm/one-of layout-types]]
    [:layout-flex-dir {:optional true} [::sm/one-of flex-direction-types]]
@@ -130,7 +130,7 @@
 (def grid-cell-justify-self-types
   #{:auto :start :center :end :stretch})
 
-(sm/def! ::grid-cell
+(sm/register! ::grid-cell
   [:map {:title "GridCell"}
    [:id ::sm/uuid]
    [:area-name {:optional true} :string]
@@ -144,7 +144,7 @@
    [:shapes
     [:vector {:gen/max 1} ::sm/uuid]]])
 
-(sm/def! ::grid-track
+(sm/register! ::grid-track
   [:map {:title "GridTrack"}
    [:type [::sm/one-of grid-track-types]]
    [:value {:optional true} [:maybe ::sm/safe-number]]])
@@ -166,7 +166,7 @@
 (def item-align-self-types
   #{:start :end :center :stretch})
 
-(sm/def! ::layout-child-attrs
+(sm/register! ::layout-child-attrs
   [:map {:title "LayoutChildAttrs"}
    [:layout-item-margin-type {:optional true} [::sm/one-of item-margin-types]]
    [:layout-item-margin {:optional true}
@@ -192,7 +192,7 @@
 (def valid-layouts
   #{:flex :grid})
 
-(sm/def! ::layout
+(sm/register! ::layout
   [::sm/one-of valid-layouts])
 
 (defn flex-layout?

--- a/common/src/app/common/types/shape/path.cljc
+++ b/common/src/app/common/types/shape/path.cljc
@@ -12,7 +12,7 @@
 ;; SCHEMA
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(sm/define! ::segment
+(sm/register! ::segment
   [:multi {:title "PathSegment" :dispatch :command}
    [:line-to
     [:map
@@ -43,5 +43,5 @@
        [:c2x ::sm/safe-number]
        [:c2y ::sm/safe-number]]]]]])
 
-(sm/define! ::content
+(sm/register! ::content
   [:vector ::segment])

--- a/common/src/app/common/types/shape/shadow.cljc
+++ b/common/src/app/common/types/shape/shadow.cljc
@@ -11,7 +11,7 @@
 
 (def styles #{:drop-shadow :inner-shadow})
 
-(sm/def! ::shadow
+(sm/register! ::shadow
   [:map {:title "Shadow"}
    [:id [:maybe ::sm/uuid]]
    [:style [::sm/one-of styles]]

--- a/common/src/app/common/types/shape/text.cljc
+++ b/common/src/app/common/types/shape/text.cljc
@@ -16,7 +16,7 @@
 
 (def node-types #{"root" "paragraph-set" "paragraph"})
 
-(sm/def! ::content
+(sm/register! ::content
   [:map
    [:type [:= "root"]]
    [:key {:optional true} :string]
@@ -64,7 +64,7 @@
 
 
 
-(sm/def! ::position-data
+(sm/register! ::position-data
   [:vector {:min 1 :gen/max 2}
    [:map
     [:x ::sm/safe-number]

--- a/common/src/app/common/types/typography.cljc
+++ b/common/src/app/common/types/typography.cljc
@@ -15,7 +15,7 @@
 ;; SCHEMA
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(sm/def! ::typography
+(sm/register! ::typography
   [:map {:title "Typography"}
    [:id ::sm/uuid]
    [:name :string]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -1042,6 +1042,9 @@
                                   {:file-id file-id
                                    :library-id library-id}))))))))))
 
+
+;; FIXME: the data should be set on the backend for clock consistency
+
 (def ignore-sync
   "Mark the file as ignore syncs. All library changes before this moment will not
    ber notified to sync."


### PR DESCRIPTION
This is the ongoing migration from spec to schema. This PR completes the migration of RPC methods params validations.
