### PR TITLE
:sparkles: Include active sets and themes in exported tokens json file

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1251,7 +1251,8 @@ Will return a value that matches this schema:
                                       (update "sets" keys)))))
           active-sets (get metadata "activeSets")
           active-themes (get metadata "activeThemes")
-          themes-data (if (empty? active-themes)
+          themes-data (if (and (seq active-sets)
+                               (empty? active-themes))
                         (conj themes-data {"name" hidden-token-theme-name
                                            "group" ""
                                            "description" nil

--- a/common/test/common_tests/types/data/tokens-default-team-only.json
+++ b/common/test/common_tests/types/data/tokens-default-team-only.json
@@ -1,0 +1,11 @@
+{
+ "dark": 
+    {"small":
+        {"$value": "8",
+         "$type":"borderRadius",
+         "$description":""}},
+ "$themes": [],
+ "$metadata": 
+    {"tokenSetOrder": ["dark"],
+     "activeThemes": [],
+     "activeSets": ["dark"]}}

--- a/common/test/common_tests/types/data/tokens-multi-set-example.json
+++ b/common/test/common_tests/types/data/tokens-multi-set-example.json
@@ -805,6 +805,8 @@
     "selectedTokenSets": {"light": "enabled"}
   } ],
   "$metadata": {
-    "tokenSetOrder": ["core", "light", "dark", "theme"]
+    "tokenSetOrder": ["core", "light", "dark", "theme"],
+    "activeSets": {}, 
+    "activeThemes": {}
   }
 }

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1241,7 +1241,8 @@
                                    "modified-at" now
                                    "name" "theme-1"
                                    "selectedTokenSets" {"core" "enabled"}}]
