### PR TITLE
:bug: Fix wasm render strokes bugs

### DIFF
--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -46,10 +46,19 @@ pub struct Stroke {
     pub style: StrokeStyle,
     pub cap_end: StrokeCap,
     pub cap_start: StrokeCap,
-    pub kind: StrokeKind,
+    kind: StrokeKind,
 }
 
 impl Stroke {
+    // Strokes for open shapes should be rendered as if they were centered.
+    pub fn render_kind(&self, is_open: bool) -> StrokeKind {
+        if is_open {
+            StrokeKind::CenterStroke
+        } else {
+            self.kind.clone()
+        }
+    }
+
     pub fn new_center_stroke(width: f32, style: i32) -> Self {
         let transparent = skia::Color::from_argb(0, 0, 0, 0);
         Stroke {
@@ -153,9 +162,9 @@ impl Stroke {
         paint
     }
 
-    pub fn to_stroked_paint(&self, rect: &math::Rect) -> skia::Paint {
+    pub fn to_stroked_paint(&self, kind: StrokeKind, rect: &math::Rect) -> skia::Paint {
         let mut paint = self.to_paint(rect);
-        match self.kind {
+        match kind {
             StrokeKind::InnerStroke => {
                 paint.set_stroke_width(2. * self.width);
                 paint

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -32,7 +32,7 @@ pub enum StrokeCap {
     // Square,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StrokeKind {
     InnerStroke,
     OuterStroke,
@@ -55,7 +55,7 @@ impl Stroke {
         if is_open {
             StrokeKind::CenterStroke
         } else {
-            self.kind.clone()
+            self.kind
         }
     }
 
@@ -133,7 +133,12 @@ impl Stroke {
             let path_effect = match self.style {
                 StrokeStyle::Dotted => {
                     let mut circle_path = skia::Path::new();
-                    circle_path.add_circle((0.0, 0.0), self.width / 2.0, None);
+                    let width = match self.kind {
+                        StrokeKind::InnerStroke => self.width,
+                        StrokeKind::CenterStroke => self.width / 2.0,
+                        StrokeKind::OuterStroke => self.width,
+                    };
+                    circle_path.add_circle((0.0, 0.0), width, None);
                     let advance = self.width + 5.0;
                     skia::PathEffect::path_1d(
                         &circle_path,


### PR DESCRIPTION
- In open paths: inner, center and outer strokes should be rendered as center: https://tree.taiga.io/project/penpot/task/9671
- In dotted paths the width was not correctly calculated (it should be doubled for inner and outeR): https://tree.taiga.io/project/penpot/task/9697