### PR TITLE
:bug: Fix WebGL warning when switching pages

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -460,11 +460,6 @@
        :stencil true
        :alpha true})
 
-(defn clear-canvas
-  []
-  ;; TODO: perform corresponding cleaning
-  )
-
 (defn resize-viewbox
   [width height]
   (h/call internal-module "_resize_viewbox" width height))
@@ -488,9 +483,13 @@
     ;; Initialize Wasm Render Engine
     (h/call internal-module "_init" (/ (.-width ^js canvas) dpr) (/ (.-height ^js canvas) dpr))
     (h/call internal-module "_set_render_options" flags dpr))
-
   (set! (.-width canvas) (* dpr (.-clientWidth ^js canvas)))
   (set! (.-height canvas) (* dpr (.-clientHeight ^js canvas))))
+
+(defn clear-canvas
+  []
+  ;; TODO: perform corresponding cleaning
+  (h/call internal-module "_clean_up"))
 
 (defn set-canvas-background
   [background]

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -41,6 +41,12 @@ pub extern "C" fn init(width: i32, height: i32) {
 }
 
 #[no_mangle]
+pub extern "C" fn clean_up() {
+    unsafe { STATE = None }
+    mem::free_bytes();
+}
+
+#[no_mangle]
 pub extern "C" fn set_render_options(debug: u32, dpr: f32) {
     let state = unsafe { STATE.as_mut() }.expect("got an invalid state pointer");
     let render_state = state.render_state();

--- a/render-wasm/src/mem.rs
+++ b/render-wasm/src/mem.rs
@@ -15,8 +15,10 @@ pub extern "C" fn alloc_bytes(len: usize) -> *mut u8 {
 }
 
 pub fn free_bytes() {
-    let buffer = unsafe { BUFFERU8.take() }.expect("uninitialized buffer");
-    std::mem::drop(buffer);
+    if unsafe { BUFFERU8.is_some() } {
+        let buffer = unsafe { BUFFERU8.take() }.expect("uninitialized buffer");
+        std::mem::drop(buffer);
+    }
 }
 
 pub fn buffer_ptr() -> *mut u8 {


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/task/9720

This fixes the `WebGL: INVALID OPERATION: delete: object does not belong to this context" warning by dropping the state & Skia resources attached to the soon-to-be-removed WebGL context.

Note that the other WebGL warning with `WebGL: INVALID_ENUM: getParameter: invalid parameter name, WEBGL_debug_renderer_info not enabled` still appears.