### PR TITLE
🐛  Fix search label in translations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix the “search” label in translations [Taiga #8402](https://tree.taiga.io/project/penpot/issue/8402)
 - Fix pencil loader [Taiga #8348](https://tree.taiga.io/project/penpot/issue/8348)
 
 ## 2.1.0 - Things can only get better!

--- a/frontend/src/app/main/ui/onboarding/questions.cljs
+++ b/frontend/src/app/main/ui/onboarding/questions.cljs
@@ -411,9 +411,9 @@
         (mf/with-memo []
           (-> (shuffle [{:label (tr "labels.youtube") :value "youtube"}
                         {:label (tr "labels.event") :value "event"}
-                        {:label (tr "labels.search") :value "search"}
-                        {:label (tr "labels.social") :value "social"}
-                        {:label (tr "labels.article") :value "article"}])
+                        {:label (tr "onboarding.questions.referer.search") :value "search"}
+                        {:label (tr "onboarding.questions.referer.social") :value "social"}
+                        {:label (tr "onboarding.questions.referer.article") :value "article"}])
               (conj {:label (tr "labels.other-short") :value "other"})))
 
         current-referer

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2581,15 +2581,15 @@ msgid "labels.event"
 msgstr "Event"
 
 #: src/app/main/ui/onboarding/questions.cljs
-msgid "labels.search"
+msgid "onboarding.questions.referer.search"
 msgstr "Search Engine (Google, Yahoo, Bing)"
 
 #: src/app/main/ui/onboarding/questions.cljs
-msgid "labels.social"
+msgid "onboarding.questions.referer.social"
 msgstr "Social Media (X, Linkedin, FB, etc)"
 
 #: src/app/main/ui/onboarding/questions.cljs
-msgid "labels.article"
+msgid "onboarding.questions.referer.article"
 msgstr "Article (Blog, Post, Newsletter)"
 
 #: src/app/main/ui/onboarding/questions.cljs


### PR DESCRIPTION
This PR fixes [ this bug](https://tree.taiga.io/project/penpot/issue/8402)
And now you should see the proper translation on swap components

![Screenshot from 2024-07-24 17-25-10](https://github.com/user-attachments/assets/0dbd1d15-1a89-4741-acdb-2b9b4fe392a1)
