### PR TITLE
Token Sets Drag & Drop

### DIFF
--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -78,6 +78,23 @@
 
 (declare index-of)
 
+(defn oreorder-before
+  "Assoc a k v pair, in the order position just before the other key."
+  [o ks k v before-k]
+  (let [f (fn [o']
+            (cond-> (reduce
+                     (fn [acc [k' v']]
+                       (cond
+                         (and before-k (= k' before-k)) (assoc acc k v k' v')
+                         (= k k') acc
+                         :else (assoc acc k' v')))
+                     (ordered-map)
+                     o')
+              (not before-k) (assoc k v)))]
+    (if (seq ks)
+      (oupdate-in o ks f)
+      (f o))))
+
 (defn oassoc-before
   "Assoc a k v pair, in the order position just before the other key"
   [o before-k k v]

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -418,8 +418,8 @@
     [:rename-token-set-group
      [:map {:title "RenameTokenSetGroup"}
       [:type [:= :rename-token-set-group]]
-      [:from-path-str :string]
-      [:to-path-str :string]]]
+      [:set-group-path [:vector :string]]
+      [:set-group-fname :string]]]
 
     [:mod-token-set
      [:map {:title "ModTokenSetChange"}
@@ -430,8 +430,18 @@
     [:move-token-set-before
      [:map {:title "MoveTokenSetBefore"}
       [:type [:= :move-token-set-before]]
-      [:set-name :string]
-      [:before-set-name [:maybe :string]]]]
+      [:from-path [:vector :string]]
+      [:to-path [:vector :string]]
+      [:before-path [:maybe [:vector :string]]]
+      [:before-group? [:maybe :boolean]]]]
+
+    [:move-token-set-group-before
+     [:map {:title "MoveTokenSetGroupBefore"}
+      [:type [:= :move-token-set-group-before]]
+      [:from-path [:vector :string]]
+      [:to-path [:vector :string]]
+      [:before-path [:maybe [:vector :string]]]
+      [:before-group? [:maybe :boolean]]]]
 
     [:del-token-set
      [:map {:title "DelTokenSetChange"}
@@ -1070,11 +1080,11 @@
                                 (ctob/add-sets (map ctob/make-token-set token-sets)))))
 
 (defmethod process-change :rename-token-set-group
-  [data {:keys [from-path-str to-path-str]}]
+  [data {:keys [set-group-path set-group-fname]}]
   (update data :tokens-lib (fn [lib]
                              (-> lib
                                  (ctob/ensure-tokens-lib)
-                                 (ctob/rename-set-group from-path-str to-path-str)))))
+                                 (ctob/rename-set-group set-group-path set-group-fname)))))
 
 (defmethod process-change :mod-token-set
   [data {:keys [name token-set]}]
@@ -1085,10 +1095,16 @@
                                                          (merge prev-set (dissoc token-set :tokens))))))))
 
 (defmethod process-change :move-token-set-before
-  [data {:keys [set-name before-set-name]}]
+  [data {:keys [from-path to-path before-path before-group?] :as changes}]
   (update data :tokens-lib #(-> %
                                 (ctob/ensure-tokens-lib)
-                                (ctob/move-set-before set-name before-set-name))))
+                                (ctob/move-set from-path to-path before-path before-group?))))
+
+(defmethod process-change :move-token-set-group-before
+  [data {:keys [from-path to-path before-path before-group?]}]
+  (update data :tokens-lib #(-> %
+                                (ctob/ensure-tokens-lib)
+                                (ctob/move-set-group from-path to-path before-path before-group?))))
 
 (defmethod process-change :del-token-set
   [data {:keys [name]}]

--- a/common/test/common_tests/runner.cljc
+++ b/common/test/common_tests/runner.cljc
@@ -28,6 +28,7 @@
    [common-tests.logic.multiple-nesting-levels-test]
    [common-tests.logic.swap-and-reset-test]
    [common-tests.logic.swap-as-override-test]
+   [common-tests.logic.token-test]
    [common-tests.pages-helpers-test]
    [common-tests.record-test]
    [common-tests.schema-test]
@@ -75,6 +76,7 @@
    'common-tests.logic.multiple-nesting-levels-test
    'common-tests.logic.swap-and-reset-test
    'common-tests.logic.swap-as-override-test
+   'common-tests.logic.token-test
    'common-tests.pages-helpers-test
    'common-tests.record-test
    'common-tests.schema-test

--- a/frontend/src/app/main/data/workspace/tokens/common.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/common.cljs
@@ -1,0 +1,8 @@
+(ns app.main.data.workspace.tokens.common
+  (:require
+   [app.main.data.helpers :as dsh]))
+
+(defn get-workspace-tokens-lib
+  [state]
+  (-> (dsh/lookup-file-data state)
+      (get :tokens-lib)))

--- a/frontend/src/app/main/data/workspace/tokens/selected_set.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/selected_set.cljs
@@ -1,0 +1,37 @@
+(ns app.main.data.workspace.tokens.selected-set
+  "The user selected token set in the ui, stored by the `:name` of the set.
+  Will default to the first set."
+  (:require
+   [app.common.types.tokens-lib :as ctob]
+   [app.main.data.workspace.tokens.common :as dwtc]
+   [potok.v2.core :as ptk]))
+
+(defn assoc-selected-token-set-name [state set-name]
+  (assoc-in state [:workspace-local :selected-token-set-name] set-name))
+
+(defn get-selected-token-set-name [state]
+  (or (get-in state [:workspace-local :selected-token-set-name])
+      (some-> (dwtc/get-workspace-tokens-lib state)
+              (ctob/get-sets)
+              (first)
+              :name)))
+
+(defn get-selected-token-set [state]
+  (when-let [set-name (get-selected-token-set-name state)]
+    (some-> (dwtc/get-workspace-tokens-lib state)
+            (ctob/get-set set-name))))
+
+(defn get-selected-token-set-token [state token-name]
+  (some-> (get-selected-token-set state)
+          (ctob/get-token token-name)))
+
+(defn get-selected-token-set-tokens [state]
+  (some-> (get-selected-token-set state)
+          :tokens))
+
+(defn set-selected-token-set-name
+  [set-name]
+  (ptk/reify ::set-selected-token-set-path-from-name
+    ptk/UpdateEvent
+    (update [_ state]
+      (assoc-selected-token-set-name state set-name))))

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -15,8 +15,8 @@
    [app.common.types.tokens-lib :as ctob]
    [app.config :as cf]
    [app.main.data.helpers :as dsh]
+   [app.main.data.workspace.tokens.selected-set :as dwts]
    [app.main.store :as st]
-   [app.main.ui.workspace.tokens.token-set :as wtts]
    [okulary.core :as l]))
 
 ;; ---- Global refs
