### PR TITLE
:bug: Fix incompatibility of binfile exportation with offload feature

### DIFF
--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -52,6 +52,15 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(def file-attrs
+  #{:id
+    :name
+    :features
+    :project-id
+    :is-shared
+    :version
+    :data})
+
 (def xf-map-id
   (map :id))
 
@@ -129,10 +138,11 @@
                  (binding [pmap/*load-fn* (partial feat.fdata/load-pointer cfg file-id)]
                    (when-let [file (db/get* conn :file {:id file-id}
                                             {::db/remove-deleted false})]
-                     (-> file
-                         (decode-row)
-                         (update :data feat.fdata/process-pointers deref)
-                         (update :data feat.fdata/process-objects (partial into {}))))))))
+                     (let [file (feat.fdata/resolve-file-data cfg file)]
+                       (-> file
+                           (decode-row)
+                           (update :data feat.fdata/process-pointers deref)
+                           (update :data feat.fdata/process-objects (partial into {})))))))))
 
 (defn clean-file-features
   [file]

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -63,10 +63,15 @@
 (def schema:pages-index
   [:map-of {:gen/max 5} ::sm/uuid ::ctp/page])
 
+(def schema:options
+  [:map {:title "FileOptions"}
+   [:components-v2 {:optional true} ::sm/boolean]])
+
 (def schema:data
   [:map {:title "FileData"}
    [:pages [:vector ::sm/uuid]]
    [:pages-index schema:pages-index]
+   [:options {:optional true} schema:options]
    [:colors {:optional true} schema:colors]
    [:components {:optional true} schema:components]
    [:typographies {:optional true} schema:typographies]
@@ -78,7 +83,15 @@
   because sometimes we want to validate file without the data."
   [:map {:title "file"}
    [:id ::sm/uuid]
+   [:revn {:optional true} :int]
+   [:vern {:optional true} :int]
+   [:created-at {:optional true} ::sm/inst]
+   [:modified-at {:optional true} ::sm/inst]
+   [:deleted-at {:optional true} ::sm/inst]
+   [:project-id {:optional true} ::sm/uuid]
+   [:is-shared {:optional true} ::sm/boolean]
    [:data {:optional true} schema:data]
+   [:version :int]
    [:features ::cfeat/features]])
 
 (sm/register! ::data schema:data)


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/9755 and other issue related with offloading mechanism. The files referenced on the issue are broken in any way because of the underlying issue with offloading mechanism (only happens on devenv).