### PR TITLE
:bug: Fix `max-` `min-` `width` `height` not being applied

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -278,8 +278,9 @@
                         :layout-item-max-w value
                         :layout-item-max-h value}
                        (select-keys attributes))]
-         (dwsl/update-layout-child shape-ids props {:ignore-touched true
-                                                    :page-id page-id}))))))
+         (rx/of
+          (dwsl/update-layout-child shape-ids props {:ignore-touched true
+                                                     :page-id page-id})))))))
 
 ;; Token Types -----------------------------------------------------------------
 


### PR DESCRIPTION
Fixes `max-` `min-` `width` `height` not being applied.

`rx/of` call was missing, so event was completely ignored because of the type mismatch with what `ptk` expects.