### PR TITLE
:bug: Fix color wrapper choppiness

### DIFF
--- a/frontend/src/app/main/ui/workspace/colorpicker/ramp.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/ramp.cljs
@@ -86,6 +86,7 @@
             (on-change new-color)))]
 
     (mf/use-effect
+     (mf/deps (:hex (enrich-color-map color)))
      (fn []
        (reset! internal-color (enrich-color-map color))))
     [:*

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -170,15 +170,13 @@ Token names should only contain letters and digits separated by . characters.")}
                           :r r :g g :b b
                           :h h :s s :v v
                           :alpha 1})))
-        value (mf/use-state (hex->value color))
         on-change' (fn [{:keys [hex]}]
-                     (reset! value (hex->value hex))
                      (when-not (and @dragging? hex)
                        (on-change hex)))]
-    (colorpicker/use-color-picker-css-variables! wrapper-node-ref @value)
+    (colorpicker/use-color-picker-css-variables! wrapper-node-ref (hex->value color))
     [:div {:ref wrapper-node-ref}
      [:& ramp-selector
-      {:color @value
+      {:color (hex->value color)
        :disable-opacity true
        :on-start-drag #(reset! dragging? true)
        :on-finish-drag #(reset! dragging? false)


### PR DESCRIPTION
# Fix color picker choppiness
## Hue slider doesn't move or moves with unwanted snaps

### Steps to reproduce:
1. Open the color token creation form.
2. Click on a color to expand the color ramp.
3. Place the picker circle in the bottom-left corner of the ramp.
4. Attempt to move the hue slider.

### Expected result:
- The hue slider can be moved.
- The picker circle moves smoothly across the color ramp.

### Actual result:
- The hue slider cannot be moved.
- The picker circle exhibits choppy movement when dragged across the color ramp.

**Before**

https://github.com/user-attachments/assets/6bd9a0c6-77c6-4205-800d-19fd2077991b

**After**

https://github.com/user-attachments/assets/6bf063fd-18ad-4a55-acd5-250db6287ca2



