### PR TITLE
:zap: Fix a performance regression with file validation with some features

### DIFF
--- a/backend/src/app/rpc/commands/files_update.clj
+++ b/backend/src/app/rpc/commands/files_update.clj
@@ -324,19 +324,21 @@
                  (update :data cpc/process-changes changes)
                  (update :data d/without-nils))]
 
-    (when (contains? cf/flags :soft-file-validation)
-      (soft-validate-file! file libs))
 
-    (when (contains? cf/flags :soft-file-schema-validation)
-      (soft-validate-file-schema! file))
+    (binding [pmap/*tracked* nil]
+      (when (contains? cf/flags :soft-file-validation)
+        (soft-validate-file! file libs))
 
-    (when (and (contains? cf/flags :file-validation)
-               (not skip-validate))
-      (val/validate-file! file libs))
+      (when (contains? cf/flags :soft-file-schema-validation)
+        (soft-validate-file-schema! file))
 
-    (when (and (contains? cf/flags :file-schema-validation)
-               (not skip-validate))
-      (val/validate-file-schema! file))
+      (when (and (contains? cf/flags :file-validation)
+                 (not skip-validate))
+        (val/validate-file! file libs))
+
+      (when (and (contains? cf/flags :file-schema-validation)
+                 (not skip-validate))
+        (val/validate-file-schema! file)))
 
     (cond-> file
       (contains? cfeat/*current* "fdata/objects-map")


### PR DESCRIPTION
The feature fdata/pointer-map tracking mechanism interacts pretty bad with possible local mutations on the validation subsystem. The fix consist on disabling the tracking mechanism on the validation.
