### PR TITLE
:bug: Backport comments decoding from develop

### DIFF
--- a/backend/src/app/rpc/commands/comments.clj
+++ b/backend/src/app/rpc/commands/comments.clj
@@ -29,10 +29,11 @@
 ;; --- GENERAL PURPOSE INTERNAL HELPERS
 
 (defn- decode-row
-  [{:keys [participants position] :as row}]
+  [{:keys [participants position mentions] :as row}]
   (cond-> row
     (db/pgpoint? position) (assoc :position (db/decode-pgpoint position))
-    (db/pgobject? participants) (assoc :participants (db/decode-transit-pgobject participants))))
+    (db/pgobject? participants) (assoc :participants (db/decode-transit-pgobject participants))
+    (db/pgarray? mentions) (assoc :mentions (db/decode-pgarray mentions #{}))))
 
 (def xf-decode-row
   (map decode-row))


### PR DESCRIPTION
Mainly for backward compatibility with database layout on comments tables from develop

https://tree.taiga.io/project/penpot/issue/9738