### PR TITLE
:bug: Fix incorrect handling request access with deleted profiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ is a number of cores)
 - Fix problem with grid layout crashing [Taiga #10127](https://tree.taiga.io/project/penpot/issue/10127)
 - Fix rename locked boards [Taiga #10174](https://tree.taiga.io/project/penpot/issue/10174)
 - Fix update-libraries dialog disappear when clicking outside [Taiga #10238](https://tree.taiga.io/project/penpot/issue/10238)
+- Fix incorrect handling of team access requests with deleted/recreated users
 
 ## 2.4.3
 

--- a/backend/resources/app/email/request-file-access-yourpenpot-view/en.html
+++ b/backend/resources/app/email/request-file-access-yourpenpot-view/en.html
@@ -207,7 +207,7 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/view/{{file-id}}?page-id={{page-id}}&section=interactions&index=0&share=true"
+                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}&section=interactions&index=0&share=true"
                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
                               target="_blank"> SEND A VIEW-ONLY LINK </a>
                           </td>

--- a/backend/resources/app/email/request-file-access-yourpenpot-view/en.txt
+++ b/backend/resources/app/email/request-file-access-yourpenpot-view/en.txt
@@ -6,7 +6,7 @@ Since this file is in your Penpot team, you can provide access by sending a view
 
 To proceed, please click the link below to generate and send the view-only link:
 
-{{ public-uri }}/#/view/{{file-id}}?page-id={{page-id}}&section=interactions&index=0&share=true
+{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}&section=interactions&index=0&share=true
 
 
 

--- a/backend/resources/app/email/request-file-access-yourpenpot/en.html
+++ b/backend/resources/app/email/request-file-access-yourpenpot/en.html
@@ -230,7 +230,7 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/view/{{file-id}}?page-id={{page-id}}&section=interactions&index=0&share=true"
+                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}"
                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
                               target="_blank"> SEND A VIEW-ONLY LINK </a>
                           </td>

--- a/backend/resources/app/email/request-file-access-yourpenpot/en.html
+++ b/backend/resources/app/email/request-file-access-yourpenpot/en.html
@@ -230,9 +230,9 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}"
-                              style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
-                              target="_blank"> SEND A VIEW-ONLY LINK </a>
+                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}&section=interactions&index=0&share=true"
+                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
+                               target="_blank"> SEND A VIEW-ONLY LINK </a>
                           </td>
                         </tr>
                       </table>

--- a/backend/resources/app/email/request-file-access-yourpenpot/en.txt
+++ b/backend/resources/app/email/request-file-access-yourpenpot/en.txt
@@ -19,7 +19,7 @@ Alternatively, you can create and share a view-only link to the file. This will 
 
 Click the link below to generate and send the link:
 
-{{ public-uri }}/#/view/{{file-id}}?page-id={{page-id}}&section=interactions&index=0&share=true
+{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}
 
 
 

--- a/backend/resources/app/email/request-file-access-yourpenpot/en.txt
+++ b/backend/resources/app/email/request-file-access-yourpenpot/en.txt
@@ -19,7 +19,7 @@ Alternatively, you can create and share a view-only link to the file. This will 
 
 Click the link below to generate and send the link:
 
-{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}
+{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}&section=interactions&index=0&share=true
 
 
 

--- a/backend/resources/app/email/request-file-access/en.html
+++ b/backend/resources/app/email/request-file-access/en.html
@@ -214,7 +214,7 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/dashboard/team/{{team-id}}/members?invite-email={{requested-by-email|urlescape }}"
+                            <a href="{{ public-uri }}/#/dashboard/members?team-id={{team-id}}&invite-email={{requested-by-email|urlescape }}"
                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
                               target="_blank"> GIVE ACCESS TO “{{team-name|abbreviate:25}}” TEAM </a>
                           </td>
@@ -247,7 +247,7 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/view/{{file-id}}?page-id={{page-id}}&section=interactions&index=0&share=true"
+                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}"
                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
                               target="_blank"> SEND A VIEW-ONLY LINK </a>
                           </td>

