### PR TITLE
:sparkles: Make the file and shape thumbnails not dependent on PUBLIC_URI

### DIFF
--- a/backend/src/app/rpc/commands/files_thumbnails.clj
+++ b/backend/src/app/rpc/commands/files_thumbnails.clj
@@ -50,8 +50,7 @@
              " where file_id=? and tag=? and deleted_at is null")
         res (db/exec! conn [sql file-id tag])]
     (->> res
-         (d/index-by :object-id (fn [row]
-                                  (files/resolve-public-uri (:media-id row))))
+         (d/index-by :object-id :media-id)
          (d/without-nils))))
 
 (defn- get-object-thumbnails
@@ -62,8 +61,7 @@
               " where file_id=? and deleted_at is null")
          res (db/exec! conn [sql file-id])]
      (->> res
-          (d/index-by :object-id (fn [row]
-                                   (files/resolve-public-uri (:media-id row))))
+          (d/index-by :object-id :media-id)
           (d/without-nils))))
 
   ([conn file-id object-ids]
@@ -75,8 +73,7 @@
          res (db/exec! conn [sql file-id ids])]
 
      (->> res
-          (d/index-by :object-id (fn [row]
-                                   (files/resolve-public-uri (:media-id row))))
+          (d/index-by :object-id :media-id)
           (d/without-nils)))))
 
 (sv/defmethod ::get-file-object-thumbnails
@@ -127,8 +124,11 @@
               (if-let [frame  (-> frames first)]
                 (let [frame-id  (:id frame)
                       object-id (thc/fmt-object-id (:id file) page-id frame-id "frame")
-                      frame     (if-let [thumb (get thumbnails object-id)]
-                                  (assoc frame :thumbnail thumb :shapes [])
+
+                      frame     (if-let [media-id (get thumbnails object-id)]
+                                  (-> frame
+                                      (assoc :thumbnail-id media-id)
+                                      (assoc :shapes []))
                                   (dissoc frame :thumbnail))
 
                       children-ids

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -1090,8 +1090,7 @@
         (t/is (contains? result :file-id))
 
         (t/is (= (:id file) (:file-id result)))
-        (t/is (str/starts-with? (get-in result [:page :objects frame1-id :thumbnail])
-                                "http://localhost:3449/assets/by-id/"))
+        (t/is (uuid? (get-in result [:page :objects frame1-id :thumbnail-id])))
         (t/is (= [] (get-in result [:page :objects frame1-id :shapes]))))
 
       ;; Delete thumbnail data

--- a/frontend/src/app/main/data/common.cljs
+++ b/frontend/src/app/main/data/common.cljs
@@ -12,7 +12,6 @@
    [app.common.schema :as sm]
    [app.common.types.components-list :as ctkl]
    [app.common.types.team :as ctt]
-   [app.config :as cf]
    [app.main.data.modal :as modal]
    [app.main.data.notifications :as ntf]
    [app.main.features :as features]
@@ -75,15 +74,13 @@
     (watch [_ _ _]
       (case code
         :upgrade-version
-        (when (or (not= (:version params) (:full cf/version))
-                  (true? (:force params)))
-          (rx/of (ntf/dialog
-                  :content (tr "notifications.by-code.upgrade-version")
-                  :controls :inline-actions
-                  :type :inline
-                  :level level
-                  :actions [{:label "Refresh" :callback force-reload!}]
-                  :tag :notification)))
+        (rx/of (ntf/dialog
+                :content (tr "notifications.by-code.upgrade-version")
+                :controls :inline-actions
+                :type :inline
+                :level level
+                :actions [{:label "Refresh" :callback force-reload!}]
+                :tag :notification))
 
         :maintenance
         (rx/of (ntf/dialog

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -881,11 +881,9 @@
          (rx/of
           (dwu/start-undo-transaction undo-id)
           (update-component shape-id undo-group)
-          (sync-file current-file-id file-id :components (:component-id shape) undo-group)
-          (update-component-thumbnail-sync state component-id file-id "frame")
-          (update-component-thumbnail-sync state component-id file-id "component")
+          (sync-file current-file-id file-id :components component-id undo-group)
           (when (not current-file?)
-            (sync-file file-id file-id :components (:component-id shape) undo-group))
+            (sync-file file-id file-id :components component-id undo-group))
           (dwu/commit-undo-transaction undo-id)))))))
 
 (defn launch-component-sync
@@ -937,9 +935,9 @@
       ;; in the grid creating new rows/columns to make space
       (let [file      (wsh/get-file state file-id)
             libraries (wsh/get-libraries state)
-            page    (wsh/lookup-page state)
-            objects (wsh/lookup-page-objects state)
-            parent (get objects (:parent-id shape))
+            page      (wsh/lookup-page state)
+            objects   (wsh/lookup-page-objects state)
+            parent    (get objects (:parent-id shape))
 
             ;; If the target parent is a grid layout we need to pass the target cell
             target-cell (when (ctl/grid-layout? parent)

--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -168,7 +168,7 @@
                            (.error js/console cause)
                            (rx/empty)))
 
-               (rx/tap #(l/trc :hint "thumbnail updated" :elapsed (dm/str (tp) "ms")))
+               (rx/tap #(l/dbg :hint "thumbnail updated" :elapsed (dm/str (tp) "ms")))
 
                ;; We cancel all the stream if user starts editing while
                ;; thumbnail is generating

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -13,6 +13,7 @@
    [app.common.types.shape-tree :as ctt]
    [app.common.types.shape.layout :as ctl]
    [app.common.types.tokens-lib :as ctob]
+   [app.config :as cf]
    [app.main.data.workspace.state-helpers :as wsh]
    [app.main.store :as st]
    [app.main.ui.workspace.tokens.token-set :as wtts]
@@ -582,7 +583,8 @@
   [object-id]
   (l/derived
    (fn [state]
-     (dm/get-in state [:workspace-thumbnails object-id]))
+     (some-> (dm/get-in state [:workspace-thumbnails object-id])
+             (cf/resolve-media)))
    st/state))
 
 (def workspace-text-modifier

--- a/frontend/src/app/main/ui/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/shapes/frame.cljs
@@ -135,7 +135,7 @@
         bounds   (mf/with-memo [bounds points]
                    (or bounds (gsb/get-frame-bounds shape)))
 
-        thumb    (:thumbnail shape)
+        thumb    (cf/resolve-media (:thumbnail-id shape))
 
         debug?   (dbg/enabled? :thumbnails)
         safari?  (cf/check-browser? :safari)
@@ -171,7 +171,7 @@
   {::mf/wrap-props false}
   [props]
   (let [shape (unchecked-get props "shape")]
-    (when ^boolean (:thumbnail shape)
+    (when ^boolean (:thumbnail-id shape)
       [:> frame-container props
        [:> frame-thumbnail-image props]])))
 

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -269,17 +269,19 @@
 
 (mf/defc component-item-thumbnail
   "Component that renders the thumbnail image or the original SVG."
-  {::mf/wrap-props false}
+  {::mf/props :obj}
   [{:keys [file-id root-shape component container class]}]
-  (let [page-id   (:main-instance-page component)
-        root-id   (:main-instance-id component)
+  (let [page-id (:main-instance-page component)
+        root-id (:main-instance-id component)
+        retry   (mf/use-state 0)
 
-        retry (mf/use-state 0)
+        thumbnail-uri*
+        (mf/with-memo [file-id page-id root-id]
+          (let [object-id (thc/fmt-object-id file-id page-id root-id "component")]
+            (refs/workspace-thumbnail-by-id object-id)))
 
-        thumbnail-uri* (mf/with-memo [file-id page-id root-id]
-                         (let [object-id (thc/fmt-object-id file-id page-id root-id "component")]
-                           (refs/workspace-thumbnail-by-id object-id)))
-        thumbnail-uri  (mf/deref thumbnail-uri*)
+        thumbnail-uri
+        (mf/deref thumbnail-uri*)
 
         on-error
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -57,15 +57,6 @@
                       component)]
       [root-shape container])))
 
-
-    ;; NOTE: We don't schedule the thumbnail generation on idle right now
-    ;; until we can queue and handle thumbnail batching properly.
-#_(mf/with-effect []
-    (when-not (some? thumbnail-uri)
-      (tm/schedule-on-idle
-       #(st/emit! (dwl/update-component-thumbnail (:id component) file-id)))))
-
-
 (mf/defc components-item
   {::mf/wrap-props false}
   [{:keys [component renaming listing-thumbs? selected


### PR DESCRIPTION
Related to: https://github.com/penpot/penpot/issues/5305

This PR:
- Fixes a bug on components thumbnails loading for libraries (incorrectly assigned to the library instead of merged to the thumbnails map on the global state)
- Removes the dependency on PUBLIC_URI to be correctly set on backend for the components, frames and file thumbnail generation / lookup (mainly exposing the id instead of uri, and leave the resolution of the final URI to the frontend runtime)
