### PR TITLE
:books: Change term for border radius

### DIFF
--- a/docs/user-guide/styling/index.njk
+++ b/docs/user-guide/styling/index.njk
@@ -124,10 +124,10 @@ title: 06· Styling
   <li><strong>Square</strong> - Adds a rectangular ending to the end of the path.</li>
 </ul>
 
-<h2 id="radius">Corner radius</h2>
-<p>You can set values for corner radius to rectangles and images. There’s also the option to edit each corner individually.</p>
+<h2 id="radius">Border radius</h2>
+<p>You can customize the border radius of rectangles and images, with the option to customize each corner individually.</p>
 <figure>
-  <video title="Corner radius" muted="" playsinline="" controls="" width="100%" poster="/img/styling/corners.webp" height="auto">
+  <video title="Border radius" muted="" playsinline="" controls="" width="100%" poster="/img/styling/corners.webp" height="auto">
     <source src="/img/styling/corners.mp4" type="video/mp4">
   </video>
 </figure>


### PR DESCRIPTION
This PR changes the term "Corner radius" to "Border radius" in the user guide so that it is consistent with Penpot's UI and the related CSS property.

Taiga US: https://tree.taiga.io/project/penpot/us/9389
