### PR TITLE
:bug: Fix problem with grid layout ordering after moving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### :bug: Bugs fixed
 
 - Fix null pointer exception on number checking functions
+- Fix problem with grid layout ordering after moving [Taiga #9179](https://tree.taiga.io/project/penpot/issue/9179)
 
 ### :books: Documentation
 

--- a/common/src/app/common/logic/shapes.cljc
+++ b/common/src/app/common/logic/shapes.cljc
@@ -391,13 +391,14 @@
           (-> (pcb/update-shapes
                [parent-id]
                (fn [frame objects]
-                 (-> frame
-                     ;; Assign the cell when pushing into a specific grid cell
-                     (cond-> (some? cell)
-                       (-> (ctl/free-cell-shapes ids)
-                           (ctl/push-into-cell ids (:row cell) (:column cell))
-                           (ctl/assign-cells objects)))
-                     (ctl/assign-cell-positions objects)))
+                 (let [[row column] cell]
+                   (-> frame
+                       ;; Assign the cell when pushing into a specific grid cell
+                       (cond-> (some? cell)
+                         (-> (ctl/free-cell-shapes ids)
+                             (ctl/push-into-cell ids row column)
+                             (ctl/assign-cells objects)))
+                       (ctl/assign-cell-positions objects))))
                {:with-objects? true})
               (pcb/reorder-grid-children [parent-id])))
 


### PR DESCRIPTION
- Fix problem with grid layout ordering after moving [Taiga #9179](https://tree.taiga.io/project/penpot/issue/9179)
