### PR TITLE
♻️  move entire image build process into Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/bundles/

--- a/docker/images/Dockerfile.backend
+++ b/docker/images/Dockerfile.backend
@@ -1,3 +1,19 @@
+FROM penpotapp/devenv:latest AS build
+
+COPY --chown=penpot:users . /home/penpot/penpot
+WORKDIR /home/penpot/penpot
+USER penpot:users
+
+RUN ./manage.sh version > build_version.txt
+
+WORKDIR /home/penpot/penpot/backend
+RUN ./scripts/build $(cat ../build_version.txt)
+
+WORKDIR /home/penpot/penpot/bundles
+RUN cp -r ../backend/target/dist ./backend
+RUN cp -r ../build_version.txt ./backend/version.txt
+RUN ../manage.sh put-license-file ./backend
+
 FROM ubuntu:22.04
 
 LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
@@ -59,7 +75,7 @@ RUN set -eux; \
     tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
     rm -rf /tmp/openjdk.tar.gz;
 
-COPY --chown=penpot:penpot ./bundle-backend/ /opt/penpot/backend/
+COPY --from=build --chown=penpot:penpot /home/penpot/penpot/bundles/backend/ /opt/penpot/backend/
 
 USER penpot:penpot
 WORKDIR /opt/penpot/backend

--- a/docker/images/Dockerfile.exporter
+++ b/docker/images/Dockerfile.exporter
@@ -1,3 +1,19 @@
+FROM penpotapp/devenv:latest AS build
+
+COPY --chown=penpot:users . /home/penpot/penpot
+WORKDIR /home/penpot/penpot
+USER penpot:users
+
+RUN ./manage.sh version > build_version.txt
+
+WORKDIR /home/penpot/penpot/exporter
+RUN ./scripts/build $(cat ../build_version.txt)
+
+WORKDIR /home/penpot/penpot/bundles
+RUN cp -r ../exporter/target ./exporter
+RUN cp -r ../build_version.txt ./exporter/version.txt
+RUN ../manage.sh put-license-file ./exporter
+
 FROM ubuntu:22.04
 LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
 
@@ -95,7 +111,7 @@ RUN set -eux; \
     mkdir -p /opt/penpot; \
     chown -R penpot:penpot /opt/penpot;
 
-ADD --chown=penpot:penpot ./bundle-exporter/ /opt/penpot/exporter
+COPY --from=build --chown=penpot:penpot /home/penpot/penpot/bundles/exporter/ /opt/penpot/exporter/
 
 WORKDIR /opt/penpot/exporter
 USER penpot:penpot

--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -1,3 +1,19 @@
+FROM penpotapp/devenv:latest AS build
+
+COPY --chown=penpot:users . /home/penpot/penpot
+WORKDIR /home/penpot/penpot
+USER penpot:users
+
+RUN ./manage.sh version > build_version.txt
+
+WORKDIR /home/penpot/penpot/frontend
+RUN ./scripts/build $(cat ../build_version.txt)
+
+WORKDIR /home/penpot/penpot/bundles
+RUN cp -r ../frontend/target/dist ./frontend
+RUN cp -r ../build_version.txt ./frontend/version.txt
+RUN ../manage.sh put-license-file ./frontend
+
 FROM nginx:1.23
 LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
 
@@ -6,11 +22,11 @@ RUN set -ex; \
     mkdir -p /opt/data/assets; \
     chown -R penpot:penpot /opt/data;
 
-ADD ./bundle-frontend/ /var/www/app/
-ADD ./files/config.js /var/www/app/js/config.js
-ADD ./files/nginx.conf /etc/nginx/nginx.conf.template
-ADD ./files/nginx-mime.types /etc/nginx/mime.types
-ADD ./files/nginx-entrypoint.sh /entrypoint.sh
+COPY --from=build /home/penpot/penpot/bundles/frontend/ /var/www/app/
+ADD ./docker/images/files/config.js /var/www/app/js/config.js
+ADD ./docker/images/files/nginx.conf /etc/nginx/nginx.conf.template
+ADD ./docker/images/files/nginx-mime.types /etc/nginx/mime.types
+ADD ./docker/images/files/nginx-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
With this change the entire image build process happens inside the Dockerfile. To not deviate too much from the current build process, I simply moved the bundle creation process from the `manage.sh` script into the Dockerfile for each image (backend, frontend and exporter). \
Then utilizing multi-stage building the bundle gets created in a separate step running the devenv image and then gets copied over to the production image.

With this change, all images can simply be built with just one invocation of `docker build` for each image. With that and especially with the removal of the `docker run` step in the `manage.sh` script, images can now be built in unprivileged containers and therefore in a wider variety of CI solutions.

Closes #4900 