### PR TITLE
:bug: Fix issues on migration 55

### DIFF
--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1057,8 +1057,9 @@
             (assoc :default-grids (:saved-grids options))
 
             (and (some? (:flows options))
-                 (not (contains? page :flows)))
-            (assoc :flows (:flows options))
+                 (or (not (contains? page :flows))
+                     (not (map? (:flows page)))))
+            (assoc :flows (d/index-by :id (:flows options)))
 
             (and (some? (:guides options))
                  (not (contains? page :guides)))

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1056,6 +1056,10 @@
                  (not (contains? page :default-grids)))
             (assoc :default-grids (:saved-grids options))
 
+            (and (some? (:background options))
+                 (not (contains? page :background)))
+            (assoc :background (:background options))
+
             (and (some? (:flows options))
                  (or (not (contains? page :flows))
                      (not (map? (:flows page)))))


### PR DESCRIPTION
The flow should be a map after the refactor. But the migration 55 just moves the value as is without properly converting it to a map. And the background property is just ignored.

How to test it:

- Load any file with flows, and try to update file -> it will fails
- Load any file with page background set from production -> on importing the background is ignored on migration

Apply the patch and downgrade the file to the previous version using sql:

```sql
update file set version = version-1 where id = '<uuid>';
```

Open the file, it should be migrated again to 55 and the bug fixed.

This only affects our devenv, so if our own team experiments issues on validating flows, the fix is simple after this patch: downgrade to the previous version.