### PR TITLE
:bug: Fix playwright test mac shortcut

### DIFF
--- a/frontend/playwright/ui/pages/DashboardPage.js
+++ b/frontend/playwright/ui/pages/DashboardPage.js
@@ -58,7 +58,7 @@ export class DashboardPage extends BaseWebSocketPage {
 
     this.sidebar = page.getByTestId("dashboard-sidebar");
     this.sidebarMenu = this.sidebar.getByRole("menu");
-    this.mainHeading = page.getByRole("heading", { level: 1 });
+    this.mainHeading = page.getByTestId("dashboard-header").getByRole("heading", { level: 1 });
 
     this.addProjectButton = page.getByRole("button", { name: "+ NEW PROJECT" });
     this.projectName = page.getByText("Project 1");

--- a/frontend/playwright/ui/specs/workspace.spec.js
+++ b/frontend/playwright/ui/specs/workspace.spec.js
@@ -50,7 +50,7 @@ test("User makes a group", async ({ page }) => {
     pageId: "6191cd35-bb1f-81f7-8004-7cc63d087375",
   });
   await workspacePage.clickLeafLayer("Rectangle");
-  await workspacePage.page.keyboard.press("ControlOrMeta+g");
+  await workspacePage.page.keyboard.press("Control+g");
   await workspacePage.expectSelectedLayer("Group");
 });
 

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -66,7 +66,7 @@
                      (dd/clear-selected-files))))]
 
 
-    [:header {:class (stl/css :dashboard-header)}
+    [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
      (if (:is-default project)
        [:div#dashboard-drafts-title {:class (stl/css :dashboard-title)}
         [:h1 (tr "labels.drafts")]]

--- a/frontend/src/app/main/ui/dashboard/fonts.cljs
+++ b/frontend/src/app/main/ui/dashboard/fonts.cljs
@@ -47,7 +47,7 @@
    ::mf/private true}
   [{:keys [section team]}]
   (use-page-title team section)
-  [:header {:class (stl/css :dashboard-header)}
+  [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
    [:div#dashboard-fonts-title {:class (stl/css :dashboard-title)}
     [:h1 (tr "labels.fonts")]]])
 

--- a/frontend/src/app/main/ui/dashboard/libraries.cljs
+++ b/frontend/src/app/main/ui/dashboard/libraries.cljs
@@ -48,7 +48,7 @@
                 (dd/clear-selected-files)))
 
     [:*
-     [:header {:class (stl/css :dashboard-header)}
+     [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
       [:div#dashboard-libraries-title {:class (stl/css :dashboard-title)}
        [:h1 (tr "dashboard.libraries-title")]]]
      [:section {:class (stl/css :dashboard-container :no-bg :dashboard-shared)  :ref rowref}

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -46,7 +46,7 @@
   {::mf/wrap [mf/memo]}
   []
   (let [on-click (mf/use-fn #(st/emit! (dd/create-project)))]
-    [:header {:class (stl/css :dashboard-header)}
+    [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
      [:div#dashboard-projects-title {:class (stl/css :dashboard-title)}
       [:h1 (tr "dashboard.projects-title")]]
      [:button {:class (stl/css :btn-secondary :btn-small)

--- a/frontend/src/app/main/ui/dashboard/search.cljs
+++ b/frontend/src/app/main/ui/dashboard/search.cljs
@@ -37,7 +37,7 @@
        (st/emit! (dd/search {:search-term search-term})
                  (dd/clear-selected-files))))
     [:*
-     [:header {:class (stl/css :dashboard-header)}
+     [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
       [:div#dashboard-search-title {:class (stl/css :dashboard-title)}
        [:h1 (tr "dashboard.title-search")]]]
 

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -81,7 +81,7 @@
                                   :team team
                                   :origin :team}))))]
 
-    [:header {:class (stl/css :dashboard-header :team)}
+    [:header {:class (stl/css :dashboard-header :team) :data-testid "dashboard-header"}
      [:div {:class (stl/css :dashboard-title)}
       [:h1 (cond
              members-section? (tr "labels.members")

--- a/frontend/src/app/main/ui/settings.cljs
+++ b/frontend/src/app/main/ui/settings.cljs
@@ -26,7 +26,7 @@
 (mf/defc header
   {::mf/wrap [mf/memo]}
   []
-  [:header {:class (stl/css :dashboard-header)}
+  [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
    [:div {:class (stl/css :dashboard-title)}
     [:h1 {:data-testid "account-title"} (tr "dashboard.your-account-title")]]])
 


### PR DESCRIPTION
Some playwright tests fixes:

- The onboarding test was working for me in UI mode, but not in the console. Probably a race condition when rendering the multiple `<h1>` (the dashboard one and the modal one) and affecting the locators.
- The "make group" test was nor working for me in my Mac machine in UI mode, because the shortcut (ctrl+g) was not working, despite using the `ControlOrMeta` alias. This is odd, I need to investigate further, but just using `Control+g` seems to work fine 🤔 