### PR TITLE
:bug: Fix CI breaking

### DIFF
--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -171,11 +171,7 @@ test.describe("Tokens: Tokens Tab", () => {
     const nameField = tokensUpdateCreateModal.getByLabel("Name");
     await nameField.pressSequentially(".changed");
 
-    const submitButton = tokensUpdateCreateModal.getByRole("button", {
-      name: "Save",
-    });
-    await expect(submitButton).toBeEnabled();
-    await submitButton.click();
+    await nameField.press("Enter");
 
     await expect(tokensUpdateCreateModal).not.toBeVisible();
 


### PR DESCRIPTION
A CI test got skipped with two PR merges at (almost) the same time that touched the same code.
Since there is no CI check after a merging into develop this caused this test to fail after merging the PR.

## The issue

A rerender introduced by the warning message for token renames shifts the submit button, which caused playwright to lose the element.
Now there's a test using `Enter`, which is good anyway to test this part of the UX.