### PR TITLE
Enable design system CSS override + fix debug css compiling

### DIFF
--- a/frontend/scripts/_helpers.js
+++ b/frontend/scripts/_helpers.js
@@ -105,16 +105,6 @@ export async function compileSassAll(worker) {
   );
 }
 
-function compare(a, b) {
-  if (a < b) {
-    return -1;
-  } else if (a > b) {
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
 export function concatSass(data) {
   const output = [];
 

--- a/frontend/scripts/_helpers.js
+++ b/frontend/scripts/_helpers.js
@@ -27,6 +27,8 @@ export function startWorker() {
   });
 }
 
+export const isDebug = process.env.NODE_ENV !== "production";
+
 async function findFiles(basePath, predicate, options = {}) {
   predicate =
     predicate ??
@@ -75,6 +77,11 @@ export async function compileSass(worker, path, options) {
   return worker.exec("compileSass", [path, options]);
 }
 
+export async function compileSassDebug(worker) {
+  const result = await compileSass(worker, "resources/styles/debug.scss", {});
+  return `${result.css}\n`;
+}
+
 export async function compileSassAll(worker) {
   const limitFn = pLimit(4);
   const sourceDir = "src";
@@ -94,10 +101,7 @@ export async function compileSassAll(worker) {
     .filter(isDesignSystemFile)
     .map((path) => ph.join(sourceDir, path));
 
-  const procs = [
-    compileSass(worker, "resources/styles/main-default.scss", {}),
-    compileSass(worker, "resources/styles/debug.scss", {}),
-  ];
+  const procs = [compileSass(worker, "resources/styles/main-default.scss", {})];
 
   for (let path of [...dsFiles, ...appFiles]) {
     const proc = limitFn(() => compileSass(worker, path, { modules: true }));
@@ -176,7 +180,7 @@ async function renderTemplate(path, context = {}, partials = {}) {
 
   context = Object.assign({}, context, {
     ts: ts,
-    isDebug: process.env.NODE_ENV !== "production",
+    isDebug,
   });
 
   return mustache.render(content, context, partials);
@@ -400,6 +404,11 @@ export async function compileStyles() {
 
   await fs.mkdir("./resources/public/css", { recursive: true });
   await fs.writeFile("./resources/public/css/main.css", result);
+
+  if (isDebug) {
+    let debugCSS = await compileSassDebug(worker);
+    await fs.writeFile("./resources/public/css/debug.css", debugCSS);
+  }
 
   const end = process.hrtime(start);
   log.info("done: compile styles", `(${ppt(end)})`);

--- a/frontend/scripts/compile.js
+++ b/frontend/scripts/compile.js
@@ -1,6 +1,3 @@
-import fs from "node:fs/promises";
-import ppt from "pretty-time";
-import log from "fancy-log";
 import * as h from "./_helpers.js";
 
 await h.compileStyles();


### PR DESCRIPTION
Closes https://tree.taiga.io/project/penpot/task/8337

- :paperclip: Remove leftover code
- :sparkles: Ensure DS scss modules are compiled before the app css modules
- :bug: Fix debug css being included in prod builds

I noticed that after the switch off from Gulp we were injecting the debug CSS into `main.css` instead of a separate sheet. This PR also fixes that.
