### PR TITLE
:bug: Fix exception on clj-kondo extension hook fn

### DIFF
--- a/.clj-kondo/hooks/export.clj
+++ b/.clj-kondo/hooks/export.clj
@@ -141,7 +141,7 @@
         result (api/list-node
                 (into [(api/token-node 'defn)
                        cname
-                       (api/vector-node (into [param1] paramN))]
+                       (api/vector-node (filter some? (cons param1 paramN)))]
                       (cons mdata body)))]
 
     ;; (prn (api/sexpr result))


### PR DESCRIPTION
The exception is hidden on normal cli invocatin of clj-kondo and hapens when component with empty params is defined.

