### PR TITLE
:bug: Fix cell size changed when scroll asset list

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.scss
@@ -101,8 +101,9 @@
 }
 
 .thumbnail {
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  width: 80%;
+  height: 80%;
   object-fit: contain;
   pointer-events: none;
   border: 0;
@@ -190,6 +191,7 @@
 
 .asset-list-thumbnail {
   @include flexCenter;
+  position: relative;
   flex-shrink: 0;
   padding: $s-2;
   height: $s-36;


### PR DESCRIPTION
Issue: https://github.com/penpot/penpot/issues/5004

Reason: The component thumbnails were being rendered in every cell, and the cells’ CSS had an aspect-ratio property. This caused the browser to calculate the actual width and height dynamically, leading to temporary changes in DOM size. As a result, during scrolling, these size changes affected the scrolling behavior.

Change: Set specific width and height values to prevent the DOM size from fluctuating during scrolling.

This is a small change, and I hope it can be accepted. Thank you very much!