@@ -450,11 +450,8 @@
 (def workspace-token-themes-no-hidden
   (l/derived #(remove ctob/hidden-temporary-theme? %) workspace-token-themes))
 
-(def workspace-selected-token-set-path
-  (l/derived wtts/get-selected-token-set-path st/state))
-
-(def workspace-token-set-group-selected?
-  (l/derived wtts/token-group-selected? st/state))
+(def workspace-selected-token-set-name
+  (l/derived dwts/get-selected-token-set-name st/state))
 
 (def workspace-ordered-token-sets
   (l/derived #(or (some-> % ctob/get-sets) []) tokens-lib))
@@ -466,11 +463,11 @@
   (l/derived (d/nilf ctob/get-active-theme-paths) tokens-lib))
 
 (defn token-sets-at-path-all-active
-  [prefixed-path]
+  [group-path]
   (l/derived
    (fn [lib]
      (when lib
-       (ctob/sets-at-path-all-active? lib prefixed-path)))
+       (ctob/sets-at-path-all-active? lib group-path)))
    tokens-lib))
 
 (def workspace-active-theme-paths-no-hidden
@@ -485,12 +482,12 @@
 (def workspace-selected-token-set-token
   (fn [token-name]
     (l/derived
-     #(some-> (wtts/get-selected-token-set %)
-              (ctob/get-token token-name))
+     #(dwts/get-selected-token-set-token % token-name)
      st/state)))
 
 (def workspace-selected-token-set-tokens
-  (l/derived #(or (wtts/get-selected-token-set-tokens %) {}) st/state))
+  (l/derived #(or (dwts/get-selected-token-set-tokens %) {}) st/state))
+
 
 (def plugins-permissions-peek
   (l/derived (fn [state]

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -207,7 +207,7 @@
                     (generic-attribute-actions #{:x} "X" (assoc context-data :on-update-shape wtch/update-shape-position))
                     (generic-attribute-actions #{:y} "Y" (assoc context-data :on-update-shape wtch/update-shape-position))))}))
 
-(defn default-actions [{:keys [token selected-token-set-path]}]
+(defn default-actions [{:keys [token selected-token-set-name]}]
   (let [{:keys [modal]} (wtty/get-token-properties token)]
     [{:title (tr "workspace.token.edit")
       :no-selectable true
@@ -220,16 +220,16 @@
                                     :position :right
                                     :fields fields
                                     :action "edit"
-                                    :selected-token-set-path selected-token-set-path
+                                    :selected-token-set-name selected-token-set-name
                                     :token token})))}
      {:title (tr "workspace.token.duplicate")
       :no-selectable true
       :action #(st/emit! (dt/duplicate-token (:name token)))}
      {:title (tr "workspace.token.delete")
       :no-selectable true
-      :action #(st/emit! (-> selected-token-set-path
-                             ctob/prefixed-set-path-string->set-name-string
-                             (dt/delete-token (:name token))))}]))
+      :action #(st/emit! (dt/delete-token
+                          (ctob/prefixed-set-path-string->set-name-string selected-token-set-name)
+                          (:name token)))}]))
 
 (defn selection-actions [{:keys [type token] :as context-data}]
   (let [with-actions (get shape-attribute-actions-map (or type (:type token)))
@@ -350,13 +350,13 @@
         selected-shapes (into [] (keep (d/getf objects)) selected)
         token-name (:token-name mdata)
         token (mf/deref (refs/workspace-selected-token-set-token token-name))
-        selected-token-set-path (mf/deref refs/workspace-selected-token-set-path)]
+        selected-token-set-name (mf/deref refs/workspace-selected-token-set-name)]
     [:ul {:class (stl/css :context-list)}
      [:& menu-tree {:submenu-offset width
                     :submenu-direction direction
                     :token token
                     :errors errors
-                    :selected-token-set-path selected-token-set-path
+                    :selected-token-set-name selected-token-set-name
                     :selected-shapes selected-shapes}]]))
 
 (mf/defc token-context-menu

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -202,7 +202,7 @@
 
 (mf/defc form
   {::mf/wrap-props false}
-  [{:keys [token token-type action selected-token-set-path]}]
+  [{:keys [token token-type action selected-token-set-name]}]
   (let [token (or token {:type token-type})
         token-properties (wtty/get-token-properties token)
         color? (wtt/color-token? token)
@@ -364,11 +364,11 @@
                                 (modal/hide!))))))))
         on-delete-token
         (mf/use-fn
-         (mf/deps selected-token-set-path)
+         (mf/deps selected-token-set-name)
          (fn [e]
            (dom/prevent-default e)
            (modal/hide!)
-           (st/emit! (dt/delete-token (ctob/prefixed-set-path-string->set-name-string selected-token-set-path) (:name token)))))
+           (st/emit! (dt/delete-token (ctob/prefixed-set-path-string->set-name-string selected-token-set-name) (:name token)))))
 
         on-cancel
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/tokens/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals.cljs
@@ -42,7 +42,7 @@
 
 (mf/defc token-update-create-modal
   {::mf/wrap-props false}
-  [{:keys [x y position token token-type action selected-token-set-path] :as _args}]
+  [{:keys [x y position token token-type action selected-token-set-name] :as _args}]
   (let [wrapper-style (use-viewport-position-style x y position)
         close-modal (mf/use-fn
                      (fn []
@@ -57,7 +57,7 @@
                        :aria-label (tr "labels.close")}]
      [:& form {:token token
                :action action
-               :selected-token-set-path selected-token-set-path
+               :selected-token-set-name selected-token-set-name
                :token-type token-type}]]))
 
 ;; Modals ----------------------------------------------------------------------

