### PR TITLE
:bug: Fix import format detection and error handling

### DIFF
--- a/frontend/scripts/_helpers.js
+++ b/frontend/scripts/_helpers.js
@@ -508,6 +508,7 @@ export async function compileStyles() {
   const start = process.hrtime();
 
   log.info("init: compile styles");
+
   let result = await compileSassAll(worker);
   result = concatSass(result);
 

--- a/frontend/scripts/watch.js
+++ b/frontend/scripts/watch.js
@@ -24,15 +24,22 @@ async function compileSassAll() {
 async function compileSass(path) {
   const start = process.hrtime();
   log.info("changed:", path);
-  const result = await h.compileSass(worker, path, { modules: true });
-  sass.index[result.outputPath] = result.css;
 
-  const output = h.concatSass(sass);
+  try {
+    const result = await h.compileSass(worker, path, { modules: true });
+    sass.index[result.outputPath] = result.css;
 
-  await fs.writeFile("./resources/public/css/main.css", output);
+    const output = h.concatSass(sass);
 
-  const end = process.hrtime(start);
-  log.info("done:", `(${ppt(end)})`);
+    await fs.writeFile("./resources/public/css/main.css", output);
+
+    const end = process.hrtime(start);
+    log.info("done:", `(${ppt(end)})`);
+  } catch (cause) {
+    console.error(cause);
+    const end = process.hrtime(start);
+    log.error("error:", `(${ppt(end)})`);
+  }
 }
 
 await fs.mkdir("./resources/public/css/", { recursive: true });

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -64,6 +64,7 @@
 }
 
 .file-entry {
+  display: flex;
   .file-name {
     @include flexRow;
     .file-icon {
@@ -114,6 +115,8 @@
   }
   .error-message,
   .progress-message {
+    display: flex;
+    align-items: center;
     height: $s-32;
     color: var(--modal-text-foreground-color);
   }


### PR DESCRIPTION
how to test: try to upload an image on importing penpot file

before fix:

penpot lets you import, so error is raised on backend, after clicking upload

after fix:

penpot detects incorrect file before uploading to backend, reporting the error to user. this is the previous behavior before binfile-v3 refactor