### PR TITLE
:whale: Use nginx-unprivileged as base image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### :boom: Breaking changes & Deprecations
 
+- Use [nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged) as base image for Penpot's frontend docker image. Now all the docker images runs with the same unprivileged user (penpot). Because of that, the default NGINX listen port now is 8080, instead of 80, so you will have to modify your infrastructure to apply this change.
+
 ### :heart: Community contributions (Thank you!)
 
 ### :sparkles: New features

--- a/docker/devenv/Dockerfile
+++ b/docker/devenv/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bookworm
-LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
+LABEL maintainer="Penpot <docker@penpot.app>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/images/Dockerfile.backend
+++ b/docker/images/Dockerfile.backend
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
+LABEL maintainer="Penpot <docker@penpot.app>"
 
-LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
 ENV LANG='en_US.UTF-8' \
     LC_ALL='en_US.UTF-8' \
     JAVA_HOME="/opt/jdk" \

--- a/docker/images/Dockerfile.exporter
+++ b/docker/images/Dockerfile.exporter
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
+LABEL maintainer="Penpot <docker@penpot.app>"
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \

--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -1,5 +1,7 @@
-FROM nginx:1.23
+FROM nginxinc/nginx-unprivileged:1.27.1
 LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
+
+USER root
 
 RUN set -ex; \
     useradd -U -M -u 1001 -s /bin/false -d /opt/penpot penpot; \
@@ -12,5 +14,13 @@ ADD ./files/nginx.conf /etc/nginx/nginx.conf.template
 ADD ./files/nginx-mime.types /etc/nginx/mime.types
 ADD ./files/nginx-entrypoint.sh /entrypoint.sh
 
+RUN chown -R 1001:0 /var/cache/nginx; \
+    chmod -R g+w /var/cache/nginx; \
+    chown -R 1001:0 /etc/nginx; \
+    chmod -R g+w /etc/nginx; \
+    chown -R 1001:0 /var/www; \
+    chmod -R g+w /var/www;
+
+USER penpot:penpot
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -1,5 +1,5 @@
 FROM nginxinc/nginx-unprivileged:1.27.1
-LABEL maintainer="Andrey Antukh <niwi@niwi.nz>"
+LABEL maintainer="Penpot <docker@penpot.app>"
 
 USER root
 

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     image: "penpotapp/frontend:latest"
     restart: always
     ports:
-      - 9001:80
+      - 9001:8080
 
     volumes:
       - penpot_assets:/opt/data/assets

--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -1,6 +1,5 @@
-user www-data;
 worker_processes auto;
-pid /run/nginx.pid;
+pid /tmp/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
@@ -9,6 +8,12 @@ events {
 }
 
 http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
