### PR TITLE
:bug: fix color-bullet props error

### DIFF
--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -189,7 +189,7 @@
                  [:& bc/color-bullet {:color {:color (:color color)
                                               :id (:id color)
                                               :opacity (:opacity color)}
-                                      :mini? true}]
+                                      :mini true}]
                  [:div {:class (stl/css :name-block)}
                   [:span {:class (stl/css :color-name)} (:name color)]
                   (when-not (= (:name color) default-name)

--- a/frontend/src/app/main/ui/viewer/inspect/attributes/common.cljs
+++ b/frontend/src/app/main/ui/viewer/inspect/attributes/common.cljs
@@ -70,7 +70,7 @@
           [:div {:class (stl/css :bullet-wrapper)
                  :style #js {"--bullet-size" "16px"}}
            [:& cb/color-bullet {:color color
-                                :mini? true}]]
+                                :mini true}]]
 
           [:div {:class (stl/css :format-wrapper)}
            [:div {:class (stl/css :image-format)}
@@ -102,7 +102,7 @@
        [:div {:class (stl/css :bullet-wrapper)
               :style #js {"--bullet-size" "16px"}}
         [:& cb/color-bullet {:color color
-                             :mini? true}]]
+                             :mini true}]]
 
        [:div {:class (stl/css :format-wrapper)}
         (when-not (and on-change-format (or (:gradient color) image))

--- a/frontend/src/app/main/ui/workspace/color_palette_ctx_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/color_palette_ctx_menu.cljs
@@ -44,7 +44,7 @@
                    :style #js {"--bullet-size" "20px"}}
              (for [[i {:keys [color id gradient]}] (map-indexed vector (take 7 colors))]
                [:& cb/color-bullet {:key (dm/str "color-" i)
-                                    :mini? true
+                                    :mini true
                                     :color {:color color :id id :gradient gradient}}])]]]))
 
       [:li {:class (stl/css-case :file-library true
@@ -68,7 +68,7 @@
                :style #js {"--bullet-size" "20px"}}
          (for [[i color] (map-indexed vector (take 7 (vals file-colors)))]
            [:& cb/color-bullet {:key (dm/str "color-" i)
-                                :mini? true
+                                :mini true
                                 :color color}])]]]
 
       [:li {:class (stl/css :recent-colors true
@@ -90,5 +90,5 @@
                :style #js {"--bullet-size" "20px"}}
          (for [[idx color] (map-indexed vector (take 7 (reverse recent-colors)))]
            [:& cb/color-bullet {:key (str "color-" idx)
-                                :mini? true
+                                :mini true
                                 :color color}])]]]]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
@@ -216,7 +216,7 @@
 
      [:div {:class (stl/css :bullet-block)}
       [:& cb/color-bullet {:color color
-                           :mini? true}]]
+                           :mini true}]]
 
      (if ^boolean editing?
        [:input

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -212,7 +212,7 @@
                                       (nil? color-name) (assoc
                                                          :id nil
                                                          :file-id nil))
-                             :mini? true
+                             :mini true
                              :on-click handle-click-color}]]
        (cond
               ;; Rendering a color with ID

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -73,7 +73,7 @@
                         (wtt/resolved-value-hex theme-token)
                         (wtt/resolved-value-hex token))]
        [:& color-bullet {:color color
-                         :mini? true}])
+                         :mini true}])
      name]))
 
 (mf/defc token-section-icon


### PR DESCRIPTION
Color bullet component was receiving a prop `mini?` that was renamed to `mini` to avoid conflict with JS.
All color-bullet in the app should be updated to receive the prop renamed.