### PR TITLE
:fire: Remove version specification from docker-compose.yaml file

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -1,6 +1,3 @@
----
-version: "3.8"
-
 networks:
   penpot:
 


### PR DESCRIPTION
It is deprecated

Replaces: https://github.com/penpot/penpot/pull/4756