### PR TITLE
:paperclip: Add missing breaking change notification on changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,16 @@
 
 - Use [nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged) as base image for
   Penpot's frontend docker image. Now all the docker images runs with the same unprivileged user
-  (penpot). Because of that, the default NGINX listen port now is 8080, instead of 80, so you will
-  have to modify your infrastructure to apply this change.
+  (penpot). Because of that, the default NGINX listen port is now 8080 instead of 80, so
+  you will have to modify your infrastructure to apply this change.
+
+- Redis 7.2 is explicitly pinned in our example docker-compose.yml file. This is done because, 
+  starting with the next versions, Redis is no longer distributed under an open-source license. 
+  On-premise users are obviously free to upgrade to the version they are using or a more modern one. 
+  Keep in mind that if you were using a version other than 7.2, you may have to recreate the volume 
+  associated with the Redis container because the 7.2 storage format may not be compatible with what 
+  you already have stored on the volume, and Redis may not start. In the near future, we will evaluate 
+  whether to move to an open-source version of Redis (such as https://valkey.io/).
 
 ### :heart: Community contributions (Thank you!)
 


### PR DESCRIPTION
About the redis version pinning to version 7.2
