### PR TITLE
:bug: Fix ulimits format in devenv/docker-compose.yaml

### DIFF
--- a/docker/devenv/docker-compose.yaml
+++ b/docker/devenv/docker-compose.yaml
@@ -125,5 +125,5 @@ services:
       - "10636:10636"
     ulimits:
       nofile:
-        soft: "1024"
-        hard: "1024"
+        soft: 1024
+        hard: 1024


### PR DESCRIPTION
ulimit nofile format is expected to be int, not string

Signed-off-by: Ryan Breen <rbreen@getfastr.com>