### PR TITLE
:bug: Fix reposition comment bubbles under viewer role

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -301,7 +301,6 @@
 
       (when show-comments?
         [:> comments/comments-layer* {:vbox vbox
-                                      :page-id page-id
                                       :file-id file-id
                                       :vport vport
                                       :zoom zoom

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -348,7 +348,6 @@
 
       (when show-comments?
         [:> comments/comments-layer* {:vbox vbox
-                                      :page-id page-id
                                       :vport vport
                                       :zoom zoom
                                       :drawing drawing}])


### PR DESCRIPTION
Fixes Taiga issue [#9709](https://tree.taiga.io/project/penpot/issue/9709)

Repositioning of comment bubbles has been disengaged from the undo/redo logic. This was the only action related to comments which was using that logic, allowing the user with a viewer role to do anything except repositioning a bubble.

We are also leaving behind the `:files :data :pages-index :comment-thread-positions` structure in the state, which is redundant. From now on we are only storing and reading the comments from `:comment-threads`, which can be found in the first level of the state.

We have also added an optimistic update when the position changes. The bubble position is synchronously stored in the state and then is asynchronously sent to the backend. This avoids a glitch after dropping the bubble.