### PR TITLE
:bug: Fix open comment in workspace from dashboard notification

### DIFF
--- a/frontend/src/app/main/data/workspace/comments.cljs
+++ b/frontend/src/app/main/data/workspace/comments.cljs
@@ -22,7 +22,6 @@
    [app.main.data.workspace.drawing :as dwd]
    [app.main.data.workspace.edition :as dwe]
    [app.main.data.workspace.selection :as dws]
-   [app.main.data.workspace.viewport :as dwv]
    [app.main.repo :as rp]
    [app.main.router :as rt]
    [app.main.streams :as ms]
@@ -118,7 +117,7 @@
                                    :page-id (:page-id thread)))
 
        (->> stream
-            (rx/filter (ptk/type? ::dwv/initialize-viewport))
+            (rx/filter (ptk/type? ::dcmt/comment-threads-fetched))
             (rx/take 1)
             (rx/mapcat #(rx/of (center-to-comment-thread thread)
                                (dwd/select-for-drawing :comments)


### PR DESCRIPTION
Fixes issue [#10099](https://tree.taiga.io/project/penpot/task/10099)

The event `initialize-viewport` is only triggered the first time the workspace is loaded. This is why the user couldn't open a comment from the dashboard notifications if they had previously gone back and forward from the workspace to the dashboard without reloading the app in the browser.

Using the event `:comment-threads-fetched` we ensure that this works properly, because the comments are always fetched when loading the workspace.