### PR TITLE
:bug: Fix board titles movement when drag and drop using render wasm

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -485,7 +485,7 @@
            :shift? @shift?}])
 
        [:& widgets/frame-titles
-        {:objects base-objects
+        {:objects (with-meta objects-modified nil)
          :selected selected
          :zoom zoom
          :show-artboard-names? show-artboard-names?


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/task/9899