### PR TITLE
:recycle: Refactor profile props

### DIFF
--- a/backend/src/app/http/websocket.clj
+++ b/backend/src/app/http/websocket.clj
@@ -279,9 +279,8 @@
   message)
 
 (def ^:private schema:params
-  (sm/define
-    [:map {:title "params"}
-     [:session-id ::sm/uuid]]))
+  [:map {:title "params"}
+   [:session-id ::sm/uuid]])
 
 (defn- http-handler
   [cfg {:keys [params ::session/profile-id] :as request}]

--- a/backend/src/app/http/websocket.clj
+++ b/backend/src/app/http/websocket.clj
@@ -282,9 +282,17 @@
   [:map {:title "params"}
    [:session-id ::sm/uuid]])
 
+(def ^:private decode-params
+  (sm/decoder schema:params sm/json-transformer))
+
+(def ^:private validate-params!
+  (sm/validate-fn schema:params))
+
 (defn- http-handler
   [cfg {:keys [params ::session/profile-id] :as request}]
-  (let [{:keys [session-id]} (sm/conform! schema:params params)]
+  (let [{:keys [session-id]} (-> params
+                                 decode-params
+                                 validate-params!)]
     (cond
       (not profile-id)
       (ex/raise :type :authentication

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -174,38 +174,34 @@
 ;; --- COMMAND QUERY: get-file (by id)
 
 (def schema:file
-  (sm/define
-    [:map {:title "File"}
-     [:id ::sm/uuid]
-     [:features ::cfeat/features]
-     [:has-media-trimmed ::sm/boolean]
-     [:comment-thread-seqn [::sm/int {:min 0}]]
-     [:name [:string {:max 250}]]
-     [:revn [::sm/int {:min 0}]]
-     [:modified-at ::dt/instant]
-     [:is-shared ::sm/boolean]
-     [:project-id ::sm/uuid]
-     [:created-at ::dt/instant]
-     [:data {:optional true} :any]]))
+  [:map {:title "File"}
+   [:id ::sm/uuid]
+   [:features ::cfeat/features]
+   [:has-media-trimmed ::sm/boolean]
+   [:comment-thread-seqn [::sm/int {:min 0}]]
+   [:name [:string {:max 250}]]
+   [:revn [::sm/int {:min 0}]]
+   [:modified-at ::dt/instant]
+   [:is-shared ::sm/boolean]
+   [:project-id ::sm/uuid]
+   [:created-at ::dt/instant]
+   [:data {:optional true} :any]])
 
 (def schema:permissions-mixin
-  (sm/define
-    [:map {:title "PermissionsMixin"}
-     [:permissions ::perms/permissions]]))
+  [:map {:title "PermissionsMixin"}
+   [:permissions ::perms/permissions]])
 
 (def schema:file-with-permissions
-  (sm/define
-    [:merge {:title "FileWithPermissions"}
-     schema:file
-     schema:permissions-mixin]))
+  [:merge {:title "FileWithPermissions"}
+   schema:file
+   schema:permissions-mixin])
 
 (def ^:private
   schema:get-file
-  (sm/define
-    [:map {:title "get-file"}
-     [:features {:optional true} ::cfeat/features]
-     [:id ::sm/uuid]
-     [:project-id {:optional true} ::sm/uuid]]))
+  [:map {:title "get-file"}
+   [:features {:optional true} ::cfeat/features]
+   [:id ::sm/uuid]
+   [:project-id {:optional true} ::sm/uuid]])
 
 (defn- migrate-file
   [{:keys [::db/conn] :as cfg} {:keys [id] :as file}]
@@ -914,10 +910,9 @@
 
 (def ^:private
   schema:set-file-shared
-  (sm/define
-    [:map {:title "set-file-shared"}
-     [:id ::sm/uuid]
-     [:is-shared ::sm/boolean]]))
+  [:map {:title "set-file-shared"}
+   [:id ::sm/uuid]
+   [:is-shared ::sm/boolean]])
 
 (sv/defmethod ::set-file-shared
   {::doc/added "1.17"
@@ -944,9 +939,8 @@
 
 (def ^:private
   schema:delete-file
-  (sm/define
-    [:map {:title "delete-file"}
-     [:id ::sm/uuid]]))
+  [:map {:title "delete-file"}
+   [:id ::sm/uuid]])
 
 (defn- delete-file
   [{:keys [::db/conn] :as cfg} {:keys [profile-id id] :as params}]
@@ -978,10 +972,9 @@
 
 (def ^:private
   schema:link-file-to-library
-  (sm/define
-    [:map {:title "link-file-to-library"}
-     [:file-id ::sm/uuid]
-     [:library-id ::sm/uuid]]))
+  [:map {:title "link-file-to-library"}
+   [:file-id ::sm/uuid]
+   [:library-id ::sm/uuid]])
 
 (sv/defmethod ::link-file-to-library
   {::doc/added "1.17"

--- a/backend/src/app/rpc/commands/files_thumbnails.clj
+++ b/backend/src/app/rpc/commands/files_thumbnails.clj
@@ -179,18 +179,16 @@
 
 (def ^:private
   schema:get-file-data-for-thumbnail
-  (sm/define
-    [:map {:title "get-file-data-for-thumbnail"}
-     [:file-id ::sm/uuid]
-     [:features {:optional true} ::cfeat/features]]))
+  [:map {:title "get-file-data-for-thumbnail"}
+   [:file-id ::sm/uuid]
+   [:features {:optional true} ::cfeat/features]])
 
 (def ^:private
   schema:partial-file
-  (sm/define
-    [:map {:title "PartialFile"}
-     [:id ::sm/uuid]
-     [:revn {:min 0} ::sm/int]
-     [:page :any]]))
+  [:map {:title "PartialFile"}
+   [:id ::sm/uuid]
+   [:revn {:min 0} ::sm/int]
+   [:page :any]])
 
 (sv/defmethod ::get-file-data-for-thumbnail
   "Retrieves the data for generate the thumbnail of the file. Used

--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -88,10 +88,9 @@
 
 (def ^:private
   schema:duplicate-file
-  (sm/define
-    [:map {:title "duplicate-file"}
-     [:file-id ::sm/uuid]
-     [:name {:optional true} [:string {:max 250}]]]))
+  [:map {:title "duplicate-file"}
+   [:file-id ::sm/uuid]
+   [:name {:optional true} [:string {:max 250}]]])
 
 (sv/defmethod ::duplicate-file
   "Duplicate a single file in the same team."
@@ -150,10 +149,9 @@
 
 (def ^:private
   schema:duplicate-project
-  (sm/define
-    [:map {:title "duplicate-project"}
-     [:project-id ::sm/uuid]
-     [:name {:optional true} [:string {:max 250}]]]))
+  [:map {:title "duplicate-project"}
+   [:project-id ::sm/uuid]
+   [:name {:optional true} [:string {:max 250}]]])
 
 (sv/defmethod ::duplicate-project
   "Duplicate an entire project with all the files"
@@ -327,10 +325,9 @@
 
 (def ^:private
   schema:move-files
-  (sm/define
-    [:map {:title "move-files"}
-     [:ids ::sm/set-of-uuid]
-     [:project-id ::sm/uuid]]))
+  [:map {:title "move-files"}
+   [:ids ::sm/set-of-uuid]
+   [:project-id ::sm/uuid]])
 
 (sv/defmethod ::move-files
   "Move a set of files from one project to other."

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -109,11 +109,10 @@
 
 (def ^:private
   schema:update-profile
-  (sm/define
-    [:map {:title "update-profile"}
-     [:fullname [::sm/word-string {:max 250}]]
-     [:lang {:optional true} [:string {:max 8}]]
-     [:theme {:optional true} [:string {:max 250}]]]))
+  [:map {:title "update-profile"}
+   [:fullname [::sm/word-string {:max 250}]]
+   [:lang {:optional true} [:string {:max 8}]]
+   [:theme {:optional true} [:string {:max 250}]]])
 
 (sv/defmethod ::update-profile
   {::doc/added "1.0"
@@ -154,11 +153,10 @@
 
 (def ^:private
   schema:update-profile-password
-  (sm/define
-    [:map {:title "update-profile-password"}
-     [:password [::sm/word-string {:max 500}]]
-     ;; Social registered users don't have old-password
-     [:old-password {:optional true} [:maybe [::sm/word-string {:max 500}]]]]))
+  [:map {:title "update-profile-password"}
+   [:password [::sm/word-string {:max 500}]]
+   ;; Social registered users don't have old-password
+   [:old-password {:optional true} [:maybe [::sm/word-string {:max 500}]]]])
 
 (sv/defmethod ::update-profile-password
   {::doc/added "1.0"
@@ -209,9 +207,8 @@
 
 (def ^:private
   schema:update-profile-photo
-  (sm/define
-    [:map {:title "update-profile-photo"}
-     [:file ::media/upload]]))
+  [:map {:title "update-profile-photo"}
+   [:file ::media/upload]])
 
 (sv/defmethod ::update-profile-photo
   {:doc/added "1.1"
@@ -278,9 +275,8 @@
 
 (def ^:private
   schema:request-email-change
-  (sm/define
-    [:map {:title "request-email-change"}
-     [:email ::sm/email]]))
+  [:map {:title "request-email-change"}
+   [:email ::sm/email]])
 
 (sv/defmethod ::request-email-change
   {::doc/added "1.0"

--- a/backend/src/app/rpc/quotes.clj
+++ b/backend/src/app/rpc/quotes.clj
@@ -26,14 +26,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^:private schema:quote
-  (sm/define
-    [:map {:title "Quote"}
-     [::team-id {:optional true} ::sm/uuid]
-     [::project-id {:optional true} ::sm/uuid]
-     [::file-id {:optional true} ::sm/uuid]
-     [::incr {:optional true} [::sm/int {:min 0}]]
-     [::id :keyword]
-     [::profile-id ::sm/uuid]]))
+  [:map {:title "Quote"}
+   [::team-id {:optional true} ::sm/uuid]
+   [::project-id {:optional true} ::sm/uuid]
+   [::file-id {:optional true} ::sm/uuid]
+   [::incr {:optional true} [::sm/int {:min 0}]]
+   [::id :keyword]
+   [::profile-id ::sm/uuid]])
 
 (def ^:private enabled (volatile! true))
 

--- a/backend/src/app/setup/templates.clj
+++ b/backend/src/app/setup/templates.clj
@@ -21,16 +21,14 @@
 
 (def ^:private
   schema:template
-  (sm/define
-    [:map {:title "Template"}
-     [:id ::sm/word-string]
-     [:name ::sm/word-string]
-     [:file-uri ::sm/word-string]]))
+  [:map {:title "Template"}
+   [:id ::sm/word-string]
+   [:name ::sm/word-string]
+   [:file-uri ::sm/word-string]])
 
 (def ^:private
   schema:templates
-  (sm/define
-    [:vector schema:template]))
+  [:vector schema:template])
 
 (defmethod ig/init-key ::setup/templates
   [_ _]

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -57,16 +57,17 @@
     :misplaced-slot
     :missing-slot})
 
-(def ^:private
-  schema:error
-  (sm/define
-    [:map {:title "ValidationError"}
-     [:code {:optional false} [::sm/one-of error-codes]]
-     [:hint {:optional false} :string]
-     [:shape {:optional true} :map] ; Cannot validate a shape because here it may be broken
-     [:shape-id {:optional true} ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:page-id {:optional true} [:maybe ::sm/uuid]]]))
+(def ^:private schema:error
+  [:map {:title "ValidationError"}
+   [:code {:optional false} [::sm/one-of error-codes]]
+   [:hint {:optional false} :string]
+   [:shape {:optional true} :map] ; Cannot validate a shape because here it may be broken
+   [:shape-id {:optional true} ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:page-id {:optional true} [:maybe ::sm/uuid]]])
+
+(def check-error!
+  (sm/check-fn schema:error))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ERROR HANDLING
@@ -95,7 +96,7 @@
 
     (dm/assert!
      "expected valid error"
-     (sm/check! schema:error error))
+     (check-error! error))
 
     (vswap! *errors* conj error)))
 

