### PR TITLE
:sparkles: Add path to color bullet title

### DIFF
--- a/frontend/src/app/main/ui/components/color_bullet.cljs
+++ b/frontend/src/app/main/ui/components/color_bullet.cljs
@@ -16,6 +16,8 @@
 (defn- color-title
   [color-item]
   (let [name (:name color-item)
+        path (:path color-item)
+        path-and-name (if path (str path " / " name) name)
         gradient (:gradient color-item)
         image (:image color-item)
         color (:color color-item)]
@@ -23,16 +25,16 @@
     (if (some? name)
       (cond
         (some? color)
-        (str/ffmt "% (%)" name color)
+        (str/ffmt "% (%)" path-and-name color)
 
         (some? gradient)
-        (str/ffmt "% (%)" name (uc/gradient-type->string (:type gradient)))
+        (str/ffmt "% (%)" path-and-name (uc/gradient-type->string (:type gradient)))
 
         (some? image)
-        (str/ffmt "% (%)" name (tr "media.image"))
+        (str/ffmt "% (%)" path-and-name (tr "media.image"))
 
         :else
-        name)
+        path-and-name)
 
       (cond
         (some? color)


### PR DESCRIPTION
So, i noticed that the html `title` for library colors in the color picker doesn't include the group name from the assets.

Assets:
![image](https://github.com/user-attachments/assets/4a0f0675-2b15-4c43-ad18-5cd51e9f463a)

Color picker title:
![image](https://github.com/user-attachments/assets/45942132-2746-47a9-b9d6-ba80a90a8294)

As you can see "blue" is missing from the title, rather confusing if you have a lot of color groups. 

This PR adds it:
![image](https://github.com/user-attachments/assets/820385cf-12b4-4ad1-9904-4aa73dac2f25)

Let me know if I you prefer something in this PR to be different!