@@ -56,7 +61,7 @@ http {
     include /etc/nginx/overrides.d/*.conf;
 
     server {
-        listen 80 default_server;
+        listen 8080 default_server;
         server_name _;
 
         client_max_body_size 100M;

--- a/manage.sh
+++ b/manage.sh
@@ -178,17 +178,24 @@ function build-exporter-bundle {
     echo ">> bundle exporter end";
 }
 
-function build-docker-images {
+function build-frontend-docker-images {
     rsync -avr --delete ./bundles/frontend/ ./docker/images/bundle-frontend/;
-    rsync -avr --delete ./bundles/backend/ ./docker/images/bundle-backend/;
-    rsync -avr --delete ./bundles/exporter/ ./docker/images/bundle-exporter/;
-
     pushd ./docker/images;
-
     docker build -t penpotapp/frontend:$CURRENT_BRANCH -t penpotapp/frontend:latest -f Dockerfile.frontend .;
-    docker build -t penpotapp/backend:$CURRENT_BRANCH -t penpotapp/backend:latest -f Dockerfile.backend .;
-    docker build -t penpotapp/exporter:$CURRENT_BRANCH -t penpotapp/exporter:latest -f Dockerfile.exporter .;
+    popd;
+}
 
+function build-backend-docker-images {
+    rsync -avr --delete ./bundles/backend/ ./docker/images/bundle-backend/;
+    pushd ./docker/images;
+    docker build -t penpotapp/backend:$CURRENT_BRANCH -t penpotapp/backend:latest -f Dockerfile.backend .;
+    popd;
+}
+
+function build-exporter-docker-images {
+    rsync -avr --delete ./bundles/exporter/ ./docker/images/bundle-exporter/;
+    pushd ./docker/images;
+    docker build -t penpotapp/exporter:$CURRENT_BRANCH -t penpotapp/exporter:latest -f Dockerfile.exporter .;
     popd;
 }
 
@@ -198,12 +205,26 @@ function usage {
     echo "Options:"
     echo "- pull-devenv                      Pulls docker development oriented image"
     echo "- build-devenv                     Build docker development oriented image"
+    echo "- build-devenv-local               Build a local docker development oriented image"
     echo "- create-devenv                    Create the development oriented docker compose service."
     echo "- start-devenv                     Start the development oriented docker compose service."
     echo "- stop-devenv                      Stops the development oriented docker compose service."
     echo "- drop-devenv                      Remove the development oriented docker compose containers, volumes and clean images."
     echo "- run-devenv                       Attaches to the running devenv container and starts development environment"
+    echo "- run-devenv-shell                 Attaches to the running devenv container and starts a bash shell."
+    echo "- log-devenv                       Show logs of the running devenv docker compose service."
     echo ""
+    echo "- build-bundle                     Build all bundles (frontend, backend and exporter)."
+    echo "- build-frontend-bundle            Build frontend bundle"
+    echo "- build-backend-bundle             Build backend bundle."
+    echo "- build-exporter-bundle            Build exporter bundle."
+    echo ""
+    echo "- build-docker-images              Build all docker images (frontend, backend and exporter)."
+    echo "- build-frontend-docker-images     Build frontend docker images."
+    echo "- build-backend-docker-images      Build backend docker images."
+    echo "- build-exporter-docker-images     Build exporter docker images."
+    echo ""
+    echo "- version                          Show penpot's version."
 }
 
 case $1 in
@@ -222,10 +243,6 @@ case $1 in
 
     build-devenv-local)
         build-devenv-local ${@:2}
-        ;;
-
-    push-devenv)
-        push-devenv ${@:2}
         ;;
 
     create-devenv)
@@ -251,7 +268,7 @@ case $1 in
         log-devenv ${@:2}
         ;;
 
-    # production builds
+    ## production builds
     build-bundle)
         build-frontend-bundle;
         build-backend-bundle;
@@ -271,10 +288,23 @@ case $1 in
         ;;
 
     build-docker-images)
-        build-docker-images
+        build-frontend-docker-images
+        build-backend-docker-images
+        build-exporter-docker-images
         ;;
 
-    # Docker Image Tasks
+    build-frontend-docker-images)
+        build-frontend-docker-images
+        ;;
+
+    build-backend-docker-images)
+        build-backend-docker-images
+        ;;
+
+    build-exporter-docker-images)
+        build-exporter-docker-images
+        ;;
+
     *)
         usage
         ;;


### PR DESCRIPTION
<div align=center> 

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHVuOTlzOHVlbzU2eXF6NnVrdGhtZDl5eGkwNHdlbWQ2NDQ3bHlveSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/yoJC2A59OCZHs1LXvW/giphy.gif)

</div>

I propose to use [nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged) as the base to build the penpot frontend docker image. 

This change aims to use non-root containers for all production docker images.  Non-root containers are recommended for the following reasons:

-  **Security**: Non-root containers are automatically more secure. If there is a container engine security issue, running the container as an unprivileged user will prevent any malicious code from gaining elevated permissions on the container host. To learn more about Docker's security features, see this guide.
- **Platform restrictions**: Some Kubernetes distributions (such as [OpenShift](https://www.openshift.com/)) run containers using random UUIDs. This approach is not compatible with root containers, which must always run with the root user's UUID. In such cases, root-only container images will simply not run and a non-root image is a must.

This PR introduces a **breaking change**: the penpot-frontent docker image now uses port 8080 instead of port 80.   

*One more thing... I have improved the manage.sh script too: completing the help command, deleting deprecated code and adding commands to create docker images of the different pieces separately.*