--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data.macros :as dm]
+   [app.common.logic.tokens :as clt]
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
@@ -308,8 +309,8 @@
         token-set-group-active?
         (mf/use-callback
          (mf/deps theme-state)
-         (fn [prefixed-path]
-           (ctob/sets-at-path-all-active? lib prefixed-path)))
+         (fn [group-path]
+           (ctob/sets-at-path-all-active? lib group-path)))
 
         token-set-active?
         (mf/use-callback
@@ -322,6 +323,12 @@
          (mf/deps theme-state)
          (fn [set-name]
            (swap! theme-state #(ctob/toggle-set % set-name))))
+
+        on-toggle-token-set-group
+        (mf/use-callback
+         (mf/deps theme-state)
+         (fn [group-path]
+           (swap! theme-state #(clt/toggle-token-set-group group-path lib %))))
 
         on-click-token-set
         (mf/use-callback
@@ -358,6 +365,7 @@
           :token-set-group-active? token-set-group-active?
           :on-select on-click-token-set
           :on-toggle-token-set on-toggle-token-set
+          :on-toggle-token-set-group on-toggle-token-set-group
           :origin "theme-modal"
           :context sets-context/static-context}]]
 
@@ -400,4 +408,5 @@
                         :aria-label (tr "labels.close")
                         :variant "action"
                         :icon "close"}]
-      [:& themes-modal-body]]]))
+      [:& sets-context/provider {}
+       [:& themes-modal-body]]]]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets_context.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets_context.cljs
@@ -6,7 +6,14 @@
 
 (ns app.main.ui.workspace.tokens.sets-context
   (:require
+   [app.common.data.macros :as dm]
    [rumext.v2 :as mf]))
