### PR TITLE
:bug: Fix layer sidebar in focus mode for long names

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layers.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.scss
@@ -91,6 +91,7 @@
   @include buttonStyle;
   display: grid;
   grid-template-columns: auto 1fr auto;
+  align-items: center;
   width: 100%;
   padding: 0;
 }
@@ -108,10 +109,8 @@
 }
 
 .focus-name {
+  @include textEllipsis;
   @include bodySmallTypography;
-  display: flex;
-  align-items: center;
-  height: 100%;
   padding-left: $s-4;
   color: var(--title-foreground-color);
 }


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/8255

<img width="280" alt="Screenshot 2024-08-09 at 12 54 02 PM" src="https://github.com/user-attachments/assets/6f627d6f-0d8a-4e86-9a0c-75f5d60dbc49">

Note re: the STR in the ticket: rather than by creating an image layer, this has to do with longer layer names. 