### PR TITLE
docs(create-a-plugin): Fix Vite script conflicts

### DIFF
--- a/docs/plugins/create-a-plugin.md
+++ b/docs/plugins/create-a-plugin.md
@@ -176,6 +176,32 @@ And then add the following scripts to your <code class="language-js">package.jso
 }
 ```
 
+However, if you encounter issues with the dev script when accessing the preview URL, it's likely caused by <code class="language-js">vite build --watch</code> and <code class="language-js">vite preview</code> running simultaneously without coordination. Here are two solutions to address this:
+
+##### Sequential Commands
+You can adjust your dev script to ensure the build completes before the preview server starts:
+
+```json
+"dev": "vite build && vite preview"
+```
+
+##### Concurrent Execution with Task Runner
+If you prefer running both commands simultaneously, you can use a task runner like concurrently. First, install it:
+
+```bash
+$ npm i -D concurrently        # install as dev dependency
+```
+
+Then update your dev script:
+
+```json
+"dev": "concurrently -k \"vite build --watch\" \"vite preview\""
+```
+The -k flag ensures both processes terminate together if one is stopped.
+
+Both approaches let you test your plugin live efficiently while avoiding potential conflicts between the build and preview processes.
+
+
 #### Esbuild
 
 ```bash


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request

This PR enhances the `Step 5. Build the plugin file` section by addressing potential issues with the dev script when using Vite. Specifically, it introduces solutions to handle conflicts caused by running `vite build --watch` and `vite preview` simultaneously.

When running `vite build --watch & vite preview`, no preview URL is provided, and accessing `localhost:port` in the browser fails. While removing `--watch` resolves the issue, it prevents automatic rebuilding when files change. This update offers solutions to handle both needs effectively.

> Explain the **details** for making this change. What existing problem does the pull request solve?

- Added an explanation of the issue when `vite build --watch` and `vite preview` run together without coordination.
- Provided two solutions:
  - Sequential Commands: Ensuring the build completes before starting the preview server.
  - Concurrent Execution with Task Runner: Running both commands simultaneously using concurrently.

> Screenshots/GIFs

N/A