### PR TITLE
:bug: Fix internal file media object references handling on instantiating components

### DIFF
--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -12,6 +12,7 @@
    [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
    [app.common.features :as cfeat]
+   [app.common.files.helpers :as cfh]
    [app.common.files.migrations :as fmg]
    [app.common.files.validate :as fval]
    [app.common.logging :as l]
@@ -24,12 +25,12 @@
    [app.features.fdata :as feat.fdata]
    [app.loggers.audit :as-alias audit]
    [app.loggers.webhooks :as-alias webhooks]
+   [app.storage :as sto]
    [app.util.blob :as blob]
    [app.util.pointer-map :as pmap]
    [app.util.time :as dt]
    [app.worker :as-alias wrk]
    [clojure.set :as set]
-   [clojure.walk :as walk]
    [cuerdas.core :as str]))
 
 (set! *warn-on-reflection* true)
@@ -123,16 +124,26 @@
     features (assoc :features (db/decode-pgarray features #{}))
     data     (assoc :data (blob/decode data))))
 
+(defn decode-file
+  "A general purpose file decoding function that resolves all external
+  pointers, run migrations and return plain vanilla file map"
+  [cfg {:keys [id] :as file}]
+  (binding [pmap/*load-fn* (partial feat.fdata/load-pointer cfg id)]
+    (-> (feat.fdata/resolve-file-data cfg file)
+        (update :features db/decode-pgarray #{})
+        (update :data blob/decode)
+        (update :data feat.fdata/process-pointers deref)
+        (update :data feat.fdata/process-objects (partial into {}))
+        (update :data assoc :id id)
+        (fmg/migrate-file))))
+
 (defn get-file
+  "A binfile exportation specific version of get-file"
   [cfg file-id]
   (db/run! cfg (fn [{:keys [::db/conn] :as cfg}]
-                 (binding [pmap/*load-fn* (partial feat.fdata/load-pointer cfg file-id)]
-                   (when-let [file (db/get* conn :file {:id file-id}
-                                            {::db/remove-deleted false})]
-                     (-> file
-                         (decode-row)
-                         (update :data feat.fdata/process-pointers deref)
-                         (update :data feat.fdata/process-objects (partial into {}))))))))
+                 (some->> (db/get* conn :file {:id file-id} {::db/remove-deleted false})
+                          (decode-file cfg)))))
+
 
 (defn clean-file-features
   [file]
@@ -225,45 +236,70 @@
             :data nil}
            {::sql/columns [:media-id :file-id :revn]}))
 
+(def ^:private sql:get-missing-media-references
+  "SELECT fmo.*
+     FROM file_media_object AS fmo
+    WHERE fmo.id = ANY(?::uuid[])
+      AND file_id != ?")
 
-(def ^:private
-  xform:collect-media-id
-  (comp
-   (map :objects)
-   (mapcat vals)
-   (mapcat (fn [obj]
-             ;; NOTE: because of some bug, we ended with
-             ;; many shape types having the ability to
-             ;; have fill-image attribute (which initially
-             ;; designed for :path shapes).
-             (sequence
-              (keep :id)
-              (concat [(:fill-image obj)
-                       (:metadata obj)]
-                      (map :fill-image (:fills obj))
-                      (map :stroke-image (:strokes obj))
-                      (->> (:content obj)
-                           (tree-seq map? :children)
-                           (mapcat :fills)
-                           (map :fill-image))))))))
+(defn upsert-media-references
+  "Check if all file media object references are in plance and create
+  new ones if some of them are missing; this prevents strange bugs on
+  having the same media object associated with two different files;"
+  [{:keys [::db/conn] :as cfg} {file-id :id :as file}]
+  (let [used-refs (cfh/collect-used-media (:data file))
 
-(defn collect-used-media
-  "Given a fdata (file data), returns all media references."
-  [data]
-  (-> #{}
-      (into xform:collect-media-id (vals (:pages-index data)))
-      (into xform:collect-media-id (vals (:components data)))
-      (into (keys (:media data)))))
+        missing-refs-index
+        (reduce (fn [result {:keys [id] :as fmo}]
+                  (assoc result id
+                         (-> fmo
+                             (assoc :id (uuid/next))
+                             (assoc :file-id file-id)
+                             (dissoc :created-at)
+                             (dissoc :deleted-at))))
+                {}
+                (db/plan conn [sql:get-missing-media-references
+                               (db/create-array conn "uuid" used-refs)
+                               file-id]))
+
+        lookup-index
+        (fn [id]
+          (if-let [mobj (get missing-refs-index id)]
+            (do
+              (l/trc :hint "lookup index"
+                     :file-id (str file-id)
+                     :snap-id (str (:snapshot-id file))
+                     :id (str id)
+                     :result (str (get mobj :id)))
+              (get mobj :id))
+
+            id))
+
+        file
+        (if (seq missing-refs-index)
+          (update file :data cfh/relink-shapes lookup-index)
+          file)]
+
+    (doseq [[old-id item] missing-refs-index]
+      (l/dbg :hint "create missing references"
+             :file-id (str file-id)
+             :snap-id (str (:snapshot-id file))
+             :old-id (str old-id)
+             :id (str (:id item)))
+      (db/insert! conn :file-media-object item
+                  {::db/return-keys false}))
+
+    file))
 
 (def sql:get-file-media
-  "SELECT * FROM file_media_object WHERE id = ANY(?) AND file_id = ?")
+  "SELECT * FROM file_media_object WHERE id = ANY(?)")
 
 (defn get-file-media
-  [cfg {:keys [data id] :as file}]
+  [cfg {:keys [data] :as file}]
   (db/run! cfg (fn [{:keys [::db/conn]}]
-                 (let [used (collect-used-media data)
+                 (let [used (cfh/collect-used-media data)
                        used (db/create-array conn "uuid" used)]
-                   (db/exec! conn [sql:get-file-media used id])))))
+                   (db/exec! conn [sql:get-file-media used])))))
 
 (def ^:private sql:get-team-files-ids
   "SELECT f.id FROM file AS f
@@ -307,48 +343,7 @@
   replace the old :component-file reference with the new
   ones, using the provided file-index."
   [data]
-  (letfn [(process-map-form [form]
-            (cond-> form
-              ;; Relink image shapes
-              (and (map? (:metadata form))
-                   (= :image (:type form)))
-              (update-in [:metadata :id] lookup-index)
-
-              ;; Relink paths with fill image
-              (map? (:fill-image form))
-              (update-in [:fill-image :id] lookup-index)
-
-              ;; This covers old shapes and the new :fills.
-              (uuid? (:fill-color-ref-file form))
-              (update :fill-color-ref-file lookup-index)
-
-              ;; This covers the old shapes and the new :strokes
-              (uuid? (:stroke-color-ref-file form))
-              (update :stroke-color-ref-file lookup-index)
-
-              ;; This covers all text shapes that have typography referenced
-              (uuid? (:typography-ref-file form))
-              (update :typography-ref-file lookup-index)
-
-              ;; This covers the component instance links
-              (uuid? (:component-file form))
-              (update :component-file lookup-index)
-
-              ;; This covers the shadows and grids (they have directly
-              ;; the :file-id prop)
-              (uuid? (:file-id form))
-              (update :file-id lookup-index)))
-
-          (process-form [form]
-            (if (map? form)
-              (try
-                (process-map-form form)
-                (catch Throwable cause
-                  (l/warn :hint "failed form" :form (pr-str form) ::l/sync? true)
-                  (throw cause)))
-              form))]
-
-    (walk/postwalk process-form data)))
+  (cfh/relink-shapes data lookup-index))
 
 (defn- relink-media
   "A function responsible of process the :media attr of file data and
@@ -417,75 +412,99 @@
                           (update :colors relink-colors)
                           (d/without-nils))))))
 
-(defn- upsert-file!
-  [conn file]
-  (let [sql (str "INSERT INTO file (id, project_id, name, revn, version, is_shared, data, created_at, modified_at) "
-                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                 "ON CONFLICT (id) DO UPDATE SET data=?, version=?")]
-    (db/exec-one! conn [sql
-                        (:id file)
-                        (:project-id file)
-                        (:name file)
-                        (:revn file)
-                        (:version file)
-                        (:is-shared file)
-                        (:data file)
-                        (:created-at file)
-                        (:modified-at file)
-                        (:data file)
-                        (:version file)])))
+(defn- encode-file
+  [{:keys [::db/conn] :as cfg} {:keys [id] :as file}]
+  (let [file (if (contains? (:features file) "fdata/objects-map")
+               (feat.fdata/enable-objects-map file)
+               file)
 
-(defn persist-file!
-  "Applies all the final validations and perist the file."
-  [{:keys [::db/conn ::timestamp] :as cfg} {:keys [id] :as file}]
+        file (if (contains? (:features file) "fdata/pointer-map")
+               (binding [pmap/*tracked* (pmap/create-tracked)]
+                 (let [file (feat.fdata/enable-pointer-map file)]
+                   (feat.fdata/persist-pointers! cfg id)
+                   file))
+               file)]
+
+    (-> file
+        (update :features db/encode-pgarray conn "text")
+        (update :data blob/encode))))
+
+(defn- file->params
+  [file]
+  (let [params {:has-media-trimmed (:has-media-trimmed file)
+                :ignore-sync-until (:ignore-sync-until file)
+                :project-id (:project-id file)
+                :features (:features file)
+                :name (:name file)
+                :version (:version file)
+                :data (:data file)
+                :id (:id file)
+                :deleted-at (:deleted-at file)
+                :created-at (:created-at file)
+                :modified-at (:modified-at file)
+                :revn (:revn file)
+                :vern (:vern file)}]
+
+    (-> (d/without-nils params)
+        (assoc :data-backend nil)
+        (assoc :data-ref-id nil))))
+
+(defn insert-file!
+  "A general purpose file persistence function, it used for this task
+  but it also used externally for the same purpose"
+  [{:keys [::db/conn] :as cfg} file]
+
+  (let [params (-> (encode-file cfg file)
+                   (file->params))]
+    (db/insert! conn :file params {::db/return-keys true})))
+
+(defn update-file!
+  "A general purpose file persistence function, it used for this task
+  but it also used externally for the same purpose"
+  [{:keys [::db/conn ::sto/storage] :as cfg} {:keys [id] :as file}]
+
+  (let [file   (encode-file cfg file)
+        params (-> (file->params file)
+                   (dissoc :id))]
+
+    ;; If file was already offloaded, we touch the underlying storage
+    ;; object for properly trigger storage-gc-touched task
+    (when (feat.fdata/offloaded? file)
+      (some->> (:data-ref-id file) (sto/touch-object! storage)))
+
+    (db/update! conn :file params {:id id} {::db/return-keys true})))
+
+(defn save-file!
+  "Applies all the final validations and perist the file, binfile
+  specific, should not be used outside"
+  [{:keys [::timestamp] :as cfg} file]
 
   (dm/assert!
    "expected valid timestamp"
    (dt/instant? timestamp))
 
-  (let [file   (-> file
-                   (assoc :created-at timestamp)
-                   (assoc :modified-at timestamp)
-                   (assoc :ignore-sync-until (dt/plus timestamp (dt/duration {:seconds 5})))
-                   (update :features
-                           (fn [features]
-                             (let [features (cfeat/check-supported-features! features)]
-                               (-> (::features cfg #{})
-                                   (set/union features)
-                                   ;; We never want to store
-                                   ;; frontend-only features on file
-                                   (set/difference cfeat/frontend-only-features))))))
+  (let [file (-> file
+                 (assoc :created-at timestamp)
+                 (assoc :modified-at timestamp)
+                 (assoc :ignore-sync-until (dt/plus timestamp (dt/duration {:seconds 5})))
+                 (update :features
+                         (fn [features]
+                           (let [features (cfeat/check-supported-features! features)]
+                             (-> (::features cfg #{})
+                                 (set/union features)
+                                 ;; We never want to store
+                                 ;; frontend-only features on file
+                                 (set/difference cfeat/frontend-only-features))))))]
 
+    (when (contains? cf/flags :file-schema-validation)
+      (fval/validate-file-schema! file))
 
-        _      (when (contains? cf/flags :file-schema-validation)
-                 (fval/validate-file-schema! file))
+    (when (contains? cf/flags :soft-file-schema-validation)
+      (let [result (ex/try! (fval/validate-file-schema! file))]
+        (when (ex/exception? result)
+          (l/error :hint "file schema validation error" :cause result))))
 
-        _      (when (contains? cf/flags :soft-file-schema-validation)
-                 (let [result (ex/try! (fval/validate-file-schema! file))]
-                   (when (ex/exception? result)
-                     (l/error :hint "file schema validation error" :cause result))))
-
-        file   (if (contains? (:features file) "fdata/objects-map")
-                 (feat.fdata/enable-objects-map file)
-                 file)
-
-        file   (if (contains? (:features file) "fdata/pointer-map")
-                 (binding [pmap/*tracked* (pmap/create-tracked)]
-                   (let [file (feat.fdata/enable-pointer-map file)]
-                     (feat.fdata/persist-pointers! cfg id)
-                     file))
-                 file)
-
-        params (-> file
-                   (update :features db/encode-pgarray conn "text")
-                   (update :data blob/encode))]
-
-    (if (::overwrite cfg)
-      (upsert-file! conn params)
-      (db/insert! conn :file params ::db/return-keys false))
-
-    file))
-
+    (insert-file! cfg file)))
 
 (defn register-pending-migrations
   "All features that are enabled and requires explicit migration are

--- a/backend/src/app/binfile/v2.clj
+++ b/backend/src/app/binfile/v2.clj
@@ -297,7 +297,7 @@
                         (set/difference (:features file)))]
       (vswap! bfc/*state* update :pending-to-migrate (fnil conj []) [feature (:id file)]))
 
-    (bfc/persist-file! cfg file))
+    (bfc/save-file! cfg file))
 
   (doseq [thumbnail (read-seq cfg :file-object-thumbnail file-id)]
     (let [thumbnail (-> thumbnail

--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -638,7 +638,7 @@
      :plugin-data plugin-data}))
 
 (defn- import-file
-  [{:keys [::db/conn ::project-id ::file-id ::file-name] :as cfg}]
+  [{:keys [::project-id ::file-id ::file-name] :as cfg}]
   (let [file-id'   (bfc/lookup-index file-id)
         file       (read-file cfg)
         media      (read-file-media cfg)
@@ -688,10 +688,7 @@
 
       (->> file
            (bfc/register-pending-migrations cfg)
-           (bfc/persist-file! cfg))
-
-      (when (::bfc/overwrite cfg)
-        (db/delete! conn :file-thumbnail {:file-id file-id'}))
+           (bfc/save-file! cfg))
 
       file-id')))
 
@@ -786,7 +783,7 @@
              ::l/sync? true)
 
       (db/insert! conn :file-media-object params
-                  {::db/on-conflict-do-nothing? (::bfc/overwrite cfg)}))))
+                  {::db/on-conflict-do-nothing? false}))))
 
 (defn- import-file-thumbnails
   [{:keys [::db/conn] :as cfg}]
@@ -807,7 +804,7 @@
              ::l/sync? true)
 
       (db/insert! conn :file-tagged-object-thumbnail params
-                  {::db/on-conflict-do-nothing? (::bfc/overwrite cfg)}))))
+                  {::db/on-conflict-do-nothing? false}))))
 
 (defn- import-files
   [{:keys [::bfc/timestamp ::input ::name] :or {timestamp (dt/now)} :as cfg}]

--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -347,6 +347,7 @@
     {:sendmail           (ig/ref ::email/handler)
      :objects-gc         (ig/ref :app.tasks.objects-gc/handler)
      :file-gc            (ig/ref :app.tasks.file-gc/handler)
+     :file-checkpoint    (ig/ref :app.tasks.file-checkpoint/handler)
      :file-gc-scheduler  (ig/ref :app.tasks.file-gc-scheduler/handler)
      :offload-file-data  (ig/ref :app.tasks.offload-file-data/handler)
      :tasks-gc           (ig/ref :app.tasks.tasks-gc/handler)
@@ -394,6 +395,10 @@
    {::db/pool (ig/ref ::db/pool)}
 
    :app.tasks.file-gc/handler
+   {::db/pool     (ig/ref ::db/pool)
+    ::sto/storage (ig/ref ::sto/storage)}
+
+   :app.tasks.file-checkpoint/handler
    {::db/pool     (ig/ref ::db/pool)
     ::sto/storage (ig/ref ::sto/storage)}
 

--- a/backend/src/app/rpc/commands/files_update.clj
+++ b/backend/src/app/rpc/commands/files_update.clj
@@ -6,6 +6,7 @@
 
 (ns app.rpc.commands.files-update
   (:require
+   [app.binfile.common :as bfc]
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
@@ -435,15 +436,26 @@
   [cfg file changes skip-validate]
   (let [;; WARNING: this ruins performance; maybe we need to find
         ;; some other way to do general validation
-        libs (when (and (or (contains? cf/flags :file-validation)
-                            (contains? cf/flags :soft-file-validation))
-                        (not skip-validate))
-               (get-file-libraries cfg file))
+        libs
+        (when (and (or (contains? cf/flags :file-validation)
+                       (contains? cf/flags :soft-file-validation))
+                   (not skip-validate))
+          (get-file-libraries cfg file))
 
-        file (-> (files/check-version! file)
-                 (update :revn inc)
-                 (update :data cpc/process-changes changes)
-                 (update :data d/without-nils))]
+        state
+        (atom {})
+
+        file
+        (binding [cpc/*state* state]
+          (-> (files/check-version! file)
+              (update :revn inc)
+              (update :data cpc/process-changes changes)
+              (update :data d/without-nils)))
+
+        file
+        (if (:has-media-refs @state)
+          (bfc/upsert-media-references cfg file)
+          file)]
 
     (binding [pmap/*tracked* nil]
       (when (contains? cf/flags :soft-file-validation)

--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -54,7 +54,7 @@
 
     ;; Process and persist file
     (let [file (->> (bfc/process-file file)
-                    (bfc/persist-file! cfg))]
+                    (bfc/save-file! cfg))]
 
       ;; The file profile creation is optional, so when no profile is
       ;; present (when this function is called from profile less

--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -37,16 +37,15 @@
   (let [;; We don't touch the original file on duplication
         file       (bfc/get-file cfg file-id)
         project-id (:project-id file)
+        fmeds      (bfc/get-file-media cfg file)
+        flibs      (bfc/get-files-rels cfg #{file-id})
         file       (-> file
                        (update :id bfc/lookup-index)
                        (update :project-id bfc/lookup-index)
                        (cond-> (string? name)
                          (assoc :name name))
                        (cond-> (true? reset-shared-flag)
-                         (assoc :is-shared false)))
-
-        flibs  (bfc/get-files-rels cfg #{file-id})
-        fmeds  (bfc/get-file-media cfg file)]
+                         (assoc :is-shared false)))]
 
     (when (uuid? profile-id)
       (proj/check-edition-permissions! conn profile-id project-id))

--- a/backend/src/app/srepl/fixes.clj
+++ b/backend/src/app/srepl/fixes.clj
@@ -53,7 +53,7 @@
   fixes all not propertly referenced file-media-object for a file"
   [{:keys [id data] :as file} & _]
   (let [conn  (db/get-connection h/*system*)
-        used  (bfc/collect-used-media data)
+        used  (cfh/collect-used-media data)
         ids   (db/create-array conn "uuid" used)
         sql   (str "SELECT * FROM file_media_object WHERE id = ANY(?)")
         rows  (db/exec! conn [sql ids])
@@ -272,6 +272,7 @@
                (reduce +)))
 
         num-missing-slots (count-slots-data (:data file))]
+
     (when (pos? num-missing-slots)
       (l/trc :info (str "Shapes with children with the same swap slot: " num-missing-slots) :file-id (str (:id file))))
     file))

--- a/backend/src/app/tasks/file_checkpoint.clj
+++ b/backend/src/app/tasks/file_checkpoint.clj
@@ -1,0 +1,97 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.tasks.file-checkpoint
+  "A maintenance task that is responsible of performing a checkpoint on a recently edited file.
+
+  The checkpoint process right now consist on the following task:
+
+  - Check all file-media-object references and create new if some of
+    them are missing
+  "
+  (:require
+   [app.binfile.common :as bfc]
+   [app.common.exceptions :as ex]
+   [app.common.files.validate :as cfv]
+   [app.common.logging :as l]
+   [app.db :as db]
+   [app.features.fdata :as feat.fdata]
+   [app.storage :as sto]
+   [app.tasks.file-gc :as fgc]
+   [app.util.blob :as blob]
+   [integrant.core :as ig]))
+
+(defn- process-file-snapshots!
+  [{:keys [::db/conn ::sto/storage] :as cfg} file-id]
+  (run! (fn [{:keys [snapshot-id] :as file}]
+          (let [file  (bfc/decode-file cfg file)
+                file' (bfc/upsert-media-references cfg file)]
+
+            (when (not= file file')
+              (cfv/validate-file-schema! file')
+              (let [data (blob/encode (:data file'))]
+                ;; If file was already offloaded, we touch the underlying storage
+                ;; object for properly trigger storage-gc-touched task
+                (when (feat.fdata/offloaded? file)
+                  (some->> (:data-ref-id file) (sto/touch-object! storage)))
+
+                (db/update! conn :file-change
+                            {:data data
+                             :data-backend nil
+                             :data-ref-id nil}
+                            {:id snapshot-id}
+                            {::db/return-keys false})))))
+
+        (db/plan cfg [fgc/sql:get-snapshots file-id])))
+
+(defn- process-file!
+  [cfg file-id]
+  (if-let [file (fgc/get-file cfg file-id)]
+    (do
+      (->> file
+           (bfc/decode-file cfg)
+           (bfc/upsert-media-references cfg)
+           (cfv/validate-file-schema!)
+           (bfc/update-file! cfg))
+
+      (process-file-snapshots! cfg file-id)
+
+      true)
+
+    (do
+      (l/dbg :hint "skip" :file-id (str (::fgc/file-id cfg)))
+      false)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; HANDLER
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod ig/assert-key ::handler
+  [_ params]
+  (assert (db/pool? (::db/pool params)) "expected a valid database pool")
+  (assert (sto/valid-storage? (::sto/storage params)) "expected valid storage to be provided"))
+
+(defmethod ig/init-key ::handler
+  [_ cfg]
+  (fn [{:keys [props] :as task}]
+    (let [cfg     (assoc cfg ::db/rollback (:rollback? props))
+          file-id (get props :file-id)]
+
+      (when-not (uuid? file-id)
+        (ex/raise :type :internal
+                  :code :invalid-props
+                  :hint "file is missing or it is not uuid instance"
+                  :file-id file-id))
+
+      (try
+        (db/tx-run! cfg (fn [{:keys [::db/conn] :as cfg}]
+                          (let [cfg (update cfg ::sto/storage sto/configure conn)]
+                            (process-file! cfg file-id))))
+
+        (catch Throwable cause
+          (l/err :hint "error file checkpoint task"
+                 :file-id (str file-id)
+                 :cause cause))))))

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -16,7 +16,9 @@
    [app.db.sql :as sql]
    [app.http :as http]
    [app.rpc :as-alias rpc]
+   [app.rpc.commands.files :as files]
    [app.storage :as sto]
+   [app.tasks.file-checkpoint]
    [app.util.time :as dt]
    [backend-tests.helpers :as th]
    [clojure.test :as t]
@@ -1658,3 +1660,689 @@
             components (get-in result [:data :components])]
         (t/is (not (contains? components c-id)))))))
 
+
+
+
+(defn add-file-media-object
+  [& {:keys [profile-id file-id]}]
+  (let [mfile  {:filename "sample.jpg"
+                :path (th/tempfile "backend_tests/test_files/sample.jpg")
+                :mtype "image/jpeg"
+                :size 312043}
+        params {::th/type :upload-file-media-object
+                ::rpc/profile-id profile-id
+                :file-id file-id
+                :is-local true
+                :name "testfile"
+                :content mfile}
+        out    (th/command! params)]
+
+    ;; (th/print-result! out)
+    (t/is (nil? (:error out)))
+    (:result out)))
+
+(t/deftest file-gc-with-components-and-media-assets
+  (let [storage (:app.storage/storage th/*system*)
+        profile (th/create-profile* 1)
+
+        file-1  (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared true})
+
+        file-2  (th/create-file* 2 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared false})
+
+        fmedia  (add-file-media-object :profile-id (:id profile) :file-id (:id file-1))
+
+
+        rel     (th/link-file-to-library*
+                 {:file-id (:id file-2)
+                  :library-id (:id file-1)})
+
+        s-id-1  (uuid/random)
+        s-id-2  (uuid/random)
+        c-id    (uuid/random)
+
+        f1-page-id (first (get-in file-1 [:data :pages]))
+        f2-page-id (first (get-in file-2 [:data :pages]))
+
+        fills
+        [{:fill-image
+          {:id (:id fmedia)
+           :name "test"
+           :width 200
+           :height 200}}]]
+
+    ;; Update file library inserting new component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-1
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance true
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}
+      {:type :add-component
+       :path ""
+       :name "Board"
+       :main-instance-id s-id-1
+       :main-instance-page f1-page-id
+       :id c-id
+       :anotation nil}])
+
+    ;; Instanciate a component in a different file
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-2
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance false
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}])
+
+
+    ;; Check that file media object references are only set on the
+    ;; original object and the instantiation does not implies changes
+    ;; on references
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    ;; Run the file-gc on file and library
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-2)})))
+
+    ;; Check that component exists
+    (let [data {::th/type :get-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+
+      (t/is (th/success? out))
+      (let [result     (:result out)
+            component (get-in result [:data :components c-id])]
+
+        (t/is (some? component))
+        (t/is (nil? (:objects component)))))
+
+    ;; Now proceed to delete a component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :del-component
+       :id c-id}
+      {:type :del-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :ignore-touched true}])
+
+    ;; Check that component is marked as deleted
+    (let [data {::th/type :get-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+
+      (t/is (th/success? out))
+      (let [result (:result out)
+            component (get-in result [:data :components c-id])]
+        (t/is (true? (:deleted component)))
+        (t/is (some? (not-empty (:objects component))))))
+
+    ;; Re-run the file-gc task
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+    (t/is (false? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-2)})))
+
+    ;; Check that component is still there after file-gc task
+    (let [data {::th/type :get-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+
+      (t/is (th/success? out))
+      (let [result (:result out)
+            component (get-in result [:data :components c-id])]
+        (t/is (true? (:deleted component)))
+        (t/is (some? (not-empty (:objects component))))))
+
+    ;; Check that file media object references are still present
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      ;; (pp/pprint rows)
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    ;; Now delete the last instance using deleted component
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :del-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :ignore-touched true}])
+
+    (th/db-exec! ["update file set has_media_trimmed = false where id = ?" (:id file-1)])
+
+    ;; Now, we have deleted the usage of component if we pass file-gc,
+    ;; that component should be deleted
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+
+    ;; Check that file media object references are still present,
+    ;; because we have snapshots
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      ;; (pp/pprint rows)
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    ;; Lets delete snapshots and run file-gc again
+    (let [result (th/db-delete! :file_change {:file-id (:id file-1)})]
+      (t/is (= 2 (db/get-update-count result))))
+
+    ;; Rerun file-gc with snapshots deleted
+    (th/db-exec! ["update file set has_media_trimmed = false where id = ?" (:id file-1)])
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+
+    ;; Check that file media object references are still present,
+    ;; because we have snapshots
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp some? :deleted-at) rows)))
+
+    ;; Check that component is properly removed
+    (let [data {::th/type :get-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+
+      (t/is (th/success? out))
+      (let [result     (:result out)
+            components (get-in result [:data :components])]
+        (t/is (not (contains? components c-id)))))))
+
+(t/deftest file-gc-with-components-and-media-assets-delete-all
+  (let [storage (:app.storage/storage th/*system*)
+        profile (th/create-profile* 1)
+
+        file-1  (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared true})
+
+        file-2  (th/create-file* 2 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared false})
+
+        fmedia  (add-file-media-object :profile-id (:id profile) :file-id (:id file-1))
+
+
+        rel     (th/link-file-to-library*
+                 {:file-id (:id file-2)
+                  :library-id (:id file-1)})
+
+        s-id-1  (uuid/random)
+        s-id-2  (uuid/random)
+        c-id    (uuid/random)
+
+        f1-page-id (first (get-in file-1 [:data :pages]))
+        f2-page-id (first (get-in file-2 [:data :pages]))
+
+        fills
+        [{:fill-image
+          {:id (:id fmedia)
+           :name "test"
+           :width 200
+           :height 200}}]]
+
+    ;; Update file library inserting new component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-1
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance true
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}
+      {:type :add-component
+       :path ""
+       :name "Board"
+       :main-instance-id s-id-1
+       :main-instance-page f1-page-id
+       :id c-id
+       :anotation nil}])
+
+    ;; Instanciate a component in a different file
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-2
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance false
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}])
+
+
+    ;; Check that file media object references are only set on the
+    ;; original object and the instantiation does not implies changes
+    ;; on references
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    ;; Run the file-gc on file and library
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-2)})))
+
+    ;; Now proceed to delete a component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :del-component
+       :id c-id}
+      {:type :del-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :ignore-touched true}])
+
+    ;; Now delete the last instance using deleted component
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :del-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :ignore-touched true}])
+
+    ;; Lets delete snapshots and run file-gc
+    (let [result (th/db-delete! :file_change {:file-id (:id file-1)})]
+      (t/is (= 2 (db/get-update-count result))))
+
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+
+    ;; Check that file media object references are marked all for deletion
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      ;; (pp/pprint rows)
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp some? :deleted-at) rows)))
+
+    ;; Check that component is properly removed
+    (let [data {::th/type :get-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+
+      (t/is (th/success? out))
+      (let [result     (:result out)
+            components (get-in result [:data :components])]
+        (t/is (not (contains? components c-id)))))))
+
+(t/deftest file-gc-and-absorb-library-with-checkpoint
+  (let [storage (:app.storage/storage th/*system*)
+        profile (th/create-profile* 1)
+
+        file-1  (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared true})
+
+        file-2  (th/create-file* 2 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared false})
+
+        fmedia  (add-file-media-object :profile-id (:id profile) :file-id (:id file-1))
+
+
+        rel     (th/link-file-to-library*
+                 {:file-id (:id file-2)
+                  :library-id (:id file-1)})
+
+        s-id-1  (uuid/random)
+        s-id-2  (uuid/random)
+        c-id    (uuid/random)
+
+        f1-page-id (first (get-in file-1 [:data :pages]))
+        f2-page-id (first (get-in file-2 [:data :pages]))
+
+        fills
+        [{:fill-image
+          {:id (:id fmedia)
+           :name "test"
+           :width 200
+           :height 200}}]]
+
+    ;; Update file library inserting new component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-1
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance true
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}
+      {:type :add-component
+       :path ""
+       :name "Board"
+       :main-instance-id s-id-1
+       :main-instance-page f1-page-id
+       :id c-id
+       :anotation nil}])
+
+    ;; Instanciate a component in a different file
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-2
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance false
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}])
+
+
+    ;; Check that file media object references are only set on the
+    ;; original object and the instantiation does not implies changes
+    ;; on references
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      ;; (pp/pprint rows)
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    (t/is (true? (th/run-task! :file-checkpoint {:file-id (:id file-1)})))
+
+    ;; This checkpoint should generate two additional file media
+    ;; references: one for the ongoing file and the other for the
+    ;; snapshot. It is implemented in this way because the reference
+    ;; checking does not maintains a global index, and operates
+    ;; snapshot by snapshot so if two snapshots has two broken
+    ;; references to the same storage file, two different references
+    ;; will be created for each snapshot analyzed.
+    (t/is (true? (th/run-task! :file-checkpoint {:file-id (:id file-2)})))
+
+    ;; Check that new file media object references are created
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      ;; (pp/pprint rows)
+      (t/is (= 3 (count rows)))
+      (t/is (= (:id file-1) (:file-id (get rows 0))))
+      (t/is (= (:id file-2) (:file-id (get rows 1))))
+      (t/is (= (:id file-2) (:file-id (get rows 2)))))
+
+    ;; Run the file-gc on file and library
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-2)})))
+
+    ;; Now proceed to delete file and absorb it
+    (let [data {::th/type :delete-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+      (t/is (th/success? out)))
+
+    (th/run-task! :delete-object
+                  {:object :file
+                   :deleted-at (dt/now)
+                   :id (:id file-1)})
+
+    ;; Check that file media object references are marked all for deletion
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      ;; (pp/pprint rows)
+      (t/is (= 3 (count rows)))
+
+      (t/is (= (:id file-1) (:file-id (get rows 0))))
+      (t/is (some? (:deleted-at (get rows 0))))
+
+      (t/is (= (:id file-2) (:file-id (get rows 1))))
+      (t/is (nil? (:deleted-at (get rows 1))))
+      (t/is (= (:id file-2) (:file-id (get rows 2))))
+      (t/is (nil? (:deleted-at (get rows 2)))))
+
+    (th/run-task! :objects-gc
+                  {:min-age 0})
+
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      (t/is (= 2 (count rows)))
+      (t/is (every? #(= (:id file-2) (:file-id %)) rows))
+      (t/is (every? (comp nil? :deleted-at) rows)))))
+
+
+
+(t/deftest file-gc-and-absorb-library-without-checkpoint
+  (let [storage (:app.storage/storage th/*system*)
+        profile (th/create-profile* 1)
+
+        file-1  (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared true})
+
+        file-2  (th/create-file* 2 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared false})
+
+        fmedia  (add-file-media-object :profile-id (:id profile) :file-id (:id file-1))
+
+
+        rel     (th/link-file-to-library*
+                 {:file-id (:id file-2)
+                  :library-id (:id file-1)})
+
+        s-id-1  (uuid/random)
+        s-id-2  (uuid/random)
+        c-id    (uuid/random)
+
+        f1-page-id (first (get-in file-1 [:data :pages]))
+        f2-page-id (first (get-in file-2 [:data :pages]))
+
+        fills
+        [{:fill-image
+          {:id (:id fmedia)
+           :name "test"
+           :width 200
+           :height 200}}]]
+
+    ;; Update file library inserting new component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-1
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance true
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}
+      {:type :add-component
+       :path ""
+       :name "Board"
+       :main-instance-id s-id-1
+       :main-instance-page f1-page-id
+       :id c-id
+       :anotation nil}])
+
+    ;; Instanciate a component in a different file
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-2
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance false
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}])
+
+
+    ;; Check that file media object references are only set on the
+    ;; original object and the instantiation does not implies changes
+    ;; on references
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object"])]
+      (t/is (= 1 (count rows)))
+      (t/is (= (:id file-1) (:file-id (first rows))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    ;; (t/is (true? (th/run-task! :file-checkpoint {:file-id (:id file-1)})))
+    ;; (t/is (true? (th/run-task! :file-checkpoint {:file-id (:id file-2)})))
+
+    ;; Check that new file media object references are created
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      (t/is (= 1 (count rows))))
+
+    ;; Run the file-gc on file and library
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-2)})))
+
+    ;; Now proceed to delete file and absorb it
+
+    ;; Check that component is properly removed
+    (let [data {::th/type :delete-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+
+      ;; (th/print-result! out)
+      (t/is (th/success? out)))
+
+    (th/run-task! :delete-object
+                  {:object :file
+                   :deleted-at (dt/now)
+                   :id (:id file-1)})
+
+    ;; Check that file media object references are marked all for deletion
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      (t/is (= 1 (count rows)))
+      (t/is (every? (comp some? :deleted-at) rows)))
+
+
+    (th/run-task! :objects-gc
+                  {:min-age 0})
+
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      (t/is (= 0 (count rows))))))

--- a/backend/test/backend_tests/rpc_management_test.clj
+++ b/backend/test/backend_tests/rpc_management_test.clj
@@ -6,6 +6,7 @@
 
 (ns backend-tests.rpc-management-test
   (:require
+   [app.binfile.common :as bfc]
    [app.common.features :as cfeat]
    [app.common.pprint :as pp]
    [app.common.types.shape :as cts]
@@ -81,7 +82,8 @@
 
       ;; Check that result is correct
       (t/is (nil? (:error out)))
-      (let [result (:result out)]
+      (let [result (->> (:result out)
+                        (bfc/decode-file th/*system*))]
 
         ;; Check that the returned result is a file but has different id
         ;; and different name.

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -221,6 +221,10 @@
       [:component-id {:optional true} ::sm/uuid]
       [:ignore-touched {:optional true} :boolean]]]
 
+    [:add-media-ref
+     [:map
+      [:id ::sm/uuid]]]
+
     [:set-guide schema:set-guide-change]
     [:set-flow schema:set-flow-change]
     [:set-default-grid schema:set-default-grid-change]
@@ -482,6 +486,11 @@
   first processing phase of changes. Should be set to a hash-set
   instance and will contain changes that caused the touched
   modification."
+  nil)
+
+(def ^:dynamic *state*
+  "A general purpose state to signal some out of order operations
+  to the processor backend."
   nil)
 
 (defmulti process-change (fn [_ change] (:type change)))
@@ -1069,6 +1078,11 @@
   (update data :tokens-lib #(-> %
                                 (ctob/ensure-tokens-lib)
                                 (ctob/delete-set name))))
+
+(defmethod process-change :add-media-ref
+  [data _]
+  (some-> *state* (swap! assoc :has-media-refs true))
+  data)
 
 ;; === Operations
 

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -968,6 +968,11 @@
                                   :id id
                                   :page-id page-id})))
 
+(defn add-media-ref
+  [changes id]
+  (update changes :redo-changes conj {:type :add-media-ref
+                                      :id id}))
+
 (defn restore-component
   [changes id page-id main-instance]
   (assert-library! changes)

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -557,7 +557,8 @@
               :code :schema-validation
               :hint (str/ffmt "invalid file data structure found on file '%'" id)
               :file-id id
-              ::sm/explain (get-fdata-explain data))))
+              ::sm/explain (get-fdata-explain data)))
+  file)
 
 (defn validate-file!
   "Validate full referential integrity and semantic coherence on file data.

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -187,22 +187,28 @@
    (generate-instantiate-component changes objects file-id component-id position page libraries nil nil nil {}))
 
   ([changes objects file-id component-id position page libraries old-id parent-id frame-id
-    {:keys [force-frame?]
-     :or {force-frame? false}}]
+    {:keys [force-frame? remap-media-refs?]
+     :or {force-frame? false
+          remap-media-refs? false}}]
    (let [component     (ctf/get-component libraries file-id component-id)
          parent        (when parent-id (get objects parent-id))
          library       (get libraries file-id)
 
          components-v2 (dm/get-in library [:data :options :components-v2])
 
-         [new-shape new-shapes]
+         [new-shape new-shapes new-media-refs]
          (ctn/make-component-instance page
                                       component
                                       (:data library)
                                       position
                                       components-v2
                                       (cond-> {}
-                                        force-frame? (assoc :force-frame-id frame-id)))
+                                        force-frame?
+                                        (assoc :force-frame-id frame-id)
+
+                                        remap-media-refs?
+                                        (assoc :remap-media-refs? true)))
+
 
          first-shape (cond-> (first new-shapes)
                        (not (nil? parent-id))
@@ -241,7 +247,11 @@
 
          changes (reduce #(pcb/add-object %1 %2 {:ignore-touched true})
                          changes
-                         (rest new-shapes))]
+                         (rest new-shapes))
+
+         changes (reduce #(pcb/add-media-ref %1 %2)
+                         changes
+                         new-media-refs)]
 
      [new-shape changes])))
 

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -601,14 +601,17 @@
          (rx/of (dwu/commit-undo-transaction undo-id)))))))
 
 (defn instantiate-component
-  "Create a new shape in the current page, from the component with the given id
-  in the given file library. Then selects the newly created instance."
+  "Create a new shape in the current page, from the component with the
+  given id in the given file library. Then selects the newly created
+  instance."
   ([file-id component-id position]
    (instantiate-component file-id component-id position nil))
   ([file-id component-id position {:keys [start-move? initial-point id-ref origin]}]
-   (dm/assert! (uuid? file-id))
-   (dm/assert! (uuid? component-id))
-   (dm/assert! (gpt/point? position))
+
+   (assert (uuid? file-id) "expected a uuid for `file-id`")
+   (assert (uuid? component-id) "expected a uuid for `component-id`")
+   (assert (gpt/point? position) "expected a point for `position`")
+
    (ptk/reify ::instantiate-component
      ptk/WatchEvent
      (watch [it state _]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -624,6 +624,9 @@
 
              current-file-id (:current-file-id state)
 
+             remap-media-refs?
+             (not= current-file-id file-id)
+
              [new-shape changes]
              (cll/generate-instantiate-component changes
                                                  objects
@@ -631,7 +634,11 @@
                                                  component-id
                                                  position
                                                  page
-                                                 libraries)
+                                                 libraries
+                                                 nil
+                                                 nil
+                                                 nil
+                                                 {:remap-media-refs? remap-media-refs?})
 
              undo-id (js/Symbol)]
 


### PR DESCRIPTION
## **The issue**

When a user instantiates a component with media references (image-fills per example) from an non-local library on the current file. The instance shape conserves the same values for :id on the `:fill-image` attribute as the original shape. As we should known, this ID represents the row on the relation between the **file** and **storage_object* and this relation is stored in the `file_media_object` table.

When the original file is deleted or the original component is deleted, all the component instances that uses some kind of media assets will point to deleted file media object row, which is susceptible to be garbage collected and leave the shape broken.

## **The fix**

The `file-checkpoint` asynchronous task & active notification of possible new refs on changes protocol.

That task is executed in a debounce mode on file modification with default timeout of 20 minutes.

This means, if you create an instance of component, this instance will be created with the same ids pointing to incorrect file media object, but at some time of inactivity, the checkpoint task will look on all references of the file and will create a correct references.

Additionally, when you create an instance of a component, new specific change will be sent to back: `:add-media-ref` with the id of the used ref. This will trigger on the file-update process the checking and creation of new media references. It will be done only when new instances are created, so the majority of update-file requests will be not affected with this penalization.

## **Rationale**

TBD

## **How to test**

TBD

