### PR TITLE
:wrench: Enable kaocha runner for frontend cljs tests

### DIFF
--- a/common/deps.edn
+++ b/common/deps.edn
@@ -58,7 +58,9 @@
 
   io.aviso/pretty {:mvn/version "1.4.4"}
   environ/environ {:mvn/version "1.2.0"}}
+
  :paths ["src" "vendor" "target/classes"]
+
  :aliases
  {:dev
   {:extra-deps

--- a/frontend/deps.edn
+++ b/frontend/deps.edn
@@ -26,8 +26,7 @@
 
   instaparse/instaparse {:mvn/version "1.5.0"}
   garden/garden {:git/url "https://github.com/noprompt/garden"
-                 :git/sha "05590ecb5f6fa670856f3d1ab400aa4961047480"}
-  }
+                 :git/sha "05590ecb5f6fa670856f3d1ab400aa4961047480"}}
 
  :aliases
  {:outdated
@@ -46,7 +45,19 @@
     org.clojure/tools.namespace {:mvn/version "RELEASE"}
     cider/cider-nrepl {:mvn/version "0.48.0"}}}
 
+  :funnel ;; needed for kaocha-cljs2
+  {:main-opts ["-m" "lambdaisland.funnel" "-vvv"]
+   :extra-deps {lambdaisland/funnel {:mvn/version "1.4.71"}}}
+
+  :test
+  {:main-opts ["-m" "kaocha.runner"]
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
+                lambdaisland/kaocha-cljs2 {:mvn/version "0.2.72"}}}
+
   :shadow-cljs
   {:main-opts ["-m" "shadow.cljs.devtools.cli"]}
 
-  }}
+  :shadow-cljs-kaocha
+  {:main-opts ["-m" "shadow.cljs.devtools.cli"]
+   :extra-deps {lambdaisland/kaocha-cljs2 {:mvn/version "0.2.72"}
+                lambdaisland/chui {:mvn/version "1.2.205"}}}}}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,7 @@
     "luxon": "^3.4.4",
     "mousetrap": "^1.6.5",
     "opentype.js": "^1.3.4",
+    "platform": "1.3.5",
     "postcss-modules": "^6.0.0",
     "randomcolor": "^0.6.2",
     "react": "18.3.1",
@@ -107,8 +108,11 @@
     "rxjs": "8.0.0-alpha.14",
     "sax": "^1.4.1",
     "source-map-support": "^0.5.21",
+    "stack-trace": "0.0.10",
+    "stacktrace-js": "2.0.2",
     "tdigest": "^0.1.2",
     "ua-parser-js": "^1.0.38",
+    "ws": "7.3.1",
     "xregexp": "^5.1.1"
   }
 }

--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -102,8 +102,8 @@
     :warnings {:fn-deprecated false}}}
 
   :lib-penpot
-   {:target :esm
-    :output-dir "resources/public/libs"
+  {:target :esm
+   :output-dir "resources/public/libs"
 
    :modules
    {:penpot {:exports {:renderPage app.libs.render/render-page-export
@@ -140,11 +140,15 @@
      :anon-fn-naming-policy :off}}}
 
   :test
-  {:target :node-test
-   :output-to "target/tests.cjs"
-   :output-dir "target/test/"
+  {:target    :node-test
    :ns-regexp "^frontend-tests.*-test$"
+   :output-to "target/tests.cjs"
+   :output-dir "target/tests/"
+   :test-dir "target/tests"
    :autorun true
+   :runner-ns kaocha.cljs2.shadow-runner
+   :main kaocha.cljs2.shadow-runner/start
+   :preloads [lambdaisland.chui.remote]
 
    :compiler-options
    {:output-feature-set :es2020
@@ -152,7 +156,4 @@
     :source-map true
     :source-map-include-sources-content true
     :source-map-detail-level :all
-    :warnings {:fn-deprecated false}}}
-
-  }}
-
+    :warnings {:fn-deprecated false}}}}}

--- a/frontend/tests.edn
+++ b/frontend/tests.edn
@@ -1,0 +1,5 @@
+#kaocha/v1
+ {:tests [{:id :unit
+           :type :kaocha.type/cljs2
+           :test-paths ["test"]}]
+  :kaocha/reporter [kaocha.report/dots]}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5642,6 +5642,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"error-stack-parser@npm:^2.0.6":
+  version: 2.1.4
+  resolution: "error-stack-parser@npm:2.1.4"
+  dependencies:
+    stackframe: "npm:^1.3.4"
+  checksum: 10c0/7679b780043c98b01fc546725484e0cfd3071bf5c906bbe358722972f04abf4fc3f0a77988017665bab367f6ef3fc2d0185f7528f45966b83e7c99c02d5509b9
+  languageName: node
+  linkType: hard
+
 "es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0, es-abstract@npm:^1.23.2":
   version: 1.23.3
   resolution: "es-abstract@npm:1.23.3"
