### PR TITLE
:tada: Stroke style support for wasm render

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -211,6 +211,14 @@
                   (store-image id))))))
         fills))
 
+(defn- translate-stroke-style
+  [stroke-style]
+  (case stroke-style
+    :dotted 1
+    :dashed 2
+    :mixed  3
+    0))
+
 (defn set-shape-strokes
   [strokes]
   (h/call internal-module "_clear_shape_strokes")
@@ -220,11 +228,12 @@
                 gradient (:stroke-color-gradient stroke)
                 image    (:stroke-image stroke)
                 width    (:stroke-width stroke)
-                align    (:stroke-alignment stroke)]
+                align    (:stroke-alignment stroke)
+                style    (-> stroke :stroke-style translate-stroke-style)]
             (case align
-              :inner (h/call internal-module "_add_shape_inner_stroke" width)
-              :outer (h/call internal-module "_add_shape_outer_stroke" width)
-              (h/call internal-module "_add_shape_center_stroke" width))
+              :inner (h/call internal-module "_add_shape_inner_stroke" width style)
+              :outer (h/call internal-module "_add_shape_outer_stroke" width style)
+              (h/call internal-module "_add_shape_center_stroke" width style))
 
             (cond
               (some? gradient)

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -347,26 +347,26 @@ pub extern "C" fn set_shape_path_content() {
 }
 
 #[no_mangle]
-pub extern "C" fn add_shape_center_stroke(width: f32) {
+pub extern "C" fn add_shape_center_stroke(width: f32, style: i32) {
     let state = unsafe { STATE.as_mut() }.expect("got an invalid state pointer");
     if let Some(shape) = state.current_shape() {
-        shape.add_stroke(shapes::Stroke::new_center_stroke(width))
+        shape.add_stroke(shapes::Stroke::new_center_stroke(width, style));
     }
 }
 
 #[no_mangle]
-pub extern "C" fn add_shape_inner_stroke(width: f32) {
+pub extern "C" fn add_shape_inner_stroke(width: f32, style: i32) {
     let state = unsafe { STATE.as_mut() }.expect("got an invalid state pointer");
     if let Some(shape) = state.current_shape() {
-        shape.add_stroke(shapes::Stroke::new_inner_stroke(width))
+        shape.add_stroke(shapes::Stroke::new_inner_stroke(width, style))
     }
 }
 
 #[no_mangle]
-pub extern "C" fn add_shape_outer_stroke(width: f32) {
+pub extern "C" fn add_shape_outer_stroke(width: f32, style: i32) {
     let state = unsafe { STATE.as_mut() }.expect("got an invalid state pointer");
     if let Some(shape) = state.current_shape() {
-        shape.add_stroke(shapes::Stroke::new_outer_stroke(width))
+        shape.add_stroke(shapes::Stroke::new_outer_stroke(width, style))
     }
 }
 


### PR DESCRIPTION
- https://tree.taiga.io/project/penpot/task/9636?
- https://tree.taiga.io/project/penpot/task/9637?
- https://tree.taiga.io/project/penpot/task/9638?

![image](https://github.com/user-attachments/assets/c9409ed3-6685-4343-b20f-f251db114d50)
