### PR TITLE
[backport] :bug: Fix missing rename shortcut translation

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -163,6 +163,7 @@
     (tr "shortcuts.paste")
     (tr "shortcuts.prev-frame")
     (tr "shortcuts.redo")
+    (tr "shortcuts.rename")
     (tr "shortcuts.reset-zoom")
     (tr "shortcuts.scale")
     (tr "shortcuts.search-placeholder")

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3622,6 +3622,9 @@ msgstr "Previous board"
 msgid "shortcuts.redo"
 msgstr "Redo"
 
+msgid "shortcuts.rename"
+msgstr "Rename"
+
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:166
 msgid "shortcuts.reset-zoom"
 msgstr "Reset zoom"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3625,6 +3625,9 @@ msgstr "Tablero anterior"
 msgid "shortcuts.redo"
 msgstr "Rehacer"
 
+msgid "shortcuts.rename"
+msgstr "Renombrar"
+
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:166
 msgid "shortcuts.reset-zoom"
 msgstr "Reiniciar zoom"


### PR DESCRIPTION
Cherry picking [this bug fix](https://github.com/penpot/penpot/commit/0228f7968735add0965b0a33f9a99e17522e7ab8) to `staging`.

Closes https://tree.taiga.io/project/penpot/issue/9477