### PR TITLE
:bug: Dont allow hex color values without # prefix

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.common.colors :as c]
    [app.common.data :as d]
+   [app.common.data.macros :as dm]
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.modal :as modal]
    [app.main.data.tokens :as dt]
@@ -321,9 +322,15 @@
         on-update-value (mf/use-fn
                          (mf/deps on-update-value-debounced)
                          (fn [e]
-                           (let [value (dom/get-target-val e)]
-                             (reset! value-ref value)
-                             (on-update-value-debounced value))))
+                           (let [value (dom/get-target-val e)
+                                 ;; Automatically add # for hex values
+                                 value' (if (and color? (tinycolor/hex-without-hash-prefix? value))
+                                          (let [hex (dm/str "#" value)]
+                                            (dom/set-value! (mf/ref-val value-input-ref) hex)
+                                            hex)
+                                          value)]
+                             (reset! value-ref value')
+                             (on-update-value-debounced value'))))
         on-update-color (mf/use-fn
                          (mf/deps on-update-value-debounced)
                          (fn [hex-value alpha]


### PR DESCRIPTION
- Fixes https://github.com/tokens-studio/penpot/issues/80
  by invalidating hex colors without `#` (they are not valid css colors and dont work in the plugin/studio)
- Adds convenience auto-adding of '#' when inserting hex similar to other color input fields in penpot


https://github.com/user-attachments/assets/5ddb8243-730a-4f2f-9120-94f62b2b63cf


For reference:
The original issue stems from the math transform which also gets applied to the color token (which it shouldn't imo, will raise issue internally for sd-transforms)
So values like `00` get truncated to a single `0` by the math resolver before going to the color resolver, unlike other values like `111`.