### PR TITLE
:sparkles: Add margin to spacing token & context menu

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -129,6 +129,10 @@
   [:p2 {:optional true} token-name-ref]
   [:p3 {:optional true} token-name-ref]
   [:p4 {:optional true} token-name-ref]
+  [:m1 {:optional true} token-name-ref]
+  [:m2 {:optional true} token-name-ref]
+  [:m3 {:optional true} token-name-ref]
+  [:m4 {:optional true} token-name-ref]
   [:x {:optional true} token-name-ref]
   [:y {:optional true} token-name-ref]])
 

--- a/frontend/src/app/main/ui/workspace/tokens/update.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/update.cljs
@@ -3,7 +3,6 @@
    [app.common.files.helpers :as cfh]
    [app.common.types.token :as ctt]
    [app.main.data.helpers :as dsh]
-   [app.main.data.workspace.shape-layout :as dwsl]
    [app.main.data.workspace.shapes :as dwsh]
    [app.main.data.workspace.thumbnails :as dwt]
    [app.main.data.workspace.undo :as dwu]
@@ -26,8 +25,8 @@
    ctt/sizing-keys wtch/update-shape-dimensions
    ctt/opacity-keys wtch/update-opacity
    #{:x :y} wtch/update-shape-position
-   #{:p1 :p2 :p3 :p4} (fn [resolved-value shape-ids attrs]
-                        (dwsl/update-layout shape-ids {:layout-padding (zipmap attrs (repeat resolved-value))}))
+   #{:p1 :p2 :p3 :p4} wtch/update-layout-padding
+   #{:m1 :m2 :m3 :m4} wtch/update-layout-item-margin
    #{:column-gap :row-gap} wtch/update-layout-spacing
    #{:width :height} wtch/update-shape-dimensions
    #{:layout-item-min-w :layout-item-min-h :layout-item-max-w :layout-item-max-h} wtch/update-layout-sizing-limits


### PR DESCRIPTION
- Closes https://github.com/tokens-studio/penpot/issues/62
- Closes https://github.com/tokens-studio/penpot/issues/79
- Closes https://github.com/tokens-studio/penpot/issues/76
- Allows applying spacing tokens to margin (only works for items inside a layout)