### PR TITLE
🐛  Fix some token bugs

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -640,6 +640,13 @@
   (let [path-split (split-path path)]
     (merge-path-item (first path-split) name)))
 
+(defn split-string-half
+  "Split string in two halfs"
+  [s]
+  (let [len (count s)
+        mid (quot len 2)]
+    [(subs s 0 mid)
+     (subs s mid)]))
 
 (defn get-frame-objects
   "Retrieves a new objects map only with the objects under frame-id (with frame-id)"

--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -70,7 +70,7 @@ test.describe("Tokens: Tokens Tab", () => {
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    await expect(tokensTabPanel.getByText("color.primary")).toBeEnabled();
+    await expect(tokensTabPanel.getByLabel("primary")).toBeEnabled();
 
     // Create token referencing the previous one with keyboard
 
@@ -87,7 +87,7 @@ test.describe("Tokens: Tokens Tab", () => {
     await expect(submitButton).toBeEnabled();
     await nameField.press("Enter");
 
-    const referenceToken = tokensTabPanel.getByText("color.secondary");
+    const referenceToken = tokensTabPanel.getByLabel("color.secondary");
     await expect(referenceToken).toBeEnabled();
 
     // Tokens tab panel should have two tokens with the color red / #ff0000
@@ -104,6 +104,35 @@ test.describe("Tokens: Tokens Tab", () => {
         name: "Global",
       }),
     ).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("User creates grouped color token", async ({ page }) => {
+    const { workspacePage, tokensUpdateCreateModal, tokenThemesSetsSidebar } =
+      await setupFileWithTokens(page);
+
+    const tokensTabPanel = page.getByRole("tabpanel", { name: "tokens" });
+    await tokensTabPanel.getByTitle("Add token: Color").click();
+
+    // Create grouped color token with mouse
+
+    await expect(tokensUpdateCreateModal).toBeVisible();
+
+    const nameField = tokensUpdateCreateModal.getByLabel("Name");
+    const valueField = tokensUpdateCreateModal.getByLabel("Value");
+
+    await nameField.click();
+    await nameField.fill("color.dark.primary");
+
+    await valueField.click();
+    await valueField.fill("red");
+
+    const submitButton = tokensUpdateCreateModal.getByRole("button", {
+      name: "Save",
+    });
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(tokensTabPanel.getByLabel("color.dark.primary")).toBeEnabled();
   });
 });
 

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -198,7 +198,6 @@
     (tr "shortcuts.toggle-lock")
     (tr "shortcuts.toggle-lock-size")
     (tr "shortcuts.toggle-rulers")
-    (tr "shortcuts.toggle-rules")
     (tr "shortcuts.toggle-snap-guides")
     (tr "shortcuts.toggle-snap-ruler-guide")
     (tr "shortcuts.toggle-textpalette")

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -321,8 +321,9 @@
          children]])]))
 
 (mf/defc menu-tree
-  [{:keys [selected-shapes submenu-offset submenu-direction type] :as context-data}]
-  (let [entries (if (seq selected-shapes)
+  [{:keys [selected-shapes submenu-offset submenu-direction type errors] :as context-data}]
+  (let [entries (if (and (not (some? errors))
+                         (seq selected-shapes))
                   (if (some? type)
                     (submenu-actions-selection-actions context-data)
                     (selection-actions context-data))
@@ -343,7 +344,7 @@
                  :selected? selected?}])])))
 
 (mf/defc token-context-menu-tree
-  [{:keys [width direction] :as mdata}]
+  [{:keys [width direction errors] :as mdata}]
   (let [objects (mf/deref refs/workspace-page-objects)
         selected (mf/deref refs/selected-shapes)
         selected-shapes (into [] (keep (d/getf objects)) selected)
@@ -354,6 +355,7 @@
      [:& menu-tree {:submenu-offset width
                     :submenu-direction direction
                     :token token
+                    :errors errors
                     :selected-token-set-path selected-token-set-path
                     :selected-shapes selected-shapes}]]))
 

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -82,6 +82,7 @@
                            (st/emit! (dt/show-token-context-menu
                                       {:type :token
                                        :position (dom/get-client-position event)
+                                       :errors (:errors token)
                                        :token-name (:name token)}))))
 
         on-toggle-open-click (mf/use-fn
@@ -120,6 +121,7 @@
        [:> icon-button* {:on-click on-popover-open-click
                          :variant "ghost"
                          :icon "add"
+                        ;;  TODO: This needs translation
                          :aria-label (str "Add token: " title)}]]
       (when open?
         [:& cmm/asset-section-block {:role :content}

--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -174,6 +174,7 @@
   [err]
   (let [[header-1 header-2 & errors] (str/split err "\n")]
     (when (and
+          ;; TODO: This needs translations
            (= header-1 "Error: ")
            (= header-2 "Reference Errors:"))
       errors)))
@@ -206,10 +207,11 @@
 
 ;; === Errors
 
-(defn humanize-errors [{:keys [errors value] :as _token}]
+(defn humanize-errors [{:keys [errors] :as token}]
   (->> (map (fn [err]
-              (case err
-                :error.style-dictionary/missing-reference (str "Could not resolve reference token with the name: " value)
+              (case (:error/code err)
+                ;; TODO: This needs translations
+                :error.style-dictionary/missing-reference (str "Could not resolve reference token with the name: " (:error/value err))
                 nil))
             errors)
        (str/join "\n")))

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -44,14 +44,13 @@
               :on-context-menu on-context-menu
               :disabled errors?}
      (cond
-       color
-       [:& color-bullet {:color color
-                         :mini true}]
        errors?
        [:> icon*
         {:icon-id "broken-link"
          :class (stl/css :token-pill-icon)}]
-
+       color
+       [:& color-bullet {:color color
+                         :mini true}]
        :else
        [:> token-status-icon*
         {:icon-id token-status-id

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -1,6 +1,7 @@
 (ns app.main.ui.workspace.tokens.token-pill
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.files.helpers :as cfh]
    [app.common.types.tokens-lib :as ctob]
    [app.main.ui.components.color-bullet :refer [color-bullet]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*]]
@@ -17,10 +18,10 @@
   [{:keys [on-click token theme-token full-applied on-context-menu half-applied]}]
   (let [{:keys [name value resolved-value errors]} token
         errors? (or (nil? theme-token) (and (seq errors) (seq (:errors theme-token))))
-
         color (when (seq (ctob/find-token-value-references value))
                 (wtt/resolved-value-hex theme-token))
-
+        contains-path? (str/includes? name ".")
+        splitted-name (cfh/split-string-half name)
         color (or color (wtt/resolved-value-hex token))
         on-click
         (mf/use-callback
@@ -64,4 +65,13 @@
        [:> token-status-icon*
         {:icon-id token-status-id
          :class (stl/css :token-pill-icon)}])
-     name]))
+     (if contains-path?
+       [:span {:class (stl/css :divided-name-wrapper)
+               :aria-label name}
+        [:span {:class (stl/css :first-name-wrapper)}
+         (first splitted-name)]
+        [:span {:class (stl/css :last-name-wrapper)}
+         (last splitted-name)]]
+       [:span {:class (stl/css :name-wrapper)
+               :aria-label name}
+        name])]))

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -7,6 +7,7 @@
    [app.main.ui.ds.foundations.utilities.token.token-status :refer [token-status-icon*]]
    [app.main.ui.workspace.tokens.style-dictionary :as sd]
    [app.main.ui.workspace.tokens.token :as wtt]
