### PR TITLE
:lipstick: Improve readability of logging messages in the browser console

### DIFF
--- a/common/src/app/common/logging.cljc
+++ b/common/src/app/common/logging.cljc
@@ -275,7 +275,7 @@
      [_ _ _ {:keys [::logger ::props ::level ::cause ::trace ::message]}]
      (when (enabled? logger level)
        (let [hstyles (str/ffmt "font-weight: 600; color: %" (level->color level))
-             mstyles (str/ffmt "font-weight: 300; color: %" "#282a2e")
+             mstyles (str/ffmt "font-weight: 300; color: %" (level->color level))
              header  (str/concat "%c" (level->name level) " [" logger "] ")
              message (str/concat header "%c" @message)]
 


### PR DESCRIPTION
This formats the logging messages that appear in the browser console with colors that can be easily readable in both dark and light modes.