### PR TITLE
:bug: Fix Action Buttons size and add example to Storybook

### DIFF
--- a/frontend/src/app/main/ui/ds/buttons/_buttons.scss
+++ b/frontend/src/app/main/ui/ds/buttons/_buttons.scss
@@ -20,14 +20,18 @@
   --button-focus-inner-ring-color: initial;
   --button-focus-outer-ring-color: initial;
 
+  --button-width: initial;
+  --button-height: #{$sz-32};
+
   appearance: none;
-  height: $sz-32;
-  border: none;
-  border-radius: $br-8;
+
+  width: var(--button-width);
+  height: var(--button-height);
 
   background: var(--button-bg-color);
   color: var(--button-fg-color);
   border: $b-1 solid var(--button-border-color);
+  border-radius: $br-8;
 
   &:hover {
     --button-bg-color: var(--button-hover-bg-color);
@@ -129,22 +133,4 @@
   &:active {
     box-shadow: inset 0 0 #{px2rem(10)} #{px2rem(2)} rgba(0, 0, 0, 0.2);
   }
-}
-
-%base-button-action {
-  --button-bg-color: transparent;
-  --button-fg-color: var(--color-foreground-secondary);
-
-  --button-hover-bg-color: transparent;
-  --button-hover-fg-color: var(--color-accent-primary);
-
-  --button-active-bg-color: var(--color-background-quaternary);
-
-  --button-disabled-bg-color: transparent;
-  --button-disabled-fg-color: var(--color-accent-primary-muted);
-
-  --button-focus-bg-color: transparent;
-  --button-focus-fg-color: var(--color-accent-primary);
-  --button-focus-inner-ring-color: transparent;
-  --button-focus-outer-ring-color: var(--color-accent-primary);
 }

--- a/frontend/src/app/main/ui/ds/buttons/buttons.mdx
+++ b/frontend/src/app/main/ui/ds/buttons/buttons.mdx
@@ -45,6 +45,24 @@ These are available in the `app.main.ds.foundations.assets.icon` namespace.
 
 <Canvas of={ButtonStories.WithIcon} />
 
+```clj
+[:> icon-button* {:variant "primary"
+                  :icon i/effects}]
+```
+
+<Canvas of={IconButtonStories.Primary} />
+
+### Action Buttons
+
+Action buttons are a variant of `icon-button*` (`"action"`) but smaller.
+
+```clj
+[:> icon-button* {:variant "action"
+                  :icon i/effects}]
+```
+
+<Canvas of={IconButtonStories.Action} />
+
 ### Accessibility
 
 Icon buttons require an `aria-label`. This is also shown in a tooltip on hovering the button.

--- a/frontend/src/app/main/ui/ds/buttons/icon_button.scss
+++ b/frontend/src/app/main/ui/ds/buttons/icon_button.scss
@@ -10,10 +10,12 @@
 
 .icon-button {
   @extend %base-button;
-  width: #{$sz-32};
-  display: flex;
-  justify-content: center;
-  align-items: center;
+
+  --button-width: #{$sz-32};
+  --button-height: #{$sz-32};
+
+  display: grid;
+  place-content: center;
 }
 
 .icon-button-primary {
@@ -33,5 +35,22 @@
 }
 
 .icon-button-action {
-  @extend %base-button-action;
+  --button-bg-color: transparent;
+  --button-fg-color: var(--color-foreground-secondary);
+
+  --button-hover-bg-color: transparent;
+  --button-hover-fg-color: var(--color-accent-primary);
+
+  --button-active-bg-color: var(--color-background-quaternary);
+
+  --button-disabled-bg-color: transparent;
+  --button-disabled-fg-color: var(--color-accent-primary-muted);
+
+  --button-focus-bg-color: transparent;
+  --button-focus-fg-color: var(--color-accent-primary);
+  --button-focus-inner-ring-color: transparent;
+  --button-focus-outer-ring-color: var(--color-accent-primary);
+
+  --button-width: #{$sz-24};
+  --button-height: #{$sz-24};
 }


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/issue/10118 

Fix:
- Add `--button-width`, `--button-height`, and `--button-padding` to the `%base-button` placeholder selector
- Apply 32px size to regular icon buttons and 24px size to the action variant, as reflected in the design
- Adjust the padding for the action variant
- Add example to Storybook

Action vs Ghost variants

![image](https://github.com/user-attachments/assets/0487d009-6a05-4ff6-bb7b-f82b27d11c5b)

![image](https://github.com/user-attachments/assets/63997e4b-bbd1-4a38-84b6-b92491b414ad)

Refactor:
- Remove `%base-button-action` placeholder selector since it's only being used for the icon button action variant for now