### PR TITLE
:bug: Add support for multiple file formats to clone-template

### DIFF
--- a/backend/resources/app/templates/debug.tmpl
+++ b/backend/resources/app/templates/debug.tmpl
@@ -114,35 +114,11 @@ Debug Main Page
     </fieldset>
     <fieldset>
       <legend>Import binfile:</legend>
-      <desc>Import penpot file in binary
-      format. If <strong>overwrite</strong> is checked, all files will
-      be overwritten using the same ids found in the file instead of
-      generating a new ones.</desc>
+      <desc>Import penpot file in binary format.</desc>
 
       <form method="post" enctype="multipart/form-data" action="/dbg/file/import">
         <div class="row">
           <input type="file" name="file" value="" />
-        </div>
-
-        <div class="row">
-          <label>Overwrite?</label>
-          <input type="checkbox" name="overwrite" />
-          <br />
-          <small>
-            Instead of creating a new file with all relations remapped,
-            reuses all ids and updates/overwrites the objects that are
-            already exists on the database.
-            <strong>Warning, this operation should be used with caution.</strong>
-          </small>
-        </div>
-
-        <div class="row">
-          <label>Migrate?</label>
-          <input type="checkbox" name="migrate" />
-          <br />
-          <small>
-            Applies the file migrations on the importation process.
-          </small>
         </div>
 
         <div class="row">

--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -30,7 +30,9 @@
    [app.worker :as-alias wrk]
    [clojure.set :as set]
    [clojure.walk :as walk]
-   [cuerdas.core :as str]))
+   [cuerdas.core :as str]
+   [datoteka.fs :as fs]
+   [datoteka.io :as io]))
 
 (set! *warn-on-reflection* true)
 
@@ -51,6 +53,20 @@
   (* 1024 1024 100))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn parse-file-format
+  [template]
+  (assert (fs/path? template) "expected InputStream for `template`")
+
+  (with-open [^java.lang.AutoCloseable input (io/input-stream template)]
+    (let [buffer (byte-array 4)]
+      (io/read-to-buffer input buffer)
+      (if (and (= (aget buffer 0) 80)
+               (= (aget buffer 1) 75)
+               (= (aget buffer 2) 3)
+               (= (aget buffer 3) 4))
+        :binfile-v3
+        :binfile-v1))))
 
 (def xf-map-id
   (map :id))

