### PR TITLE
:bug: Fix dragging path points incorrect start-position

### DIFF
--- a/frontend/src/app/main/data/workspace/path/edition.cljs
+++ b/frontend/src/app/main/data/workspace/path/edition.cljs
@@ -160,7 +160,7 @@
 
             selected-points (dm/get-in state [:workspace-local :edit-path id :selected-points] #{})
 
-            start-position (apply min #(gpt/distance start-position %) selected-points)
+            start-position (apply min-key #(gpt/distance start-position %) selected-points)
 
             content (st/get-path state :content)
             points (upg/content->points content)]


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

Closes #4459 

> Explain the **details** for making this change. What existing problem does the pull request solve?

The original code
`start-position (apply min #(gpt/distance start-position %) selected-points)`
returns the distance from start-position to the closest point from selected-points

I suspect this was a typo, using `min` instead of `min-key`,
min returned the distance to the closest point
min-key here will return the actual closest point

> Screenshots/GIFs

Before (dragged path points jump when dragging)
![drag-path-points-before](https://github.com/user-attachments/assets/ae9f9f87-bd60-4603-a37e-ab99f6f9026c)

After (works as expected)
![drag-path-points-after](https://github.com/user-attachments/assets/ee6a5397-b815-406e-b9e7-47c53447a456)

