### PR TITLE
Wasm save buffer pointer

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -132,7 +132,6 @@
                              (aget buffer 1)
                              (aget buffer 2)
                              (aget buffer 3)
-                             image-ptr
                              image-size)
                      true))))))
 

--- a/render-wasm/src/mem.rs
+++ b/render-wasm/src/mem.rs
@@ -1,17 +1,25 @@
+static mut BUFFERU8: Option<Box<Vec<u8>>> = None;
+
 #[no_mangle]
 pub extern "C" fn alloc_bytes(len: usize) -> *mut u8 {
-    // create a new mutable buffer with capacity `len`
-    let mut buf: Vec<u8> = Vec::with_capacity(len);
-    let ptr = buf.as_mut_ptr();
-    // take ownership of the memory block and ensure the its destructor is not
-    // called when the object goes out of scope at the end of the function
-    std::mem::forget(buf);
+    // TODO: Figure out how to deal with Result<T> from Emscripten
+    if unsafe { BUFFERU8.is_some() } {
+        panic!("Bytes already allocated");
+    }
+
+    let mut buffer = Box::new(Vec::<u8>::with_capacity(len));
+    let ptr = buffer.as_mut_ptr();
+
+    unsafe { BUFFERU8 = Some(buffer) };
     return ptr;
 }
 
-pub fn free(ptr: *mut u8, len: usize) {
-    unsafe {
-        let buf = Vec::<u8>::from_raw_parts(ptr, len, len);
-        std::mem::forget(buf);
-    }
+pub fn free_bytes() {
+    let buffer = unsafe { BUFFERU8.take() }.expect("uninitialized buffer");
+    std::mem::drop(buffer);
+}
+
+pub fn buffer_ptr() -> *mut u8 {
+    let buffer = unsafe { BUFFERU8.as_mut() }.expect("uninitializied buffer");
+    buffer.as_mut_ptr()
 }

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -98,7 +98,7 @@ pub(crate) struct RenderState {
     pub cached_surface_image: Option<CachedSurfaceImage>,
     options: RenderOptions,
     pub viewbox: Viewbox,
-    pub images: HashMap<String, Image>,
+    images: HashMap<Uuid, Image>,
 }
 
 impl RenderState {
@@ -123,6 +123,18 @@ impl RenderState {
             viewbox: Viewbox::new(width as f32, height as f32),
             images: HashMap::with_capacity(2048),
         }
+    }
+
+    pub fn add_image(&mut self, id: Uuid, image_data: &[u8]) -> Result<(), String> {
+        let image_data = skia::Data::new_copy(image_data);
+        let image = Image::from_encoded(image_data).ok_or("Error decoding image data")?;
+
+        self.images.insert(id, image);
+        Ok(())
+    }
+
+    pub fn has_image(&mut self, id: &Uuid) -> bool {
+        self.images.contains_key(id)
     }
 
     pub fn set_debug_flags(&mut self, debug: u32) {
@@ -214,12 +226,12 @@ impl RenderState {
 
         for fill in shape.fills().rev() {
             if let Fill::Image(image_fill) = fill {
-                let image = self.images.get(&image_fill.id.to_string());
+                let image = self.images.get(&image_fill.id());
                 if let Some(image) = image {
                     draw_image_in_container(
                         &self.drawing_surface.canvas(),
                         &image,
-                        (image_fill.width, image_fill.height),
+                        image_fill.size(),
                         shape.selrect,
                         &fill.to_paint(&shape.selrect),
                     );

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -92,14 +92,16 @@ impl Shape {
         self.fills.clear();
     }
 
-    pub fn add_gradient_stop(&mut self, color: skia::Color, offset: f32) -> Result<(), String> {
+    pub fn add_gradient_stops(&mut self, buffer: Vec<RawStopData>) -> Result<(), String> {
         let fill = self.fills.last_mut().ok_or("Shape has no fills")?;
         let gradient = match fill {
             Fill::LinearGradient(g) => Ok(g),
             _ => Err("Active fill is not a gradient"),
         }?;
 
-        gradient.add_stop(color, offset);
+        for stop in buffer.into_iter() {
+            gradient.add_stop(stop.color(), stop.offset());
+        }
 
         Ok(())
     }

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -4,6 +4,23 @@ use super::Color;
 use crate::math;
 use uuid::Uuid;
 
+#[derive(Debug)]
+#[repr(C)]
+pub struct RawStopData {
+    color: [u8; 4],
+    offset: u8,
+}
+
+impl RawStopData {
+    pub fn color(&self) -> skia::Color {
+        skia::Color::from_argb(self.color[3], self.color[0], self.color[1], self.color[2])
+    }
+
+    pub fn offset(&self) -> f32 {
+        self.offset as f32 / 100.0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Gradient {
     colors: Vec<Color>,

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -60,10 +60,20 @@ impl Gradient {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ImageFill {
-    pub id: Uuid,
-    pub alpha: u8,
-    pub height: f32,
-    pub width: f32,
+    id: Uuid,
+    opacity: u8,
+    height: i32,
+    width: i32,
+}
+
+impl ImageFill {
+    pub fn size(&self) -> (i32, i32) {
+        (self.width, self.height)
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -84,10 +94,10 @@ impl Fill {
         })
     }
 
-    pub fn new_image_fill(id: Uuid, alpha: u8, height: f32, width: f32) -> Self {
+    pub fn new_image_fill(id: Uuid, opacity: u8, (width, height): (i32, i32)) -> Self {
         Self::Image(ImageFill {
             id,
-            alpha,
+            opacity,
             height,
             width,
         })
@@ -116,7 +126,7 @@ impl Fill {
                 p.set_style(skia::PaintStyle::Fill);
                 p.set_anti_alias(true);
                 p.set_blend_mode(skia::BlendMode::SrcOver);
-                p.set_alpha(image_fill.alpha);
+                p.set_alpha(image_fill.opacity);
                 p
             }
         }

--- a/render-wasm/src/shapes/images.rs
+++ b/render-wasm/src/shapes/images.rs
@@ -6,12 +6,12 @@ pub type Image = skia::Image;
 pub fn draw_image_in_container(
     canvas: &skia::Canvas,
     image: &Image,
-    size: (f32, f32),
+    size: (i32, i32),
     container: skia::Rect,
     paint: &skia::Paint,
 ) {
-    let width = size.0;
-    let height = size.1;
+    let width = size.0 as f32;
+    let height = size.1 as f32;
     let image_aspect_ratio = width / height;
 
     // Container size


### PR DESCRIPTION
This PR:

- Introduces a refactor on handling fills.
- Uses a static `Vec<u8>` to allocate bytes.
