### PR TITLE
:bug: Fix border-radius applied to all corners on token update

### DIFF
--- a/common/src/app/common/types/shape/radius.cljc
+++ b/common/src/app/common/types/shape/radius.cljc
@@ -56,3 +56,11 @@
     (cond-> shape
       (can-get-border-radius? shape)
       (assoc attr value))))
+
+(defn set-radius-for-corners
+  "Set border radius to `value` for each radius `attr`."
+  [shape attrs value]
+  (reduce
+   (fn [shape' attr]
+     (set-radius-to-single-corner shape' attr value))
+   shape attrs))

--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -104,16 +104,12 @@
                        :attrs ctt/border-radius-keys}))
 
 (defn update-shape-radius-for-corners [value shape-ids attributes]
-  (ptk/reify ::update-shape-radius-for-corners
-    ptk/WatchEvent
-    (watch [_ _ _]
-      (rx/of
-       (dwsh/update-shapes shape-ids
-                           (fn [shape]
-                             (ctsr/set-radius-for-corners shape attributes value))
-                           {:reg-objects? true
-                            :ignore-touched true
-                            :attrs ctt/border-radius-keys})))))
+  (dwsh/update-shapes shape-ids
+                      (fn [shape]
+                        (ctsr/set-radius-for-corners shape attributes value))
+                      {:reg-objects? true
+                       :ignore-touched true
+                       :attrs ctt/border-radius-keys}))
 
 (defn update-opacity [value shape-ids]
   (when (<= 0 value 1)

--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -96,22 +96,24 @@
 (defn update-shape-radius-all [value shape-ids]
   (dwsh/update-shapes shape-ids
                       (fn [shape]
-                        (when (ctsr/can-get-border-radius? shape)
-                          (ctsr/set-radius-to-all-corners shape value)))
+                        (ctsr/set-radius-to-all-corners shape value))
                       {:reg-objects? true
                        :ignore-touched true
                        :attrs ctt/border-radius-keys}))
 
-(defn update-shape-radius-single-corner [value shape-ids attributes]
-  ;; NOTE: This key should be namespaced on data tokens, but these events are not there.
-  (st/emit! (ptk/data-event :expand-border-radius))
-  (dwsh/update-shapes shape-ids
-                      (fn [shape]
-                        (when (ctsr/can-get-border-radius? shape)
-                          (ctsr/set-radius-to-single-corner shape (first attributes) value)))
-                      {:reg-objects? true
-                       :ignore-touched true
-                       :attrs ctt/border-radius-keys}))
+(defn update-shape-radius-for-corners [value shape-ids attributes]
+  (ptk/reify ::update-shape-radius-for-corners
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (rx/of
+       ;; NOTE: This key should be namespaced on data tokens, but these events are not there.
+       (ptk/data-event :expand-border-radius)
+       (dwsh/update-shapes shape-ids
+                           (fn [shape]
+                             (ctsr/set-radius-for-corners shape attributes value))
+                           {:reg-objects? true
+                            :ignore-touched true
+                            :attrs ctt/border-radius-keys})))))
 
 (defn update-opacity [value shape-ids]
   (when (<= 0 value 1)

--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -86,8 +86,6 @@
                            :token token
                            :shape-ids shape-ids}))
           (rx/of
-           (when (seq (set/intersection ctt/border-radius-keys attributes))
-             (st/emit! (ptk/data-event ::expand-border-radius)))
            (apply-token {:attributes attributes
                          :token token
                          :shape-ids shape-ids

--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -86,6 +86,8 @@
                            :token token
                            :shape-ids shape-ids}))
           (rx/of
+           (when (seq (set/intersection ctt/border-radius-keys attributes))
+             (st/emit! (ptk/data-event ::expand-border-radius)))
            (apply-token {:attributes attributes
                          :token token
                          :shape-ids shape-ids
@@ -106,8 +108,6 @@
     ptk/WatchEvent
     (watch [_ _ _]
       (rx/of
-       ;; NOTE: This key should be namespaced on data tokens, but these events are not there.
-       (ptk/data-event :expand-border-radius)
        (dwsh/update-shapes shape-ids
                            (fn [shape]
                              (ctsr/set-radius-for-corners shape attributes value))

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -23,6 +23,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.timers :as timers]
    [okulary.core :as l]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 ;; Actions ---------------------------------------------------------------------
@@ -179,14 +180,24 @@
                               :on-update-shape wtch/update-layout-sizing-limits}
                              context-data)))
 
+(defn update-shape-radius-all [value shape-ids]
+  (st/emit!
+   (ptk/data-event ::expand-border-radius)
+   (wtch/update-shape-radius-all value shape-ids)))
+
+(defn update-shape-radius-for-corners [value shape-ids attributes]
+  (st/emit!
+   (ptk/data-event ::expand-border-radius)
+   (wtch/update-shape-radius-for-corners value shape-ids attributes)))
+
 (def shape-attribute-actions-map
   (let [stroke-width (partial generic-attribute-actions #{:stroke-width} "Stroke Width")]
     {:border-radius (partial all-or-sepearate-actions {:attribute-labels {:r1 "Top Left"
                                                                           :r2 "Top Right"
                                                                           :r4 "Bottom Left"
                                                                           :r3 "Bottom Right"}
-                                                       :on-update-shape-all wtch/update-shape-radius-all
-                                                       :on-update-shape wtch/update-shape-radius-for-corners})
+                                                       :on-update-shape-all update-shape-radius-all
+                                                       :on-update-shape update-shape-radius-for-corners})
      :color (fn [context-data]
               [(generic-attribute-actions #{:fill} "Fill" (assoc context-data :on-update-shape wtch/update-fill))
                (generic-attribute-actions #{:stroke-color} "Stroke" (assoc context-data :on-update-shape wtch/update-stroke-color))])

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -186,7 +186,7 @@
                                                                           :r4 "Bottom Left"
                                                                           :r3 "Bottom Right"}
                                                        :on-update-shape-all wtch/update-shape-radius-all
-                                                       :on-update-shape wtch/update-shape-radius-single-corner})
+                                                       :on-update-shape wtch/update-shape-radius-for-corners})
      :color (fn [context-data]
               [(generic-attribute-actions #{:fill} "Fill" (assoc context-data :on-update-shape wtch/update-fill))
                (generic-attribute-actions #{:stroke-color} "Stroke" (assoc context-data :on-update-shape wtch/update-stroke-color))])

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -180,14 +180,9 @@
                               :on-update-shape wtch/update-layout-sizing-limits}
                              context-data)))
 
-(defn update-shape-radius-all [value shape-ids]
-  (st/emit!
-   (ptk/data-event ::expand-border-radius)
-   (wtch/update-shape-radius-all value shape-ids)))
-
 (defn update-shape-radius-for-corners [value shape-ids attributes]
   (st/emit!
-   (ptk/data-event ::expand-border-radius)
+   (ptk/data-event :expand-border-radius)
    (wtch/update-shape-radius-for-corners value shape-ids attributes)))
 
 (def shape-attribute-actions-map
@@ -196,7 +191,7 @@
                                                                           :r2 "Top Right"
                                                                           :r4 "Bottom Left"
                                                                           :r3 "Bottom Right"}
-                                                       :on-update-shape-all update-shape-radius-all
+                                                       :on-update-shape-all wtch/update-shape-radius-all
                                                        :on-update-shape update-shape-radius-for-corners})
      :color (fn [context-data]
               [(generic-attribute-actions #{:fill} "Fill" (assoc context-data :on-update-shape wtch/update-fill))

--- a/frontend/src/app/main/ui/workspace/tokens/update.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/update.cljs
@@ -17,7 +17,7 @@
 (def filter-existing-values? false)
 
 (def attributes->shape-update
-  {#{:r1 :r2 :r3 :r4} wtch/update-shape-radius-for-corners
+  {ctt/border-radius-keys wtch/update-shape-radius-for-corners
    ctt/color-keys wtch/update-fill-stroke
    ctt/stroke-width-keys wtch/update-stroke-width
    ctt/sizing-keys wtch/update-shape-dimensions

--- a/frontend/src/app/main/ui/workspace/tokens/update.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/update.cljs
@@ -17,7 +17,7 @@
 (def filter-existing-values? false)
 
 (def attributes->shape-update
-  {#{:r1 :r2 :r3 :r4} wtch/update-shape-radius-all
+  {#{:r1 :r2 :r3 :r4} wtch/update-shape-radius-for-corners
    ctt/color-keys wtch/update-fill-stroke
    ctt/stroke-width-keys wtch/update-stroke-width
    ctt/sizing-keys wtch/update-shape-dimensions


### PR DESCRIPTION
Fixes border radius being overwritten for all corners when updating a token.
Closes https://github.com/tokens-studio/penpot/issues/56