### PR TITLE
:bug: Fix null pointer exception on validating nil with number schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ node_modules
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/render-wasm/target/
+/**/.yarn/*

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -681,8 +681,8 @@
      (let [pred int?
            pred (if (some? min)
                   (fn [v]
-                    (and (>= v min)
-                         (pred v)))
+                    (and (pred v)
+                         (>= v min)))
                   pred)
            pred (if (some? max)
                   (fn [v]
@@ -719,8 +719,8 @@
      (let [pred double?
            pred (if (some? min)
                   (fn [v]
-                    (and (>= v min)
-                         (pred v)))
+                    (and (pred v)
+                         (>= v min)))
                   pred)
            pred (if (some? max)
                   (fn [v]
@@ -749,8 +749,8 @@
      (let [pred number?
            pred (if (some? min)
                   (fn [v]
-                    (and (>= v min)
-                         (pred v)))
+                    (and (pred v)
+                         (>= v min)))
                   pred)
            pred (if (some? max)
                   (fn [v]


### PR DESCRIPTION
It happens only when the `:min` option is set