### PR TITLE
Fix broken visual regression test + refactor Dashboard POM

### DIFF
--- a/frontend/playwright/ui/pages/DashboardPage.js
+++ b/frontend/playwright/ui/pages/DashboardPage.js
@@ -68,12 +68,12 @@ export class DashboardPage extends BaseWebSocketPage {
     this.libsTitle = page.getByRole("heading", { name: "Libraries", level: 1 });
     this.searchButton = page.getByRole("button", { name: "dashboard-search" });
     this.searchTitle = page.getByRole("heading", { name: "Search results" });
-    this.searchInput = page.getByPlaceholder('Search…');
+    this.searchInput = page.getByPlaceholder("Search…");
     this.newFileName = page.getByText("New File 3");
-    this.teamDropdown = page.getByRole('button', { name: 'Your Penpot' });
-    this.userAccount = page.getByRole('button', { name: "Princesa Leia Princesa Leia" });
+    this.teamDropdown = page.getByRole("button", { name: "Your Penpot" });
+    this.userAccount = page.getByRole("button", { name: "Princesa Leia Princesa Leia" });
     this.userProfileOption = page.getByText("Your account");
-    this.userAccountTitle = page.getByRole("heading", {name: "Your account"});
+    this.userAccountTitle = page.getByRole("heading", { name: "Your account" });
   }
 
   async setupDraftsEmpty() {
@@ -106,8 +106,8 @@ export class DashboardPage extends BaseWebSocketPage {
     await this.mockRPC("get-team-shared-files?project-id=*", "dashboard/get-shared-files.json");
     await this.mockRPC("get-team-recent-files?team-id=*", "dashboard/get-team-recent-files.json");
     await this.mockRPC("get-font-variants?team-id=*", "dashboard/get-font-variants.json");
-    await this.mockRPC("search-files", "dashboard/search-files.json",  { method: "POST" });
-    await this.mockRPC("search-files", "dashboard/search-files.json" );
+    await this.mockRPC("search-files", "dashboard/search-files.json", { method: "POST" });
+    await this.mockRPC("search-files", "dashboard/search-files.json");
     await this.mockRPC("get-teams", "logged-in-user/get-teams-complete.json");
   }
 
@@ -182,7 +182,6 @@ export class DashboardPage extends BaseWebSocketPage {
   }
 
   async goToAccount() {
-
     await this.userAccount.click();
 
     await this.userProfileOption.click();

--- a/frontend/playwright/ui/pages/DashboardPage.js
+++ b/frontend/playwright/ui/pages/DashboardPage.js
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { BaseWebSocketPage } from "./BaseWebSocketPage";
 
 export class DashboardPage extends BaseWebSocketPage {
@@ -49,31 +50,38 @@ export class DashboardPage extends BaseWebSocketPage {
   }
 
   static anyTeamId = "c7ce0794-0992-8105-8004-38e630f40f6d";
-
   static secondTeamId = "dd33ff88-f4e5-8033-8003-8096cc07bdf3";
-
   static draftProjectId = "c7ce0794-0992-8105-8004-38e630f7920b";
 
   constructor(page) {
     super(page);
-    this.titleLabel = page.getByRole("heading", { name: "Projects" });
-    this.addProjectBtn = page.getByRole("button", { name: "+ NEW PROJECT" });
+
+    this.sidebar = page.getByTestId("dashboard-sidebar");
+    this.sidebarMenu = this.sidebar.getByRole("menu");
+
+    this.projectsHeading = page.getByRole("heading", { name: "Projects" });
+    this.addProjectButton = page.getByRole("button", { name: "+ NEW PROJECT" });
     this.projectName = page.getByText("Project 1");
-    this.draftTitle = page.getByRole("heading", { name: "Drafts" });
-    this.draftLink = page.getByTestId("drafts-link-sidebar");
+
+    this.draftsTitle = page.getByRole("heading", { name: "Drafts" });
+    this.draftsLink = this.sidebar.getByText("Drafts");
     this.draftsFile = page.getByText(/New File 1/);
-    this.fontsLink = page.getByTestId("fonts-link-sidebar");
+
+    this.fontsLink = this.sidebar.getByText("Fonts");
     this.fontsTitle = page.getByRole("heading", { name: "Fonts", level: 1 });
-    this.libsLink = page.getByTestId("libs-link-sidebar");
+
+    this.libsLink = this.sidebar.getByText("Libraries");
     this.libsTitle = page.getByRole("heading", { name: "Libraries", level: 1 });
+
     this.searchButton = page.getByRole("button", { name: "dashboard-search" });
     this.searchTitle = page.getByRole("heading", { name: "Search results" });
     this.searchInput = page.getByPlaceholder("Search…");
     this.newFileName = page.getByText("New File 3");
-    this.teamDropdown = page.getByRole("button", { name: "Your Penpot" });
-    this.userAccount = page.getByRole("button", { name: "Princesa Leia Princesa Leia" });
-    this.userProfileOption = page.getByText("Your account");
-    this.userAccountTitle = page.getByRole("heading", { name: "Your account" });
+
+    this.teamDropdown = this.sidebar.getByRole("button", { name: "Your Penpot" });
+    this.userAccount = this.sidebar.getByRole("button", { name: /Princesa Leia/ });
+    this.userProfileOption = this.sidebarMenu.getByText("Your account");
+    this.userAccountHeading = page.getByRole("heading", { name: "Your account" });
   }
 
   async setupDraftsEmpty() {
@@ -145,6 +153,7 @@ export class DashboardPage extends BaseWebSocketPage {
 
   async goToDashboard() {
     await this.page.goto(`#/dashboard/team/${DashboardPage.anyTeamId}/projects`);
+    await expect(this.projectsHeading).toBeVisible();
   }
 
   async goToSecondTeamDashboard() {

--- a/frontend/playwright/ui/pages/DashboardPage.js
+++ b/frontend/playwright/ui/pages/DashboardPage.js
@@ -64,15 +64,11 @@ export class DashboardPage extends BaseWebSocketPage {
     this.projectName = page.getByText("Project 1");
 
     this.draftsLink = this.sidebar.getByText("Drafts");
-    this.draftsFile = page.getByText(/New File 1/);
-
     this.fontsLink = this.sidebar.getByText("Fonts");
-
     this.libsLink = this.sidebar.getByText("Libraries");
 
     this.searchButton = page.getByRole("button", { name: "dashboard-search" });
     this.searchInput = page.getByPlaceholder("Search…");
-    this.newFileName = page.getByText("New File 3");
 
     this.teamDropdown = this.sidebar.getByRole("button", { name: "Your Penpot" });
     this.userAccount = this.sidebar.getByRole("button", { name: /Princesa Leia/ });
@@ -183,6 +179,7 @@ export class DashboardPage extends BaseWebSocketPage {
     await this.page.goto(
       `#/dashboard/team/${DashboardPage.anyTeamId}/projects/${DashboardPage.draftProjectId}`,
     );
+    await expect(this.mainHeading).toHaveText("Drafts");
   }
 
   async goToAccount() {

--- a/frontend/playwright/ui/pages/DashboardPage.js
+++ b/frontend/playwright/ui/pages/DashboardPage.js
@@ -58,30 +58,25 @@ export class DashboardPage extends BaseWebSocketPage {
 
     this.sidebar = page.getByTestId("dashboard-sidebar");
     this.sidebarMenu = this.sidebar.getByRole("menu");
+    this.mainHeading = page.getByRole("heading", { level: 1 });
 
-    this.projectsHeading = page.getByRole("heading", { name: "Projects" });
     this.addProjectButton = page.getByRole("button", { name: "+ NEW PROJECT" });
     this.projectName = page.getByText("Project 1");
 
-    this.draftsTitle = page.getByRole("heading", { name: "Drafts" });
     this.draftsLink = this.sidebar.getByText("Drafts");
     this.draftsFile = page.getByText(/New File 1/);
 
     this.fontsLink = this.sidebar.getByText("Fonts");
-    this.fontsTitle = page.getByRole("heading", { name: "Fonts", level: 1 });
 
     this.libsLink = this.sidebar.getByText("Libraries");
-    this.libsTitle = page.getByRole("heading", { name: "Libraries", level: 1 });
 
     this.searchButton = page.getByRole("button", { name: "dashboard-search" });
-    this.searchTitle = page.getByRole("heading", { name: "Search results" });
     this.searchInput = page.getByPlaceholder("Search…");
     this.newFileName = page.getByText("New File 3");
 
     this.teamDropdown = this.sidebar.getByRole("button", { name: "Your Penpot" });
     this.userAccount = this.sidebar.getByRole("button", { name: /Princesa Leia/ });
     this.userProfileOption = this.sidebarMenu.getByText("Your account");
-    this.userAccountHeading = page.getByRole("heading", { name: "Your account" });
   }
 
   async setupDraftsEmpty() {
@@ -153,7 +148,7 @@ export class DashboardPage extends BaseWebSocketPage {
 
   async goToDashboard() {
     await this.page.goto(`#/dashboard/team/${DashboardPage.anyTeamId}/projects`);
-    await expect(this.projectsHeading).toBeVisible();
+    await expect(this.mainHeading).toBeVisible();
   }
 
   async goToSecondTeamDashboard() {

--- a/frontend/playwright/ui/specs/dashboard.spec.js
+++ b/frontend/playwright/ui/specs/dashboard.spec.js
@@ -12,7 +12,7 @@ test("Dashboad page has title ", async ({ page }) => {
   await dashboardPage.goToDashboard();
 
   await expect(dashboardPage.page).toHaveURL(/dashboard/);
-  await expect(dashboardPage.projectsHeading).toBeVisible();
+  await expect(dashboardPage.mainHeading).toBeVisible();
 });
 
 test("User can create a new project", async ({ page }) => {
@@ -32,7 +32,7 @@ test("User goes to draft page", async ({ page }) => {
   await dashboardPage.goToDashboard();
   await dashboardPage.draftsLink.click();
 
-  await expect(dashboardPage.draftsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Drafts");
 });
 
 test("User loads the draft page", async ({ page }) => {

--- a/frontend/playwright/ui/specs/dashboard.spec.js
+++ b/frontend/playwright/ui/specs/dashboard.spec.js
@@ -35,11 +35,12 @@ test("User goes to draft page", async ({ page }) => {
   await expect(dashboardPage.mainHeading).toHaveText("Drafts");
 });
 
-test("User loads the draft page", async ({ page }) => {
+test("Lists files in the drafts page", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
   await dashboardPage.setupDrafts();
 
   await dashboardPage.goToDrafts();
 
-  await expect(dashboardPage.draftsFile).toBeVisible();
+  await expect(dashboardPage.page.getByRole("button", { name: /New File 1/ })).toBeVisible();
+  await expect(dashboardPage.page.getByRole("button", { name: /New File 2/ })).toBeVisible();
 });

--- a/frontend/playwright/ui/specs/dashboard.spec.js
+++ b/frontend/playwright/ui/specs/dashboard.spec.js
@@ -3,11 +3,7 @@ import DashboardPage from "../pages/DashboardPage";
 
 test.beforeEach(async ({ page }) => {
   await DashboardPage.init(page);
-  await DashboardPage.mockRPC(
-    page,
-    "get-profile",
-    "logged-in-user/get-profile-logged-in-no-onboarding.json",
-  );
+  await DashboardPage.mockRPC(page, "get-profile", "logged-in-user/get-profile-logged-in-no-onboarding.json");
 });
 
 test("Dashboad page has title ", async ({ page }) => {
@@ -16,7 +12,7 @@ test("Dashboad page has title ", async ({ page }) => {
   await dashboardPage.goToDashboard();
 
   await expect(dashboardPage.page).toHaveURL(/dashboard/);
-  await expect(dashboardPage.titleLabel).toBeVisible();
+  await expect(dashboardPage.projectsHeading).toBeVisible();
 });
 
 test("User can create a new project", async ({ page }) => {
@@ -24,7 +20,7 @@ test("User can create a new project", async ({ page }) => {
   await dashboardPage.setupNewProject();
 
   await dashboardPage.goToDashboard();
-  await dashboardPage.addProjectBtn.click();
+  await dashboardPage.addProjectButton.click();
 
   await expect(dashboardPage.projectName).toBeVisible();
 });
@@ -34,9 +30,9 @@ test("User goes to draft page", async ({ page }) => {
   await dashboardPage.setupDraftsEmpty();
 
   await dashboardPage.goToDashboard();
-  await dashboardPage.draftLink.click();
+  await dashboardPage.draftsLink.click();
 
-  await expect(dashboardPage.draftTitle).toBeVisible();
+  await expect(dashboardPage.draftsTitle).toBeVisible();
 });
 
 test("User loads the draft page", async ({ page }) => {

--- a/frontend/playwright/ui/visual-specs/visual-dashboard.spec.js
+++ b/frontend/playwright/ui/visual-specs/visual-dashboard.spec.js
@@ -11,7 +11,7 @@ test("User goes to an empty dashboard", async ({ page }) => {
 
   await dashboardPage.goToDashboard();
 
-  await expect(dashboardPage.projectsHeading).toBeVisible();
+  await expect(dashboardPage.mainHeading).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -24,7 +24,7 @@ test("User goes to an empty draft page", async ({ page }) => {
   await dashboardPage.goToDashboard();
   await dashboardPage.draftsLink.click();
 
-  await expect(dashboardPage.draftsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Drafts");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -34,7 +34,7 @@ test("User goes to an empty fonts page", async ({ page }) => {
   await dashboardPage.goToDashboard();
   await dashboardPage.fontsLink.click();
 
-  await expect(dashboardPage.fontsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Fonts");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -45,7 +45,7 @@ test("User goes to an empty libraries page", async ({ page }) => {
   await dashboardPage.goToDashboard();
   await dashboardPage.libsLink.click();
 
-  await expect(dashboardPage.libsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Libraries");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -55,7 +55,7 @@ test("User goes to an empty search page", async ({ page }) => {
 
   await dashboardPage.goToSearch();
 
-  await expect(dashboardPage.searchTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Search results");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -81,40 +81,40 @@ test("User goes to a full dashboard", async ({ page }) => {
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
-test("User goes to an full draft page", async ({ page }) => {
+test("User goes to a full draft page", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
   await dashboardPage.setupDashboardFull();
 
   await dashboardPage.goToDashboard();
   await dashboardPage.draftsLink.click();
 
-  await expect(dashboardPage.draftsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Drafts");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
-test("User goes to an full library page", async ({ page }) => {
+test("User goes to a full library page", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
   await dashboardPage.setupDashboardFull();
 
   await dashboardPage.goToDashboard();
   await dashboardPage.libsLink.click();
 
-  await expect(dashboardPage.libsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Libraries");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
-test("User goes to an full fonts page", async ({ page }) => {
+test("User goes to a full fonts page", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
   await dashboardPage.setupDashboardFull();
 
   await dashboardPage.goToDashboard();
   await dashboardPage.fontsLink.click();
 
-  await expect(dashboardPage.fontsTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Fonts");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
-test("User goes to an full search page", async ({ page }) => {
+test("User goes to a full search page", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
   await dashboardPage.setupDashboardFull();
 
@@ -123,7 +123,7 @@ test("User goes to an full search page", async ({ page }) => {
 
   await dashboardPage.searchInput.fill("New");
 
-  await expect(dashboardPage.searchTitle).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Search results");
   await expect(dashboardPage.newFileName).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
@@ -146,7 +146,7 @@ test("User goes to user profile", async ({ page }) => {
   await dashboardPage.goToDashboard();
   await dashboardPage.goToAccount();
 
-  await expect(dashboardPage.userAccountHeading).toBeVisible();
+  await expect(dashboardPage.mainHeading).toHaveText("Your account");
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -180,8 +180,6 @@ test("User opens teams selector with only one team", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
 
   await dashboardPage.goToDashboard();
-  await expect(dashboardPage.projectsHeading).toBeVisible();
-
   await dashboardPage.teamDropdown.click();
 
   await expect(page.getByText("Create new team")).toBeVisible();
@@ -193,8 +191,6 @@ test("User opens teams selector with more than one team", async ({ page }) => {
   await dashboardPage.setupDashboardFull();
 
   await dashboardPage.goToDashboard();
-  await expect(dashboardPage.projectsHeading).toBeVisible();
-
   await dashboardPage.teamDropdown.click();
 
   await expect(page.getByText("Second Team")).toBeVisible();

--- a/frontend/playwright/ui/visual-specs/visual-dashboard.spec.js
+++ b/frontend/playwright/ui/visual-specs/visual-dashboard.spec.js
@@ -77,7 +77,6 @@ test("User goes to a full dashboard", async ({ page }) => {
 
   await dashboardPage.goToDashboard();
 
-  await expect(dashboardPage.draftsFile).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -121,10 +120,10 @@ test("User goes to a full search page", async ({ page }) => {
   await dashboardPage.goToSearch();
   await expect(dashboardPage.searchInput).toBeVisible();
 
-  await dashboardPage.searchInput.fill("New");
+  await dashboardPage.searchInput.fill("3");
 
   await expect(dashboardPage.mainHeading).toHaveText("Search results");
-  await expect(dashboardPage.newFileName).toBeVisible();
+  await expect(dashboardPage.page.getByRole("button", { name: "New File 3" })).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 

--- a/frontend/playwright/ui/visual-specs/visual-dashboard.spec.js
+++ b/frontend/playwright/ui/visual-specs/visual-dashboard.spec.js
@@ -11,7 +11,7 @@ test("User goes to an empty dashboard", async ({ page }) => {
 
   await dashboardPage.goToDashboard();
 
-  await expect(dashboardPage.titleLabel).toBeVisible();
+  await expect(dashboardPage.projectsHeading).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -22,9 +22,9 @@ test("User goes to an empty draft page", async ({ page }) => {
   await dashboardPage.setupDraftsEmpty();
 
   await dashboardPage.goToDashboard();
-  await dashboardPage.draftLink.click();
+  await dashboardPage.draftsLink.click();
 
-  await expect(dashboardPage.draftTitle).toBeVisible();
+  await expect(dashboardPage.draftsTitle).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -86,9 +86,9 @@ test("User goes to an full draft page", async ({ page }) => {
   await dashboardPage.setupDashboardFull();
 
   await dashboardPage.goToDashboard();
-  await dashboardPage.draftLink.click();
+  await dashboardPage.draftsLink.click();
 
-  await expect(dashboardPage.draftTitle).toBeVisible();
+  await expect(dashboardPage.draftsTitle).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -146,7 +146,7 @@ test("User goes to user profile", async ({ page }) => {
   await dashboardPage.goToDashboard();
   await dashboardPage.goToAccount();
 
-  await expect(dashboardPage.userAccountTitle).toBeVisible();
+  await expect(dashboardPage.userAccountHeading).toBeVisible();
   await expect(dashboardPage.page).toHaveScreenshot();
 });
 
@@ -180,7 +180,7 @@ test("User opens teams selector with only one team", async ({ page }) => {
   const dashboardPage = new DashboardPage(page);
 
   await dashboardPage.goToDashboard();
-  await expect(dashboardPage.titleLabel).toBeVisible();
+  await expect(dashboardPage.projectsHeading).toBeVisible();
 
   await dashboardPage.teamDropdown.click();
 
@@ -193,7 +193,7 @@ test("User opens teams selector with more than one team", async ({ page }) => {
   await dashboardPage.setupDashboardFull();
 
   await dashboardPage.goToDashboard();
-  await expect(dashboardPage.titleLabel).toBeVisible();
+  await expect(dashboardPage.projectsHeading).toBeVisible();
 
   await dashboardPage.teamDropdown.click();
 

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -786,7 +786,6 @@
        [:li {:class (stl/css-case :current drafts?
                                   :sidebar-nav-item true)}
         [:& link {:action go-drafts
-                  :data-testid "drafts-link-sidebar"
                   :class (stl/css :sidebar-link)
                   :keyboard-action go-drafts-with-key}
          [:span {:class (stl/css :element-title)} (tr "labels.drafts")]]]
@@ -1052,7 +1051,7 @@
   [props]
   (let [team    (obj/get props "team")
         profile (obj/get props "profile")]
-    [:nav {:class (stl/css :dashboard-sidebar)}
+    [:nav {:class (stl/css :dashboard-sidebar) :data-testid "dashboard-sidebar"}
      [:> sidebar-content props]
      [:& profile-section
       {:profile profile


### PR DESCRIPTION
In #4758 there was a visual regression test broken when merging two test IDs for the same element. While looking at it I saw that the Dashboard POM had redundant / unneeded locators and I took the opportunity to clean it up.

- :lipstick: Reformat DashboardPage.js according to prettier rules
- :sparkles: Avoid using unneeded test ids in dashboard POM
- :sparkles: Remove redundant locators for Dashboard POM
- :sparkles: Remove unneeded draftsFile and newFile locators in dashboard POM

PS: Regarding the formatting commit, I created a US in Taiga [8181](https://tree.taiga.io/project/penpot/us/8181) to add Prettier to the project, since we will be adding more JS files for the component Storybook files.