### PR TITLE
:tada: Handle WebGL Context

### DIFF
--- a/frontend/src/app/main/data/render_wasm.cljs
+++ b/frontend/src/app/main/data/render_wasm.cljs
@@ -1,0 +1,17 @@
+(ns app.main.data.render-wasm
+  (:require
+   [potok.v2.core :as ptk]))
+
+(defn context-lost
+  []
+  (ptk/reify ::context-lost
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :render-state #(assoc % :lost true)))))
+
+(defn context-restored
+  []
+  (ptk/reify ::context-restored
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :render-state #(dissoc % :lost)))))

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -114,6 +114,12 @@
 
 ;; ---- Workspace refs
 
+(def render-state
+  (l/derived :render-state st/state))
+
+(def render-context-lost?
+  (l/derived :lost render-state))
+
 (def workspace-local
   (l/derived :workspace-local st/state))
 

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.scss
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.scss
@@ -35,3 +35,13 @@
   right: 0;
   z-index: 10;
 }
+
+.context-lost {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: grid;
+  place-items: center;
+  cursor: default;
+}

--- a/frontend/src/app/util/debug.cljs
+++ b/frontend/src/app/util/debug.cljs
@@ -89,7 +89,10 @@
     :display-touched
 
     ;; Show some visual indicators for bool shape
-    :bool-shapes})
+    :bool-shapes
+
+    ;; Show some information about the WebGL context.
+    :gl-context})
 
 (defn enable!
   [option]

--- a/render-wasm/Cargo.lock
+++ b/render-wasm/Cargo.lock
@@ -97,6 +97,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "emscripten-functions"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c026cc030b24957ca45d9555f9fa241d6b3a01d725cd98a25924de249b840a"
+dependencies = [
+ "cc",
+ "emscripten-functions-sys",
+]
+
+[[package]]
+name = "emscripten-functions-sys"
+version = "4.1.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65715a5f07b03636d7cd5508a45d1b62486840cb7d91a66564a73f1d7aa70b79"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +386,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "render"
 version = "0.1.0"
 dependencies = [
+ "emscripten-functions",
+ "emscripten-functions-sys",
  "gl",
  "skia-safe",
 ]

--- a/render-wasm/Cargo.toml
+++ b/render-wasm/Cargo.toml
@@ -11,6 +11,8 @@ name = "render_wasm"
 path = "src/main.rs"
 
 [dependencies]
+emscripten-functions = "0.2.3"
+emscripten-functions-sys = "4.1.67"
 gl = "0.14.0"
 skia-safe = { version = "0.78.2", features = ["gl"] }
 


### PR DESCRIPTION
When the context is lost, an event is triggered that updates the render state and shows a message to restore context.