### PR TITLE
:bug: Fix detach when top copy is dangling and nested copy is not

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -305,7 +305,12 @@
                         (and (some? (ctk/get-swap-slot ref-shape))
                              (nil? (ctk/get-swap-slot shape))
                              (not= (:id shape) shape-id))
-                        (pcb/update-shapes [(:id shape)] #(ctk/set-swap-slot % (ctk/get-swap-slot ref-shape))))))]
+                        (pcb/update-shapes [(:id shape)] #(ctk/set-swap-slot % (ctk/get-swap-slot ref-shape)))
+
+                        ;; If we can't get the ref-shape (e.g. it's in an external library not linked),
+                        ;: we can't do a suitable advance. So it's better to detach the shape
+                        (nil? ref-shape)
+                        (pcb/update-shapes [(:id shape)] ctk/detach-shape))))]
 
     (reduce skip-near changes children)))
 

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -738,16 +738,20 @@
                         (:component-id shape) "@"
                         :else "-")
 
-                  (when (and (:component-file shape) component-file)
+                  (when (:component-file shape)
                     (str/format "<%s> "
-                                (if (= (:id component-file) (:id file))
-                                  "local"
-                                  (:name component-file))))
+                                (if component-file
+                                  (if (= (:id component-file) (:id file))
+                                    "local"
+                                    (:name component-file))
+                                  (if show-ids
+                                    (str/format "¿%s?" (:component-file shape))
+                                    "?"))))
 
                   (or (:name component-shape)
-                      (str/format "?%s"
-                                  (when show-ids
-                                    (str " " (:shape-ref shape)))))
+                      (if show-ids
+                        (str/format "¿%s?" (:shape-ref shape))
+                        "?"))
 
                   (when (and show-ids component-shape)
                     (str/format " %s" (:id component-shape)))

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -180,6 +180,7 @@
    [:main-instance {:optional true} :boolean]
    [:remote-synced {:optional true} :boolean]
    [:shape-ref {:optional true} ::sm/uuid]
+   [:touched {:optional true} [:maybe [:set :keyword]]]
    [:blocked {:optional true} :boolean]
    [:collapsed {:optional true} :boolean]
    [:locked {:optional true} :boolean]
@@ -215,8 +216,7 @@
    [:grow-type {:optional true}
     [::sm/one-of grow-types]]
    [:applied-tokens {:optional true} ::cto/applied-tokens]
-   [:plugin-data {:optional true} ::ctpg/plugin-data]
-   [:touched {:optional true} [:maybe [:set :keyword]]]])
+   [:plugin-data {:optional true} ::ctpg/plugin-data]])
 
 (def schema:group-attrs
   [:map {:title "GroupAttrs"}


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/9699

Also did a small enhancement of the `dump-subtree` utility to better show copies with dangling files.