### PR TITLE
:books: Remove broken video about History versions

### DIFF
--- a/docs/user-guide/workspace-basics/index.njk
+++ b/docs/user-guide/workspace-basics/index.njk
@@ -250,11 +250,6 @@ geometric structure. In Penpot there are three types of guides:
 <h4>Navigate actions</h4>
 <p>To navigate through the actions press <kbd>Ctrl/⌘</kbd> + <kbd>Z</kbd> to go backwards and <kbd>Ctrl/⌘</kbd> + <kbd>Shift/⇧</kbd> + <kbd>Z</kbd> to go forward.</p>
 <p>You can also press any item of the actions list to get to this specific state.</p>
-<figure>
-  <video title="Navigate history" muted="" playsinline="" controls="" width="auto" poster="/img/workspace-basics/history-navigate.webp" height="auto">
-    <source src="/img/workspace-basics/history-navigate.mp4" type="video/mp4">
-  </video>
-</figure>
 
 <h2 id="comments">Comments</h2>
 <p>Comments allow the team to have one priceless conversation getting and providing feedback right over the designs and prototypes.<p>


### PR DESCRIPTION
This video showed the feature before 2.4 and is now outdated, so the fix is simply to remove it.