### PR TITLE
:wrench: Add rustfmt to the devenv

### DIFF
--- a/docker/devenv/Dockerfile
+++ b/docker/devenv/Dockerfile
@@ -263,7 +263,8 @@ RUN set -eux; \
     chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME;
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup component add rustfmt;
 
 WORKDIR /usr/local
 


### PR DESCRIPTION
Needed for https://tree.taiga.io/project/penpot/task/9202. After this is merged, we'd need to update the devenv docker image so we can enable formatting in CI with `cargo fmt --check`.

How to test:

- Build the local devenv image `./manage.sh build-devenv-local`
- Start the devenv and open a new tmux tab
- `cd penpot/render_wasm`
- Run `cargo fmt --check` 