### PR TITLE
:whale: Improve flags configuration in docker-compose

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -1,3 +1,34 @@
+## Common flags:
+# demo-users
+# email-verification
+# log-emails
+# log-invitation-tokens
+# login-with-github
+# login-with-gitlab
+# login-with-google
+# login-with-ldap
+# login-with-oidc
+# login-with-password
+# prepl-server
+# registration
+# secure-session-cookies
+# smtp
+# smtp-debug
+# telemetry
+# webhooks
+##
+## You can read more about all available flags and other
+## environment variables here:
+## https://help.penpot.app/technical-guide/configuration/#advanced-configuration
+#
+# WARNING: if you're exposing Penpot to the internet, you should remove the flags
+# 'disable-secure-session-cookies' and 'disable-email-verification'
+x-flags: &penpot-flags
+  PENPOT_FLAGS: disable-email-verification enable-smtp enable-prepl-server disable-secure-session-cookies
+
+x-uri: &penpot-public-uri
+  PENPOT_PUBLIC_URI: http://localhost:9001
+
 networks:
   penpot:
 
@@ -71,26 +102,8 @@ services:
       # - "traefik.http.routers.penpot-https.tls=true"
       # - "traefik.http.routers.penpot-https.tls.certresolver=letsencrypt"
 
-    ## Configuration envronment variables for the frontend container. In this case, the
-    ## container only needs the `PENPOT_FLAGS`. This environment variable is shared with
-    ## other services, but not all flags are relevant to all services.
-
     environment:
-      ## Relevant flags for frontend:
-      ## - demo-users
-      ## - login-with-github
-      ## - login-with-gitlab
-      ## - login-with-google
-      ## - login-with-ldap
-      ## - login-with-oidc
-      ## - login-with-password
-      ## - registration
-      ## - webhooks
-      ##
-      ## You can read more about all available flags on:
-      ## https://help.penpot.app/technical-guide/configuration/#advanced-configuration
-
-      - PENPOT_FLAGS=enable-registration enable-login-with-password
+      << : *penpot-flags
 
   penpot-backend:
     image: "penpotapp/backend:latest"
@@ -110,31 +123,7 @@ services:
     ## container.
 
     environment:
-
-      ## Relevant flags for backend:
-      ## - demo-users
-      ## - email-verification
-      ## - log-emails
-      ## - log-invitation-tokens
-      ## - login-with-github
-      ## - login-with-gitlab
-      ## - login-with-google
-      ## - login-with-ldap
-      ## - login-with-oidc
-      ## - login-with-password
-      ## - registration
-      ## - secure-session-cookies
-      ## - smtp
-      ## - smtp-debug
-      ## - telemetry
-      ## - webhooks
-      ## - prepl-server
-      ##
-      ## You can read more about all available flags and other
-      ## environment variables for the backend here:
-      ## https://help.penpot.app/technical-guide/configuration/#advanced-configuration
-
-      - PENPOT_FLAGS=enable-registration enable-login-with-password disable-email-verification enable-smtp enable-prepl-server
+      << : [*penpot-flags, *penpot-public-uri]
 
       ## Penpot SECRET KEY. It serves as a master key from which other keys for subsystems
       ## (eg http sessions, or invitations) are derived.
@@ -147,70 +136,61 @@ services:
       ##
       ## python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 
-      # - PENPOT_SECRET_KEY=my-insecure-key
+      # PENPOT_SECRET_KEY: my-insecure-key
 
       ## The PREPL host. Mainly used for external programatic access to penpot backend
       ## (example: admin). By default it will listen on `localhost` but if you are going to use
       ## the `admin`, you will need to uncomment this and set the host to `0.0.0.0`.
 
-      # - PENPOT_PREPL_HOST=0.0.0.0
-
-      ## Public URI. If you are going to expose this instance to the internet and use it
-      ## under a different domain than 'localhost', you will need to adjust it to the final
-      ## domain.
-      ##
-      ## Consider using traefik and set the 'disable-secure-session-cookies' if you are
-      ## not going to serve penpot under HTTPS.
-
-      - PENPOT_PUBLIC_URI=http://localhost:9001
+      # PENPOT_PREPL_HOST: 0.0.0.0
 
       ## Database connection parameters. Don't touch them unless you are using custom
       ## postgresql connection parameters.
 
-      - PENPOT_DATABASE_URI=postgresql://penpot-postgres/penpot
-      - PENPOT_DATABASE_USERNAME=penpot
-      - PENPOT_DATABASE_PASSWORD=penpot
+      PENPOT_DATABASE_URI: postgresql://penpot-postgres/penpot
+      PENPOT_DATABASE_USERNAME: penpot
+      PENPOT_DATABASE_PASSWORD: penpot
 
       ## Redis is used for the websockets notifications. Don't touch unless the redis
       ## container has different parameters or different name.
 
