### PR TITLE
:books: Minor fix to plugin docs

### DIFF
--- a/docs/plugins/create-a-plugin.md
+++ b/docs/plugins/create-a-plugin.md
@@ -60,10 +60,10 @@ npm install @penpot/plugin-types
 
 If you're using typescript, don't forget to add <code class="language-js">@penpot/plugin-types</code> to your typings in your <code class="language-js">tsconfig.json</code>.
 
-```json
+```js
 {
   "compilerOptions": {
-    [...]
+    // ...
     "typeRoots": ["./node_modules/@types", "./node_modules/@penpot"],
     "types": ["plugin-types"],
   }
@@ -148,7 +148,7 @@ If you're using Vite you can simply edit the configuration file and add the buil
 
 ```ts
 export default defineConfig({
-[...]
+  // ...
   build: {
     rollupOptions: {
       input: {
@@ -168,11 +168,12 @@ export default defineConfig({
 
 And then add the following scripts to your <code class="language-js">package.json</code>:
 
-```json
+```js
 "scripts": {
-  "dev": "vite build --watch & vite preview",
+  "dev": "vite dev",
   "build": "tsc && vite build",
-  [...]
+  "preview": "npm run build && vite preview",
+  // ...
 }
 ```
 
@@ -190,11 +191,11 @@ esbuild your-folder/plugin.ts --minify --outfile=your-folder/public/plugin.js
 
 You can add it to your <code class="language-js">package.json</code> scripts so you don't need to manually re-run the build:
 
-```json
+```js
   "scripts": {
     "start": "npm run build:plugin && ng serve",
     "build:plugin": "esbuild your-folder/plugin.ts --minify --outfile=your-folder/public/plugin.js"
-    [...]
+    // ...
   },
 ```
 


### PR DESCRIPTION
Prompted by #5387 , since the issue they are commenting is a Vite config issue, I believe it's best if we updated the script shown in the docs to keep the text on the shorter side.

Also, switched from `[...]` to a comment `// ...` since it was messing the preview by GitHub and other markdown previewers.