--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -19,33 +19,31 @@
    [potok.v2.core :as ptk]))
 
 (def ^:private schema:comment-thread
-  (sm/define
-    [:map {:title "CommentThread"}
-     [:id ::sm/uuid]
-     [:page-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:project-id ::sm/uuid]
-     [:owner-id ::sm/uuid]
-     [:page-name :string]
-     [:file-name :string]
-     [:seqn :int]
-     [:content :string]
-     [:participants ::sm/set-of-uuid]
-     [:created-at ::sm/inst]
-     [:modified-at ::sm/inst]
-     [:position ::gpt/point]
-     [:count-unread-comments {:optional true} :int]
-     [:count-comments {:optional true} :int]]))
+  [:map {:title "CommentThread"}
+   [:id ::sm/uuid]
+   [:page-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:project-id ::sm/uuid]
+   [:owner-id ::sm/uuid]
+   [:page-name :string]
+   [:file-name :string]
+   [:seqn :int]
+   [:content :string]
+   [:participants ::sm/set-of-uuid]
+   [:created-at ::sm/inst]
+   [:modified-at ::sm/inst]
+   [:position ::gpt/point]
+   [:count-unread-comments {:optional true} :int]
+   [:count-comments {:optional true} :int]])
 
 (def ^:private schema:comment
-  (sm/define
-    [:map {:title "Comment"}
-     [:id ::sm/uuid]
-     [:thread-id ::sm/uuid]
-     [:owner-id ::sm/uuid]
-     [:created-at ::sm/inst]
-     [:modified-at ::sm/inst]
-     [:content :string]]))
+  [:map {:title "Comment"}
+   [:id ::sm/uuid]
+   [:thread-id ::sm/uuid]
+   [:owner-id ::sm/uuid]
+   [:created-at ::sm/inst]
+   [:modified-at ::sm/inst]
+   [:content :string]])
 
 (def check-comment-thread!
   (sm/check-fn schema:comment-thread))
