### PR TITLE
:bug: Fix token set selection & rename

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -37,7 +37,7 @@
   (st/emit! (dwts/set-selected-token-set-name set-name)))
 
 (defn on-update-token-set [set-name token-set]
-  (st/emit! (wdt/update-token-set set-name (ctob/update-name token-set set-name))))
+  (st/emit! (wdt/update-token-set (:name token-set) (ctob/update-name token-set set-name))))
 
 (defn on-update-token-set-group [set-group-path set-group-fname]
   (st/emit! (wdt/rename-token-set-group set-group-path set-group-fname)))


### PR DESCRIPTION
- Fixes sets not being renamed correctly
- Adds integration test for further cases of set/set-group renaming + better assertion then 

## Tickets

- Closes https://github.com/tokens-studio/penpot/issues/78
- Closes https://github.com/tokens-studio/penpot/issues/71