### PR TITLE
:paperclip: Make 'Copy link' the default text when copying to clipboard

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3524,7 +3524,7 @@ msgstr "Copy"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:94
 msgid "shortcuts.copy-link"
-msgstr "Copy link to clipboard"
+msgstr "Copy link"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:106
 msgid "shortcuts.copy-props"
@@ -6184,7 +6184,7 @@ msgstr "Copy as CSS (nested layers)"
 
 #: src/app/main/ui/workspace/context_menu.cljs:188
 msgid "workspace.shape.menu.copy-link"
-msgstr "Copy link to clipboard"
+msgstr "Copy link"
 
 #: src/app/main/ui/workspace/context_menu.cljs:201
 msgid "workspace.shape.menu.copy-paste-as"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3528,7 +3528,7 @@ msgstr "Copiar"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:94
 msgid "shortcuts.copy-link"
-msgstr "Copiar enlace al portapapeles"
+msgstr "Copiar enlace"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:95
 msgid "shortcuts.create-component"
@@ -6190,7 +6190,7 @@ msgstr "Copiar como CSS (capas anidadas)"
 
 #: src/app/main/ui/workspace/context_menu.cljs:188
 msgid "workspace.shape.menu.copy-link"
-msgstr "Copiar enlace al portapapeles"
+msgstr "Copiar enlace"
 
 #: src/app/main/ui/workspace/context_menu.cljs:201
 msgid "workspace.shape.menu.copy-paste-as"


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/task/10135

Before:

![image](https://github.com/user-attachments/assets/89b9a417-b03c-45d2-b2b9-24577424af92)


After:

![image](https://github.com/user-attachments/assets/8c7f8dae-d382-4873-89e3-9f4a17ad21e2)

