### PR TITLE
:books: Add links to Kubernetes documentation

### DIFF
--- a/docs/technical-guide/getting-started.md
+++ b/docs/technical-guide/getting-started.md
@@ -4,7 +4,8 @@ title: 1. Self-hosting Guide
 
 # Self-hosting Guide
 
-This guide explains how to get your own Penpot instance, running on a machine you control, to test it, use it by you or your team, or even customize and extend it any way you like.
+This guide explains how to get your own Penpot instance, running on a machine you control,
+to test it, use it by you or your team, or even customize and extend it any way you like.
 
 If you need more context you can look at the <a
 href="https://community.penpot.app/t/self-hosting-penpot-i/2336" target="_blank">post
@@ -14,13 +15,16 @@ about self-hosting</a> in Penpot community.
 href="https://design.penpot.app">our SaaS offer</a> for Penpot and your
 self-hosted Penpot platform!**
 
-There are two main options for creating a Penpot instance:
+There are three main options for creating a Penpot instance:
 
 1. Using the platform of our partner <a href="https://elest.io/open-source/penpot" target="_blank">Elestio</a>.
 2. Using <a href="https://docker.com" target="_blank">Docker</a> tool.
+3. Using <a href="https://kubernetes.io/" target="_blank">Kubernetes</a>.
 
 <p class="advice">
-The recommended way is to use Elestio, since it's simpler, fully automatic and still greatly flexible. Use Docker if you already know the tool, if need full control of the process or have extra requirements and do not want to depend on any external provider, or need to do any special customization.
+The recommended way is to use Elestio, since it's simpler, fully automatic and still greatly flexible.
+Use Docker if you already know the tool, if need full control of the process or have extra requirements
+and do not want to depend on any external provider, or need to do any special customization.
 </p>
 
 Or you can try <a href="#unofficial-self-host-options">other options</a>,
@@ -261,7 +265,7 @@ itself.
 
 This section details everything you need to know to get Penpot up and running in
 production environments using a Kubernetes cluster of your choice. To do this, we have
-created a <a href="https://helm.sh/" target="_blank">Helm<a> repository with everything
+created a <a href="https://helm.sh/" target="_blank">Helm</a> repository with everything
 you need.
 
 Therefore, your prerequisite will be to have a Kubernetes cluster on which we can install
@@ -287,7 +291,7 @@ in turn have its own release name.
 With these concepts in mind, we can now explain Helm like this:
 
 > Helm installs charts into Kubernetes clusters, creating a new release for each
-> installation. And to find new charts, you can search Helm chart repositories.
+> installation. To find new charts, you can search Helm chart repositories.
 
 
 ### Install Helm

--- a/docs/technical-guide/index.md
+++ b/docs/technical-guide/index.md
@@ -20,6 +20,8 @@ machine.
 
 * In the [Install with Docker][2] section, you can find the official Docker installation guide.
 
+* In the [Install with Kubernetes][7] section, you can find the official Kubernetes installation guide.
+
 * In the [Configuration][3] section, you can find all the customization options you can set up after installing.
 
 * Or you can try other, not supported by Penpot, [Unofficial options][4].
@@ -28,9 +30,11 @@ machine.
 
 The [Integration Guide][5] explains how to connect Penpot with external apps, so they get notified
 when certain events occur and may create your own interconnections and collaboration features.
+
 ## Developing Penpot
 
-Also, if you are a developer, you can get into the code, to explore it, learn how it is made, or extend it and contribute with new functionality. For this, we have a different Docker installation.
+Also, if you are a developer, you can get into the code, to explore it, learn how it is made,
+or extend it and contribute with new functionality. For this, we have a different Docker installation.
 In the [Developer Guide][6] you can find how to setup a development environment and many other dev-oriented documentation.
 
 [1]: /technical-guide/getting-started/#install-with-elestio
@@ -39,3 +43,4 @@ In the [Developer Guide][6] you can find how to setup a development environment 
 [4]: /technical-guide/getting-started/#unofficial-self-host-options
 [5]: /technical-guide/integration/
 [6]: /technical-guide/developer/
+[7]: /technical-guide/getting-started/#install-with-kubernetes


### PR DESCRIPTION
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExYTJnejd0ODhnNDYyY2VpNWlhZTF4eGpkcWNtZG41bGpvZ2swdHR0cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2ZDN1zGGfKjdlSGQ/giphy-downsized.gif)

This PR adds some links to the k8s documentation in the [getting-started page](https://help.penpot.app/technical-guide/getting-started/), so it's clearer that the option is available.