+
+(defn set-group-path->id [set-group-path]
+  (dm/str "group-" set-group-path))
+
+(defn set-path->id [set-path]
+  (dm/str "set-" set-path))
 
 (def initial {:editing-id nil
               :new? false})
@@ -35,7 +42,8 @@
                   (mf/deps editing-id)
                   #(= editing-id %))
         on-edit (mf/use-fn
-                 #(swap! ctx assoc :editing-id %))
+                 (fn [editing-id]
+                   (reset! ctx (assoc @ctx :editing-id editing-id))))
         on-create (mf/use-fn
                    #(swap! ctx assoc :editing-id (random-uuid) :new? true))
         on-reset (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
@@ -7,7 +7,6 @@
 (ns app.main.ui.workspace.tokens.sets-context-menu
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.types.tokens-lib :as ctob]
    [app.main.data.tokens :as wdt]
    [app.main.refs :as refs]
    [app.main.store :as st]
@@ -35,13 +34,20 @@
    [:span {:class (stl/css :title)} title]])
 
 (mf/defc menu
-  [{:keys [prefixed-set-path]}]
+  [{:keys [group? path]}]
   (let [{:keys [on-edit]} (sets-context/use-context)
-        edit-name (mf/use-fn #(on-edit prefixed-set-path))
-        delete-set (mf/use-fn #(st/emit! (wdt/delete-token-set-path prefixed-set-path)))]
+        edit-name (mf/use-fn
+                   (mf/deps group?)
+                   (fn []
+                     (let [path (if group?
+                                  (sets-context/set-group-path->id path)
+                                  (sets-context/set-path->id path))]
+                       (on-edit path))))
+        delete-set (mf/use-fn #(st/emit! (wdt/delete-token-set-path group? path)))]
     [:ul {:class (stl/css :context-list)}
-     (when (ctob/prefixed-set-path-final-group? prefixed-set-path)
-       [:& menu-entry {:title "Add set to this group" :on-click js/console.log}])
+     ;; TODO Implement
+     ;; (when (ctob/prefixed-set-path-final-group? prefixed-set-path)
+     ;;   [:& menu-entry {:title "Add set to this group" :on-click js/console.log}])
      [:& menu-entry {:title (tr "labels.rename") :on-click edit-name}]
      [:& menu-entry {:title (tr "labels.delete")  :on-click delete-set}]]))
 
@@ -63,4 +69,5 @@
             :ref dropdown-ref
             :style {:top top :left left}
             :on-context-menu prevent-default}
-      [:& menu {:prefixed-set-path (:prefixed-set-path mdata)}]]]))
+      [:& menu {:group? (:group? mdata)
+                :path (:path mdata)}]]]))

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -8,7 +8,6 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data :as d]
-   [app.common.data.macros :as dm]
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
@@ -269,7 +268,7 @@
 
         selected-token-set-tokens (mf/deref refs/workspace-selected-token-set-tokens)
 
