### PR TITLE
:paperclip: Remove invalid aria label on div

### DIFF
--- a/frontend/src/app/main/ui/components/select.cljs
+++ b/frontend/src/app/main/ui/components/select.cljs
@@ -103,7 +103,6 @@
           current-icon-ref (i/key->icon current-icon)]
       [:div {:on-click open-dropdown
              :role "combobox"
-             :aria-activedescendent current-value
              :class (dm/str (stl/css-case :custom-select true
                                           :disabled disabled
                                           :icon (some? current-icon-ref))


### PR DESCRIPTION
Minor change to fix a warning regarding an invalid aria attribute:

```
[...]
ibs.js?ts=1739960365150:7513 Warning: Invalid aria prop \`aria-activedescendent\` on <div> tag. For details, see https://reactjs.org/link/invalid-aria-props at div at app$main$ui$components$select$select (http://localhost:3449/js/cljs-runtime/app.main.ui.components.select.js:24:38) at div at div at app$main$ui$inspect$attributes$common$color\_row (http://localhost:3449/js/cljs-runtime/app.main.ui.inspect.attributes.common.js:48:60) at div at
[...]
``` 