+   [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
@@ -21,6 +22,13 @@
                 (wtt/resolved-value-hex theme-token))
 
         color (or color (wtt/resolved-value-hex token))
+        on-click
+        (mf/use-callback
+         (mf/deps errors? on-click)
+         (fn [event]
+           (dom/stop-propagation event)
+           (when (and (not (seq errors)) on-click)
+             (on-click event))))
 
         token-status-id (cond
                           half-applied
@@ -35,14 +43,15 @@
                                    :token-pill-invalid-applied (and full-applied errors?))
               :type "button"
               :title (cond
-                       errors? (sd/humanize-errors token)
+                       errors? (if (nil? theme-token)
+                                 (tr "workspace.token-set.not-active")
+                                 (sd/humanize-errors token))
                        :else (->> [(str "Token: " name)
                                    (tr "workspace.token.original-value" value)
                                    (tr "workspace.token.resolved-value" resolved-value)]
                                   (str/join "\n")))
               :on-click on-click
-              :on-context-menu on-context-menu
-              :disabled errors?}
+              :on-context-menu on-context-menu}
      (cond
        errors?
        [:> icon*

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.scss
@@ -60,22 +60,23 @@
   white-space: nowrap;
 }
 
-.group-name-wrapper::before, span::after {
-  vertical-align: middle;
+.divided-name-wrapper {
+  height: $s-16;
+}
+
+.first-name-wrapper {
   display: inline-block;
   max-width: 50%;
   overflow: hidden;
   white-space: pre;
-}
-
-.group-name-wrapper::before {
-  content: attr(data-content-start);
   text-overflow: ellipsis;
 }
 
-.group-name-wrapper::after {
-  content: attr(data-content-end);
-  text-overflow: '';
+.last-name-wrapper {
+  display: inline-block;
+  max-width: 50%;
+  overflow: hidden;
+  white-space: pre;
   direction: rtl;
 }
 

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.scss
@@ -53,6 +53,31 @@
     --token-pill-accent: var(--color-background-tertiary);
   }
 }
+.name-wrapper {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.group-name-wrapper::before, span::after {
+  vertical-align: middle;
+  display: inline-block;
+  max-width: 50%;
+  overflow: hidden;
+  white-space: pre;
+}
+
+.group-name-wrapper::before {
+  content: attr(data-content-start);
+  text-overflow: ellipsis;
+}
+
+.group-name-wrapper::after {
+  content: attr(data-content-end);
+  text-overflow: '';
+  direction: rtl;
+}
 
 .token-pill-applied {
   --token-pill-background: var(--color-token-background);
@@ -84,8 +109,7 @@
   }
 }
 
-.token-pill-invalid,
-.token-pill-invalid-applied {
+.token-pill-invalid {
   --token-pill-background: var(--color-background-tertiary);
   --token-pill-foreground: var(--color-foreground-error);
   --token-pill-border: var(--color-background-tertiary);
@@ -98,6 +122,15 @@
     --token-pill-foreground: var(--color-foreground-error);
     --token-pill-border: var(--color-background-tertiary);
     --token-pill-accent: var(--color-foreground-error);
+  }
+}
+
+.token-pill-invalid-applied {
+  --token-pill-border: var(--color-foreground-error);
+  &:hover,
+  &:focus-visible,
+  &:disabled {
+    --token-pill-border: var(--color-foreground-error);
   }
 }
 

--- a/frontend/translations/af.po
+++ b/frontend/translations/af.po
@@ -287,7 +287,7 @@ msgstr "Genereer nuwe token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Toegangstoken is suksesvol geskep."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/ar.po
+++ b/frontend/translations/ar.po
@@ -295,7 +295,7 @@ msgstr "قم بإنشاء رمز جديد"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "تم إنشاء رمز الوصول بنجاح."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/cs.po
+++ b/frontend/translations/cs.po
@@ -329,7 +329,7 @@ msgstr "Generovat nový token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Přístupový token byl úspěšně vytvořen."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -336,7 +336,7 @@ msgstr "Neues Token generieren"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Der Zugangstoken wurde erfolgreich erstellt."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -324,14 +324,8 @@ msgid "dashboard.access-tokens.create"
 msgstr "Generate new token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
-#, unused
-msgid "dashboard.access-tokens.create-success"
-msgstr "Access token created successfully."
-
-#: src/app/main/ui/settings/access_tokens.cljs:65
-#, fuzzy
 msgid "dashboard.access-tokens.create.success"
-msgstr ""
+msgstr "Access token created successfully."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289
 msgid "dashboard.access-tokens.empty.add-one"
@@ -1153,9 +1147,8 @@ msgid "errors.member-is-muted"
 msgstr "The profile you inviting has emails muted (spam reports or high bounces)."
 
 #: src/app/main/errors.cljs:228
-#, fuzzy
 msgid "errors.migration-in-progress"
-msgstr ""
+msgstr "Migration in progress"
 
 #: src/app/main/ui/settings/password.cljs
 #, unused
@@ -1251,11 +1244,6 @@ msgstr "Email or password is incorrect."
 #, unused
 msgid "errors.wrong-old-password"
 msgstr "Old password is incorrect"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/bool.cljs:85
-#, fuzzy
-msgid "exclude"
-msgstr ""
 
 #: src/app/main/ui/settings/feedback.cljs:74
 msgid "feedback.description"
@@ -1556,11 +1544,6 @@ msgstr "Text"
 #: src/app/main/ui/viewer/inspect/right_sidebar.cljs:101
 msgid "inspect.tabs.info"
 msgstr "Info"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/bool.cljs:80
-#, fuzzy
-msgid "intersection"
-msgstr ""
 
 #: src/app/main/ui/workspace/main_menu.cljs:163
 msgid "label.shortcuts"
@@ -2314,11 +2297,6 @@ msgstr "Create token"
 #: src/app/main/ui/settings/access_tokens.cljs:112
 msgid "modals.create-access-token.title"
 msgstr "Generate access token"
-
-#: src/app/main/ui/settings/access_tokens.cljs:152
-#, fuzzy
-msgid "modals.create-access-token.token"
-msgstr ""
 
 #: src/app/main/ui/dashboard/team.cljs:911
 msgid "modals.create-webhook.submit-label"
@@ -3826,11 +3804,6 @@ msgstr "Lock proportions"
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:200
 msgid "shortcuts.toggle-rulers"
 msgstr "Show / Hide rulers"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:201
-#, fuzzy
-msgid "shortcuts.toggle-rules"
-msgstr ""
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:202
 msgid "shortcuts.toggle-snap-guides"
@@ -6293,21 +6266,6 @@ msgstr "Edit themes"
 msgid "workspace.token.edit-token"
 msgstr "Edit token"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:408
-#, fuzzy
-msgid "workspace.token.enter-token-description"
-msgstr ""
-
-#: src/app/main/ui/workspace/tokens/form.cljs:370
-#, fuzzy
-msgid "workspace.token.enter-token-name"
-msgstr ""
-
-#: src/app/main/ui/workspace/tokens/form.cljs:390
-#, fuzzy
-msgid "workspace.token.enter-token-value"
-msgstr ""
-
 #: src/app/main/ui/workspace/tokens/sets.cljs:186
 #, unused
 msgid "workspace.token.grouping-set-alert"
@@ -6365,11 +6323,6 @@ msgstr "Select set."
 msgid "workspace.token.set-selection-theme"
 msgstr "Define what token sets should be used as part of this theme option:"
 
-#: src/app/main/ui/workspace/tokens/modals/themes.cljs:119
-#, fuzzy
-msgid "workspace.token.theme"
-msgstr ""
-
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs
 #, unused
 msgid "workspace.token.theme-name"
@@ -6379,20 +6332,9 @@ msgstr "Theme %s"
 msgid "workspace.token.themes"
 msgstr "Themes"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:409
-#, fuzzy
-msgid "workspace.token.token-description"
-msgstr ""
-
-#: src/app/main/ui/workspace/tokens/form.cljs:373
-#, fuzzy
-msgid "workspace.token.token-name"
-msgstr ""
-
-#: src/app/main/ui/workspace/tokens/form.cljs:391
-#, fuzzy
-msgid "workspace.token.token-value"
-msgstr ""
+#: src/app/main/ui/workspace/tokens/token_pill.cljs:47
+msgid "workspace.token-set.not-active"
+msgstr "Token set is not active"
 
 #: src/app/main/ui/workspace/sidebar.cljs:117, src/app/main/ui/workspace/sidebar.cljs:126
 msgid "workspace.toolbar.assets"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -332,7 +332,7 @@ msgstr "Generar nuevo token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Access token creado con éxito."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289
@@ -1162,6 +1162,10 @@ msgid "errors.member-is-muted"
 msgstr ""
 "El perfil que esta invitando tiene los emails silenciados (por reportes de "
 "spam o alto indice de rebote)."
+
+#: src/app/main/errors.cljs:228
+msgid "errors.migration-in-progress"
+msgstr "Migración en proceso"
 
 #: src/app/main/ui/settings/password.cljs
 #, unused
@@ -6741,6 +6745,10 @@ msgstr "Nuevo tema"
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs
 msgid "workspace.token.themes"
 msgstr "Temas"
+
+#: src/app/main/ui/workspace/tokens/token_pill.cljs:47
+msgid "workspace.token-set.not-active"
+msgstr "El set de tokens no está aplicado"
 
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs
 msgid "workspace.token.theme-name"

--- a/frontend/translations/es_419.po
+++ b/frontend/translations/es_419.po
@@ -294,7 +294,7 @@ msgstr "Generar nuevo token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Token de acceso creado correctamente."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -332,7 +332,7 @@ msgstr "Générer un nouveau jeton"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Jeton d'accès créé avec succès."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/ha.po
+++ b/frontend/translations/ha.po
@@ -270,7 +270,7 @@ msgstr "samo sabuwar lambar tsaro"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "ka sami lambar tsaron da aka yi."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -318,7 +318,7 @@ msgstr "יצירת אסימון חדש"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "אסימון הגישה נוצר בהצלחה."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -331,12 +331,8 @@ msgstr "Buat token baru"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
-msgstr "Token akses berhasil dibuat."
-
-#: src/app/main/ui/settings/access_tokens.cljs:65
 msgid "dashboard.access-tokens.create.success"
-msgstr " "
+msgstr "Token akses berhasil dibuat."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289
 msgid "dashboard.access-tokens.empty.add-one"
@@ -1051,10 +1047,6 @@ msgstr ""
 "Profil yang Anda undang membisukan surel (laporan spam atau lompatan "
 "tinggi)."
 
-#: src/app/main/errors.cljs:228
-msgid "errors.migration-in-progress"
-msgstr " "
-
 #: src/app/main/ui/settings/password.cljs
 #, unused
 msgid "errors.password-invalid-confirmation"
@@ -1153,10 +1145,6 @@ msgstr "Surel atau kata sandi tidak benar."
 #, unused
 msgid "errors.wrong-old-password"
 msgstr "Kata sandi lama tidak benar"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/bool.cljs:85
-msgid "exclude"
-msgstr " "
 
 #: src/app/main/ui/settings/feedback.cljs:74
 msgid "feedback.description"
@@ -1460,10 +1448,6 @@ msgstr "Teks"
 #: src/app/main/ui/viewer/inspect/right_sidebar.cljs:96
 msgid "inspect.tabs.info"
 msgstr "Info"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/bool.cljs:80
-msgid "intersection"
-msgstr " "
 
 #: src/app/main/ui/workspace/main_menu.cljs:162
 msgid "label.shortcuts"
@@ -2150,10 +2134,6 @@ msgstr "Buat token"
 #: src/app/main/ui/settings/access_tokens.cljs:112
 msgid "modals.create-access-token.title"
 msgstr "Buat token baru"
-
-#: src/app/main/ui/settings/access_tokens.cljs:152
-msgid "modals.create-access-token.token"
-msgstr " "
 
 #: src/app/main/ui/dashboard/team.cljs:911
 msgid "modals.create-webhook.submit-label"
@@ -3639,10 +3619,6 @@ msgstr "Kunci proporsi"
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:198
 msgid "shortcuts.toggle-rulers"
 msgstr "Tampilkan / Sembunyikan penggaris"
-
-#: src/app/main/ui/workspace/sidebar/shortcuts.cljs:199
-msgid "shortcuts.toggle-rules"
-msgstr " "
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:200
 msgid "shortcuts.toggle-snap-guides"
@@ -6106,10 +6082,6 @@ msgstr "Klik untuk menutup jalur"
 #: src/app/main/ui/dashboard/files.cljs:185, src/app/main/ui/dashboard/projects.cljs:279
 msgid "dashboard.empty-placeholder-drafts-title"
 msgstr "Belum ada draf."
-
-#: src/app/main/ui/workspace/tokens/modals/themes.cljs:119
-msgid "workspace.token.theme"
-msgstr "  "
 
 #: src/app/main/ui/dashboard/fonts.cljs:445
 msgid "dashboard.fonts.empty-placeholder-viewer-sub"

--- a/frontend/translations/ig.po
+++ b/frontend/translations/ig.po
@@ -256,7 +256,7 @@ msgstr "Mepụta ọdịmara ọhụrụ"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Mmepụtara ọdịmara nnweta gara nke ọma ."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -5122,7 +5122,7 @@ msgstr "Elimina"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Token di accesso creato con successo."
 
 #: src/app/main/ui/settings/access_tokens.cljs:143

--- a/frontend/translations/ko.po
+++ b/frontend/translations/ko.po
@@ -303,7 +303,7 @@ msgstr "새로운 토큰 생성하기"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "엑세스 토큰이 성공적으로 생성되었습니다."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -330,7 +330,7 @@ msgstr "Izveidot jaunu pilnvaru"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Piekļuves pilnvara ir veiksmīgi izveidota."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/ms.po
+++ b/frontend/translations/ms.po
@@ -277,7 +277,7 @@ msgstr "Jana token baru"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Token capaian berjaya dihasilkan."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -329,7 +329,7 @@ msgstr "Nieuw toegangsbewijs aanmaken"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Toegangsbewijs is succesvol aangemaakt."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/pt_PT.po
+++ b/frontend/translations/pt_PT.po
@@ -328,7 +328,7 @@ msgstr "Gerar novo token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Token de acesso criado com sucesso."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -314,7 +314,7 @@ msgstr "Generați jeton nou"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Jeton de acces creat cu succes."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -329,7 +329,7 @@ msgstr "Skapa ny token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Accesstoken skapad."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/th.po
+++ b/frontend/translations/th.po
@@ -757,7 +757,7 @@ msgstr "สร้างโทเคนใหม่"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "สร้างโทเคนสำหรับการเข้าถึงสำเร็จแล้ว"
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -330,7 +330,7 @@ msgstr "Yeni belirteç oluştur"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Erişim belirteci başarıyla oluşturuldu."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/ukr_UA.po
+++ b/frontend/translations/ukr_UA.po
@@ -334,7 +334,7 @@ msgstr "Згенерувати новий токен"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "Токен доступу успішно створено."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/yo.po
+++ b/frontend/translations/yo.po
@@ -268,7 +268,7 @@ msgstr "ṣe ìpilẹ̀sẹ̀ àmì tókìnnì"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "ṣe àyẹ̀wò àmì tókìnnì tí o ṣẹ̀dá bó ṣeyẹ."
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -300,7 +300,7 @@ msgstr "生成新令牌"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "成功创建访问令牌。"
 
 #: src/app/main/ui/settings/access_tokens.cljs:289

--- a/frontend/translations/zh_Hant.po
+++ b/frontend/translations/zh_Hant.po
@@ -283,7 +283,7 @@ msgstr "產生新的 Token"
 
 #: src/app/main/ui/settings/access-tokens.cljs
 #, unused
-msgid "dashboard.access-tokens.create-success"
+msgid "dashboard.access-tokens.create.success"
 msgstr "已成功建立 Access Token。"
 
 #: src/app/main/ui/settings/access_tokens.cljs:289


### PR DESCRIPTION
This PR fixes: 
- Remove empty, fuzzy or duplicated translations
 - https://tree.taiga.io/project/penpot/issue/9748 -> Broken color token must show icon and not swatch
 - https://tree.taiga.io/project/penpot/task/9726 -> Fix context menu on tokens with errors (firefox)
NOTE: Token with errors should be able to edit, and now is not working, that is going to be fixed separatelly. 
- https://tree.taiga.io/project/penpot/issue/9745 -> Ellipsis in token pills
This PR closes
https://github.com/tokens-studio/penpot/issues/40
https://github.com/tokens-studio/penpot/issues/43
https://github.com/tokens-studio/penpot/issues/40