--- a/backend/src/app/http/sse.clj
+++ b/backend/src/app/http/sse.clj
@@ -64,7 +64,8 @@
                           (catch Throwable cause
                             (events/tap :error (errors/handle' cause request))
                             (when-not (ex/instance? java.io.EOFException cause)
-                              (l/err :hint "unexpected error on processing sse response" :cause cause)))
+                              (binding [l/*context* (errors/request->context request)]
+                                (l/err :hint "unexpected error on processing sse response" :cause cause))))
                           (finally
                             (sp/close! events/*channel*)
                             (px/await! listener)))))))}))

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -7,6 +7,7 @@
 (ns app.rpc.commands.binfile
   (:refer-clojure :exclude [assert])
   (:require
+   [app.binfile.common :as bfc]
    [app.binfile.v1 :as bf.v1]
    [app.binfile.v3 :as bf.v3]
    [app.common.logging :as l]
@@ -46,9 +47,9 @@
    (fn [_ output-stream]
      (try
        (-> cfg
-           (assoc ::bf.v1/ids #{file-id})
-           (assoc ::bf.v1/embed-assets embed-assets)
-           (assoc ::bf.v1/include-libraries include-libraries)
+           (assoc ::bfc/ids #{file-id})
+           (assoc ::bfc/embed-assets embed-assets)
+           (assoc ::bfc/include-libraries include-libraries)
            (bf.v1/export-files! output-stream))
        (catch Throwable cause
          (l/err :hint "exception on exporting file"
@@ -61,9 +62,9 @@
    (fn [_ output-stream]
      (try
        (-> cfg
-           (assoc ::bf.v3/ids #{file-id})
-           (assoc ::bf.v3/embed-assets embed-assets)
-           (assoc ::bf.v3/include-libraries include-libraries)
+           (assoc ::bfc/ids #{file-id})
+           (assoc ::bfc/embed-assets embed-assets)
+           (assoc ::bfc/include-libraries include-libraries)
            (bf.v3/export-files! output-stream))
        (catch Throwable cause
          (l/err :hint "exception on exporting file"
@@ -93,10 +94,10 @@
 (defn- import-binfile-v1
   [{:keys [::wrk/executor] :as cfg} {:keys [project-id profile-id name file]}]
   (let [cfg (-> cfg
-                (assoc ::bf.v1/project-id project-id)
-                (assoc ::bf.v1/profile-id profile-id)
-                (assoc ::bf.v1/name name)
-                (assoc ::bf.v1/input (:path file)))]
+                (assoc ::bfc/project-id project-id)
+                (assoc ::bfc/profile-id profile-id)
+                (assoc ::bfc/name name)
+                (assoc ::bfc/input (:path file)))]
 
     ;; NOTE: the importation process performs some operations that are
     ;; not very friendly with virtual threads, and for avoid
@@ -107,10 +108,10 @@
 (defn- import-binfile-v3
   [{:keys [::wrk/executor] :as cfg} {:keys [project-id profile-id name file]}]
   (let [cfg (-> cfg
-                (assoc ::bf.v3/project-id project-id)
-                (assoc ::bf.v3/profile-id profile-id)
-                (assoc ::bf.v3/name name)
-                (assoc ::bf.v3/input (:path file)))]
+                (assoc ::bfc/project-id project-id)
+                (assoc ::bfc/profile-id profile-id)
+                (assoc ::bfc/name name)
+                (assoc ::bfc/input (:path file)))]
     ;; NOTE: the importation process performs some operations that are
     ;; not very friendly with virtual threads, and for avoid
     ;; unexpected blocking of other concurrent operations we dispatch

--- a/backend/src/app/setup/templates.clj
+++ b/backend/src/app/setup/templates.clj
@@ -54,6 +54,7 @@
                               (::setup/templates cfg))]
     (let [dest (fs/join fs/*cwd* "builtin-templates")
           path (or (:path template) (fs/join dest template-id))]
+
       (if (fs/exists? path)
         (io/input-stream path)
         (let [resp (http/req! cfg

--- a/backend/src/app/storage/tmp.clj
+++ b/backend/src/app/storage/tmp.clj
@@ -16,10 +16,13 @@
    [app.util.time :as dt]
    [app.worker :as wrk]
    [datoteka.fs :as fs]
+   [datoteka.io :as io]
    [integrant.core :as ig]
    [promesa.exec :as px]
    [promesa.exec.csp :as sp])
   (:import
+   java.io.InputStream
+   java.io.OutputStream
    java.nio.file.Files))
 
 (def default-tmp-dir "/tmp/penpot")
@@ -85,4 +88,13 @@
         path  (Files/createFile path attrs)]
     (fs/delete-on-exit! path)
     (sp/offer! queue [path (some-> min-age dt/duration)])
+    path))
+
+(defn tempfile-from
+  "Create a new tempfile from from consuming the stream"
+  [input & {:as options}]
+  (let [path (tempfile options)]
+    (with-open [^InputStream input (io/input-stream input)]
+      (with-open [^OutputStream output (io/output-stream path)]
+        (io/copy input output)))
     path))

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -7,6 +7,7 @@
 (ns backend-tests.binfile-test
   "Internal binfile test, no RPC involved"
   (:require
+   [app.binfile.common :as bfc]
    [app.binfile.v3 :as v3]
    [app.common.features :as cfeat]
    [app.common.pprint :as pp]
@@ -93,15 +94,15 @@
 
     (v3/export-files!
      (-> th/*system*
-         (assoc ::v3/ids #{(:id file)})
-         (assoc ::v3/embed-assets false)
-         (assoc ::v3/include-libraries false))
+         (assoc ::bfc/ids #{(:id file)})
+         (assoc ::bfc/embed-assets false)
+         (assoc ::bfc/include-libraries false))
      (io/output-stream output))
 
     (let [result (-> th/*system*
-                     (assoc ::v3/project-id (:default-project-id profile))
-                     (assoc ::v3/profile-id (:id profile))
-                     (assoc ::v3/input output)
+                     (assoc ::bfc/project-id (:default-project-id profile))
+                     (assoc ::bfc/profile-id (:id profile))
+                     (assoc ::bfc/input output)
                      (v3/import-files!))]
       (t/is (= (count result) 1))
       (t/is (every? uuid? result)))))


### PR DESCRIPTION
The issue:
- Our default templates carousel right now points to files, which at some time becomes to use different formats when the code was never adapted to support that

Fix:
- Add support for multiple formats on clone-template

How to test:

- Import the penpot plant template, it will fail on current PRO but will work with this fix. Other templates also should work