@@ -84,12 +82,11 @@
 
 (def ^:private
   schema:create-thread-on-workspace
-  (sm/define
-    [:map {:title "created-thread-on-workspace"}
-     [:page-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:position ::gpt/point]
-     [:content :string]]))
+  [:map {:title "created-thread-on-workspace"}
+   [:page-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:position ::gpt/point]
+   [:content :string]])
 
 (defn create-thread-on-workspace
   [params]
@@ -136,13 +133,12 @@
 
 (def ^:private
   schema:create-thread-on-viewer
-  (sm/define
-    [:map {:title "created-thread-on-viewer"}
-     [:page-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:frame-id ::sm/uuid]
-     [:position ::gpt/point]
-     [:content :string]]))
+  [:map {:title "created-thread-on-viewer"}
+   [:page-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:frame-id ::sm/uuid]
+   [:position ::gpt/point]
+   [:content :string]])
 
 (defn create-thread-on-viewer
   [params]
@@ -469,11 +465,10 @@
 
 (def ^:private
   schema:create-draft
-  (sm/define
-    [:map {:title "create-draft"}
-     [:page-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:position ::gpt/point]]))
+  [:map {:title "create-draft"}
+   [:page-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:position ::gpt/point]])
 
 (defn create-draft
   [params]

--- a/frontend/src/app/main/data/events.cljs
+++ b/frontend/src/app/main/data/events.cljs
@@ -15,7 +15,7 @@
    [app.util.http :as http]
    [app.util.i18n :as i18n]
    [app.util.object :as obj]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
    [beicon.v2.operators :as rxo]
@@ -170,7 +170,7 @@
         (let [session (atom nil)
               stopper (rx/filter (ptk/type? ::initialize) stream)
               buffer  (atom #queue [])
-              profile (->> (rx/from-atom storage {:emit-current-value? true})
+              profile (->> (rx/from-atom storage/user {:emit-current-value? true})
                            (rx/map :profile)
                            (rx/map :id)
                            (rx/pipe (rxo/distinct-contiguous)))]

--- a/frontend/src/app/main/data/fonts.cljs
+++ b/frontend/src/app/main/data/fonts.cljs
@@ -18,7 +18,7 @@
    [app.main.repo :as rp]
    [app.main.store :as st]
    [app.util.i18n :refer [tr]]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [app.util.webapi :as wa]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
@@ -335,8 +335,9 @@
         (assoc-in state [:workspace-data :recent-fonts] most-recent-fonts)))
     ptk/EffectEvent
     (effect [_ state _]
-      (let [most-recent-fonts      (get-in state [:workspace-data :recent-fonts])]
-        (swap! storage assoc ::recent-fonts most-recent-fonts)))))
+      (let [most-recent-fonts (get-in state [:workspace-data :recent-fonts])]
+        ;; FIXME: this should be prefixed by team
+        (swap! storage/user assoc ::recent-fonts most-recent-fonts)))))
 
 (defn load-recent-fonts
   [fonts]
@@ -344,7 +345,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (let [fonts-map (d/index-by :id fonts)
-            saved-recent-fonts (->> (::recent-fonts @storage)
+            saved-recent-fonts (->> (::recent-fonts storage/user)
                                     (keep #(get fonts-map (:id %)))
                                     (into #{}))]
         (assoc-in state [:workspace-data :recent-fonts] saved-recent-fonts)))))

--- a/frontend/src/app/main/data/shortcuts.cljs
+++ b/frontend/src/app/main/data/shortcuts.cljs
@@ -129,12 +129,11 @@
 
 (def ^:private
   schema:shortcuts
-  (sm/define
-    [:map-of :keyword
-     [:map
-      [:command [:or :string [:vector :any]]]
-      [:fn {:optional true} fn?]
-      [:tooltip {:optional true} :string]]]))
+  [:map-of :keyword
+   [:map
+    [:command [:or :string [:vector :any]]]
+    [:fn {:optional true} fn?]
+    [:tooltip {:optional true} :string]]])
 
 (def check-shortcuts!
   (sm/check-fn schema:shortcuts))

--- a/frontend/src/app/main/data/users.cljs
+++ b/frontend/src/app/main/data/users.cljs
@@ -32,14 +32,13 @@
 
 (def ^:private
   schema:profile
-  (sm/define
-    [:map {:title "Profile"}
-     [:id ::sm/uuid]
-     [:created-at {:optional true} :any]
-     [:fullname {:optional true} :string]
-     [:email {:optional true} :string]
-     [:lang {:optional true} :string]
-     [:theme {:optional true} :string]]))
+  [:map {:title "Profile"}
+   [:id ::sm/uuid]
+   [:created-at {:optional true} :any]
+   [:fullname {:optional true} :string]
+   [:email {:optional true} :string]
+   [:lang {:optional true} :string]
+   [:theme {:optional true} :string]])
 
 (def check-profile!
   (sm/check-fn schema:profile))
@@ -251,10 +250,9 @@
              (rx/catch on-error))))))
 
 (def ^:private schema:login-with-ldap
-  (sm/define
-    [:map
-     [:email ::sm/email]
-     [:password :string]]))
+  [:map {:title "login-with-ldap"}
+   [:email ::sm/email]
+   [:password :string]])
 
 (defn login-with-ldap
   [params]
@@ -484,6 +482,7 @@
 
     ;; TODO: for the release 1.13 we should skip fetching profile and just use
     ;; the response value of update-profile-props RPC call
+    ;; FIXME
     ptk/WatchEvent
     (watch [_ _ _]
       (->> (rp/cmd! :update-profile-props {:props props})
@@ -593,9 +592,8 @@
 
 (def ^:private
   schema:request-profile-recovery
-  (sm/define
-    [:map {:title "request-profile-recovery" :closed true}
-     [:email ::sm/email]]))
+  [:map {:title "request-profile-recovery" :closed true}
+   [:email ::sm/email]])
 
 (defn request-profile-recovery
   [data]
@@ -619,10 +617,9 @@
 
 (def ^:private
   schema:recover-profile
-  (sm/define
-    [:map {:title "recover-profile" :closed true}
-     [:password :string]
-     [:token :string]]))
+  [:map {:title "recover-profile" :closed true}
+   [:password :string]
+   [:token :string]])
 
 (defn recover-profile
   [data]

--- a/frontend/src/app/main/data/users.cljs
+++ b/frontend/src/app/main/data/users.cljs
@@ -22,7 +22,7 @@
    [app.plugins.register :as register]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
-   [app.util.storage :as s]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -52,14 +52,14 @@
 
 (defn get-current-team-id
   [profile]
-  (let [team-id (::current-team-id @s/storage)]
+  (let [team-id (::current-team-id storage/user)]
     (or team-id (:default-team-id profile))))
 
 (defn set-current-team!
   [team-id]
   (if (nil? team-id)
-    (swap! s/storage dissoc ::current-team-id)
-    (swap! s/storage assoc ::current-team-id team-id)))
+    (swap! storage/user dissoc ::current-team-id)
+    (swap! storage/user assoc ::current-team-id team-id)))
 
 ;; --- EVENT: fetch-teams
 
@@ -79,9 +79,9 @@
       ;; if not, dissoc it from storage.
 
       (let [ids (into #{} (map :id) teams)]
-        (when-let [ctid (::current-team-id @s/storage)]
+        (when-let [ctid (::current-team-id storage/user)]
           (when-not (contains? ids ctid)
-            (swap! s/storage dissoc ::current-team-id)))))))
+            (swap! storage/user dissoc ::current-team-id)))))))
 
 (defn fetch-teams
   []
@@ -132,10 +132,10 @@
     (effect [_ state _]
       (let [profile          (:profile state)
             email            (:email profile)
-            previous-profile (:profile @s/storage)
+            previous-profile (:profile storage/user)
             previous-email   (:email previous-profile)]
         (when profile
-          (swap! s/storage assoc :profile profile)
+          (swap! storage/user assoc :profile profile)
           (i18n/set-locale! (:lang profile))
           (when (not= previous-email email)
             (set-current-team! nil))
@@ -334,7 +334,7 @@
      ptk/EffectEvent
      (effect [_ _ _]
        ;; We prefer to keek some stuff in the storage like the current-team-id and the profile
-       (swap! s/storage (constantly {}))))))
+       (swap! storage/user (constantly {}))))))
 
 (defn logout
   ([] (logout {}))

--- a/frontend/src/app/main/data/viewer.cljs
+++ b/frontend/src/app/main/data/viewer.cljs
@@ -49,11 +49,10 @@
 
 (def ^:private
   schema:initialize
-  (sm/define
-    [:map {:title "initialize"}
-     [:file-id ::sm/uuid]
-     [:share-id {:optional true} [:maybe ::sm/uuid]]
-     [:page-id {:optional true} ::sm/uuid]]))
+  [:map {:title "initialize"}
+   [:file-id ::sm/uuid]
+   [:share-id {:optional true} [:maybe ::sm/uuid]]
+   [:page-id {:optional true} ::sm/uuid]])
 
 (defn initialize
   [{:keys [file-id share-id interactions-show?] :as params}]
@@ -102,11 +101,10 @@
 
 (def ^:private
   schema:fetch-bundle
-  (sm/define
-    [:map {:title "fetch-bundle"}
-     [:page-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:share-id {:optional true} ::sm/uuid]]))
+  [:map {:title "fetch-bundle"}
+   [:page-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:share-id {:optional true} ::sm/uuid]])
 
 (defn- fetch-bundle
   [{:keys [file-id share-id] :as params}]

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -79,7 +79,7 @@
    [app.util.http :as http]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [app.util.timers :as tm]
    [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
@@ -336,7 +336,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (assoc state
-             :recent-colors (:recent-colors @storage)
+             :recent-colors (:recent-colors storage/user)
              :workspace-ready? false
              :current-file-id file-id
              :current-project-id project-id

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1676,17 +1676,19 @@
 
 (def ^:private
   schema:paste-data
-  (sm/define
-    [:map {:title "paste-data"}
-     [:type [:= :copied-shapes]]
-     [:features ::sm/set-of-strings]
-     [:version :int]
-     [:file-id ::sm/uuid]
-     [:selected ::sm/set-of-uuid]
-     [:objects
-      [:map-of ::sm/uuid :map]]
-     [:images [:set :map]]
-     [:position {:optional true} ::gpt/point]]))
+  [:map {:title "paste-data"}
+   [:type [:= :copied-shapes]]
+   [:features ::sm/set-of-strings]
+   [:version :int]
+   [:file-id ::sm/uuid]
+   [:selected ::sm/set-of-uuid]
+   [:objects
+    [:map-of ::sm/uuid :map]]
+   [:images [:set :map]]
+   [:position {:optional true} ::gpt/point]])
+
+(def validate-paste-data!
+  (sm/validate-fn schema:paste-data))
 
 (defn- paste-transit
   [{:keys [images] :as pdata}]
@@ -1711,9 +1713,8 @@
         (let [file-id (:current-file-id state)
               features (features/get-team-enabled-features state)]
 
-          (sm/validate! schema:paste-data pdata
-                        {:hint "invalid paste data"
-                         :code :invalid-paste-data})
+          (validate-paste-data! pdata {:hint "invalid paste data"
+                                       :code :invalid-paste-data})
 
           (cfeat/check-paste-features! features (:features pdata))
           (if (= file-id (:file-id pdata))

--- a/frontend/src/app/main/data/workspace/assets.cljs
+++ b/frontend/src/app/main/data/workspace/assets.cljs
@@ -7,22 +7,22 @@
 (ns app.main.data.workspace.assets
   "Workspace assets management events and helpers."
   (:require
-   [app.util.storage :refer [storage]]))
+   [app.util.storage :as storage]))
 
 (defn get-current-assets-ordering
   []
-  (let [ordering (::ordering @storage)]
+  (let [ordering (::ordering storage/user)]
     (or ordering :asc)))
 
 (defn set-current-assets-ordering!
   [ordering]
-  (swap! storage assoc ::ordering ordering))
+  (swap! storage/user assoc ::ordering ordering))
 
 (defn get-current-assets-list-style
   []
-  (let [list-style (::list-style @storage)]
+  (let [list-style (::list-style storage/user)]
     (or list-style :thumbs)))
 
 (defn set-current-assets-list-style!
   [list-style]
-  (swap! storage assoc ::list-style list-style))
+  (swap! storage/user assoc ::list-style list-style))

--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -22,7 +22,7 @@
    [app.main.data.workspace.texts :as dwt]
    [app.main.data.workspace.undo :as dwu]
    [app.util.color :as uc]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
    [potok.v2.core :as ptk]))
@@ -718,9 +718,9 @@
 
 (defn get-active-color-tab
   []
-  (let [tab (::tab @storage)]
+  (let [tab (::tab storage/user)]
     (or tab :ramp)))
 
 (defn set-active-color-tab!
   [tab]
-  (swap! storage assoc ::tab tab))
+  (swap! storage/user assoc ::tab tab))

--- a/frontend/src/app/main/data/workspace/layout.cljs
+++ b/frontend/src/app/main/data/workspace/layout.cljs
@@ -10,7 +10,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.main.data.events :as ev]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [clojure.set :as set]
    [potok.v2.core :as ptk]))
 
