### PR TITLE
:bug: Fix swapped horizontal and vertical padding

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -90,11 +90,11 @@
                        :p4 "Left"}
         all-padding-attrs (into #{} (keys padding-attrs))
         {:keys [all-selected? selected-pred shape-ids]} (attribute-actions token selected-shapes all-padding-attrs)
-        horizontal-attributes #{:p1 :p3}
+        horizontal-attributes #{:p2 :p4}
         horizontal-padding-selected? (and
                                       (not all-selected?)
                                       (every? selected-pred horizontal-attributes))
-        vertical-attributes #{:p2 :p4}
+        vertical-attributes #{:p1 :p3}
         vertical-padding-selected? (and
                                     (not all-selected?)
                                     (every? selected-pred vertical-attributes))

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -113,7 +113,7 @@
                                   (let [props {:token token
                                                :shape-ids shape-ids}
                                         event (cond
-                                                all-selected? (wtch/apply-token (assoc props :attributes-to-remove vertical-attributes))
+                                                all-selected? (wtch/apply-token (assoc props :attributes-to-remove horizontal-attributes))
                                                 horizontal-padding-selected? (wtch/apply-token (assoc props :attributes-to-remove horizontal-attributes))
                                                 :else (wtch/apply-token (assoc props
                                                                                :attributes horizontal-attributes


### PR DESCRIPTION
# Fixes dimension or spacing token pill context menu items functionality

## Before
- `Horizontal` option applies vertical padding
- `Vertical` option applies horizontal padding
- When `All` option is selected clicking `Horizontal` toggles vertical padding

## After
- `Horizontal` option applies horizontal padding
- `Vertical` option applies vertical padding
- When `All` option is selected clicking `Horizontal` toggles horizontal padding
