### PR TITLE
Fix export deleted components

### DIFF
--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -23,6 +23,7 @@
    [app.common.geom.shapes.bounds :as gsb]
    [app.common.logging :as l]
    [app.common.math :as mth]
+   [app.common.types.components-list :as ctkl]
    [app.common.types.file :as ctf]
    [app.common.types.modifiers :as ctm]
    [app.common.types.shape-tree :as ctst]
@@ -525,8 +526,10 @@
 
 (mf/defc components-svg
   {::mf/wrap-props false}
-  [{:keys [data children embed include-metadata source]}]
-  (let [source (keyword (d/nilv source "components"))]
+  [{:keys [data children embed include-metadata deleted?]}]
+  (let [components (if (not deleted?)
+                     (ctkl/components-seq data)
+                     (ctkl/deleted-components-seq data))]
     [:& (mf/provider embed/context) {:value embed}
      [:& (mf/provider export/include-metadata-ctx) {:value include-metadata}
       [:svg {:version "1.1"
@@ -536,9 +539,9 @@
              :style {:display (when-not (some? children) "none")}
              :fill "none"}
        [:defs
-        (for [[id component] (source data)]
+        (for [component components]
           (let [component (ctf/load-component-objects data component)]
-            [:& component-symbol {:key (dm/str id) :component component}]))]
+            [:& component-symbol {:key (dm/str (:id component)) :component component}]))]
 
        children]]]))
 
@@ -595,10 +598,12 @@
              (rds/renderToStaticMarkup elem)))))))
 
 (defn render-components
-  [data source]
+  [data deleted?]
   (let [;; Join all components objects into a single map
-        objects (->> (source data)
-                     (vals)
+        components  (if (not deleted?)
+                      (ctkl/components-seq data)
+                      (ctkl/deleted-components-seq data))
+        objects (->> components
                      (map (partial ctf/load-component-objects data))
                      (map :objects)
                      (reduce conj))]
@@ -615,7 +620,7 @@
                                     #js {:data data
                                          :embed true
                                          :include-metadata true
-                                         :source (name source)})]
+                                         :deleted? deleted?})]
                (rds/renderToStaticMarkup elem))))))))
 
 (defn render-frame

--- a/frontend/src/app/main/render.cljs
+++ b/frontend/src/app/main/render.cljs
@@ -485,15 +485,18 @@
         path       (:path component)
         root-id    (or (:main-instance-id component)
                        (:id component))
+        orig-root  (get (:objects component) root-id)
         objects    (adapt-objects-for-shape (:objects component)
                                             root-id)
         root-shape (get objects root-id)
         selrect    (:selrect root-shape)
 
-        main-instance-id   (:main-instance-id component)
-        main-instance-page (:main-instance-page component)
-        main-instance-x    (:main-instance-x component)
-        main-instance-y    (:main-instance-y component)
+        main-instance-id     (:main-instance-id component)
+        main-instance-page   (:main-instance-page component)
+        main-instance-x      (when (:deleted component) (:x orig-root))
+        main-instance-y      (when (:deleted component) (:y orig-root))
+        main-instance-parent (when (:deleted component) (:parent-id orig-root))
+        main-instance-frame  (when (:deleted component) (:frame-id orig-root))
 
         vbox
         (format-viewbox
@@ -517,7 +520,9 @@
                         "penpot:main-instance-id" main-instance-id
                         "penpot:main-instance-page" main-instance-page
                         "penpot:main-instance-x" main-instance-x
-                        "penpot:main-instance-y" main-instance-y}
+                        "penpot:main-instance-y" main-instance-y
+                        "penpot:main-instance-parent" main-instance-parent
+                        "penpot:main-instance-frame" main-instance-frame}
        [:title name]
        [:> shape-container {:shape root-shape}
         (case (:type root-shape)

--- a/frontend/src/app/worker/export.cljs
+++ b/frontend/src/app/worker/export.cljs
@@ -52,7 +52,7 @@
                           :libraries            (->> (:libraries file) (into #{}) (mapv str))
                           :exportType           (d/name export-type)
                           :hasComponents        (d/not-empty? (ctkl/components-seq (:data file)))
-                          :hasDeletedComponents (d/not-empty? (get-in file [:data :deleted-components]))
+                          :hasDeletedComponents (d/not-empty? (ctkl/deleted-components-seq (:data file)))
                           :hasMedia             (d/not-empty? (get-in file [:data :media]))
                           :hasColors            (d/not-empty? (get-in file [:data :colors]))
                           :hasTypographies      (d/not-empty? (get-in file [:data :typographies]))}))))]
@@ -151,12 +151,12 @@
 
 (defn parse-library-components
   [file]
-  (->> (r/render-components (:data file) :components)
+  (->> (r/render-components (:data file) false)
        (rx/map #(vector (str (:id file) "/components.svg") %))))
 
 (defn parse-deleted-components
   [file]
-  (->> (r/render-components (:data file) :deleted-components)
+  (->> (r/render-components (:data file) true)
        (rx/map #(vector (str (:id file) "/deleted-components.svg") %))))
 
 (defn fetch-file-with-libraries
@@ -380,7 +380,7 @@
         deleted-components-stream
         (->> files-stream
              (rx/merge-map vals)
-             (rx/filter #(d/not-empty? (get-in % [:data :deleted-components])))
+             (rx/filter #(d/not-empty? (ctkl/deleted-components-seq (:data %))))
              (rx/merge-map parse-deleted-components))
 
         pages-stream


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/8073

This is not really a bug, but that this feature was not implemented. All existing code was working on components v1 or early versions of v2. I've changed greatly the way deleted components are exported / imported.

~~WARNING: there is still a bug. The shapes inside the deleted component are imported with wrong coordinates, relative to the component they belong. This causes that when the component is restored, the shapes are positioned outside. When importing, they must be moved to be absolute coordinates when added to the page before deleting the component.~~