### PR TITLE
:lipstick: Fix tokens modal block size when colorpicker is displayed

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals.cljs
@@ -44,10 +44,17 @@
   {::mf/wrap-props false}
   [{:keys [x y position token token-type action selected-token-set-name] :as _args}]
   (let [wrapper-style (use-viewport-position-style x y position)
+        modal-size-large* (mf/use-state false)
+        modal-size-large? (deref modal-size-large*)
         close-modal (mf/use-fn
                      (fn []
-                       (modal/hide!)))]
-    [:div {:class (stl/css :token-modal-wrapper)
+                       (modal/hide!)))
+        update-modal-size (mf/use-fn
+                           (fn [visible]
+                             (reset! modal-size-large* visible)))]
+    [:div {:class (stl/css-case
+                   :token-modal-wrapper true
+                   :token-modal-large modal-size-large?)
            :style wrapper-style
            :data-testid "token-update-create-modal"}
      [:> icon-button* {:on-click close-modal
@@ -58,7 +65,8 @@
      [:& form {:token token
                :action action
                :selected-token-set-name selected-token-set-name
-               :token-type token-type}]]))
+               :token-type token-type
+               :on-display-colorpicker update-modal-size}]]))
 
 ;; Modals ----------------------------------------------------------------------
 

--- a/frontend/src/app/main/ui/workspace/tokens/modals.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals.scss
@@ -15,6 +15,9 @@
   z-index: 11;
   overflow-y: auto;
   overflow-x: hidden;
+  &.token-modal-large {
+    min-block-size: 38rem;
+  }
 }
 
 .close-btn {


### PR DESCRIPTION
This PR updates the modal size of token edition/creation modal when the user displays a colorpicker.
Fixes this issue: https://tree.taiga.io/project/penpot/issue/9942 
