### PR TITLE
:sparkles: Add warning when editing a token name

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/form.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/form.scss
@@ -44,6 +44,10 @@
   font-size: $fs-12;
 }
 
+.warning-name-change-notification-wrapper {
+  margin-block-start: $s-16;
+}
+
 .error {
   padding: $s-4 $s-6;
   margin-bottom: 0;

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6706,6 +6706,10 @@ msgid "workspace.token.token-value"
 msgstr "Value"
 
 #: src/app/main/ui/workspace/tokens/form.cljs
+msgid "workspace.token.warning-name-change"
+msgstr "Renaming this token will break any reference to its old name."
+
+#: src/app/main/ui/workspace/tokens/form.cljs
 msgid "workspace.token.enter-token-value"
 msgstr "Enter token value or alias"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6705,6 +6705,10 @@ msgid "workspace.token.token-value"
 msgstr "Valor"
 
 #: src/app/main/ui/workspace/tokens/form.cljs
+msgid "workspace.token.warning-name-change"
+msgstr "Al renombrar este token se romperán las referencias al nombre anterior"
+
+#: src/app/main/ui/workspace/tokens/form.cljs
 msgid "workspace.token.enter-token-value"
 msgstr "Introduce un valor o alias"
 


### PR DESCRIPTION
The users should be able to rename tokens, but the references will be broken. 
So we need to display a warning to explain this until we fix this behavior (post MVP)

This PR displays a warning when a user edits a token name.

More info https://tree.taiga.io/project/penpot/us/9916?milestone=424330