@@ -144,7 +144,7 @@
   stored in Storage."
   [layout]
   (reduce (fn [layout [flag key]]
-            (condp = (get @storage key ::none)
+            (condp = (get storage/user key ::none)
               ::none layout
               false  (disj layout flag)
               true   (conj layout flag)))
@@ -155,7 +155,7 @@
   "Given a set of layout flags, and persist a subset of them to the Storage."
   [layout]
   (doseq [[flag key] layout-flags-persistence-mapping]
-    (swap! storage assoc key (contains? layout flag))))
+    (swap! storage/user assoc key (contains? layout flag))))
 
 (def layout-state-persistence-mapping
   "A mapping of keys that need to be persisted from `:workspace-global` into Storage."
@@ -167,7 +167,7 @@
   props that are previously persisted in the Storage."
   [state]
   (reduce (fn [state [key skey]]
-            (let [val (get @storage skey ::none)]
+            (let [val (get storage/user skey ::none)]
               (if (= val ::none)
                 state
                 (assoc state key val))))
@@ -181,7 +181,7 @@
   (doseq [[key skey] layout-state-persistence-mapping]
     (let [val (get state key ::does-not-exist)]
       (if (= val ::does-not-exist)
-        (swap! storage dissoc skey)
-        (swap! storage assoc skey val)))))
+        (swap! storage/user dissoc skey)
+        (swap! storage/user assoc skey val)))))
 
 

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -48,7 +48,7 @@
    [app.util.color :as uc]
    [app.util.i18n :refer [tr]]
    [app.util.router :as rt]
