### PR TITLE
Fix incorrect behavior of ::sm/vec and ::sm/set decoder

### DIFF
--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -326,7 +326,7 @@
 (def ^:private
   schema:move-files
   [:map {:title "move-files"}
-   [:ids ::sm/set-of-uuid]
+   [:ids [::sm/set {:min 1} ::sm/uuid]]
    [:project-id ::sm/uuid]])
 
 (sv/defmethod ::move-files
@@ -335,7 +335,7 @@
    ::webhooks/event? true
    ::sm/params schema:move-files}
   [cfg {:keys [::rpc/profile-id] :as params}]
-  (db/tx-run! cfg #(move-files % (assoc params :profile-id profile-id))))
+  (db/tx-run! cfg move-files (assoc params :profile-id profile-id)))
 
 ;; --- COMMAND: Move project
 

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -275,7 +275,7 @@
               (= :set (:type s))
               (m/-collection-schema s)
 
-              (= :vec (:type s))
+              (= :vector (:type s))
               (m/-collection-schema s)
 
               :else
@@ -449,24 +449,12 @@
              (fn [value]
                (every? pred value)))
 
-
-           decode-string-child
-           (decoder kind string-transformer)
-
-           decode-string
+           decode
            (fn [v]
-             (let [v (if (string? v) (str/split v #"[\s,]+") v)
-                   x (comp xf:filter-word-strings (map decode-string-child))]
-               (into #{} x v)))
-
-           decode-json-child
-           (decoder kind json-transformer)
-
-           decode-json
-           (fn [v]
-             (let [v (if (string? v) (str/split v #"[\s,]+") v)
-                   x (comp xf:filter-word-strings (map decode-json-child))]
-               (into #{} x v)))
+             (if (string? v)
+               (let [v  (str/split v #"[\s,]+")]
+                 (into #{} xf:filter-word-strings v))
+               v))
 
            encode-string-child
            (encoder kind string-transformer)
@@ -475,14 +463,7 @@
            (fn [o]
              (if (set? o)
                (str/join ", " (map encode-string-child o))
-               o))
-
-           encode-json
-           (fn [o]
-             (if (set? o)
-               (vec o)
                o))]
-
 
        {:pred pred
         :empty #{}
@@ -491,10 +472,10 @@
          :description "Set of Strings"
          :error/message "should be a set of strings"
          :gen/gen (-> kind sg/generator sg/set)
-         :decode/string decode-string
-         :decode/json decode-json
+         :decode/string decode
+         :decode/json decode
          :encode/string encode-string
-         :encode/json encode-json
+         :encode/json identity
          ::oapi/type "array"
          ::oapi/format "set"
          ::oapi/items {:type "string"}
@@ -542,23 +523,12 @@
              (fn [value]
                (every? pred value)))
 
-           decode-string-child
-           (decoder kind string-transformer)
-
-           decode-json-child
-           (decoder kind json-transformer)
-
-           decode-string
+           decode
            (fn [v]
-             (let [v (if (string? v) (str/split v #"[\s,]+") v)
-                   x (comp xf:filter-word-strings (map decode-string-child))]
-               (into #{} x v)))
-
-           decode-json
-           (fn [v]
-             (let [v (if (string? v) (str/split v #"[\s,]+") v)
-                   x (comp xf:filter-word-strings (map decode-json-child))]
-               (into #{} x v)))
+             (if (string? v)
+               (let [v (str/split v #"[\s,]+")]
+                 (into #{} xf:filter-word-strings v))
+               v))
 
            encode-string-child
            (encoder kind string-transformer)
@@ -575,9 +545,10 @@
          :description "Set of Strings"
          :error/message "should be a set of strings"
          :gen/gen (-> kind sg/generator sg/set)
-         :decode/string decode-string
-         :decode/json decode-json
+         :decode/string decode
+         :decode/json decode
          :encode/string encode-string
+         :encode/json identity
          ::oapi/type "array"
          ::oapi/format "set"
          ::oapi/items {:type "string"}

--- a/common/test/common_tests/schema_test.cljc
+++ b/common/test/common_tests/schema_test.cljc
@@ -39,3 +39,63 @@
     (let [schema    [::sm/set ::sm/email]
           value     (sg/generate schema)]
       (t/is (true? (sm/validate schema (sg/generate schema)))))))
+
+
+(t/deftest test-set-1
+  (let [candidate-1 "cff4b058-ca31-8197-8005-32aeb2377d83, cff4b058-ca31-8197-8005-32aeb2377d82"
+        candidate-2 ["cff4b058-ca31-8197-8005-32aeb2377d82",
+                     "cff4b058-ca31-8197-8005-32aeb2377d83"]
+        candidate-3 #{"cff4b058-ca31-8197-8005-32aeb2377d82", "cff4b058-ca31-8197-8005-32aeb2377d83"}
+        candidate-4 [#uuid "cff4b058-ca31-8197-8005-32aeb2377d82"
+                     #uuid "cff4b058-ca31-8197-8005-32aeb2377d83"]
+        candidate-5 #{#uuid "cff4b058-ca31-8197-8005-32aeb2377d82"
+                      #uuid "cff4b058-ca31-8197-8005-32aeb2377d83"}
+
+        expected    candidate-5
+
+        schema      [::sm/set ::sm/uuid]
+        decode-s    (sm/decoder schema sm/string-transformer)
+        decode-j    (sm/decoder schema sm/json-transformer)
+        encode-s    (sm/encoder schema sm/string-transformer)
+        encode-j    (sm/encoder schema sm/json-transformer)]
+
+
+    (t/is (= expected (decode-s candidate-1)))
+    (t/is (= expected (decode-s candidate-2)))
+    (t/is (= expected (decode-s candidate-3)))
+    (t/is (= expected (decode-s candidate-4)))
+    (t/is (= expected (decode-s candidate-5)))
+
+    (t/is (= candidate-1 (encode-s expected)))
+    (t/is (= candidate-3 (encode-j expected)))))
+
+
+(t/deftest test-vec-1
+  (let [candidate-1 "cff4b058-ca31-8197-8005-32aeb2377d83, cff4b058-ca31-8197-8005-32aeb2377d82"
+        candidate-2 ["cff4b058-ca31-8197-8005-32aeb2377d83",
+                     "cff4b058-ca31-8197-8005-32aeb2377d82"]
+        candidate-3 #{"cff4b058-ca31-8197-8005-32aeb2377d82", "cff4b058-ca31-8197-8005-32aeb2377d83"}
+        candidate-4 [#uuid "cff4b058-ca31-8197-8005-32aeb2377d83"
+                     #uuid "cff4b058-ca31-8197-8005-32aeb2377d82"]
+        candidate-5 #{#uuid "cff4b058-ca31-8197-8005-32aeb2377d82"
+                      #uuid "cff4b058-ca31-8197-8005-32aeb2377d83"}
+
+        expected    candidate-4
+
+        schema      [::sm/vec ::sm/uuid]
+        decode-s    (sm/decoder schema sm/string-transformer)
+        decode-j    (sm/decoder schema sm/json-transformer)
+        encode-s    (sm/encoder schema sm/string-transformer)
+        encode-j    (sm/encoder schema sm/json-transformer)]
+
+
+    (t/is (= expected (decode-s candidate-1)))
+    (t/is (= expected (decode-s candidate-2)))
+    (t/is (= expected (decode-s candidate-3)))
+    (t/is (= expected (decode-s candidate-4)))
+    (t/is (= expected (decode-s candidate-5)))
+
+    (t/is (= candidate-1 (encode-s expected)))
+    (t/is (= candidate-2 (encode-j expected)))))
+
+


### PR DESCRIPTION
Improves how decode and encode works for `::sm/vec` and `::sm/set` schemas. No explicit tests needed because this PR adds specific unit tests for that schemas. Only general code review.