### PR TITLE
:bug: Fix issue where users can import tokens with invalid characters

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -59,7 +59,8 @@
   [t]
   (token-types t))
 
-(def token-name-ref :string)
+(def token-name-ref
+  [:and :string [:re #"^(?!\$)([a-zA-Z0-9-$]+\.?)*(?<!\.)$"]])
 
 (defn valid-token-name-ref?
   [n]

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -53,7 +53,7 @@
    {:type :token/invalid-token-name
     :pred #(re-matches valid-token-name-regexp %)
     :type-properties {:error/fn #(str (:value %) " is not a valid token name.
-Token names should only contain letters and digits separated by . characters.")}}))
+Token names should only contain letters and digits separated by . characters and must not start with a $ sign.")}}))
 
 (defn token-name-schema
   "Generate a dynamic schema validation to check if a token path derived from the name already exists at `tokens-tree`."

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -52,8 +52,7 @@
   (m/-simple-schema
    {:type :token/invalid-token-name
     :pred #(re-matches valid-token-name-regexp %)
-    :type-properties {:error/fn #(str (:value %) " is not a valid token name.
-Token names should only contain letters and digits separated by . characters and must not start with a $ sign.")}}))
+    :type-properties {:error/fn #(str (:value %) (tr "workspace.token.token-name-validation-error"))}}))
 
 (defn token-name-schema
   "Generate a dynamic schema validation to check if a token path derived from the name already exists at `tokens-tree`."

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -46,7 +46,7 @@
   Caution: This will allow a trailing dot like `token-name.`,
   But we will trim that in the `finalize-name`,
   to not throw too many errors while the user is editing."
-  #"([a-zA-Z0-9-]+\.?)*")
+  #"(?!\$)([a-zA-Z0-9-$]+\.?)*")
 
 (def valid-token-name-schema
   (m/-simple-schema

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6318,6 +6318,12 @@ msgstr "You currently have no themes."
 msgid "workspace.token.num-sets"
 msgstr "%s sets"
 
+
+#: src/app/main/ui/workspace/tokens/form.cljs:55
+msgid "workspace.token.token-name-validation-error"
+msgstr " is not a valid token name.
+Token names should only contain letters and digits separated by . characters and must not start with a $ sign."
+
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:66
 msgid "workspace.token.original-value"
 msgstr "Original value: "
@@ -6931,4 +6937,3 @@ msgstr "Notifications"
 
 msgid "comments.mentions.not-found"
 msgstr "No people found for @%s"
-


### PR DESCRIPTION
# Token Name Validation and Import Restrictions

## Changes Made
- Fixed validation in the token name input to only disallow `$` at the beginning of the token name
- Added restriction to prevent importing files that don't match our token naming specifications (consistent with token form validation)

## Case 1: Token Name Input Incorrectly Validates `$` Characters
### Steps to Reproduce
1. Open any token creation form
2. Type a token name with a `$` sign anywhere except the first character (e.g., `foo$bar`)

### Expected Result
- No validation error shown below the input

### Actual Result
- Validation error shown below the input

## Case 2: Incorrect Handling of Invalid Token Names During Import
### Steps to Reproduce
1. Click the `TOOLS` button, then select `Import`
2. Select a file containing tokens with names starting with `$`, for example:
```json
{
  "Global": {
    "$foo": {
      "$value": "#2b9aa6",
      "$type": "color"
    }
  },
  "$themes": [],
  "$metadata": {
    "tokenSetOrder": [
      "Global"
    ]
  }
}
```

### Expected Result
- Toast notification should appear indicating invalid token names

### Actual Result
- File imports successfully without any validation errors