-   [app.util.storage :as s]
+   [app.util.storage :as storage]
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
@@ -147,7 +147,7 @@
     ptk/EffectEvent
     (effect [_ state _]
       (let [recent-colors (:recent-colors state)]
-        (swap! s/storage assoc :recent-colors recent-colors)))))
+        (swap! storage/user assoc :recent-colors recent-colors)))))
 
 (def clear-color-for-rename
   (ptk/reify ::clear-color-for-rename

--- a/frontend/src/app/main/data/workspace/media.cljs
+++ b/frontend/src/app/main/data/workspace/media.cljs
@@ -200,14 +200,13 @@
 
 (def ^:private
   schema:process-media-objects
-  (sm/define
-    [:map {:title "process-media-objects"}
-     [:file-id ::sm/uuid]
-     [:local? :boolean]
-     [:name {:optional true} :string]
-     [:data {:optional true} :any] ; FIXME
-     [:uris {:optional true} [:sequential :string]]
-     [:mtype {:optional true} :string]]))
+  [:map {:title "process-media-objects"}
+   [:file-id ::sm/uuid]
+   [:local? :boolean]
+   [:name {:optional true} :string]
+   [:data {:optional true} :any] ; FIXME
+   [:uris {:optional true} [:sequential :string]]
+   [:mtype {:optional true} :string]])
 
 (defn- process-media-objects
   [{:keys [uris on-error] :as params}]
@@ -427,10 +426,9 @@
 
 (def ^:private
   schema:clone-media-object
-  (sm/define
-    [:map {:title "clone-media-object"}
-     [:file-id ::sm/uuid]
-     [:object-id ::sm/uuid]]))
+  [:map {:title "clone-media-object"}
+   [:file-id ::sm/uuid]
+   [:object-id ::sm/uuid]])
 
 (defn clone-media-object
   [{:keys [file-id object-id] :as params}]

--- a/frontend/src/app/main/data/workspace/notifications.cljs
+++ b/frontend/src/app/main/data/workspace/notifications.cljs
@@ -198,21 +198,23 @@
 
 (def ^:private
   schema:handle-file-change
-  (sm/define
-    [:map {:title "handle-file-change"}
-     [:type :keyword]
-     [:profile-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:session-id ::sm/uuid]
-     [:revn :int]
-     [:changes ::cpc/changes]]))
+  [:map {:title "handle-file-change"}
+   [:type :keyword]
+   [:profile-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:session-id ::sm/uuid]
+   [:revn :int]
+   [:changes ::cpc/changes]])
+
+(def ^:private check-file-change-params!
+  (sm/check-fn schema:handle-file-change))
 
 (defn handle-file-change
   [{:keys [file-id changes revn] :as msg}]
 
   (dm/assert!
    "expected valid parameters"
-   (sm/check! schema:handle-file-change msg))
+   (check-file-change-params! msg))
 
   (ptk/reify ::handle-file-change
     IDeref
@@ -230,23 +232,24 @@
                           :redo-changes (vec changes)
                           :undo-changes []})))))
 
