### PR TITLE
:bug: Fix workspace hot reload race condtion

### DIFF
--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -460,10 +460,11 @@
 
     ptk/UpdateEvent
     (update [_ state]
-      (-> state
-          (assoc-in [:files id] file)
-          (assoc-in [:recent-files id] file)
-          (update-in [:projects project-id :count] inc)))))
+      (let [file (dissoc file :data)]
+        (-> state
+            (assoc-in [:files id] file)
+            (assoc-in [:recent-files id] file)
+            (update-in [:projects project-id :count] inc))))))
 
 (defn create-file
   [{:keys [project-id name] :as params}]

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -319,8 +319,6 @@
     ptk/UpdateEvent
     (update [_ state]
       (-> state
-          (dissoc :files)
-          (dissoc :workspace-ready)
           (assoc :recent-colors (:recent-colors storage/user))
           (assoc :recent-fonts (:recent-fonts storage/user))
           (assoc :current-file-id file-id)
@@ -395,11 +393,9 @@
           (dissoc
            :current-file-id
            :workspace-editor-state
-           :files
            :workspace-media-objects
            :workspace-persistence
            :workspace-presence
-           :workspace-ready
            :workspace-undo)
           (update :workspace-global dissoc :read-only?)
           (assoc-in [:workspace-global :options-mode] :design)))
@@ -427,18 +423,18 @@
 (defmethod ptk/resolve ::reload-current-file [_ _] (reload-current-file))
 
 (defn initialize-page
-  [page-id]
-  (assert (uuid? page-id) "expected valid uuid for `page-id`")
+  [file-id page-id]
+  (assert (uuid? file-id) "expected valid uuid for `file-id`")
 
   (ptk/reify ::initialize-page
     ptk/UpdateEvent
     (update [_ state]
-      (if-let [{:keys [id] :as page} (dsh/lookup-page state page-id)]
+      (if-let [page (dsh/lookup-page state file-id page-id)]
         ;; we maintain a cache of page state for user convenience with the exception of the
         ;; selection; when user abandon the current page, the selection is lost
-        (let [local (dm/get-in state [:workspace-cache id] default-workspace-local)]
+        (let [local (dm/get-in state [:workspace-cache [file-id page-id]] default-workspace-local)]
           (-> state
-              (assoc :current-page-id id)
+              (assoc :current-page-id page-id)
               (assoc :workspace-local (assoc local :selected (d/ordered-set)))
               (assoc :workspace-trimmed-page (dm/select-keys page [:id :name]))
 
@@ -450,24 +446,25 @@
 
     ptk/WatchEvent
     (watch [_ state _]
-      (if (dsh/lookup-page state page-id)
-        (let [file-id (:current-file-id state)]
-          (rx/of (preload-data-uris page-id)
-                 (dwth/watch-state-changes file-id page-id)
-                 (dwl/watch-component-changes)))
-        (rx/of (dcm/go-to-workspace))))))
+      (if (dsh/lookup-page state file-id page-id)
+        (rx/of (preload-data-uris page-id)
+               (dwth/watch-state-changes file-id page-id)
+               (dwl/watch-component-changes))
+        (rx/of (dcm/go-to-workspace :file-id file-id ::rt/replace true))))))
 
 (defn finalize-page
-  [page-id]
+  [file-id page-id]
+  (assert (uuid? file-id) "expected valid uuid for `file-id`")
   (assert (uuid? page-id) "expected valid uuid for `page-id`")
+
   (ptk/reify ::finalize-page
     ptk/UpdateEvent
     (update [_ state]
       (let [local (-> (:workspace-local state)
                       (dissoc :edition :edit-path :selected))
-            exit? (not= :workspace (dm/get-in state [:route :data :name]))
+            exit? (not= :workspace (rt/lookup-name state))
             state (-> state
-                      (update :workspace-cache assoc page-id local)
+                      (update :workspace-cache assoc [file-id page-id] local)
                       (dissoc :current-page-id
                               :workspace-local
                               :workspace-trimmed-page

--- a/frontend/src/app/main/router.cljs
+++ b/frontend/src/app/main/router.cljs
@@ -120,6 +120,11 @@
   ([id params & {:as options}]
    (navigate id params options)))
 
+(defn lookup-name
+  [state]
+  (dm/get-in state [:route :data :name]))
+
+;; FIXME: rename to lookup-params
 (defn get-params
   [state]
   (dm/get-in state [:route :params :query]))

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -127,7 +127,6 @@
   {::mf/props :obj
    ::mf/private true}
   [{:keys [team-id children]}]
-
   (mf/with-effect [team-id]
     (st/emit! (dtm/initialize-team team-id))
     (fn []

--- a/frontend/test/frontend_tests/logic/copying_and_duplicating_test.cljs
+++ b/frontend/test/frontend_tests/logic/copying_and_duplicating_test.cljs
@@ -63,10 +63,10 @@
         target-container-id (or target-container-id (:parent-id shape))]
 
     (filter some?
-            [(when target-page-id (dw/initialize-page target-page-id))
+            [(when target-page-id (dw/initialize-page (:id file) target-page-id))
              (dws/select-shape target-container-id)
              (dw/paste-shapes pdata)
-             (when target-page-id (dw/initialize-page (:id page)))])))
+             (when target-page-id (dw/initialize-page (:id file) (:id page)))])))
 
 (defn- sync-file [file]
   (map (fn [component-tag]


### PR DESCRIPTION
Mainly ensure that all required paramers for workspace file and page bootstrap are always available from parameters and not taken from context.

