### PR TITLE
:recycle: Refactor component thumbnails as configurable

### DIFF
--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -69,7 +69,8 @@
    :enable-onboarding-questions
    :enable-onboarding-newsletter
    :enable-dashboard-templates-section
-   :enable-google-fonts-provider])
+   :enable-google-fonts-provider
+   :enable-component-thumbnails])
 
 (defn- parse-flags
   [global]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -24,6 +24,7 @@
    [app.common.types.shape.layout :as ctl]
    [app.common.types.typography :as ctt]
    [app.common.uuid :as uuid]
+   [app.config :as cf]
    [app.main.data.changes :as dch]
    [app.main.data.comments :as dc]
    [app.main.data.events :as ev]
@@ -1203,7 +1204,7 @@
                  (rx/debounce 5000)
                  (rx/tap #(log/trc :hint "buffer initialized")))]
 
-        (when components-v2?
+        (when (and components-v2? (contains? cf/flags :component-thumbnails))
           (->> (rx/merge
                 changes-s
 

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -14,6 +14,7 @@
    [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
    [app.common.types.file :as ctf]
+   [app.config :as cf]
    [app.main.data.modal :as modal]
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.libraries :as dwl]
@@ -287,7 +288,7 @@
            (when (< @retry 3)
              (inc retry))))]
 
-    (if (some? thumbnail-uri)
+    (if (and (some? thumbnail-uri) (contains? cf/flags :component-thumbnails))
       [:& component-svg-thumbnail
        {:thumbnail-uri thumbnail-uri
         :class class


### PR DESCRIPTION
Added a configuration parameter in `config.cljs` called `component-thumbnaills-enabled` to enable/disable component thumbnail generation.