-(def ^:private
-  schema:handle-library-change
-  (sm/define
-    [:map {:title "handle-library-change"}
-     [:type :keyword]
-     [:profile-id ::sm/uuid]
-     [:file-id ::sm/uuid]
-     [:session-id ::sm/uuid]
-     [:revn :int]
-     [:modified-at ::sm/inst]
-     [:changes ::cpc/changes]]))
+(def ^:private schema:handle-library-change
+  [:map {:title "handle-library-change"}
+   [:type :keyword]
+   [:profile-id ::sm/uuid]
+   [:file-id ::sm/uuid]
+   [:session-id ::sm/uuid]
+   [:revn :int]
+   [:modified-at ::sm/inst]
+   [:changes ::cpc/changes]])
+
+(def ^:private check-library-change-params!
+  (sm/check-fn schema:handle-library-change))
 
 (defn handle-library-change
   [{:keys [file-id modified-at changes revn] :as msg}]
   (dm/assert!
    "expected valid arguments"
-   (sm/check! schema:handle-library-change msg))
+   (check-library-change-params! msg))
 
   (ptk/reify ::handle-library-change
     ptk/WatchEvent

--- a/frontend/src/app/main/data/workspace/path/common.cljs
+++ b/frontend/src/app/main/data/workspace/path/common.cljs
@@ -27,20 +27,19 @@
 
 (def ^:private
   schema:path-content
-  (sm/define
-    [:vector {:title "PathContent"}
-     [:map {:title "PathContentEntry"}
-      [:command [::sm/one-of valid-commands]]
-      ;; FIXME: remove the `?` from prop name
-      [:relative? {:optional true} :boolean]
-      [:params {:optional true}
-       [:map {:title "PathContentEntryParams"}
-        [:x :double]
-        [:y :double]
-        [:c1x {:optional true} :double]
-        [:c1y {:optional true} :double]
-        [:c2x {:optional true} :double]
-        [:c2y {:optional true} :double]]]]]))
+  [:vector {:title "PathContent"}
+   [:map {:title "PathContentEntry"}
+    [:command [::sm/one-of valid-commands]]
+    ;; FIXME: remove the `?` from prop name
+    [:relative? {:optional true} :boolean]
+    [:params {:optional true}
+     [:map {:title "PathContentEntryParams"}
+      [:x :double]
+      [:y :double]
+      [:c1x {:optional true} :double]
+      [:c1y {:optional true} :double]
+      [:c2x {:optional true} :double]
+      [:c2y {:optional true} :double]]]]])
 
 (def check-path-content!
   (sm/check-fn schema:path-content))

--- a/frontend/src/app/main/data/workspace/undo.cljs
+++ b/frontend/src/app/main/data/workspace/undo.cljs
@@ -26,10 +26,9 @@
 
 (def ^:private
   schema:undo-entry
-  (sm/define
-    [:map {:title "undo-entry"}
-     [:undo-changes [:vector ::cpc/change]]
-     [:redo-changes [:vector ::cpc/change]]]))
+  [:map {:title "undo-entry"}
+   [:undo-changes [:vector ::cpc/change]]
+   [:redo-changes [:vector ::cpc/change]]])
 
 (def check-undo-entry!
   (sm/check-fn schema:undo-entry))

--- a/frontend/src/app/main/ui/auth/register.cljs
+++ b/frontend/src/app/main/ui/auth/register.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.icons :as i]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.router :as rt]
-   [app.util.storage :as sto]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
@@ -198,7 +198,7 @@
 
                :else
                (do
-                 (swap! sto/storage assoc ::email (:email params))
+                 (swap! storage/user assoc ::email (:email params))
                  (st/emit! (rt/nav :auth-register-success)))))))
 
         on-error
