### PR TITLE
:bug: Fix token name conflict on duplication

### DIFF
--- a/backend/src/app/features/components_v2.clj
+++ b/backend/src/app/features/components_v2.clj
@@ -1071,7 +1071,7 @@
         groups (d/group-by #(first (cfh/split-path (:path %))) assets)
         ;; If there is a group called as the generic-name we have to preserve it
         unames (into #{} (keep str) (keys groups))
-        groups (rename-keys groups {generic-name (cfh/generate-unique-name unames generic-name)})
+        groups (rename-keys groups {generic-name (cfh/generate-unique-name generic-name unames)})
 
         ;; Split large groups in chunks of max-group-size elements
         groups (loop [groups (seq groups)

--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -9,7 +9,6 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.geom.shapes.common :as gco]
-   [app.common.schema :as sm]
    [app.common.uuid :as uuid]
    [clojure.set :as set]
    [clojure.walk :as walk]
@@ -424,7 +423,7 @@
 
    Parameters:
    - `base-name` - string used as the base for name generation.
-   - `existing-names` - a set of existing names to check for uniqueness.
+   - `existing-names` - a collection of existing names to check for uniqueness.
    - Options:
      - `:suffix-fn` - a function that generates suffixes, given an integer (default: `get-suffix`).
      - `:immediate-suffix?` - if `true`, the base name is considered taken, and suffixing starts immediately.
@@ -435,7 +434,7 @@
                                :or {suffix-fn get-suffix}}]
   (dm/assert!
    "expected a set of strings"
-   (sm/check-set-of-strings! existing-names))
+   (coll? existing-names))
 
   (dm/assert!
    "expected a string for `basename`."

--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -401,11 +401,12 @@
     (into #{} (keep :name) elements)))
 
 (defn- name-seq
-  "Creates a lazy sequence of names in the pattern:
-   (str name),
-   (str name (suffix-fn 1)),
-   (str name (suffix-fn 2)),
-   (str name (suffix-fn 3))..."
+  "Creates a lazy, infinite sequence of names starting with `base-name`,
+   followed by variants with suffixes applied. The sequence follows this pattern:
+   - `base-name`
+   - `(str base-name (suffix-fn 1))`
+   - `(str base-name (suffix-fn 2))`
+   - `(str base-name (suffix-fn 3))`, etc."
   [base-name suffix-fn]
   (concat
    [base-name]
@@ -418,14 +419,18 @@
   (str/concat " " copy-count))
 
 (defn generate-unique-name
-  "Generates unique name by
-   returning first unique name from the sequence that doesn't exist in existing-names
-  - `base-name` - a name used for further unique name geneations
-  - `existing-names` - exitsing entity names to check uniqness against
-  - options
-    - `:suffix-fn` - a function that generates unique suffix
-       - accepts `copy-number`, returns `string`
-    - `:immediate-suffix?` - boolean, if `true` suffix added immediately"
+  "Generates a unique name by selecting the first available name from a generated sequence.
+   The sequence consists of `base-name` and its variants, avoiding conflicts with `existing-names`.
+
+   Parameters:
+   - `base-name` - string used as the base for name generation.
+   - `existing-names` - a set of existing names to check for uniqueness.
+   - Options:
+     - `:suffix-fn` - a function that generates suffixes, given an integer (default: `get-suffix`).
+     - `:immediate-suffix?` - if `true`, the base name is considered taken, and suffixing starts immediately.
+
+   Returns:
+   - A unique name not present in `existing-names`."
   [base-name existing-names & {:keys [suffix-fn immediate-suffix?]
                                :or {suffix-fn get-suffix}}]
   (dm/assert!

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2010,7 +2010,7 @@
         has-flow?        (partial ctp/get-frame-flow flows)]
 
     (reduce (fn [changes frame-id]
-              (let [name     (cfh/generate-unique-name @unames "Flow 1")
+              (let [name     (cfh/generate-unique-name "Flow" @unames :immediate-suffix? true)
                     frame-id (get ids-map frame-id)
                     flow-id  (uuid/next)
                     new-flow {:id flow-id

--- a/common/test/common_tests/files/helpers_test.cljc
+++ b/common/test/common_tests/files/helpers_test.cljc
@@ -1,0 +1,38 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.files.helpers-test
+  (:require
+   [app.common.files.helpers :as cfh]
+   [clojure.test :as t]))
+
+(t/deftest test-generate-unique-name
+  (t/testing "Test unique name generation"
+    (let [suffix-fn #(str "-copy-" %)]
+      (t/is (cfh/generate-unique-name "base-name"
+                                      #{"base-name" "base-name-copy-1"}
+                                      :suffix-fn suffix-fn)
+            "base-name-copy-2")
+      (t/is (cfh/generate-unique-name "base-name"
+                                      #{"base-name-copy-2"}
+                                      :suffix-fn suffix-fn)
+            "base-name-copy-1")
+      (t/is (cfh/generate-unique-name "base-name"
+                                      #{"base-namec-copy"}
+                                      :suffix-fn suffix-fn)
+            "base-name-copy-1")
+      (t/is (cfh/generate-unique-name "base-name"
+                                      #{"base-name"}
+                                      :suffix-fn suffix-fn)
+            "base-name-copy-1")))
+
+  (t/testing "Test unique name generation with immidate suffix and default suffix-fn"
+    (t/is (cfh/generate-unique-name "base-name" #{} :immediate-suffix? true)
+          "base-name 1")
+    (t/is (cfh/generate-unique-name "base-name"
+                                    #{"base-name 1" "base-name 2"}
+                                    :immediate-suffix? true)
+          "base-name 3")))

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -25,6 +25,7 @@
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
    [clojure.set :as set]
+   [cuerdas.core :as str]
    [potok.v2.core :as ptk]))
 
 (log/set-level! :warn)
@@ -247,9 +248,9 @@
   (ptk/reify ::create-project
     ptk/WatchEvent
     (watch [_ state _]
-      (let [projects (get state :projects)
-            unames   (cfh/get-used-names projects)
-            name     (cfh/generate-unique-name unames (str (tr "dashboard.new-project-prefix") " 1"))
+      (let [unames   (cfh/get-used-names (get state :projects))
+            base-name (tr "dashboard.new-project-prefix")
+            name     (cfh/generate-unique-name base-name unames :immediate-suffix? true)
             team-id  (:current-team-id state)
             params   {:name name
                       :team-id team-id}
@@ -280,13 +281,18 @@
        :name name})
 
     ptk/WatchEvent
-    (watch [_ _ _]
+    (watch [_ state _]
       (let [{:keys [on-success on-error]
              :or {on-success identity
                   on-error rx/throw}} (meta params)
-
-            new-name (str name " " (tr "dashboard.copy-suffix"))]
-
+            projects (get state :projects)
+            unames (cfh/get-used-names projects)
+            suffix-fn (fn [copy-count]
+                        (str/concat " "
+                                    (tr "dashboard.copy-suffix")
+                                    (when (> copy-count 1)
+                                      (str " " copy-count))))
+            new-name (cfh/generate-unique-name name unames :suffix-fn suffix-fn)]
         (->> (rp/cmd! :duplicate-project {:project-id id :name new-name})
              (rx/tap on-success)
              (rx/map project-duplicated)
@@ -476,15 +482,15 @@
       (let [{:keys [on-success on-error]
              :or {on-success identity
                   on-error rx/throw}} (meta params)
-
-            files    (get state :files)
-            unames   (cfh/get-used-names files)
-            name     (or name (cfh/generate-unique-name unames (str (tr "dashboard.new-file-prefix") " 1")))
-            features (-> (features/get-team-enabled-features state)
-                         (set/difference cfeat/frontend-only-features))
-            params   (-> params
-                         (assoc :name name)
-                         (assoc :features features))]
+            unames    (cfh/get-used-names (get state :files))
+            base-name (tr "dashboard.new-file-prefix")
+            name      (or name
+                          (cfh/generate-unique-name base-name unames :immediate-suffix? true))
+            features  (-> (features/get-team-enabled-features state)
+                          (set/difference cfeat/frontend-only-features))
+            params    (-> params
+                          (assoc :name name)
+                          (assoc :features features))]
 
         (->> (rp/cmd! :create-file params)
              (rx/tap on-success)
@@ -499,13 +505,17 @@
   (dm/assert! (string? name))
   (ptk/reify ::duplicate-file
     ptk/WatchEvent
-    (watch [_ _ _]
+    (watch [_ state _]
       (let [{:keys [on-success on-error]
              :or {on-success identity
                   on-error rx/throw}} (meta params)
-
-            new-name (str name " " (tr "dashboard.copy-suffix"))]
-
+            unames (cfh/get-used-names (get state :files))
+            suffix-fn (fn [copy-count]
+                        (str/concat " "
+                                    (tr "dashboard.copy-suffix")
+                                    (when (> copy-count 1)
+                                      (str " " copy-count))))
+            new-name (cfh/generate-unique-name name unames :suffix-fn suffix-fn)]
         (->> (rp/cmd! :duplicate-file {:file-id id :name new-name})
              (rx/tap on-success)
              (rx/map file-created)
@@ -588,10 +598,10 @@
             name          (if in-project?
                             (let [files  (get state :files)
                                   unames (cfh/get-used-names files)]
-                              (cfh/generate-unique-name unames (str (tr "dashboard.new-file-prefix") " 1")))
+                              (cfh/generate-unique-name (tr "dashboard.new-file-prefix") unames :immediate-suffix? true))
                             (let [projects (get state :projects)
                                   unames   (cfh/get-used-names projects)]
-                              (cfh/generate-unique-name unames (str (tr "dashboard.new-project-prefix") " 1"))))
+                              (cfh/generate-unique-name (tr "dashboard.new-project-prefix") unames :immediate-suffix? true)))
             params        (if in-project?
                             {:project-id (:project-id pparams)
                              :name name}

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -507,10 +507,8 @@
       (watch [it state _]
         (let [pages   (-> (dsh/lookup-file-data state)
                           (get :pages-index))
-
               unames  (cfh/get-used-names pages)
-              name    (cfh/generate-unique-name unames "Page 1")
-
+              name    (cfh/generate-unique-name "Page" unames :immediate-suffix? true)
               changes (-> (pcb/empty-changes it)
                           (pcb/add-empty-page id name))]
 
@@ -527,7 +525,13 @@
             page               (get pages page-id)
 
             unames             (cfh/get-used-names pages)
-            name               (cfh/generate-unique-name unames (:name page))
+            suffix-fn          (fn [copy-count]
+                                 (str/concat " "
+                                             (tr "dashboard.copy-suffix")
+                                             (when (> copy-count 1)
+                                               (str " " copy-count))))
+            base-name          (:name page)
+            name               (cfh/generate-unique-name base-name unames :suffix-fn suffix-fn)
             objects            (update-vals (:objects page) #(dissoc % :use-for-thumbnail))
 
             main-instances-ids (set (keep #(when (ctk/main-instance? (val %)) (key %)) objects))

--- a/frontend/src/app/main/data/workspace/interactions.cljs
+++ b/frontend/src/app/main/data/workspace/interactions.cljs
@@ -44,9 +44,9 @@
                        (dsh/lookup-page state page-id)
                        (dsh/lookup-page state))
 
-             flows   (get page :flows)
-             unames  (cfh/get-used-names (vals flows))
-             name    (or name (cfh/generate-unique-name unames "Flow 1"))
+             unames  (cfh/get-used-names (vals (get page :flows)))
+             name    (or name
+                         (cfh/generate-unique-name "Flow" unames :immediate-suffix? true))
 
              flow-id (or flow-id (uuid/next))
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1143,6 +1143,10 @@ msgstr "Cannot drop a parent set to an own child path."
 msgid "errors.drag-drop.set-exists"
 msgstr "Cannot complete drop, a set with same name already exists at path %s."
 
+#: src/app/main/data/tokens.cljs:294
+msgid "workspace.token.duplicate-suffix"
+msgstr "copy"
+
 #: src/app/main/ui/auth/verify_token.cljs:84, src/app/main/ui/settings/change_email.cljs:29
 msgid "errors.email-already-exists"
 msgstr "Email already used"
@@ -6453,7 +6457,23 @@ msgstr "Edit theme"
 msgid "workspace.token.edit-themes"
 msgstr "Edit themes"
 
-#: src/app/main/ui/workspace/tokens/sets.cljs:186
+#: src/app/main/ui/workspace/tokens/form.cljs:430
+msgid "workspace.token.edit-token"
+msgstr "Edit token"
+
+#: src/app/main/ui/workspace/tokens/form.cljs:481
+msgid "workspace.token.enter-token-description"
+msgstr "Add a description (optional)"
+
+#: src/app/main/ui/workspace/tokens/form.cljs:437
+msgid "workspace.token.enter-token-name"
+msgstr "Enter %s token name"
+
+#: src/app/main/ui/workspace/tokens/form.cljs:463
+msgid "workspace.token.enter-token-value"
+msgstr "Enter token value or alias"
+
+#: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"
 msgstr "Token Set grouping is not supported yet."

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6453,23 +6453,7 @@ msgstr "Edit theme"
 msgid "workspace.token.edit-themes"
 msgstr "Edit themes"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:430
-msgid "workspace.token.edit-token"
-msgstr "Edit token"
-
-#: src/app/main/ui/workspace/tokens/form.cljs:481
-msgid "workspace.token.enter-token-description"
-msgstr "Add a description (optional)"
-
-#: src/app/main/ui/workspace/tokens/form.cljs:437
-msgid "workspace.token.enter-token-name"
-msgstr "Enter %s token name"
-
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Enter token value or alias"
-
-#: src/app/main/ui/workspace/tokens/sets.cljs
+#: src/app/main/ui/workspace/tokens/sets.cljs:186
 #, unused
 msgid "workspace.token.grouping-set-alert"
 msgstr "Token Set grouping is not supported yet."


### PR DESCRIPTION
# Fix Duplicated Token Name Conflict

## Issue
When duplicating a token twice, the second token is not created due to a naming clash.

## Solution
This PR resolves the issue by introducing a unique name generation function to prevent name conflicts when duplicating tokens.

### Steps to Reproduce
1. Create a token.
2. Click **Duplicate Token** in the token's context menu.
3. Click **Duplicate Token** again in the same token's context menu (on the original token, not the copy).

### Expected Result
- A new token is successfully created with a unique name.

### Actual Result
- The token is not created due to a name conflict.
