### PR TITLE
:arrow_up: Pin redis@7.2 in docker-compose, as it's the latest open source version

### DIFF
--- a/docker/devenv/docker-compose.yaml
+++ b/docker/devenv/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
       - postgres_data_pg16:/var/lib/postgresql/data
 
   redis:
-    image: redis:7
+    image: redis:7.2
     hostname: "penpot-devenv-redis"
     container_name: "penpot-devenv-redis"
     restart: always

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -224,7 +224,7 @@ services:
       - POSTGRES_PASSWORD=penpot
 
   penpot-redis:
-    image: redis:7
+    image: redis:7.2
     restart: always
     networks:
       - penpot


### PR DESCRIPTION
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWhod2gzcmRuaWNxNjFwejhtdGlkNmFleGo4ZTdqNnRjMnp2cHd5cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8OPIWC23nOvs6cxLxO/giphy-downsized.gif)

Update the pinned version of redis to the latest one that it's open source (7.2.x), to prevent using unintentially the 7.4.x versions which have non open source licenses.