### PR TITLE
:bug: Fix internal file media object references handling on instantiating components v2

### DIFF
--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -12,6 +12,7 @@
    [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
    [app.common.features :as cfeat]
+   [app.common.files.helpers :as cfh]
    [app.common.files.migrations :as fmg]
    [app.common.files.validate :as fval]
    [app.common.logging :as l]
@@ -24,12 +25,12 @@
    [app.features.fdata :as feat.fdata]
    [app.loggers.audit :as-alias audit]
    [app.loggers.webhooks :as-alias webhooks]
+   [app.storage :as sto]
    [app.util.blob :as blob]
    [app.util.pointer-map :as pmap]
    [app.util.time :as dt]
    [app.worker :as-alias wrk]
    [clojure.set :as set]
-   [clojure.walk :as walk]
    [cuerdas.core :as str]))
 
 (set! *warn-on-reflection* true)
@@ -52,7 +53,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def xf-map-id
+(def xf:map-id
   (map :id))
 
 (def xf-map-media-id
@@ -123,16 +124,26 @@
     features (assoc :features (db/decode-pgarray features #{}))
     data     (assoc :data (blob/decode data))))
 
+(defn decode-file
+  "A general purpose file decoding function that resolves all external
+  pointers, run migrations and return plain vanilla file map"
+  [cfg {:keys [id] :as file}]
+  (binding [pmap/*load-fn* (partial feat.fdata/load-pointer cfg id)]
+    (-> (feat.fdata/resolve-file-data cfg file)
+        (update :features db/decode-pgarray #{})
+        (update :data blob/decode)
+        (update :data feat.fdata/process-pointers deref)
+        (update :data feat.fdata/process-objects (partial into {}))
+        (update :data assoc :id id)
+        (fmg/migrate-file))))
+
 (defn get-file
-  [cfg file-id]
+  "A binfile exportation specific version of get-file"
+  [cfg file-id & {:as opts}]
   (db/run! cfg (fn [{:keys [::db/conn] :as cfg}]
-                 (binding [pmap/*load-fn* (partial feat.fdata/load-pointer cfg file-id)]
-                   (when-let [file (db/get* conn :file {:id file-id}
-                                            {::db/remove-deleted false})]
-                     (-> file
-                         (decode-row)
-                         (update :data feat.fdata/process-pointers deref)
-                         (update :data feat.fdata/process-objects (partial into {}))))))))
+                 (some->> (db/get* conn :file {:id file-id}
+                                   (assoc opts ::db/remove-deleted false))
+                          (decode-file cfg)))))
 
 (defn clean-file-features
   [file]
@@ -206,7 +217,7 @@
   (db/run! cfg (fn [{:keys [::db/conn]}]
                  (let [ids' (db/create-array conn "uuid" ids)]
                    (->> (db/exec! conn [sql:get-libraries ids'])
-                        (into #{} xf-map-id))))))
+                        (into #{} xf:map-id))))))
 
 (defn get-file-object-thumbnails
   "Return all file object thumbnails for a given file."
@@ -225,49 +236,70 @@
             :data nil}
            {::sql/columns [:media-id :file-id :revn]}))
 
+(def ^:private sql:get-missing-media-references
+  "SELECT fmo.*
+     FROM file_media_object AS fmo
+    WHERE fmo.id = ANY(?::uuid[])
+      AND file_id != ?")
 
-(def ^:private
-  xform:collect-media-id
-  (comp
-   (map :objects)
-   (mapcat vals)
-   (mapcat (fn [obj]
-             ;; NOTE: because of some bug, we ended with
-             ;; many shape types having the ability to
-             ;; have fill-image attribute (which initially
-             ;; designed for :path shapes).
-             (sequence
-              (keep :id)
-              (concat [(:fill-image obj)
-                       (:metadata obj)]
-                      (map :fill-image (:fills obj))
-                      (map :stroke-image (:strokes obj))
-                      (->> (:content obj)
-                           (tree-seq map? :children)
-                           (mapcat :fills)
-                           (map :fill-image))))))))
+(defn update-media-references
+  "Given a file and a coll of media-refs, check if all provided
+  references are correct or fix them in-place"
+  [{:keys [::db/conn] :as cfg} {file-id :id :as file} media-refs]
+  (let [missing-index
+        (reduce (fn [result {:keys [id] :as fmo}]
+                  (assoc result id
+                         (-> fmo
+                             (assoc :id (uuid/next))
+                             (assoc :file-id file-id)
+                             (dissoc :created-at)
+                             (dissoc :deleted-at))))
+                {}
+                (db/plan conn [sql:get-missing-media-references
+                               (->> (into #{} xf:map-id media-refs)
+                                    (db/create-array conn "uuid"))
+                               file-id]))
 
-(defn collect-used-media
-  "Given a fdata (file data), returns all media references."
-  [data]
-  (-> #{}
-      (into xform:collect-media-id (vals (:pages-index data)))
-      (into xform:collect-media-id (vals (:components data)))
-      (into (keys (:media data)))))
+        lookup-index
+        (fn [id]
+          (if-let [mobj (get missing-index id)]
+            (do
+              (l/trc :hint "lookup index"
+                     :file-id (str file-id)
+                     :snap-id (str (:snapshot-id file))
+                     :id (str id)
+                     :result (str (get mobj :id)))
+              (get mobj :id))
+
+            id))
+
+        update-shapes
+        (fn [data {:keys [page-id shape-id]}]
+          (d/update-in-when data [:pages-index page-id :objects shape-id] cfh/relink-media-refs lookup-index))
+
+        file
+        (update file :data #(reduce update-shapes % media-refs))]
+
+    (doseq [[old-id item] missing-index]
+      (l/dbg :hint "create missing references"
+             :file-id (str file-id)
+             :snap-id (str (:snapshot-id file))
+             :old-id (str old-id)
+             :id (str (:id item)))
+      (db/insert! conn :file-media-object item
+                  {::db/return-keys false}))
+
+    file))
+
+(def sql:get-file-media
+  "SELECT * FROM file_media_object WHERE id = ANY(?)")
 
 (defn get-file-media
-  [cfg {:keys [data id] :as file}]
+  [cfg {:keys [data] :as file}]
   (db/run! cfg (fn [{:keys [::db/conn]}]
-                 (let [ids (collect-used-media data)
-                       ids (db/create-array conn "uuid" ids)
-                       sql (str "SELECT * FROM file_media_object WHERE id = ANY(?)")]
-
-                   ;; We assoc the file-id again to the file-media-object row
-                   ;; because there are cases that used objects refer to other
-                   ;; files and we need to ensure in the exportation process that
-                   ;; all ids matches
-                   (->> (db/exec! conn [sql ids])
-                        (mapv #(assoc % :file-id id)))))))
+                 (let [used (cfh/collect-used-media data)
+                       used (db/create-array conn "uuid" used)]
+                   (db/exec! conn [sql:get-file-media used])))))
 
 (def ^:private sql:get-team-files-ids
   "SELECT f.id FROM file AS f
@@ -278,7 +310,7 @@
   "Get a set of file ids for the specified team-id"
   [{:keys [::db/conn]} team-id]
   (->> (db/exec! conn [sql:get-team-files-ids team-id])
-       (into #{} xf-map-id)))
+       (into #{} xf:map-id)))
 
 (def ^:private sql:get-team-projects
   "SELECT p.* FROM project AS p
@@ -289,7 +321,7 @@
   "Get a set of project ids for the team"
   [cfg team-id]
   (->> (db/exec! cfg [sql:get-team-projects team-id])
-       (into #{} xf-map-id)))
+       (into #{} xf:map-id)))
 
 (def ^:private sql:get-project-files
   "SELECT f.id FROM file AS f
@@ -300,7 +332,7 @@
   "Get a set of file ids for the project"
   [{:keys [::db/conn]} project-id]
   (->> (db/exec! conn [sql:get-project-files project-id])
-       (into #{} xf-map-id)))
+       (into #{} xf:map-id)))
 
 (defn remap-thumbnail-object-id
   [object-id file-id]
@@ -311,48 +343,7 @@
   replace the old :component-file reference with the new
   ones, using the provided file-index."
   [data]
-  (letfn [(process-map-form [form]
-            (cond-> form
-              ;; Relink image shapes
-              (and (map? (:metadata form))
-                   (= :image (:type form)))
-              (update-in [:metadata :id] lookup-index)
-
-              ;; Relink paths with fill image
-              (map? (:fill-image form))
-              (update-in [:fill-image :id] lookup-index)
-
-              ;; This covers old shapes and the new :fills.
-              (uuid? (:fill-color-ref-file form))
-              (update :fill-color-ref-file lookup-index)
-
-              ;; This covers the old shapes and the new :strokes
-              (uuid? (:stroke-color-ref-file form))
-              (update :stroke-color-ref-file lookup-index)
-
-              ;; This covers all text shapes that have typography referenced
-              (uuid? (:typography-ref-file form))
-              (update :typography-ref-file lookup-index)
-
-              ;; This covers the component instance links
-              (uuid? (:component-file form))
-              (update :component-file lookup-index)
-
-              ;; This covers the shadows and grids (they have directly
-              ;; the :file-id prop)
-              (uuid? (:file-id form))
-              (update :file-id lookup-index)))
-
-          (process-form [form]
-            (if (map? form)
-              (try
-                (process-map-form form)
-                (catch Throwable cause
-                  (l/warn :hint "failed form" :form (pr-str form) ::l/sync? true)
-                  (throw cause)))
-              form))]
-
-    (walk/postwalk process-form data)))
+  (cfh/relink-media-refs data lookup-index))
 
 (defn- relink-media
   "A function responsible of process the :media attr of file data and
@@ -421,75 +412,99 @@
                           (update :colors relink-colors)
                           (d/without-nils))))))
 
-(defn- upsert-file!
-  [conn file]
-  (let [sql (str "INSERT INTO file (id, project_id, name, revn, version, is_shared, data, created_at, modified_at) "
-                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                 "ON CONFLICT (id) DO UPDATE SET data=?, version=?")]
-    (db/exec-one! conn [sql
-                        (:id file)
-                        (:project-id file)
-                        (:name file)
-                        (:revn file)
-                        (:version file)
-                        (:is-shared file)
-                        (:data file)
-                        (:created-at file)
-                        (:modified-at file)
-                        (:data file)
-                        (:version file)])))
+(defn- encode-file
+  [{:keys [::db/conn] :as cfg} {:keys [id] :as file}]
+  (let [file (if (contains? (:features file) "fdata/objects-map")
+               (feat.fdata/enable-objects-map file)
+               file)
 
-(defn persist-file!
-  "Applies all the final validations and perist the file."
-  [{:keys [::db/conn ::timestamp] :as cfg} {:keys [id] :as file}]
+        file (if (contains? (:features file) "fdata/pointer-map")
+               (binding [pmap/*tracked* (pmap/create-tracked)]
+                 (let [file (feat.fdata/enable-pointer-map file)]
+                   (feat.fdata/persist-pointers! cfg id)
+                   file))
+               file)]
+
+    (-> file
+        (update :features db/encode-pgarray conn "text")
+        (update :data blob/encode))))
+
+(defn- file->params
+  [file]
+  (let [params {:has-media-trimmed (:has-media-trimmed file)
+                :ignore-sync-until (:ignore-sync-until file)
+                :project-id (:project-id file)
+                :features (:features file)
+                :name (:name file)
+                :version (:version file)
+                :data (:data file)
+                :id (:id file)
+                :deleted-at (:deleted-at file)
+                :created-at (:created-at file)
+                :modified-at (:modified-at file)
+                :revn (:revn file)
+                :vern (:vern file)}]
+
+    (-> (d/without-nils params)
+        (assoc :data-backend nil)
+        (assoc :data-ref-id nil))))
+
+(defn insert-file!
+  "A general purpose file persistence function, it used for this task
+  but it also used externally for the same purpose"
+  [{:keys [::db/conn] :as cfg} file]
+
+  (let [params (-> (encode-file cfg file)
+                   (file->params))]
+    (db/insert! conn :file params {::db/return-keys true})))
+
+(defn update-file!
+  "A general purpose file persistence function, it used for this task
+  but it also used externally for the same purpose"
+  [{:keys [::db/conn ::sto/storage] :as cfg} {:keys [id] :as file}]
+
+  (let [file   (encode-file cfg file)
+        params (-> (file->params file)
+                   (dissoc :id))]
+
+    ;; If file was already offloaded, we touch the underlying storage
+    ;; object for properly trigger storage-gc-touched task
+    (when (feat.fdata/offloaded? file)
+      (some->> (:data-ref-id file) (sto/touch-object! storage)))
+
+    (db/update! conn :file params {:id id} {::db/return-keys true})))
+
+(defn save-file!
+  "Applies all the final validations and perist the file, binfile
+  specific, should not be used outside"
+  [{:keys [::timestamp] :as cfg} file]
 
   (dm/assert!
    "expected valid timestamp"
    (dt/instant? timestamp))
 
-  (let [file   (-> file
-                   (assoc :created-at timestamp)
-                   (assoc :modified-at timestamp)
-                   (assoc :ignore-sync-until (dt/plus timestamp (dt/duration {:seconds 5})))
-                   (update :features
-                           (fn [features]
-                             (let [features (cfeat/check-supported-features! features)]
-                               (-> (::features cfg #{})
-                                   (set/union features)
-                                   ;; We never want to store
-                                   ;; frontend-only features on file
-                                   (set/difference cfeat/frontend-only-features))))))
+  (let [file (-> file
+                 (assoc :created-at timestamp)
+                 (assoc :modified-at timestamp)
+                 (assoc :ignore-sync-until (dt/plus timestamp (dt/duration {:seconds 5})))
+                 (update :features
+                         (fn [features]
+                           (let [features (cfeat/check-supported-features! features)]
+                             (-> (::features cfg #{})
+                                 (set/union features)
+                                 ;; We never want to store
+                                 ;; frontend-only features on file
+                                 (set/difference cfeat/frontend-only-features))))))]
 
+    (when (contains? cf/flags :file-schema-validation)
+      (fval/validate-file-schema! file))
 
-        _      (when (contains? cf/flags :file-schema-validation)
-                 (fval/validate-file-schema! file))
+    (when (contains? cf/flags :soft-file-schema-validation)
+      (let [result (ex/try! (fval/validate-file-schema! file))]
+        (when (ex/exception? result)
+          (l/error :hint "file schema validation error" :cause result))))
 
-        _      (when (contains? cf/flags :soft-file-schema-validation)
-                 (let [result (ex/try! (fval/validate-file-schema! file))]
-                   (when (ex/exception? result)
-                     (l/error :hint "file schema validation error" :cause result))))
-
-        file   (if (contains? (:features file) "fdata/objects-map")
-                 (feat.fdata/enable-objects-map file)
-                 file)
-
-        file   (if (contains? (:features file) "fdata/pointer-map")
-                 (binding [pmap/*tracked* (pmap/create-tracked)]
-                   (let [file (feat.fdata/enable-pointer-map file)]
-                     (feat.fdata/persist-pointers! cfg id)
-                     file))
-                 file)
-
-        params (-> file
-                   (update :features db/encode-pgarray conn "text")
-                   (update :data blob/encode))]
-
-    (if (::overwrite cfg)
-      (upsert-file! conn params)
-      (db/insert! conn :file params ::db/return-keys false))
-
-    file))
-
+    (insert-file! cfg file)))
 
 (defn register-pending-migrations
   "All features that are enabled and requires explicit migration are

--- a/backend/src/app/binfile/v2.clj
+++ b/backend/src/app/binfile/v2.clj
@@ -167,7 +167,7 @@
     (vswap! bfc/*state* (fn [state]
                           (-> state
                               (update :files conj file-id)
-                              (update :file-media-objects into bfc/xf-map-id media)
+                              (update :file-media-objects into bfc/xf:map-id media)
                               (bfc/collect-storage-objects thumbs)
                               (bfc/collect-storage-objects media))))
 
@@ -297,7 +297,7 @@
                         (set/difference (:features file)))]
       (vswap! bfc/*state* update :pending-to-migrate (fnil conj []) [feature (:id file)]))
 
-    (bfc/persist-file! cfg file))
+    (bfc/save-file! cfg file))
 
   (doseq [thumbnail (read-seq cfg :file-object-thumbnail file-id)]
     (let [thumbnail (-> thumbnail

--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -55,7 +55,7 @@
 
     ;; Process and persist file
     (let [file (->> (bfc/process-file file)
-                    (bfc/persist-file! cfg))]
+                    (bfc/save-file! cfg))]
 
       ;; The file profile creation is optional, so when no profile is
       ;; present (when this function is called from profile less
@@ -84,7 +84,7 @@
                                fmeds)]
         (db/insert! conn :file-media-object params ::db/return-keys false))
 
-      file)))
+      (bfc/decode-file cfg file))))
 
 (def ^:private
   schema:duplicate-file

--- a/backend/src/app/srepl/fixes.clj
+++ b/backend/src/app/srepl/fixes.clj
@@ -53,7 +53,7 @@
   fixes all not propertly referenced file-media-object for a file"
   [{:keys [id data] :as file} & _]
   (let [conn  (db/get-connection h/*system*)
-        used  (bfc/collect-used-media data)
+        used  (cfh/collect-used-media data)
         ids   (db/create-array conn "uuid" used)
         sql   (str "SELECT * FROM file_media_object WHERE id = ANY(?)")
         rows  (db/exec! conn [sql ids])
@@ -272,6 +272,7 @@
                (reduce +)))
 
         num-missing-slots (count-slots-data (:data file))]
+
     (when (pos? num-missing-slots)
       (l/trc :info (str "Shapes with children with the same swap slot: " num-missing-slots) :file-id (str (:id file))))
     file))

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -16,6 +16,7 @@
    [app.db.sql :as sql]
    [app.http :as http]
    [app.rpc :as-alias rpc]
+   [app.rpc.commands.files :as files]
    [app.storage :as sto]
    [app.util.time :as dt]
    [backend-tests.helpers :as th]
@@ -1658,3 +1659,172 @@
             components (get-in result [:data :components])]
         (t/is (not (contains? components c-id)))))))
 
+
+
+
+(defn add-file-media-object
+  [& {:keys [profile-id file-id]}]
+  (let [mfile  {:filename "sample.jpg"
+                :path (th/tempfile "backend_tests/test_files/sample.jpg")
+                :mtype "image/jpeg"
+                :size 312043}
+        params {::th/type :upload-file-media-object
+                ::rpc/profile-id profile-id
+                :file-id file-id
+                :is-local true
+                :name "testfile"
+                :content mfile}
+        out    (th/command! params)]
+
+    ;; (th/print-result! out)
+    (t/is (nil? (:error out)))
+    (:result out)))
+
+
+
+(t/deftest file-gc-with-media-assets-and-absorb-library
+  (let [storage (:app.storage/storage th/*system*)
+        profile (th/create-profile* 1)
+
+        file-1  (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared true})
+
+        file-2  (th/create-file* 2 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared false})
+
+        fmedia  (add-file-media-object :profile-id (:id profile) :file-id (:id file-1))
+
+
+        rel     (th/link-file-to-library*
+                 {:file-id (:id file-2)
+                  :library-id (:id file-1)})
+
+        s-id-1  (uuid/random)
+        s-id-2  (uuid/random)
+        c-id    (uuid/random)
+
+        f1-page-id (first (get-in file-1 [:data :pages]))
+        f2-page-id (first (get-in file-2 [:data :pages]))
+
+        fills
+        [{:fill-image
+          {:id (:id fmedia)
+           :name "test"
+           :width 200
+           :height 200}}]]
+
+    ;; Update file library inserting new component
+    (update-file!
+     :file-id (:id file-1)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f1-page-id
+       :id s-id-1
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-1
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance true
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}
+      {:type :add-component
+       :path ""
+       :name "Board"
+       :main-instance-id s-id-1
+       :main-instance-page f1-page-id
+       :id c-id
+       :anotation nil}])
+
+    ;; Instanciate a component in a different file
+    (update-file!
+     :file-id (:id file-2)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-obj
+       :page-id f2-page-id
+       :id s-id-2
+       :parent-id uuid/zero
+       :frame-id uuid/zero
+       :components-v2 true
+       :obj (cts/setup-shape
+             {:id s-id-2
+              :name "Board"
+              :frame-id uuid/zero
+              :parent-id uuid/zero
+              :type :frame
+              :fills fills
+              :main-instance false
+              :component-root true
+              :component-file (:id file-1)
+              :component-id c-id})}])
+
+    ;; Check that file media object references are present for both objects
+    ;; the original one and the instance.
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      (t/is (= 2 (count rows)))
+      (t/is (= (:id file-1) (:file-id (get rows 0))))
+      (t/is (= (:id file-2) (:file-id (get rows 1))))
+      (t/is (every? (comp nil? :deleted-at) rows)))
+
+    ;; Check if the underlying media reference on shape is different
+    ;; from the instantiation
+    (let [data {::th/type :get-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-2)}
+          out  (th/command! data)]
+
+      (t/is (th/success? out))
+      (let [result (:result out)
+            fill   (get-in result [:data :pages-index f2-page-id :objects s-id-2 :fills 0 :fill-image])]
+        (t/is (some? fill))
+        (t/is (not= (:id fill) (:id fmedia)))))
+
+    ;; Run the file-gc on file and library
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-1)})))
+    (t/is (true? (th/run-task! :file-gc {:min-age 0 :file-id (:id file-2)})))
+
+    ;; Now proceed to delete file and absorb it
+    (let [data {::th/type :delete-file
+                ::rpc/profile-id (:id profile)
+                :id (:id file-1)}
+          out  (th/command! data)]
+      (t/is (th/success? out)))
+
+    (th/run-task! :delete-object
+                  {:object :file
+                   :deleted-at (dt/now)
+                   :id (:id file-1)})
+
+    ;; Check that file media object references are marked all for deletion
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      ;; (pp/pprint rows)
+      (t/is (= 2 (count rows)))
+
+      (t/is (= (:id file-1) (:file-id (get rows 0))))
+      (t/is (some? (:deleted-at (get rows 0))))
+
+      (t/is (= (:id file-2) (:file-id (get rows 1))))
+      (t/is (nil? (:deleted-at (get rows 1)))))
+
+    (th/run-task! :objects-gc
+                  {:min-age 0})
+
+    (let [rows (th/db-exec! ["SELECT * FROM file_media_object ORDER BY created_at ASC"])]
+      (t/is (= 1 (count rows)))
+
+      (t/is (= (:id file-2) (:file-id (get rows 0))))
+      (t/is (nil? (:deleted-at (get rows 0)))))))

--- a/backend/test/backend_tests/rpc_management_test.clj
+++ b/backend/test/backend_tests/rpc_management_test.clj
@@ -6,6 +6,7 @@
 
 (ns backend-tests.rpc-management-test
   (:require
+   [app.binfile.common :as bfc]
    [app.common.features :as cfeat]
    [app.common.pprint :as pp]
    [app.common.types.shape :as cts]
@@ -82,7 +83,6 @@
       ;; Check that result is correct
       (t/is (nil? (:error out)))
       (let [result (:result out)]
-
         ;; Check that the returned result is a file but has different id
         ;; and different name.
         (t/is (= "file 1 (copy)" (:name result)))

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -484,6 +484,11 @@
   modification."
   nil)
 
+(def ^:dynamic *state*
+  "A general purpose state to signal some out of order operations
+  to the processor backend."
+  nil)
+
 (defmulti process-change (fn [_ change] (:type change)))
 (defmulti process-operation (fn [_ op] (:type op)))
 
@@ -622,6 +627,27 @@
   (let [update-container
         (fn [container]
           (ctst/add-shape id obj container frame-id parent-id index ignore-touched))]
+
+    ;; The main purpose of this is ensure that all created shapes has
+    ;; valid media references; so for make sure of it, we analyze each
+    ;; shape added via `:add-obj` change for media usage, and if shape
+    ;; has media refs, we put that media refs on the check list (on
+    ;; the *state*) which will subsequently be processed and all
+    ;; incorrect references will be corrected.  The media ref is
+    ;; anything that can be pointing to a file-media-object on the
+    ;; shape, per example we have fill-image, stroke-image, etc.
+    (when *state*
+      (let [media-refs
+            (-> (cfh/collect-shape-media-refs obj)
+                (not-empty))
+
+            xform
+            (map (fn [id]
+                   {:page-id page-id
+                    :shape-id (:id obj)
+                    :id id}))]
+
+        (swap! *state* update :media-refs into xform media-refs)))
 
     (if page-id
       (d/update-in-when data [:pages-index page-id] update-container)

--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -12,6 +12,7 @@
    [app.common.schema :as sm]
    [app.common.uuid :as uuid]
    [clojure.set :as set]
+   [clojure.walk :as walk]
    [cuerdas.core :as str]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -532,6 +533,86 @@
        first
        (get-position-on-parent objects)
        inc))
+
+(defn collect-shape-media-refs
+  "Collect all media refs on the provided shape. Returns a set of ids"
+  [shape]
+  (sequence
+   (keep :id)
+   ;; NOTE: because of some bug, we ended with
+   ;; many shape types having the ability to
+   ;; have fill-image attribute (which initially
+   ;; designed for :path shapes).
+   (concat [(:fill-image shape)
+            (:metadata shape)]
+           (map :fill-image (:fills shape))
+           (map :stroke-image (:strokes shape))
+           (->> (:content shape)
+                (tree-seq map? :children)
+                (mapcat :fills)
+                (map :fill-image)))))
+
+(def ^:private
+  xform:collect-media-refs
+  "A transducer for collect media-id usage across a container (page or
+  component)"
+  (comp
+   (map :objects)
+   (mapcat vals)
+   (mapcat collect-shape-media-refs)))
+
+(defn collect-used-media
+  "Given a fdata (file data), returns all media references used in the
+  file data"
+  [data]
+  (-> #{}
+      (into xform:collect-media-refs (vals (:pages-index data)))
+      (into xform:collect-media-refs (vals (:components data)))
+      (into (keys (:media data)))))
+
+(defn relink-media-refs
+  "A function responsible to analyze all file data and replace the
+  old :component-file reference with the new ones, using the provided
+  file-index."
+  [data lookup-index]
+  (letfn [(process-map-form [form]
+            (cond-> form
+              ;; Relink image shapes
+              (and (map? (:metadata form))
+                   (= :image (:type form)))
+              (update-in [:metadata :id] lookup-index)
+
+              ;; Relink paths with fill image
+              (map? (:fill-image form))
+              (update-in [:fill-image :id] lookup-index)
+
+              ;; This covers old shapes and the new :fills.
+              (uuid? (:fill-color-ref-file form))
+              (update :fill-color-ref-file lookup-index)
+
+              ;; This covers the old shapes and the new :strokes
+              (uuid? (:stroke-color-ref-file form))
+              (update :stroke-color-ref-file lookup-index)
+
+              ;; This covers all text shapes that have typography referenced
+              (uuid? (:typography-ref-file form))
+              (update :typography-ref-file lookup-index)
+
+              ;; This covers the component instance links
+              (uuid? (:component-file form))
+              (update :component-file lookup-index)
+
+              ;; This covers the shadows and grids (they have directly
+              ;; the :file-id prop)
+              (uuid? (:file-id form))
+              (update :file-id lookup-index)))
+
+          (process-form [form]
+            (if (map? form)
+              (process-map-form form)
+              form))]
+
+    (walk/postwalk process-form data)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; SHAPES ORGANIZATION (PATH MANAGEMENT)

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -571,7 +571,8 @@
               :code :schema-validation
               :hint (str/ffmt "invalid file data structure found on file '%'" id)
               :file-id id
-              ::sm/explain (get-fdata-explain data))))
+              ::sm/explain (get-fdata-explain data)))
+  file)
 
 (defn validate-file!
   "Validate full referential integrity and semantic coherence on file data.

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -202,7 +202,8 @@
                                       position
                                       components-v2
                                       (cond-> {}
-                                        force-frame? (assoc :force-frame-id frame-id)))
+                                        force-frame?
+                                        (assoc :force-frame-id frame-id)))
 
          first-shape (cond-> (first new-shapes)
                        (not (nil? parent-id))

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -352,12 +352,15 @@
   Warnign: This process does not remap media references (on fills, strokes, ...); that is
   delegated to an async process on the backend side that checks unreferenced shapes and
   automatically creates correct references."
-  ([container component library-data position components-v2]
-   (make-component-instance container component library-data position components-v2 {}))
+  ([page component library-data position components-v2]
+   (make-component-instance page component library-data position components-v2 {}))
 
-  ([container component library-data position components-v2
+  ([page component library-data position components-v2
     {:keys [main-instance? force-id force-frame-id keep-ids?]
-     :or {main-instance? false force-id nil force-frame-id nil keep-ids? false}}]
+     :or {main-instance? false
+          force-id nil
+          force-frame-id nil
+          keep-ids? false}}]
    (let [component-page  (when components-v2
                            (ctpl/get-page library-data (:main-instance-page component)))
 
@@ -372,7 +375,7 @@
                                     (:y component-shape))
          delta           (gpt/subtract position orig-pos)
 
-         objects         (:objects container)
+         objects         (:objects page)
          unames          (volatile! (cfh/get-used-names objects))
 
          component-children
@@ -389,7 +392,7 @@
                                                                           (nil? (get component-children (:id %)))
                                                                           ;; We must avoid that destiny frame is inside a copy
                                                                           (not (ctk/in-component-copy? %)))}))
-         frame           (get-shape container frame-id)
+         frame           (get-shape page frame-id)
          component-frame (get-component-shape objects frame {:allow-main? true})
 
          ;; This map stores the relation between old shapes (present on the main
@@ -445,7 +448,7 @@
                            :force-id force-id
                            :keep-ids? keep-ids?
                            :frame-id frame-id
-                           :dest-objects (:objects container))
+                           :dest-objects (:objects page))
 
          ;; Fix empty parent-id and remap all grid cells to the new ids.
          remap-ids

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -601,14 +601,17 @@
          (rx/of (dwu/commit-undo-transaction undo-id)))))))
 
 (defn instantiate-component
-  "Create a new shape in the current page, from the component with the given id
-  in the given file library. Then selects the newly created instance."
+  "Create a new shape in the current page, from the component with the
+  given id in the given file library. Then selects the newly created
+  instance."
   ([file-id component-id position]
    (instantiate-component file-id component-id position nil))
   ([file-id component-id position {:keys [start-move? initial-point id-ref origin]}]
-   (dm/assert! (uuid? file-id))
-   (dm/assert! (uuid? component-id))
-   (dm/assert! (gpt/point? position))
+
+   (assert (uuid? file-id) "expected a uuid for `file-id`")
+   (assert (uuid? component-id) "expected a uuid for `component-id`")
+   (assert (gpt/point? position) "expected a point for `position`")
+
    (ptk/reify ::instantiate-component
      ptk/WatchEvent
      (watch [it state _]


### PR DESCRIPTION
## The issue

When a user instantiates a component with media references (image-fills per example) from an non-local library on the current file. The instance shape conserves the same values for :id on the `:fill-image` attribute as the original shape. As we should known, this ID represents the row on the relation between the **file** and **storage_object* and this relation is stored in the `file_media_object` table.

When the original file is deleted or the original component is deleted, all the component instances that uses some kind of media assets will point to deleted file media object row, which is susceptible to be garbage collected and leave the shape broken.

## The fix

**Check for media refs on `:add-obj` change and fix that references and remap them on the file on update-file**

On all changes of type `:add-obj` each shape is checked if it has media references, if references are found then that references will be processed by a secondary step on update-file request and will create the missing references and will update the file shapes accordingly with new ids.

## Other fixes & Changes

- Normalize how file is retrieved, decoded and persisted (inserted or updated) a cross binfile impl, srepl helpers (for processing files) and asynchronous tasks like file-gc. There are many inconsistencies and now they are using the same code; 
  - There are some issues related to file offload feature and file exportation that also is fixed with this approach.
  - Proper file fields filtering on binfile importation (caused several error reports)
- Remove the unused/internal option of "overwrite" on binfile importation

## **How to test**

- Create a library file with single componen with fill image
- Create other file A and link it to the Library file
- Instantiate a component from Library on the A

What is happening without the PR:

- The shapes created has fill-image pointing to a row on `file_media_object` that is part of file Library, there are no rows associated with file A.

What is happening with the FIX:

- The shapes created has fill-image pointing to a row on `file_media_object` that is part of file Library, but you also has an entry for the file A with different ID.
- If you refresh, the shape is now pointing to other ID (the correct one, with the corresponding row on file_media_object pointing  to the file A)

## Known Problems

When you instantiate a component, we still use original media references that points to the Library File instead to a correct one. This is because we can't create new ids on frontend and we can't wait for a rpc request for explicit creation of the references before create instance and draw it on workspace, it will introduce a lot of latency (because of need to wait backend response before allowing user drag and drop the new instance)

There are a solution for this, but it is out of scope of this PR that is already very big for a bugfix.

