### PR TITLE
:sparkles: Explicitly display icon IDs in storybook

### DIFF
--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.stories.jsx
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.stories.jsx
@@ -26,16 +26,26 @@ export const All = {
     <>
       <StoryHeader>
         <h1>All Icons</h1>
-        <p>Hover on an icon to see its ID.</p>
       </StoryHeader>
-      <StoryGrid>
+      <StoryGrid size="256">
         {icons.map((iconId) => (
           <StoryGridCell
-            title={iconId}
             key={iconId}
-            style={{ color: "var(--color-accent-primary)" }}
+            style={{
+              color: "var(--color-accent-primary)",
+              display: "grid",
+              gap: "0.5rem",
+            }}
           >
             <Icon id={iconId} size={size} />
+            <code
+              style={{
+                "font-family": "monospace",
+                color: "var(--color-foreground-secondary)",
+              }}
+            >
+              {iconId}
+            </code>
           </StoryGridCell>
         ))}
       </StoryGrid>

--- a/frontend/src/app/main/ui/ds/storybook.scss
+++ b/frontend/src/app/main/ui/ds/storybook.scss
@@ -16,6 +16,7 @@
 
 .story-header {
   color: var(--color-foreground-primary);
+  margin-bottom: 1rem;
 }
 
 .story-grid-row {


### PR DESCRIPTION
<img width="1055" alt="Screenshot 2024-12-03 at 9 59 42 AM" src="https://github.com/user-attachments/assets/0a03efe6-8491-4df2-9f4c-1a6cdf200a12">
