### PR TITLE
:tada: Allow import a template from a link

### DIFF
--- a/frontend/src/app/config.cljs
+++ b/frontend/src/app/config.cljs
@@ -111,6 +111,7 @@
 (def grid-help-uri        (obj/get global "penpotGridHelpURI" "https://help.penpot.app/user-guide/flexible-layouts/"))
 (def plugins-list-uri     (obj/get global "penpotPluginsListUri" "https://penpot.app/penpothub/plugins"))
 (def plugins-whitelist    (into #{} (obj/get global "penpotPluginsWhitelist" [])))
+(def templates-uri        (obj/get global "penpotTemplatesUri" "https://penpot.github.io/penpot-files/"))
 
 (defn- normalize-uri
   [uri-str]

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -70,7 +70,7 @@
 (mf/defc dashboard-legacy-redirect*
   {::mf/props :obj
    ::mf/private true}
-  [{:keys [section team-id project-id search-term plugin-url]}]
+  [{:keys [section team-id project-id search-term plugin-url template-url]}]
   (let [section (case section
                   :dashboard-legacy-search
                   :dashboard-search
@@ -97,7 +97,8 @@
       (let [params {:team-id team-id
                     :project-id project-id
                     :search-term search-term
-                    :plugin plugin-url}]
+                    :plugin plugin-url
+                    :template-url template-url}]
         (st/emit! (rt/nav section (d/without-nils params)))))
 
     [:> loader*
@@ -211,11 +212,12 @@
         :dashboard-invitations
         :dashboard-webhooks
         :dashboard-settings)
-       (let [params      (get params :query)
-             team-id     (some-> params :team-id uuid)
-             project-id  (some-> params :project-id uuid)
-             search-term (some-> params :search-term)
-             plugin-url  (some-> params :plugin)]
+       (let [params        (get params :query)
+             team-id       (some-> params :team-id uuid)
+             project-id    (some-> params :project-id uuid)
+             search-term   (some-> params :search-term)
+             plugin-url    (some-> params :plugin)
+             template-url  (some-> params :template)]
          [:?
           #_[:& app.main.ui.releases/release-notes-modal {:version "2.4"}]
           #_[:& app.main.ui.onboarding/onboarding-templates-modal]
@@ -241,7 +243,8 @@
                                :team-id team-id
                                :search-term search-term
                                :plugin-url plugin-url
-                               :project-id project-id}]]])
+                               :project-id project-id
+                               :template-url template-url}]]])
 
        :workspace
        (let [params     (get params :query)
@@ -322,13 +325,15 @@
        (let [team-id     (some-> params :path :team-id uuid)
              project-id  (some-> params :path :project-id uuid)
              search-term (some-> params :query :search-term)
-             plugin-url  (some-> params :query :plugin)]
+             plugin-url  (some-> params :query :plugin)
+             template-url  (some-> params :template)]
          [:> dashboard-legacy-redirect*
           {:team-id team-id
            :section section
            :project-id project-id
            :search-term search-term
-           :plugin-url plugin-url}])
+           :plugin-url plugin-url
+           :template-url template-url}])
 
        :viewer-legacy
        (let [{:keys [query-params path-params]} route

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -170,7 +170,7 @@
            (let [data
                  (with-meta
                    {:project-id project-id
-                    :name (dm/str "Try plugin: " (:name plugin))}
+                    :name (dm/str (tr "dashboard.plugins.try-plugin") (:name plugin))}
                    {:on-success (partial navegate-file! plugin)})]
              (-> (dd/create-file data)
                  (with-meta {::ev/origin "plugin-try-out"})))))
@@ -207,9 +207,9 @@
                   (do
                     (st/emit! (ptk/event ::ev/event {::ev/name "install-plugin" :name (:name plugin) :url plugin-url}))
                     (open-permissions-dialog plugin))
