### PR TITLE
:bug: Fix opacity in frame containers

### DIFF
--- a/frontend/src/app/main/ui/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/shapes/frame.cljs
@@ -94,33 +94,32 @@
     ;; We need to separate blur from shadows because the blur is applied to the strokes
     ;; while the shadows have to be placed *under* the stroke (for example, the inner shadows)
     ;; and the shadows needs to be applied only to the content (without the stroke)
-    [:g {:filter filter-str-blur :opacity opacity}
-     [:defs
-      [:& filters/filters {:shape (dissoc shape :blur) :filter-id filter-id-shadows}]
-      [:& filters/filters {:shape (assoc shape :shadow []) :filter-id filter-id-blur}]]
+    [:g.frame-container-wrapper {:opacity opacity}
+     [:g.frame-container-blur {:filter filter-str-blur}
+      [:defs
+       [:& filters/filters {:shape (dissoc shape :blur) :filter-id filter-id-shadows}]
+       [:& filters/filters {:shape (assoc shape :shadow []) :filter-id filter-id-blur}]]
 
      ;; This need to be separated in two layers so the clip doesn't affect the shadow filters
      ;; otherwise the shadow will be clipped and not visible
-     [:g {:filter filter-str-shadows}
-      [:g {:clip-path (when-not ^boolean show-content? (frame-clip-url shape render-id))
-           ;; A frame sets back normal fill behavior (default
-           ;; transparent). It may have been changed to default black
-           ;; if a shape coming from an imported SVG file is
-           ;; rendered. See main.ui.shapes.attrs/add-style-attrs.
-           :opacity "1"
-           :fill "none"}
+      [:g.frame-container-shadows {:filter filter-str-shadows}
+       [:g {:clip-path (when-not ^boolean show-content? (frame-clip-url shape render-id))
+        ;; A frame sets back normal fill behavior (default
+        ;; transparent). It may have been changed to default black
+        ;; if a shape coming from an imported SVG file is
+        ;; rendered. See main.ui.shapes.attrs/add-style-attrs.
+            :fill "none"}
 
-       [:& shape-fills {:shape shape}
-        (if ^boolean path?
-          [:> :path props]
-          [:> :rect props])]
+        [:& shape-fills {:shape shape}
+         (if ^boolean path?
+           [:> :path props]
+           [:> :rect props])]
+        children]]
 
-       children]]
-
-     [:& shape-strokes {:shape shape}
-      (if ^boolean path?
-        [:> :path props]
-        [:> :rect props])]]))
+      [:& shape-strokes {:shape shape}
+       (if ^boolean path?
+         [:> :path props]
+         [:> :rect props])]]]))
 
 (mf/defc frame-thumbnail-image
   {::mf/wrap-props false}

--- a/frontend/src/app/main/ui/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/shapes/frame.cljs
@@ -94,7 +94,7 @@
     ;; We need to separate blur from shadows because the blur is applied to the strokes
     ;; while the shadows have to be placed *under* the stroke (for example, the inner shadows)
     ;; and the shadows needs to be applied only to the content (without the stroke)
-    [:g {:filter filter-str-blur}
+    [:g {:filter filter-str-blur :opacity opacity}
      [:defs
       [:& filters/filters {:shape (dissoc shape :blur) :filter-id filter-id-shadows}]
       [:& filters/filters {:shape (assoc shape :shadow []) :filter-id filter-id-blur}]]
@@ -107,8 +107,8 @@
            ;; transparent). It may have been changed to default black
            ;; if a shape coming from an imported SVG file is
            ;; rendered. See main.ui.shapes.attrs/add-style-attrs.
-           :fill "none"
-           :opacity opacity}
+           :opacity "1"
+           :fill "none"}
 
        [:& shape-fills {:shape shape}
         (if ^boolean path?

--- a/frontend/src/app/main/ui/workspace/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/frame.cljs
@@ -185,7 +185,6 @@
             (d/close! task)))
 
         (fdm/use-dynamic-modifiers objects (mf/ref-val content-ref) modifiers)
-
         [:& shape-container {:shape shape}
          [:g.frame-container
           {:id (dm/str "frame-container-" frame-id)


### PR DESCRIPTION
Related ticket https://tree.taiga.io/project/penpot/issue/10126 

## Context

Board elements (`frame` shapes in the codebase) are not applying opacity to the whole shape-container. 

## Fix

Apply opacity only in the parent frame container. Tested with different stroke types (inside, outside, center), different export format (png, svg, jpg). Shadow and blur seem to work fine as well for both workspace and export.

**Workspace:**

Comparing board vs rect

![image](https://github.com/user-attachments/assets/04a1d461-8d3b-432b-ac8e-2ef35c43d2f1)

**Export results:**

![Board - Border Center](https://github.com/user-attachments/assets/f9d5d73d-cbd4-4cda-a17a-b1b89a34f866)
![Board - Border Inside](https://github.com/user-attachments/assets/299311b7-e8cb-485a-8262-ea8ecc33bf9d)
![Board - Border Outside](https://github.com/user-attachments/assets/f8f01cd4-d44b-4687-8c0a-3a4612732109)
