### PR TITLE
🐛 Add missing tooltips to typography options

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -293,6 +293,7 @@
          :show-recent show-recent}])
 
      [:div {:class (stl/css :font-option)
+            :title (tr "inspect.attributes.typography.font-family")
             :on-click #(reset! open-selector? true)}
       (cond
         (= :multiple font-id)
@@ -309,7 +310,8 @@
         (tr "dashboard.fonts.deleted-placeholder"))]
 
      [:div {:class (stl/css :font-modifiers)}
-      [:div {:class (stl/css :font-size-options)}
+      [:div {:class (stl/css :font-size-options)
+             :title (tr "inspect.attributes.typography.font-size")}
        (let [size-options [8 9 10 11 12 14 16 18 24 36 48 72]
              size-options (if (= font-size :multiple) (into [""] size-options) size-options)]
          [:& editable-select
@@ -324,7 +326,8 @@
            :on-change on-font-size-change
            :on-blur on-blur}])]
 
-      [:div {:class (stl/css :font-variant-options)}
+      [:div {:class (stl/css :font-variant-options)
+             :title (tr "inspect.attributes.typography.font-style")}
        (let [basic-variant-options (->> (:variants font)
                                         (map (fn [variant]
                                                {:value (:id variant)
@@ -336,7 +339,7 @@
                                       :key :multiple-variants
                                       :label "--"})
                                basic-variant-options)]
-               ;;  TODO Add disabled mode
+         ;;  TODO Add disabled mode
          [:& select
           {:class (stl/css :font-variant-select)
            :default-value (attr->string font-variant-id)
@@ -359,7 +362,8 @@
           (on-change {attr (str value)}))]
 
     [:div {:class (stl/css :spacing-options)}
-     [:div {:class (stl/css :line-height)}
+     [:div {:class (stl/css :line-height)
+            :title (tr "inspect.attributes.typography.line-height")}
       [:span {:class (stl/css :icon)
               :alt (tr "workspace.options.text-options.line-height")}
        i/text-lineheight]
@@ -375,7 +379,8 @@
         :on-change #(handle-change % :line-height)
         :on-blur on-blur}]]
 
-     [:div {:class (stl/css :letter-spacing)}
+     [:div {:class (stl/css :letter-spacing)
+            :title (tr "inspect.attributes.typography.letter-spacing")}
       [:span
        {:class (stl/css :icon)
         :alt (tr "workspace.options.text-options.letter-spacing")}
@@ -407,14 +412,17 @@
                         :name "text-transform"}
       [:& radio-button {:icon i/text-uppercase
                         :type "checkbox"
+                        :title (tr "inspect.attributes.typography.text-transform.uppercase")
                         :value "uppercase"
                         :id "text-transform-uppercase"}]
       [:& radio-button {:icon i/text-mixed
                         :type "checkbox"
                         :value "capitalize"
+                        :title (tr "inspect.attributes.typography.text-transform.titlecase")
                         :id "text-transform-capitalize"}]
       [:& radio-button {:icon i/text-lowercase
                         :type "checkbox"
+                        :title (tr "inspect.attributes.typography.text-transform.lowercase")
                         :value "lowercase"
                         :id "text-transform-lowercase"}]]]))
 


### PR DESCRIPTION
This PR fixes[ this bug](https://tree.taiga.io/project/penpot/issue/8572)