### PR TITLE
:bug: Fix api docs page issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Fix detach when top copy is dangling and nested copy is not [Taiga #9699](https://tree.taiga.io/project/penpot/issue/9699)
 - Fix problem in plugins with `replaceColor` method [#174](https://github.com/penpot/penpot-plugins/issues/174)
+- Fix missing methods reference on API Docs
+
 
 ## 2.4.1
 

--- a/backend/src/app/rpc/doc.clj
+++ b/backend/src/app/rpc/doc.clj
@@ -87,6 +87,7 @@
       (let [params  (:query-params request)
             pstyle  (:type params "js")
             context (assoc context :param-style pstyle)]
+
         {::yres/status 200
          ::yres/body (-> (io/resource "app/templates/api-doc.tmpl")
                          (tmpl/render context))}))
@@ -207,7 +208,7 @@
   (assert (sm/valid? ::rpc/methods (::rpc/methods params)) "expected valid methods"))
 
 (defmethod ig/init-key ::routes
-  [_ {:keys [methods] :as cfg}]
+  [_ {:keys [::rpc/methods] :as cfg}]
   [(let [context (prepare-doc-context methods)]
      [["/_doc"
        {:handler (doc-handler context)

--- a/frontend/src/app/main.cljs
+++ b/frontend/src/app/main.cljs
@@ -30,20 +30,21 @@
    [app.util.i18n :as i18n]
    [app.util.theme :as theme]
    [beicon.v2.core :as rx]
-   [cuerdas.core :as str]
    [debug]
    [features]
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (log/setup! {:app :info})
+(log/set-level! :debug)
 
 (when (= :browser cf/target)
-  (log/info :version (:full cf/version)
-            :asserts *assert*
-            :build-date cf/build-date
-            :public-uri (dm/str cf/public-uri))
-  (log/info :flags (str/join "," (map name cf/flags))))
+  (log/inf :version (:full cf/version)
+           :asserts *assert*
+           :build-date cf/build-date
+           :public-uri (dm/str cf/public-uri))
+  (doseq [flag cf/flags]
+    (log/dbg :hint "flag enabled" :flag (name flag))))
 
 (declare reinit)
 


### PR DESCRIPTION
Right now on production, the documentation has no methods reference (regression). This PR fixes it.