### PR TITLE
:bug: Fix layer width on the left sidebar

### DIFF
--- a/frontend/src/app/main/ui/workspace.scss
+++ b/frontend/src/app/main/ui/workspace.scss
@@ -8,7 +8,7 @@
 
 .workspace {
   @extend .new-scrollbar;
-  --layer-indentation-size: calc($s-4 * 6);
+  --layer-indentation-size: calc(#{$s-4} * 6);
   width: 100vw;
   height: 100vh;
   max-height: 100vh;


### PR DESCRIPTION
@Alotor spotted a bug in the left sidebar (no ticket for this)

<img width="309" alt="Screenshot 2024-07-02 at 3 19 42 PM" src="https://github.com/penpot/penpot/assets/63681/fbfb0715-5efe-4df7-a243-b511fe5db2ba">


