### PR TITLE
Enable translations for the DS / Storybook

### DIFF
--- a/frontend/resources/templates/preview-head.mustache
+++ b/frontend/resources/templates/preview-head.mustache
@@ -1,4 +1,5 @@
 <link href="./css/ds.css?ts={{& ts}}" rel="stylesheet" type="text/css" />
+
 <style>
   body {
     overflow-y: scroll;
@@ -8,3 +9,7 @@
     height: 100%;
   }
 </style>
+
+<script>
+  window.penpotTranslations = JSON.parse({{& translations}});
+</script>

--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -91,7 +91,6 @@
    :modules
    {:base
     {:entries []}
-
     :components
     {:exports {default app.main.ui.ds/default}
      :depends-on #{:base}}}

--- a/frontend/src/app/main/ui/ds.cljs
+++ b/frontend/src/app/main/ui/ds.cljs
@@ -6,6 +6,7 @@
 
 (ns app.main.ui.ds
   (:require
+   [app.config :as cf]
    [app.main.ui.ds.buttons.button :refer [button*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.forms.input :refer [input*]]
@@ -17,7 +18,11 @@
    [app.main.ui.ds.notifications.toast :refer [toast*]]
    [app.main.ui.ds.product.loader :refer [loader*]]
    [app.main.ui.ds.storybook :as sb]
-   [app.main.ui.ds.tab-switcher :refer [tab-switcher*]]))
+   [app.main.ui.ds.tab-switcher :refer [tab-switcher*]]
+   [app.util.i18n :as i18n]))
+
+
+(i18n/init! cf/translations)
 
 (def default
   "A export used for storybook"

--- a/frontend/src/app/main/ui/ds/product/loader.cljs
+++ b/frontend/src/app/main/ui/ds/product/loader.cljs
@@ -10,6 +10,7 @@
    [app.main.style :as stl])
   (:require
    [app.common.math :as mth]
+   [app.util.i18n :as i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
 (mf/defc loader-icon*
@@ -40,10 +41,8 @@
         h (or height (when (some? width) (mth/ceil (* width (/ 27 100)))) 27)
         class (dm/str (or class "") " " (stl/css-case :wrapper true
                                                       :wrapper-overlay overlay))
+        title (or title (tr "labels.loading"))
         props (mf/spread-props props {:class class})]
-
-    (assert title
-            (dm/str "You must provide an accesible name for the component"))
 
     [:> "div" props
      [:> loader-icon* {:title title

--- a/frontend/src/app/main/ui/ds/product/loader.stories.jsx
+++ b/frontend/src/app/main/ui/ds/product/loader.stories.jsx
@@ -7,10 +7,10 @@ export default {
   title: "Product/Loader",
   component: Loader,
   args: {
-    title: "Loading…",
     overlay: false,
   },
   argTypes: {
+    title: { control: "text" },
     width: { control: "number" },
     height: { control: "number" },
     overlay: { control: "boolean" },


### PR DESCRIPTION
Closes https://tree.taiga.io/project/penpot/task/8615

- **:sparkles: Add English translations to storybook template**
- **:sparkles: Use translations in a DS component story**

This PR:

- Adds translations to the Storybook template `preview-head`. To cut down file size and JSON parsing time, only English locale is added, and only those keys starting by `"labels."`.
- Exports a new `initTranslation` function meant to be used from within Storybook. This is needed so the translated strings are available to the i18n library.
- Uses the new capability in the `loader*` component, to set a default accessible title for the SVG (see screenshot below)

I'm not sure the `initTranslation` function exporting is done in the best way, please do check. I tried to use the `init-fn` setting in `shadow-cljs.edn` to have this function to run automatically but couldn't manage to do it :(

<img width="1019" alt="Screenshot 2024-08-30 at 3 43 21 PM" src="https://github.com/user-attachments/assets/81eb92f3-249f-4001-ad86-7d70a7bea438">
