### PR TITLE
:bug: Fix swap slots when detaching a copy with subcopies

### DIFF
--- a/backend/src/app/srepl/fixes.clj
+++ b/backend/src/app/srepl/fixes.clj
@@ -184,10 +184,7 @@
                                              (ctk/instance-head? child))
                                       (let [slot (guess-swap-slot component-child component-container)]
                                         (l/dbg :hint "child" :id (:id child) :name (:name child) :slot slot)
-                                        (ctn/update-shape container (:id child)
-                                                          #(update % :touched
-                                                                   cfh/set-touched-group
-                                                                   (ctk/build-swap-slot-group slot))))
+                                        (ctn/update-shape container (:id child) #(ctk/set-swap-slot % slot)))
                                       container)]
                       (recur (process-copy-head container child)
                              (rest children)

--- a/common/src/app/common/files/repair.cljc
+++ b/common/src/app/common/files/repair.cljc
@@ -481,7 +481,7 @@
           (let [slot (:swap-slot args)]
             (when (some? slot)
               (log/debug :hint (str "  -> set swap-slot to " slot))
-              (update shape :touched cfh/set-touched-group (ctk/build-swap-slot-group slot)))))]
+              (ctk/set-swap-slot shape slot))))]
 
     (log/dbg :hint "repairing shape :missing-slot" :id (:id shape) :name (:name shape) :page-id page-id)
     (-> (pcb/empty-changes nil page-id)

--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -183,6 +183,15 @@
   (and (= shape-id (:main-instance-id component))
        (= page-id (:main-instance-page component))))
 
+(defn set-touched-group
+  [touched group]
+  (when group
+    (conj (or touched #{}) group)))
+
+(defn touched-group?
+  [shape group]
+  ((or (:touched shape) #{}) group))
+
 (defn build-swap-slot-group
   "Convert a swap-slot into a :touched group"
   [swap-slot]
@@ -203,6 +212,13 @@
   (let [group (d/seek swap-slot? (:touched shape))]
     (when group
       (group->swap-slot group))))
+
+(defn set-swap-slot
+  "Add a touched group with a form :swap-slot-<uuid>."
+  [shape swap-slot]
+  (cond-> shape
+    (some? swap-slot)
+    (update :touched set-touched-group (build-swap-slot-group swap-slot))))
 
 (defn match-swap-slot?
   [shape-main shape-inst]


### PR DESCRIPTION
Fixes one case of https://tree.taiga.io/project/penpot/issue/8016

Warning: there may be other cases that cause the same bug, so don't close the issue when testing this PR.