-                       "$metadata" {"tokenSetOrder" ["core"]}
+                       "$metadata" {"tokenSetOrder" ["core"]
+                                    "activeSets" #{},  "activeThemes" #{}}
                        "core"
                        {"colors" {"red" {"600" {"$value" "#e53e3e"
                                                 "$type" "color"

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1286,4 +1286,134 @@
              (t/is (not= with-prev-tokens-lib tokens-lib))
              (t/is (= @with-prev-tokens-lib @tokens-lib)))
            (t/testing "fresh tokens library is also equal"
-             (= @with-empty-tokens-lib @tokens-lib)))))))
+             (= @with-empty-tokens-lib @tokens-lib)))))
+
+     (t/testing "encode-default-theme-json"
+       (let [tokens-lib (-> (ctob/make-tokens-lib)
+                            (ctob/add-set (ctob/make-token-set :name "core"
+                                                               :tokens {"colors.red.600"
+                                                                        (ctob/make-token
+                                                                         {:name "colors.red.600"
+                                                                          :type :color
+                                                                          :value "#e53e3e"})
+                                                                        "spacing.multi-value"
+                                                                        (ctob/make-token
+                                                                         {:name "spacing.multi-value"
+                                                                          :type :spacing
+                                                                          :value "{dimension.sm} {dimension.xl}"
+                                                                          :description "You can have multiple values in a single spacing token"})
+                                                                        "button.primary.background"
+                                                                        (ctob/make-token
+                                                                         {:name "button.primary.background"
+                                                                          :type :color
+                                                                          :value "{accent.default}"})})))
+             result   (ctob/encode-dtcg tokens-lib)
+             expected {"$themes" []
+                       "$metadata" {"tokenSetOrder" ["core"]
+                                    "activeSets" #{},  "activeThemes" #{}}
+                       "core"
+                       {"colors" {"red" {"600" {"$value" "#e53e3e"
+                                                "$type" "color"
+                                                "$description" ""}}}
+                        "spacing"
+                        {"multi-value"
+                         {"$value" "{dimension.sm} {dimension.xl}"
+                          "$type" "spacing"
+                          "$description" "You can have multiple values in a single spacing token"}}
+                        "button"
+                        {"primary" {"background" {"$value" "{accent.default}"
+                                                  "$type" "color"
+                                                  "$description" ""}}}}}]
+
+         (t/is (= expected result))))
+
+     (t/testing "encode-default-theme-json-with-active-sets"
+       (let [tokens-lib (-> (ctob/make-tokens-lib)
+                            (ctob/add-set (ctob/make-token-set :name "core"
+                                                               :tokens {"colors.red.600"
+                                                                        (ctob/make-token
+                                                                         {:name "colors.red.600"
+                                                                          :type :color
+                                                                          :value "#e53e3e"})
+                                                                        "spacing.multi-value"
+                                                                        (ctob/make-token
+                                                                         {:name "spacing.multi-value"
+                                                                          :type :spacing
+                                                                          :value "{dimension.sm} {dimension.xl}"
+                                                                          :description "You can have multiple values in a single spacing token"})
+                                                                        "button.primary.background"
+                                                                        (ctob/make-token
+                                                                         {:name "button.primary.background"
+                                                                          :type :color
+                                                                          :value "{accent.default}"})}))
+                            (assoc-in ["$metadata" "activeSets"] "core"))
+             result   (ctob/encode-dtcg tokens-lib)
+             expected {"$themes" []
+                       "$metadata" {"tokenSetOrder" ["core"]
+                                    "activeSets" #{"core"},  "activeThemes" #{}}
+                       "core"
+                       {"colors" {"red" {"600" {"$value" "#e53e3e"
+                                                "$type" "color"
+                                                "$description" ""}}}
+                        "spacing"
+                        {"multi-value"
+                         {"$value" "{dimension.sm} {dimension.xl}"
+                          "$type" "spacing"
+                          "$description" "You can have multiple values in a single spacing token"}}
+                        "button"
+                        {"primary" {"background" {"$value" "{accent.default}"
+                                                  "$type" "color"
+                                                  "$description" ""}}}}}]
+
+         (t/is (= expected result))))
+     
+     (t/testing "encode-dtcg-json-with-active-theme-and-set"
+       (let [now (dt/now)
+             tokens-lib (-> (ctob/make-tokens-lib)
+                            (ctob/add-set (ctob/make-token-set :name "core"
+                                                               :tokens {"colors.red.600"
+                                                                        (ctob/make-token
+                                                                         {:name "colors.red.600"
+                                                                          :type :color
+                                                                          :value "#e53e3e"})
+                                                                        "spacing.multi-value"
+                                                                        (ctob/make-token
+                                                                         {:name "spacing.multi-value"
+                                                                          :type :spacing
+                                                                          :value "{dimension.sm} {dimension.xl}"
+                                                                          :description "You can have multiple values in a single spacing token"})
+                                                                        "button.primary.background"
+                                                                        (ctob/make-token
+                                                                         {:name "button.primary.background"
+                                                                          :type :color
+                                                                          :value "{accent.default}"})}))
+                            (ctob/add-theme (ctob/make-token-theme :name "theme-1"
+                                                                   :group "group-1"
+                                                                   :modified-at now
+                                                                   :sets #{"core"}))
+                            (assoc-in ["$metadata" "activeSets"] "core")
+                            (ctob/toggle-theme-active? "group-1" "theme-1"))
+             result   (ctob/encode-dtcg tokens-lib)
+             expected {"$themes" [{"description" ""
+                                   "group" "group-1"
+                                   "is-source" false
+                                   "modified-at" now
+                                   "name" "theme-1"
+                                   "selectedTokenSets" {"core" "enabled"}}]
+                       "$metadata" {"tokenSetOrder" ["core"]
+                                    "activeSets" #{"core"},
+                                    "activeThemes" #{"group-1/theme-1"}}
+                       "core"
+                       {"colors" {"red" {"600" {"$value" "#e53e3e"
+                                                "$type" "color"
+                                                "$description" ""}}}
+                        "spacing"
+                        {"multi-value"
+                         {"$value" "{dimension.sm} {dimension.xl}"
+                          "$type" "spacing"
+                          "$description" "You can have multiple values in a single spacing token"}}
+                        "button"
+                        {"primary" {"background" {"$value" "{accent.default}"
+                                                  "$type" "color"
+                                                  "$description" ""}}}}}]
+         (t/is (= expected result))))))

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1210,6 +1210,27 @@
          (t/testing "invalid tokens got discarded"
            (t/is (nil? (get-set-token "typography" "H1.Bold"))))))
 
+     (t/testing "decode-dtcg-json-default-team"
+       (let [json (-> (slurp "test/common_tests/types/data/tokens-default-team-only.json")
+                      (tr/decode-str))
+             lib (ctob/decode-dtcg-json (ctob/ensure-tokens-lib nil) json)
+             get-set-token (fn [set-name token-name]
+                             (some-> (ctob/get-set lib set-name)
+                                     (ctob/get-token token-name)))
+             themes (ctob/get-themes lib)
+             first-theme (first themes)]
+         (t/is (= '("dark") (ctob/get-ordered-set-names lib)))
+         (t/is (= 1 (count themes)))
+         (t/testing "existing theme is default theme"
+           (t/is (= (:group first-theme) ""))
+           (t/is (= (:name first-theme) ctob/hidden-token-theme-name)))
+         (t/testing "token exist in dark set"
+           (t/is (tht/token-data-eq? (get-set-token "dark" "small")
+                                     {:name "small"
+                                      :value "8"
+                                      :type :border-radius
+                                      :description ""})))))
+
      (t/testing "encode-dtcg-json"
        (let [now (dt/now)
              tokens-lib (-> (ctob/make-tokens-lib)
@@ -1327,46 +1348,6 @@
 
          (t/is (= expected result))))
 
-     (t/testing "encode-default-theme-json-with-active-sets"
-       (let [tokens-lib (-> (ctob/make-tokens-lib)
-                            (ctob/add-set (ctob/make-token-set :name "core"
-                                                               :tokens {"colors.red.600"
-                                                                        (ctob/make-token
-                                                                         {:name "colors.red.600"
-                                                                          :type :color
-                                                                          :value "#e53e3e"})
-                                                                        "spacing.multi-value"
-                                                                        (ctob/make-token
-                                                                         {:name "spacing.multi-value"
-                                                                          :type :spacing
-                                                                          :value "{dimension.sm} {dimension.xl}"
-                                                                          :description "You can have multiple values in a single spacing token"})
-                                                                        "button.primary.background"
-                                                                        (ctob/make-token
-                                                                         {:name "button.primary.background"
-                                                                          :type :color
-                                                                          :value "{accent.default}"})}))
-                            (assoc-in ["$metadata" "activeSets"] "core"))
-             result   (ctob/encode-dtcg tokens-lib)
-             expected {"$themes" []
-                       "$metadata" {"tokenSetOrder" ["core"]
-                                    "activeSets" #{"core"},  "activeThemes" #{}}
-                       "core"
-                       {"colors" {"red" {"600" {"$value" "#e53e3e"
-                                                "$type" "color"
-                                                "$description" ""}}}
-                        "spacing"
-                        {"multi-value"
-                         {"$value" "{dimension.sm} {dimension.xl}"
-                          "$type" "spacing"
-                          "$description" "You can have multiple values in a single spacing token"}}
-                        "button"
-                        {"primary" {"background" {"$value" "{accent.default}"
-                                                  "$type" "color"
-                                                  "$description" ""}}}}}]
-
-         (t/is (= expected result))))
-     
      (t/testing "encode-dtcg-json-with-active-theme-and-set"
        (let [now (dt/now)
              tokens-lib (-> (ctob/make-tokens-lib)
@@ -1391,7 +1372,6 @@
                                                                    :group "group-1"
                                                                    :modified-at now
                                                                    :sets #{"core"}))
-                            (assoc-in ["$metadata" "activeSets"] "core")
                             (ctob/toggle-theme-active? "group-1" "theme-1"))
              result   (ctob/encode-dtcg tokens-lib)
              expected {"$themes" [{"description" ""

--- a/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
@@ -84,6 +84,7 @@
                         (> active-themes-count 1) (tr "workspace.token.active-themes" active-themes-count)
                         (= active-themes-count 1) (some->> (first active-theme-paths)
                                                            (ctob/split-token-theme-path)
+                                                           (remove empty?)
                                                            (str/join " / "))
                         :else (tr "workspace.token.no-active-theme"))
 


### PR DESCRIPTION
Implements https://tree.taiga.io/project/penpot/task/9885