### PR TITLE
:bug: Removed "merge assets" option from export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 ### :boom: Breaking changes & Deprecations
 
+- Removed "merge assets" option when exporting ".svg + .json" files. After the components changes the option wasn't
+working properly and we're planning to change the format soon. We think it's better to deprecate the option for the
+time being.
+
 ### :heart: Community contributions (Thank you!)
 
 - Set proper default tenant on exporter (by @june128) [#4946](https://github.com/penpot/penpot/pull/4946)

--- a/frontend/src/app/main/ui/export.cljs
+++ b/frontend/src/app/main/ui/export.cljs
@@ -369,7 +369,9 @@
         selected        (:selected state)
         status          (:status state)
 
-
+        ;; We've deprecated the merge option on non-binary files because it wasn't working
+        ;; and we're planning to remove this export in future releases.
+        export-types (if binary? export-types [:all :detach])
 
         start-export
         (mf/use-fn


### PR DESCRIPTION
- Removed "merge assets" option when exporting ".svg + .json" files. After the components changes the option wasn't
working properly and we're planning to change the format soon. We think it's better to deprecate the option for the
time being.

Related to https://tree.taiga.io/project/penpot/issue/8758