### PR TITLE
:bug: Fix styles by webkit on DS input autocomplete

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/input.scss
+++ b/frontend/src/app/main/ui/ds/controls/input.scss
@@ -65,6 +65,12 @@
   &::placeholder {
     --input-fg-color: var(--color-foreground-secondary);
   }
+
+  &:is(:autofill, :autofill:hover, :autofill:focus, :autofill:active) {
+    -webkit-text-fill-color: var(--input-fg-color);
+    -webkit-background-clip: text;
+    caret-color: var(--input-bg-color);
+  }
 }
 
 .icon {


### PR DESCRIPTION
This PR overwrites the styles applied by WebKit when the browser autocompletes an input field.
Only testable at the new input* from the DS.

More info https://github.com/tokens-studio/penpot/issues/46
Taiga https://tree.taiga.io/project/penpot/issue/9831
