### PR TITLE
:bug: Fix custom smtp port with ssl enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### :bug: Bugs fixed
 
 - User switch language to "zh_hant" will get 400 [Github #4884](https://github.com/penpot/penpot/issues/4884)
+- Smtp config ignoring port if ssl is set [Github #4872](https://github.com/penpot/penpot/issues/4872)
 
 ## 2.1.1
 

--- a/backend/src/app/email.clj
+++ b/backend/src/app/email.clj
@@ -306,6 +306,8 @@
       (let [session (create-smtp-session cfg)]
         (with-open [transport (.getTransport session (if (::ssl cfg) "smtps" "smtp"))]
           (.connect ^Transport transport
+                    ^String (::host cfg)
+                    ^String (::port cfg)
                     ^String (::username cfg)
                     ^String (::password cfg))
 


### PR DESCRIPTION
Related to https://tree.taiga.io/project/penpot/issue/8471

To replicate the issue you can start your backend with this settings:

```
export PENPOT_SMTP_HOST="kaleidos.net"
export PENPOT_SMTP_PORT=666
export PENPOT_SMTP_TLS=true
export PENPOT_SMTP_SSL=true
```

If you execute any action sending emails (for example retry an invitation) you will see the port used is the default one for ssl and not the specified one 