### PR TITLE
:bug: Fix race condition when rendering the background

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -284,8 +284,7 @@
              (p/fmap (fn [ready?]
                        (when ready?
                          (reset! canvas-init? true)
-                         (wasm.api/assign-canvas canvas)
-                         (wasm.api/set-canvas-background background)))))
+                         (wasm.api/assign-canvas canvas)))))
         (fn []
           (wasm.api/clear-canvas))))
 
@@ -293,15 +292,15 @@
       (when @canvas-init?
         (wasm.api/resize-viewbox (:width vport) (:height vport))))
 
-    (mf/with-effect [base-objects canvas-init?]
+    (mf/with-effect [base-objects @canvas-init?]
       (when @canvas-init?
         (wasm.api/set-objects base-objects)))
 
-    (mf/with-effect [preview-blend canvas-init?]
+    (mf/with-effect [preview-blend @canvas-init?]
       (when (and @canvas-init? preview-blend)
         (wasm.api/request-render)))
 
-    (mf/with-effect [vbox canvas-init?]
+    (mf/with-effect [vbox @canvas-init?]
       (when @canvas-init?
         (wasm.api/set-view zoom vbox)))
 


### PR DESCRIPTION
We have a Wasm panic when loading a penpot file and trying to render the background before we have initialized the shape there.

<img width="847" alt="Screenshot 2025-01-08 at 11 38 45 AM" src="https://github.com/user-attachments/assets/746cc616-1c97-4aa8-b03a-dfe230c3dfeb" />

(We are trying to fetch the root shape from the tree and do an `unwrap`, but the tree is empty)