### PR TITLE
🐛  Fix border radius tooltip

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/border_radius.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/border_radius.cljs
@@ -116,8 +116,7 @@
      [:> icon-button* {:class (stl/css-case :selected radius-expanded)
                        :variant "ghost"
                        :on-click toggle-radius-mode
-                       :aria-label (tr "workspace.options.radius")
-                       :title (if radius-expanded
-                                (tr "workspace.options.radius.all-corners")
-                                (tr "workspace.options.radius.single-corners"))
+                       :aria-label (if radius-expanded
+                                     (tr "workspace.options.radius.all-corners")
+                                     (tr "workspace.options.radius.single-corners"))
                        :icon "corner-radius"}]]))


### PR DESCRIPTION
This PR restores the border radius button tooltip. 
Only the second point of [this review](https://tree.taiga.io/project/penpot/task/9545) is solved in this PR 