### PR TITLE
:lipstick: Spacing on token sets

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
@@ -35,6 +35,7 @@
 
 .sets-sidebar {
   position: relative;
+  padding-block-end: $s-16;
 }
 
 .themes-header {


### PR DESCRIPTION
This PR adds some spacing at the bottom of the token set list as requested in issue [tg-10212](https://tree.taiga.io/project/penpot/issue/10212)