@@ -6648,6 +6657,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     opentype.js: "npm:^1.3.4"
     p-limit: "npm:^5.0.0"
+    platform: "npm:1.3.5"
     postcss: "npm:^8.4.38"
     postcss-clean: "npm:^1.2.2"
     postcss-modules: "npm:^6.0.0"
@@ -6665,6 +6675,8 @@ __metadata:
     sax: "npm:^1.4.1"
     shadow-cljs: "npm:2.28.11"
     source-map-support: "npm:^0.5.21"
+    stack-trace: "npm:0.0.10"
+    stacktrace-js: "npm:2.0.2"
     storybook: "npm:^8.2.2"
     svg-sprite: "npm:^2.0.4"
     tdigest: "npm:^0.1.2"
@@ -6674,6 +6686,7 @@ __metadata:
     vitest: "npm:^1.3.1"
     watcher: "npm:^2.3.1"
     workerpool: "npm:^9.1.1"
+    ws: "npm:7.3.1"
     xregexp: "npm:^5.1.1"
   languageName: unknown
   linkType: soft
@@ -10137,6 +10150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"platform@npm:1.3.5":
+  version: 1.3.5
+  resolution: "platform@npm:1.3.5"
+  checksum: 10c0/9d58cde5ed8e6f7c2865be6fd988fb018dd1ded022e09f021eedc723da77f1e9ce4ef9aa6648984951de4ecdd2d57bd48843ede294c413b97bf5d106d69fbfad
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.44.1":
   version: 1.44.1
   resolution: "playwright-core@npm:1.44.1"
@@ -11993,6 +12013,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: 10c0/beb2c5974bb58954d75e86249953d47ae16f7df1a8531abb9fcae0cd262d9fa09c2db3a134e20e99358b1adba42b6b054a32c8e16b571b3efcf6af644c329f0d
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.5.1, source-map@npm:^0.5.6":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
@@ -12094,6 +12121,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-generator@npm:^2.0.5":
+  version: 2.0.10
+  resolution: "stack-generator@npm:2.0.10"
+  dependencies:
+    stackframe: "npm:^1.3.4"
+  checksum: 10c0/c3f6f6c580488e65c0fee806a57f6ae4b79e6435f144be471c1f20328a8d9d8492d4f3beed31840f6dae03e2633325e2764fd3aca5c3126a0639e7c9ddfa45ce
+  languageName: node
+  linkType: hard
+
 "stack-trace@npm:0.0.10, stack-trace@npm:0.0.x":
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
@@ -12105,6 +12141,34 @@ __metadata:
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"stackframe@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "stackframe@npm:1.3.4"
+  checksum: 10c0/18410f7a1e0c5d211a4effa83bdbf24adbe8faa8c34db52e1cd3e89837518c592be60b60d8b7270ac53eeeb8b807cd11b399a41667f6c9abb41059c3ccc8a989
+  languageName: node
+  linkType: hard
+
+"stacktrace-gps@npm:^3.0.4":
+  version: 3.1.2
+  resolution: "stacktrace-gps@npm:3.1.2"
+  dependencies:
+    source-map: "npm:0.5.6"
+    stackframe: "npm:^1.3.4"
+  checksum: 10c0/0dcc1aa46e364a2b4d1eabce4777fecf337576a11ee3cfc92f07b9ec79ccb76810752431eeb9771289d250d0bb58dbe19a178b96bf7b2e9f773334d03aa96bb9
+  languageName: node
+  linkType: hard
+
+"stacktrace-js@npm:2.0.2":
+  version: 2.0.2
+  resolution: "stacktrace-js@npm:2.0.2"
+  dependencies:
+    error-stack-parser: "npm:^2.0.6"
+    stack-generator: "npm:^2.0.5"
+    stacktrace-gps: "npm:^3.0.4"
+  checksum: 10c0/9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
   languageName: node
   linkType: hard
 
@@ -13801,6 +13865,21 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^3.0.2"
   checksum: 10c0/8cb4bba0c1ab814a9b127844da0db4fb8c5e06ddbe6317b8b319377c73b283673036c8b9360120062898508b9428d81611cf7fa97584504a00bc179b2a580b92
+  languageName: node
+  linkType: hard
+
+"ws@npm:7.3.1":
+  version: 7.3.1
+  resolution: "ws@npm:7.3.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/b77fa0f9ce83eebdb0f9142a016e67a23e9e6c8cb731a52aba13a008ba4a3aa9e57d2d0bb52a03be34aa2dd34580ce795857e87ccacbbb07f9c11d5b8dcd38a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
All in `penpot/frontend`:

 - terminal 1, `clojure -M:dev:funnel`
 - terminal 2, `clojure -M:dev:shadow-cljs-kaocha compile test`
 - terminal 3, `clojure -M:dev:test <other args>`

(PENDING: recompile automatically the bundle when source changes)