### PR TITLE
:whale: Improve docker compose

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -188,6 +188,7 @@ services:
       ## audit what data we send with the code available on github.
 
       PENPOT_TELEMETRY_ENABLED: true
+      PENPOT_TELEMETRY_REFERER: compose
 
       ## Example SMTP/Email configuration. By default, emails are sent to the mailcatch
       ## service, but for production usage it is recommended to setup a real SMTP

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
   #     - "443:443"
 
   penpot-frontend:
-    image: "penpotapp/frontend:latest"
+    image: "penpotapp/frontend:${PENPOT_VERSION:-latest}"
     restart: always
     ports:
       - 9001:8080
@@ -115,7 +115,7 @@ services:
       << : [*penpot-flags, *penpot-http-body-size]
 
   penpot-backend:
-    image: "penpotapp/backend:latest"
+    image: "penpotapp/backend:${PENPOT_VERSION:-latest}"
     restart: always
 
     volumes:
@@ -205,7 +205,7 @@ services:
       PENPOT_SMTP_SSL: false
 
   penpot-exporter:
-    image: "penpotapp/exporter:latest"
+    image: "penpotapp/exporter:${PENPOT_VERSION:-latest}"
     restart: always
 
     depends_on:

--- a/docs/technical-guide/getting-started.md
+++ b/docs/technical-guide/getting-started.md
@@ -175,6 +175,17 @@ docker compose -p penpot -f docker-compose.yaml up -d
 
 At the end it will start listening on http://localhost:9001
 
+<p class="advice">
+    If you don't change anything, by default this will use the latest image published in dockerhub.
+</p>
+
+If you want to have more control over the version (which is recommended), you can use the PENPOT_VERSION envvar in the common ways:
+- setting the value in the .env file
+- or passing the envvar in the command line
+
+```bash
+PENPOT_VERSION=2.4.3 docker compose -p penpot -f docker-compose.yaml up -d
+```
 
 ### Stop Penpot
 


### PR DESCRIPTION
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDJtbjc3bTRjcDhpeTVqYW1wMXYzZ2p4bWJubWZrZGl0dWRnZ3FxcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/6nb0o3e3KYhpe/giphy.gif)

This PR has two improvements to docker compose installation.
1. adds `compose` as a telemetry referer
2. uses the same PENPOT_VERSION envvar for backend, exporter and frontend, and defaults to `latest`. Documentation updated to note this option.

To test the point2, follow the documentation and check if it's understandable.