### PR TITLE
:bug: Fix color slider not updating the hue of the ramp

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -183,18 +183,21 @@
         on-finish-drag
         (mf/use-fn #(mf/set-ref-val! dragging-ref false))
 
+        internal-color* (mf/use-state (hex->value color))
+
         on-change'
         (mf/use-fn
          (mf/deps on-change)
-         (fn [{:keys [hex alpha]}]
+         (fn [{:keys [hex alpha] :as selector-color}]
            (let [dragging? (mf/ref-val dragging-ref)]
              (when-not (and dragging? hex)
+               (reset! internal-color* selector-color)
                (on-change hex alpha)))))]
 
-    (colorpicker/use-color-picker-css-variables! wrapper-node-ref (hex->value color))
+    (colorpicker/use-color-picker-css-variables! wrapper-node-ref @internal-color*)
     [:div {:ref wrapper-node-ref}
      [:> ramp-selector*
-      {:color (hex->value color)
+      {:color @internal-color*
        :on-start-drag on-start-drag
        :on-finish-drag on-finish-drag
        :on-change on-change'}]]))


### PR DESCRIPTION
Fix the color picker not updating the color ramp hue when the hue slider at the bottom is moved.
**Before**

https://github.com/user-attachments/assets/f7da6a86-1836-4501-93b7-a6c0f97b6faf



**After**

https://github.com/user-attachments/assets/e100e590-59fb-45b1-9b6e-fe1a4a6f0a2a


