### PR TITLE
:bug: Fix outer stroke with image fill extra artifacts

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -19,7 +19,12 @@ pub use blend::BlendMode;
 pub use images::*;
 
 pub trait Renderable {
-    fn render(&self, surface: &mut skia::Surface, images: &ImageStore) -> Result<(), String>;
+    fn render(
+        &self,
+        surface: &mut skia::Surface,
+        images: &ImageStore,
+        scale: f32,
+    ) -> Result<(), String>;
     fn blend_mode(&self) -> BlendMode;
     fn opacity(&self) -> f32;
     fn bounds(&self) -> math::Rect;
@@ -157,8 +162,9 @@ impl RenderState {
     }
 
     pub fn render_single_element(&mut self, element: &impl Renderable) {
+        let scale = self.viewbox.zoom * self.options.dpr();
         element
-            .render(&mut self.drawing_surface, &self.images)
+            .render(&mut self.drawing_surface, &self.images, scale)
             .unwrap();
 
         self.drawing_surface.draw(

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -155,10 +155,17 @@ impl Stroke {
         outer
     }
 
-    pub fn to_paint(&self, rect: &math::Rect) -> skia::Paint {
+    pub fn to_paint(&self, rect: &math::Rect, scale: f32) -> skia::Paint {
         let mut paint = self.fill.to_paint(rect);
         paint.set_style(skia::PaintStyle::Stroke);
-        paint.set_stroke_width(self.width);
+
+        let width = match self.kind {
+            StrokeKind::InnerStroke => self.width,
+            StrokeKind::CenterStroke => self.width,
+            StrokeKind::OuterStroke => self.width + (1. / scale),
+        };
+
+        paint.set_stroke_width(width);
         paint.set_anti_alias(true);
 
         if self.style != StrokeStyle::Solid {
@@ -199,17 +206,16 @@ impl Stroke {
         paint
     }
 
-    pub fn to_stroked_paint(&self, kind: StrokeKind, rect: &math::Rect) -> skia::Paint {
-        let mut paint = self.to_paint(rect);
-        match kind {
+    pub fn to_stroked_paint(&self, is_open: bool, rect: &math::Rect, scale: f32) -> skia::Paint {
+        let mut paint = self.to_paint(rect, scale);
+        match self.render_kind(is_open) {
             StrokeKind::InnerStroke => {
-                paint.set_stroke_width(2. * self.width);
+                paint.set_stroke_width(2. * paint.stroke_width());
                 paint
             }
-
             StrokeKind::CenterStroke => paint,
             StrokeKind::OuterStroke => {
-                paint.set_stroke_width(2. * self.width);
+                paint.set_stroke_width(2. * paint.stroke_width());
                 paint
             }
         }


### PR DESCRIPTION
- Related to https://tree.taiga.io/project/penpot/task/9820:

- Currently:

![image](https://github.com/user-attachments/assets/d658c60e-8103-4465-85e3-1b65dd16e37d)

- With the fix:

![image](https://github.com/user-attachments/assets/1a8c9d12-ac3a-4518-83f7-a181ef581c68)