-                  (st/emit! (notif/error "Cannot parser the plugin manifest"))))
+                  (st/emit! (notif/error (tr "dashboard.plugins.parse-error")))))
               (fn [_]
-                (st/emit! (notif/error "The plugin URL is incorrect")))))))))
+                (st/emit! (notif/error (tr "dashboard.plugins.bad-url"))))))))))
 
 (defn use-templates-import
   [can-edit? template-url default-project-id]
@@ -262,6 +262,7 @@
 
         can-edit?       (dm/get-in team [:permissions :can-edit])
         template-url    (or template-url (:template-url storage/session))
+        plugin-url      (or plugin-url (:plugin-url storage/session))
 
         default-project
         (mf/with-memo [projects]

--- a/frontend/src/app/main/ui/routes.cljs
+++ b/frontend/src/app/main/ui/routes.cljs
@@ -78,11 +78,14 @@
 
 
 (defn- store-session-params
-  [{:keys [template]}]
+  [{:keys [template plugin]}]
   (binding [storage/*sync* true]
     (when (some? template)
       (swap! storage/session assoc
-             :template-url template))))
+             :template-url template))
+    (when (some? plugin)
+      (swap! storage/session assoc
+             :plugin-url plugin))))
 
 (defn on-navigate
   [router path]

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6960,6 +6960,15 @@ msgstr "Import failed. The template URL is incorrect"
 msgid "dashboard.import.no-perms"
 msgstr "You don’t have permission to import to this team"
 
+msgid "dashboard.plugins.try-plugin"
+msgstr "Try plugin: "
+
+msgid "dashboard.plugins.parse-error"
+msgstr "Cannot parser the plugin manifest"
+
+msgid "dashboard.plugins.bad-url"
+msgstr "The plugin URL is incorrect"
+
 msgid "labels.notifications"
 msgstr "Notifications"
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6951,6 +6951,15 @@ msgstr "None"
 msgid "dashboard.settings.notifications.submit"
 msgstr "Update settings"
 
+msgid "dashboard.import.error"
+msgstr "Import failed. Please try again"
+
+msgid "dashboard.import.bad-url"
+msgstr "Import failed. The template URL is incorrect"
+
+msgid "dashboard.import.no-perms"
+msgstr "You don’t have permission to import to this team"
+
 msgid "labels.notifications"
 msgstr "Notifications"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6917,6 +6917,15 @@ msgstr "La importación ha fallado. La URL de la plantilla es incorrecta"
 msgid "dashboard.import.no-perms"
 msgstr "No tienes permisos para importar en este equipo"
 
+msgid "dashboard.plugins.try-plugin"
+msgstr "Prueba la extensión: "
+
+msgid "dashboard.plugins.parse-error"
+msgstr "No se puede analizar el manifiest de la extensión"
+
+msgid "dashboard.plugins.bad-url"
+msgstr "La URL de la extensión es incorrecta"
+
 msgid "labels.notifications"
 msgstr "Notificaciones"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6672,7 +6672,7 @@ msgstr "Nombre"
 
 #: src/app/main/ui/workspace/tokens/form.cljs
 msgid "workspace.token.enter-token-name"
-msgstr "Introduce un nombre para el token %s" 
+msgstr "Introduce un nombre para el token %s"
 
 #: src/app/main/ui/workspace/tokens/form.cljs
 msgid "workspace.token.token-value"
@@ -6907,6 +6907,15 @@ msgstr "Ninguna"
 
 msgid "dashboard.settings.notifications.submit"
 msgstr "Actualizar configuración"
+
+msgid "dashboard.import.error"
+msgstr "La importación ha fallado. Intentalo de nuevo, por favor"
+
+msgid "dashboard.import.bad-url"
+msgstr "La importación ha fallado. La URL de la plantilla es incorrecta"
+
+msgid "dashboard.import.no-perms"
+msgstr "No tienes permisos para importar en este equipo"
 
 msgid "labels.notifications"
 msgstr "Notificaciones"


### PR DESCRIPTION
Implements: https://tree.taiga.io/project/penpot/task/9777

You can test it in local with this links:

* http://localhost:3449/#?template=https://penpot.github.io/penpot-files/wireframing-kit.penpot
* http://localhost:3449/#?template=https://penpot.github.io/penpot-files/Plants-app.penpot




Also added an improvement so that when a user tries to install a plugin via link and is not logged in, the link is saved to display the installation dialog once they log in.

You can test it in local with this links:

* http://localhost:3449/#?plugin=https://cardforge-dn5.pages.dev/manifest.json
* http://localhost:3449/#?plugin=https://rename-layers-penpot-plugin.pages.dev/assets/manifest.json