@@ -264,7 +264,7 @@
 (mf/defc register-success-page
   {::mf/props :obj}
   [{:keys [params]}]
-  (let [email (or (:email params) (::email @sto/storage))]
+  (let [email (or (:email params) (::email storage/user))]
     [:div {:class (stl/css :auth-form-wrapper :register-success)}
      (when-not (:hide-logo params)
        [:h1 {:class (stl/css :logo-container)}

--- a/frontend/src/app/main/ui/hooks.cljs
+++ b/frontend/src/app/main/ui/hooks.cljs
@@ -16,7 +16,7 @@
    [app.main.store :as st]
    [app.util.dom :as dom]
    [app.util.dom.dnd :as dnd]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [app.util.timers :as ts]
    [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
@@ -294,7 +294,7 @@
   `key` for new values."
   [key default]
   (let [id     (mf/use-id)
-        state* (mf/use-state #(get @storage key default))
+        state* (mf/use-state #(get storage/user key default))
         state  (deref state*)
         stream (mf/with-memo [id]
                  (->> mbc/stream
@@ -304,7 +304,7 @@
 
     (mf/with-effect [state key id]
       (mbc/emit! id key state)
-      (swap! storage assoc key state))
+      (swap! storage/user assoc key state))
 
     (use-stream stream (partial reset! state*))
 

--- a/frontend/src/app/main/ui/hooks/resize.cljs
+++ b/frontend/src/app/main/ui/hooks/resize.cljs
@@ -14,7 +14,7 @@
    [app.main.ui.context :as ctx]
    [app.main.ui.hooks :as hooks]
    [app.util.dom :as dom]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [rumext.v2 :as mf]))
 
 (log/set-level! :warn)
@@ -23,7 +23,7 @@
 
 (defn- get-initial-state
   [initial file-id key]
-  (let [saved (dm/get-in @storage [::state file-id key])]
+  (let [saved (dm/get-in storage/user [::state file-id key])]
     (d/nilv saved initial)))
 
 (defn- update-persistent-state
@@ -81,7 +81,7 @@
                     start-size (mf/ref-val start-size-ref)
                     new-size (-> (+ start-size delta) (max min-val) (min max-val))]
                 (reset! current-size* new-size)
-                (swap! storage update-persistent-state file-id key new-size)))))
+                (swap! storage/user update-persistent-state file-id key new-size)))))
 
          set-size
          (mf/use-fn
@@ -89,7 +89,7 @@
           (fn [new-size]
             (let [new-size (mth/clamp new-size min-val max-val)]
               (reset! current-size* new-size)
-              (swap! storage update-persistent-state file-id key new-size))))]
+              (swap! storage/user update-persistent-state file-id key new-size))))]
 
      (mf/with-effect [on-change-size current-size]
        (when on-change-size

--- a/frontend/src/app/util/i18n.cljs
+++ b/frontend/src/app/util/i18n.cljs
@@ -11,7 +11,7 @@
    [app.common.logging :as log]
    [app.config :as cfg]
    [app.util.globals :as globals]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [cuerdas.core :as str]
    [goog.object :as gobj]
    [okulary.core :as l]
@@ -76,7 +76,7 @@
         cfg/default-language))))
 
 (defonce translations #js {})
-(defonce locale (l/atom (or (get @storage ::locale)
+(defonce locale (l/atom (or (get storage/global ::locale)
                             (autodetect))))
 
 (defn init!
@@ -93,7 +93,7 @@
   (if (or (nil? lname)
           (str/empty? lname))
     (let [lname (autodetect)]
-      (swap! storage dissoc ::locale)
+      (swap! storage/global dissoc ::locale)
       (reset! locale lname))
     (let [supported (into #{} (map :value supported-locales))
           lname     (loop [locales (seq (parse-locale lname))]
@@ -102,7 +102,7 @@
                           locale
                           (recur (rest locales)))
                         cfg/default-language))]
-      (swap! storage assoc ::locale lname)
+      (swap! storage/global assoc ::locale lname)
       (reset! locale lname))))
 
 (deftype C [val]

--- a/frontend/src/app/util/storage.cljs
+++ b/frontend/src/app/util/storage.cljs
@@ -10,7 +10,8 @@
    [app.common.transit :as t]
    [app.util.functions :as fns]
    [app.util.globals :as g]
-   [cuerdas.core :as str]))
+   [cuerdas.core :as str]
+   [okulary.util :as ou]))
 
 ;; Using ex/ignoring because can receive a DOMException like this when
 ;; importing the code as a library: Failed to read the 'localStorage'
