### PR TITLE
:bug: Fix incorrect number of replies in comments

### DIFF
--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -621,9 +621,10 @@
     [:> comment-content* {:content (:content item)}]]
 
    [:div {:class (stl/css :replies)}
-    (let [total-comments (:count-comments item 1)
-          total-replies  (dec total-comments)
-          unread-replies (:count-unread-comments item 0)]
+    (let [total-comments  (:count-comments item)
+          unread-comments (:count-unread-comments item)
+          total-replies   (dec total-comments)
+          unread-replies  (if (= unread-comments total-comments) (dec unread-comments) unread-comments)]
       [:*
        (when (> total-replies 0)
          (if (= total-replies 1)


### PR DESCRIPTION
Fixes Taiga issue [#10249](https://tree.taiga.io/project/penpot/issue/10249)

In the state, every element of the thread is a comment, but in the UI we need to differentiate between head an replies. So, when the number of total comments is the same as the number of unread comments (which means that a user has not opened this thread yet), we need to subtract 1 to show the actual number of replies, because otherwise the head would count as an unread reply.