-      - PENPOT_REDIS_URI=redis://penpot-redis/0
+      PENPOT_REDIS_URI: redis://penpot-redis/0
 
       ## Default configuration for assets storage: using filesystem based with all files
       ## stored in a docker volume.
 
-      - PENPOT_ASSETS_STORAGE_BACKEND=assets-fs
-      - PENPOT_STORAGE_ASSETS_FS_DIRECTORY=/opt/data/assets
+      PENPOT_ASSETS_STORAGE_BACKEND: assets-fs
+      PENPOT_STORAGE_ASSETS_FS_DIRECTORY: /opt/data/assets
 
       ## Also can be configured to to use a S3 compatible storage
       ## service like MiniIO. Look below for minio service setup.
 
-      # - AWS_ACCESS_KEY_ID=<KEY_ID>
-      # - AWS_SECRET_ACCESS_KEY=<ACCESS_KEY>
-      # - PENPOT_ASSETS_STORAGE_BACKEND=assets-s3
-      # - PENPOT_STORAGE_ASSETS_S3_ENDPOINT=http://penpot-minio:9000
-      # - PENPOT_STORAGE_ASSETS_S3_BUCKET=<BUKET_NAME>
+      # AWS_ACCESS_KEY_ID: <KEY_ID>
+      # AWS_SECRET_ACCESS_KEY: <ACCESS_KEY>
+      # PENPOT_ASSETS_STORAGE_BACKEND: assets-s3
+      # PENPOT_STORAGE_ASSETS_S3_ENDPOINT: http://penpot-minio:9000
+      # PENPOT_STORAGE_ASSETS_S3_BUCKET: <BUKET_NAME>
 
       ## Telemetry. When enabled, a periodical process will send anonymous data about this
       ## instance. Telemetry data will enable us to learn how the application is used,
       ## based on real scenarios. If you want to help us, please leave it enabled. You can
       ## audit what data we send with the code available on github.
 
-      - PENPOT_TELEMETRY_ENABLED=true
+      PENPOT_TELEMETRY_ENABLED: true
 
       ## Example SMTP/Email configuration. By default, emails are sent to the mailcatch
       ## service, but for production usage it is recommended to setup a real SMTP
       ## provider. Emails are used to confirm user registrations & invitations. Look below
       ## how the mailcatch service is configured.
 
-      - PENPOT_SMTP_DEFAULT_FROM=no-reply@example.com
-      - PENPOT_SMTP_DEFAULT_REPLY_TO=no-reply@example.com
-      - PENPOT_SMTP_HOST=penpot-mailcatch
-      - PENPOT_SMTP_PORT=1025
-      - PENPOT_SMTP_USERNAME=
-      - PENPOT_SMTP_PASSWORD=
-      - PENPOT_SMTP_TLS=false
-      - PENPOT_SMTP_SSL=false
+      PENPOT_SMTP_DEFAULT_FROM: no-reply@example.com
+      PENPOT_SMTP_DEFAULT_REPLY_TO: no-reply@example.com
+      PENPOT_SMTP_HOST: penpot-mailcatch
+      PENPOT_SMTP_PORT: 1025
+      PENPOT_SMTP_USERNAME:
+      PENPOT_SMTP_PASSWORD:
+      PENPOT_SMTP_TLS: false
+      PENPOT_SMTP_SSL: false
 
   penpot-exporter:
     image: "penpotapp/exporter:latest"
@@ -221,10 +201,10 @@ services:
     environment:
       # Don't touch it; this uses an internal docker network to
       # communicate with the frontend.
-      - PENPOT_PUBLIC_URI=http://penpot-frontend
+      PENPOT_PUBLIC_URI: http://penpot-frontend
 
       ## Redis is used for the websockets notifications.
-      - PENPOT_REDIS_URI=redis://penpot-redis/0
+      PENPOT_REDIS_URI: redis://penpot-redis/0
 
   penpot-postgres:
     image: "postgres:15"


### PR DESCRIPTION
This PR changes the way to configure flags in docker-compose, using [extensions](https://docs.docker.com/reference/compose-file/extension/). With the new style, the configuration is made only once at the top of the docker-compose file.

It also adds another generalization useful for both frontend and backend services.

It requires to make a change in the yaml file: instead of configuring `environment` block as a list, we have to configure it as a map, due to docker-compose/yaml restrictions, as explained in the extensions documentation:

![image](https://github.com/user-attachments/assets/7d613cf1-0c68-478b-bb3e-601fa819d421)

How to test it:
- download the proposed docker-compose.yaml and test different flags

The publication of these changes should be done at the same time as the update of the corresponding documentation.