### PR TITLE
:bug: Fix create team without invitations on onboarding

### DIFF
--- a/frontend/src/app/main/ui/onboarding/team_choice.cljs
+++ b/frontend/src/app/main/ui/onboarding/team_choice.cljs
@@ -57,7 +57,7 @@
 (def ^:private schema:invite-form
   [:map {:title "InviteForm"}
    [:role :keyword]
-   [:emails [::sm/set {:kind ::sm/email}]]])
+   [:emails {:optional true} [::sm/set {:kind ::sm/email}]]])
 
 (defn- get-available-roles
   []


### PR DESCRIPTION
This PR fixes https://tree.taiga.io/project/penpot/issue/8725