-        selected-token-set-path (mf/deref refs/workspace-selected-token-set-path)
+        selected-token-set-name (mf/deref refs/workspace-selected-token-set-name)
 
         token-groups (mf/with-memo [tokens selected-token-set-tokens]
                        (-> (select-keys tokens (keys selected-token-set-tokens))
@@ -277,7 +276,7 @@
     [:*
      [:& token-context-menu]
      [:& title-bar {:all-clickable true
-                    :title (dm/str "TOKENS - " (ctob/set-path->set-name selected-token-set-path))}]
+                    :title (tr "workspace.token.tokens-section-title" selected-token-set-name)}]
 
      (for [{:keys [token-key token-type-props tokens]} (concat (:filled token-groups)
                                                                (:empty token-groups))]

--- a/frontend/src/app/main/ui/workspace/tokens/token_set.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_set.cljs
@@ -43,38 +43,3 @@
 (defn get-active-theme-sets-tokens-names-map [state]
   (when-let [lib (get-workspace-tokens-lib state)]
     (ctob/get-active-themes-set-tokens lib)))
-
-;; === Set selection
-
-(defn get-selected-token-set-path [state]
-  (or (get-in state [:workspace-local :selected-token-set-path])
-      (some-> (get-workspace-tokens-lib state)
-              (ctob/get-sets)
-              (first)
-              (ctob/get-set-prefixed-path-string))))
-
-(defn get-selected-token-set-node [state]
-  (when-let [path (some-> (get-selected-token-set-path state)
-                          (ctob/split-token-set-path))]
-    (some-> (get-workspace-tokens-lib state)
-            (ctob/get-in-set-tree path))))
-
-(defn get-selected-token-set [state]
-  (let [set-node (get-selected-token-set-node state)]
-    (when (instance? ctob/TokenSet set-node)
-      set-node)))
-
-(defn get-selected-token-set-group [state]
-  (let [set-node (get-selected-token-set-node state)]
-    (when (and set-node (not (instance? ctob/TokenSet set-node)))
-      set-node)))
-
-(defn get-selected-token-set-tokens [state]
-  (some-> (get-selected-token-set state)
-          :tokens))
-
-(defn token-group-selected? [state]
-  (some? (get-selected-token-set-group state)))
-
-(defn assoc-selected-token-set-path [state id]
-  (assoc-in state [:workspace-local :selected-token-set-path] id))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1200,6 +1200,14 @@ msgstr "An unexpected error occurred."
 msgid "errors.unexpected-token"
 msgstr "Unknown token"
 
+#: src/app/main/data/tokens.cljs
+msgid "errors.drag-drop.set-exists"
+msgstr "Cannot complete drop, a set with same name already exists at path %s."
+
+#: src/app/main/data/tokens.cljs
+msgid "errors.drag-drop.parent-to-child"
+msgstr "Cannot drop a parent set to an own child path."
+
 #, unused
 msgid "errors.validation"
 msgstr "Validation Error"
@@ -6716,6 +6724,10 @@ msgstr "Description"
 #: src/app/main/ui/workspace/tokens/form.cljs
 msgid "workspace.token.enter-token-description"
 msgstr "Add a description (optional)"
+
+#: src/app/main/ui/workspace/tokens/sidebar.cljs
+msgid "workspace.token.tokens-section-title"
+msgstr "TOKENS -  %s"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs
 msgid "workspace.token.original-value"


### PR DESCRIPTION
This PR adds drag & drop for sets and set groups.

To not further introduce any implementation leaks of set/set-group prefixes with the drag & drop implementation and keeping the release date in mind, I've changed a couple of other things in the selection logic.

Now there are divided functions for sets and set groups, so the consumer side doesn't know about prefixed paths.

## Drag & Drop UX

Drag & Drop should behave UX wise simlar to D&D of layers and layer groups.

Two key differences from the Layers D&D are:
- Set groups are not visible the UI if they don't have sets inside
- Sets inside set groups must have a unique name. 
  So no two sets/set groups should be named equally at their level in the sets tree.
  But sets & set groups may have the same name at the same level.
  
## Demos

### Drag & Drop


https://github.com/user-attachments/assets/04741d69-4786-4b99-94b1-a3a3a4b9c57f

### Errors


https://github.com/user-attachments/assets/272a9ae4-0545-4bf8-bc8e-8bd01ebee531