@@ -19,26 +20,27 @@
   (ex/ignoring (unchecked-get g/global "localStorage")))
 
 (defn- encode-key
-  [k]
+  [prefix k]
   (assert (keyword? k) "key must be keyword")
   (let [kns (namespace k)
         kn  (name k)]
-    (str "penpot:" kns "/" kn)))
+    (str prefix ":" kns "/" kn)))
 
 (defn- decode-key
-  [k]
-  (when (str/starts-with? k "penpot:")
-    (let [k (subs k 7)]
+  [prefix k]
+  (when (str/starts-with? k prefix)
+    (let [l (+ (count prefix) 1)
+          k (subs k l)]
       (if (str/starts-with? k "/")
         (keyword (subs k 1))
         (let [[kns kn] (str/split k "/" 2)]
           (keyword kns kn))))))
 
 (defn- lookup-by-index
-  [result index]
+  [prefix result index]
   (try
     (let [key  (.key ^js local-storage index)
-          key' (decode-key key)]
+          key' (decode-key prefix key)]
       (if key'
         (let [val (.getItem ^js local-storage key)]
           (assoc! result key' (t/decode-str val)))
@@ -46,39 +48,95 @@
     (catch :default _
       result)))
 
-(defn- load
-  []
-  (when (some? local-storage)
+(defn- load-data
+  [prefix]
+  (if (some? local-storage)
     (let [length (.-length ^js local-storage)]
       (loop [index  0
              result (transient {})]
         (if (< index length)
           (recur (inc index)
-                 (lookup-by-index result index))
-          (persistent! result))))))
+                 (lookup-by-index prefix result index))
+          (persistent! result))))
+    {}))
 
-(defonce ^:private latest-state (load))
+(defn create-storage
+  [prefix]
+  (let [initial   (load-data prefix)
+        curr-data #js {:content initial}
+        last-data #js {:content initial}
+        watches   (js/Map.)
 
-(defn- on-change*
-  [curr-state]
-  (let [prev-state latest-state]
-    (try
-      (run! (fn [key]
-              (let [prev-val (get prev-state key)
-                    curr-val (get curr-state key)]
-                (when-not (identical? curr-val prev-val)
-                  (if (some? curr-val)
-                    (.setItem ^js local-storage (encode-key key) (t/encode-str curr-val))
-                    (.removeItem ^js local-storage (encode-key key))))))
-            (into #{} (concat (keys curr-state)
-                              (keys prev-state))))
-      (finally
-        (set! latest-state curr-state)))))
+        on-change*
+        (fn [curr-state]
+          (let [prev-state (unchecked-get last-data "content")]
+            (try
+              (run! (fn [key]
+                      (let [prev-val (get prev-state key)
+                            curr-val (get curr-state key)]
+                        (when-not (identical? curr-val prev-val)
+                          (if (some? curr-val)
+                            (.setItem ^js local-storage (encode-key prefix key) (t/encode-str curr-val))
+                            (.removeItem ^js local-storage (encode-key prefix key))))))
+                    (into #{} (concat (keys curr-state)
+                                      (keys prev-state))))
+              (finally
+                (unchecked-set last-data "content" curr-state)))))
 
-(defonce on-change
-  (fns/debounce on-change* 2000))
+        on-change
+        (fns/debounce on-change* 2000)]
 
-(defonce storage (atom latest-state))
-(add-watch storage :persistence
-           (fn [_ _ _ curr-state]
-             (on-change curr-state)))
+    (reify
+      IAtom
+
+      IDeref
+      (-deref [_] (unchecked-get curr-data "content"))
+
+      ILookup
+      (-lookup [coll k]
+        (-lookup coll k nil))
+      (-lookup [_ k not-found]
+        (let [state (unchecked-get curr-data "content")]
+          (-lookup state k not-found)))
+
+      IReset
+      (-reset! [self newval]
+        (let [oldval (unchecked-get curr-data "content")]
+          (unchecked-set curr-data "content" newval)
+          (on-change newval)
+          (when (> (.-size watches) 0)
+            (-notify-watches self oldval newval))
+          newval))
+
+      ISwap
+      (-swap! [self f]
+        (let [state (unchecked-get curr-data "content")]
+          (-reset! self (f state))))
+      (-swap! [self f x]
+        (let [state (unchecked-get curr-data "content")]
+          (-reset! self (f state x))))
+      (-swap! [self f x y]
+        (let [state (unchecked-get curr-data "content")]
+          (-reset! self (f state x y))))
+      (-swap! [self f x y more]
+        (let [state (unchecked-get curr-data "content")]
+          (-reset! self (apply f state x y more))))
+
+      IWatchable
+      (-notify-watches [self oldval newval]
+        (ou/doiter
+         (.entries watches)
+         (fn [n]
+           (let [f (aget n 1)
+                 k (aget n 0)]
+             (f k self oldval newval)))))
+
+      (-add-watch [self key f]
+        (.set watches key f)
+        self)
+
+      (-remove-watch [_ key]
+        (.delete watches key)))))
+
+(defonce global (create-storage "penpot-global"))
+(defonce user (create-storage "penpot-user"))

--- a/frontend/src/app/util/theme.cljs
+++ b/frontend/src/app/util/theme.cljs
@@ -10,11 +10,11 @@
   (:require
    [app.config :as cfg]
    [app.util.dom :as dom]
-   [app.util.storage :refer [storage]]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
-(defonce theme (get @storage ::theme cfg/default-theme))
+(defonce theme (get storage/global ::theme cfg/default-theme))
 (defonce theme-sub (rx/subject))
 (defonce themes #js {})
 
@@ -27,7 +27,7 @@
   (when (not= theme v)
     (when-some [el (dom/get-element "theme")]
       (set! (.-href el) (str "css/main-" v ".css")))
-    (swap! storage assoc ::theme v)
+    (swap! storage/global assoc ::theme v)
     (set! theme v)
     (rx/push! theme-sub v)))
 

--- a/frontend/src/app/worker.cljs
+++ b/frontend/src/app/worker.cljs
@@ -24,24 +24,27 @@
 
 ;; --- Messages Handling
 
-(def ^:private
-  schema:message
-  (sm/define
-    [:map {:title "WorkerMessage"}
-     [:sender-id ::sm/uuid]
-     [:payload
-      [:map
-       [:cmd :keyword]]]
-     [:buffer? {:optional true} :boolean]]))
+(def ^:private schema:message
+  [:map {:title "WorkerMessage"}
+   [:sender-id ::sm/uuid]
+   [:payload
+    [:map
+     [:cmd :keyword]]]
+   [:buffer? {:optional true} :boolean]])
+
+(def ^:private check-message!
+  (sm/check-fn schema:message))
 
 (def buffer (rx/subject))
 
 (defn- handle-message
   "Process the message and returns to the client"
   [{:keys [sender-id payload transfer] :as message}]
+
   (dm/assert!
    "expected valid message"
-   (sm/check! schema:message message))
+   (check-message! message))
+
   (letfn [(post [msg]
             (let [msg (-> msg (assoc :reply-to sender-id) (wm/encode))]
               (.postMessage js/self msg)))


### PR DESCRIPTION
This PR mainly consists on flowing things:

- Add separated (namespaced) storage implementation for separate user and global values. User values are automatically cleared on logout but global are persisted.
- Use storage/user for almost all the things where storage is used previously
- Move several props stored on user profile to the storage/global namespace on the browser
- Add schema validation for known profile props.
- Add minor internal refactor on schema ns (removes unused code and makes private several functions)

From now, all props on profile should be added to the schema for proper validation and decoding.

How to test:

- Profile post registration steps should work correctly (they set many props)
- Not default team hero on dashboard project page, the collapsed state is persisted among refresh and logout
- Recent colors should be persisted for restarts but reset on logout
- Builtin templates collapsed state should persist restart and logout