### PR TITLE
:bug: Fix error when swapping a copy that is the only child of a group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,7 @@ time being.
 - Fix issue when exporting libraries when merging libraries [Taiga #8758](https://tree.taiga.io/project/penpot/issue/8758)
 - Fix problem with comments max length [Taiga #8778](https://tree.taiga.io/project/penpot/issue/8778)
 - Fix copy/paste images in Safari [Taiga #8771](https://tree.taiga.io/project/penpot/issue/8771)
+- Fix swap when the copy is the only child of a group [#5075](https://github.com/penpot/penpot/issues/5075)
 
 ## 2.1.5
 

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -545,6 +545,7 @@
                       (d/update-in-when [pid :shapes] d/without-obj sid)
                       (d/update-in-when [pid :shapes] d/vec-without-nils)
                       (cond-> component? (d/update-when pid #(dissoc % :remote-synced))))))))
+
           (update-parent-id [objects id]
             (-> objects
                 (d/update-when id assoc :parent-id parent-id)))

--- a/common/src/app/common/logic/shapes.cljc
+++ b/common/src/app/common/logic/shapes.cljc
@@ -158,7 +158,11 @@
 
         empty-parents
         ;; Any parent whose children are all deleted, must be deleted too.
-        (into (d/ordered-set) (find-all-empty-parents #{}))
+        ;; Unless we are during a component swap: in this case we are replacing a shape by
+        ;; other one, so must not delete empty parents.
+        (if-not component-swap
+          (into (d/ordered-set) (find-all-empty-parents #{}))
+          #{})
 
         components-to-delete
         (if components-v2


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/8736
and https://github.com/penpot/penpot/issues/5075