### PR TITLE
:whale: Ensure that postgresql and redis are running before starting Penpot services

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -113,8 +113,10 @@ services:
       - penpot_assets:/opt/data/assets
 
     depends_on:
-      - penpot-postgres
-      - penpot-redis
+      penpot-postgres:
+        condition: service_healthy
+      penpot-redis:
+        condition: service_healthy
 
     networks:
       - penpot
@@ -195,6 +197,11 @@ services:
   penpot-exporter:
     image: "penpotapp/exporter:latest"
     restart: always
+
+    depends_on:
+      penpot-redis:
+        condition: service_healthy
+
     networks:
       - penpot
 
@@ -211,6 +218,13 @@ services:
     restart: always
     stop_signal: SIGINT
 
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U penpot"]
+      interval: 2s
+      timeout: 10s
+      retries: 5
+      start_period: 2s
+
     volumes:
       - penpot_postgres_v15:/var/lib/postgresql/data
 
@@ -226,6 +240,14 @@ services:
   penpot-redis:
     image: redis:7.2
     restart: always
+
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
+      start_period: 3s
+
     networks:
       - penpot
 


### PR DESCRIPTION
<div align="center">

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYTJzYmRxMmN6cXB1Y2ZqeW5vOWRpaDIycGk0ZzRtdGdvcHAzNHJ3ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/URp0uqsA7Spr0pImBN/giphy.gif)

</div>

This PR defines new dependency conditions, via healhcheck, to ensure that posrtgresql and redis are ready to receive connections before starting the rest of the penpot services (backend and exporter).

This is intended to solve the concurrency problems that arise randomly when starting docker compose.

## How to test it

Try to start several times, even from a ‘clean’ environment, and check that you don't get connection errors with postgresql and redis from the backend and the exporter and make sure you can access penpot from the browser.