### PR TITLE
🐛 Fix assets proxy SSL handshake error

### DIFF
--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -90,6 +90,7 @@ http {
             proxy_hide_header x-amz-meta-server-side-encryption;
             proxy_hide_header x-amz-server-side-encryption;
             proxy_pass $redirect_uri;
+            proxy_ssl_server_name on;
 
             add_header x-internal-redirect "$redirect_uri";
             add_header x-cache-control "$redirect_cache_control";

--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -92,6 +92,7 @@ http {
             proxy_hide_header x-amz-request-id;
             proxy_hide_header x-amz-meta-server-side-encryption;
             proxy_hide_header x-amz-server-side-encryption;
+            proxy_ssl_server_name on;
             proxy_pass $redirect_uri;
 
             add_header x-internal-redirect "$redirect_uri";


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/uxbox/uxbox/blob/develop/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

Fix issue: https://github.com/penpot/penpot/issues/5478

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

When using S3 assets storage backend with Cloudflare R2, Nginx will send wrong server name for SSL handshake, it will cause all the asset proxy requests return 502.

To fix this issue, we can simply add `proxy_ssl_server_name on;` to the Nginx config.
