### PR TITLE
:sparkles: Add the ability to set http body size on docker images

### DIFF
--- a/backend/src/app/http.clj
+++ b/backend/src/app/http.clj
@@ -42,8 +42,8 @@
 (def default-params
   {::port 6060
    ::host "0.0.0.0"
-   ::max-body-size (* 1024 1024 30)             ; default 30 MiB
-   ::max-multipart-body-size (* 1024 1024 120)}) ; default 120 MiB
+   ::max-body-size 31457280              ; default  30 MiB
+   ::max-multipart-body-size 367001600}) ; default 350 MiB
 
 (defmethod ig/expand-key ::server
   [k v]

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -29,6 +29,15 @@ x-flags: &penpot-flags
 x-uri: &penpot-public-uri
   PENPOT_PUBLIC_URI: http://localhost:9001
 
+x-body-size: &penpot-http-body-size
+  # Max body size (30MiB); Used for plain requests, should never be
+  # greater than multi-part size
+  PENPOT_HTTP_SERVER_MAX_BODY_SIZE: 31457280
+
+  # Max multipart body size (350MiB)
+  PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE: 367001600
+
+
 networks:
   penpot:
 
@@ -103,7 +112,7 @@ services:
       # - "traefik.http.routers.penpot-https.tls.certresolver=letsencrypt"
 
     environment:
-      << : *penpot-flags
+      << : [*penpot-flags, *penpot-http-body-size]
 
   penpot-backend:
     image: "penpotapp/backend:latest"
@@ -123,7 +132,7 @@ services:
     ## container.
 
     environment:
-      << : [*penpot-flags, *penpot-public-uri]
+      << : [*penpot-flags, *penpot-public-uri, *penpot-http-body-size]
 
       ## Penpot SECRET KEY. It serves as a master key from which other keys for subsystems
       ## (eg http sessions, or invitations) are derived.
@@ -261,5 +270,3 @@ services:
   #   ports:
   #     - 9000:9000
   #     - 9001:9001
-
-

--- a/docker/images/files/nginx-entrypoint.sh
+++ b/docker/images/files/nginx-entrypoint.sh
@@ -22,7 +22,9 @@ update_flags /var/www/app/js/config.js
 export PENPOT_BACKEND_URI=${PENPOT_BACKEND_URI:-http://penpot-backend:6060};
 export PENPOT_EXPORTER_URI=${PENPOT_EXPORTER_URI:-http://penpot-exporter:6061};
 export PENPOT_INTERNAL_RESOLVER=${PENPOT_INTERNAL_RESOLVER:-127.0.0.11};
+export PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE=${PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE:-367001600}; # Default to 350MiB
 
-envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI,\$PENPOT_INTERNAL_RESOLVER" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI,\$PENPOT_INTERNAL_RESOLVER,\$PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE" \
+         < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 exec "$@";

--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -64,7 +64,7 @@ http {
         listen 8080 default_server;
         server_name _;
 
-        client_max_body_size 350M;
+        client_max_body_size $PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE;
         charset utf-8;
 
         proxy_http_version 1.1;

--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -64,7 +64,7 @@ http {
         listen 8080 default_server;
         server_name _;
 
-        client_max_body_size 100M;
+        client_max_body_size 350M;
         charset utf-8;
 
         proxy_http_version 1.1;


### PR DESCRIPTION
And set a good default on the example compose file.