### PR TITLE
Revert ":bug: Set proper default tenant on exporter"

### DIFF
--- a/exporter/src/app/config.cljs
+++ b/exporter/src/app/config.cljs
@@ -17,7 +17,7 @@
 
 (def ^:private defaults
   {:public-uri "http://localhost:3449"
-   :tenant "dev"
+   :tenant "default"
    :host "localhost"
    :http-server-port 6061
    :http-server-host "0.0.0.0"


### PR DESCRIPTION
This reverts commit 86b2ce4dab9d70733c448e9b73c0905c6a66f949.
I'm not sure why this commit was made, but having the tenant be `dev` for the exporter by default, while for all other components the default tenant is `default`, breaks some communication between the exporter and other components (like e.g. the progress bar update messages) in a default deployment using docker compose as shown in the deployment docs.

Closes #4906 