--- a/backend/resources/app/email/request-file-access/en.html
+++ b/backend/resources/app/email/request-file-access/en.html
@@ -247,9 +247,9 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}"
-                              style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
-                              target="_blank"> SEND A VIEW-ONLY LINK </a>
+                            <a href="{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}&section=interactions&index=0&share=true"
+                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
+                               target="_blank"> SEND A VIEW-ONLY LINK </a>
                           </td>
                         </tr>
                       </table>

--- a/backend/resources/app/email/request-file-access/en.txt
+++ b/backend/resources/app/email/request-file-access/en.txt
@@ -23,7 +23,7 @@ Alternatively, you can create and share a view-only link to the file. This will 
 
 Click the link below to generate and send the link:
 
-{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}
+{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}&section=interactions&index=0&share=true
 
 
 If you do not wish to grant access at this time, you can simply disregard this email.

--- a/backend/resources/app/email/request-file-access/en.txt
+++ b/backend/resources/app/email/request-file-access/en.txt
@@ -13,7 +13,7 @@ This will automatically include {{requested-by|abbreviate:25}} in the team, so t
 
 Click the link below to provide team access:
 
-{{ public-uri }}/#/dashboard/team/{{team-id}}/members?invite-email={{requested-by-email|urlescape}}
+{{ public-uri }}/#/dashboard/members?team-id{{team-id}}&invite-email={{requested-by-email|urlescape}}
 
 
 
@@ -23,8 +23,7 @@ Alternatively, you can create and share a view-only link to the file. This will 
 
 Click the link below to generate and send the link:
 
-{{ public-uri }}/#/view/{{file-id}}?page-id={{page-id}}&section=interactions&index=0&share=true
-
+{{ public-uri }}/#/view?file-id={{file-id}}&page-id={{page-id}}
 
 
 If you do not wish to grant access at this time, you can simply disregard this email.

--- a/backend/resources/app/email/request-team-access/en.html
+++ b/backend/resources/app/email/request-team-access/en.html
@@ -205,7 +205,7 @@
                           <td align="center" bgcolor="#6911d4" role="presentation"
                             style="border:none;border-radius:8px;cursor:auto;mso-padding-alt:10px 25px;background:#6911d4;"
                             valign="middle">
-                            <a href="{{ public-uri }}/#/dashboard/team/{{team-id}}/members?invite-email={{requested-by-email|urlescape}}"
+                            <a href="{{ public-uri }}/#/dashboard/members?team-id={{team-id}}&invite-email={{requested-by-email|urlescape}}"
                               style="display:inline-block;background:#6911d4;color:#FFFFFF;font-family:Source Sans Pro, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:8px;"
                               target="_blank"> GIVE ACCESS TO “{{team-name|abbreviate:25}}” TEAM </a>
                           </td>

--- a/backend/resources/app/email/request-team-access/en.txt
+++ b/backend/resources/app/email/request-team-access/en.txt
@@ -4,7 +4,7 @@ Hello!
 
 To provide access, please click the link below:
 
-{{ public-uri }}/#/dashboard/team/{{team-id}}/members?invite-email={{requested-by-email|urlescape}}
+{{ public-uri }}/#/dashboard/members?team-id={{team-id}}&invite-email={{requested-by-email|urlescape}}
 
 
 If you do not wish to grant access at this time, you can simply disregard this email.

--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -72,6 +72,7 @@
 (def profile-fetched?
   (ptk/type? ::profile-fetched))
 
+;; FIXME: make it as general purpose handler, not only on profile
 (defn- on-fetch-profile-exception
   [cause]
   (let [data (ex-data cause)]


### PR DESCRIPTION
Hot to test:

- Create a test team X
- Create profile with email A
- request access to a team X with profile A
- Delete profile A
- Create again a profile with email A'
- Request acces to a team X with profile A'
- Try to invite profile A' from team X

Without the fix: a deleted profile added as a member
With the fix: a correct profile added as a member 