### PR TITLE
:sparkles: Create a separate viewport for wasm/canvas

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport_wasm.scss
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.scss
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+.viewport {
+  cursor: none;
+  grid-column: 1 / span 2;
+  grid-row: 1 / span 2;
+  overflow: hidden;
+  position: relative;
+}
+
+.viewport-controls {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.render-shapes {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+
+.viewport-overlays {
+  cursor: initial;
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 10;
+}


### PR DESCRIPTION
This splits the viewport into two different types, to isolate the changes we will be doing for the new canvas-based render.

> :warning: **You will need to rebuild the devenv** with `./manage.sh build-devenv-local` if the docker image hasn't been updated yet.

To test the "classic" (aka current in PRO) variant:

- Make sure the config flag `render-wasm` is **disabled**.
- Load the workspace as usual and check that everything works as expected.

To test the new canvas viewport:

- Enable `render-wasm` flag in `config.js`
- In tmux, build the wasm module: `cd render_wasm && ./build`
- Load the workspace and check
