### PR TITLE
:books: Document how to use a proxy

### DIFF
--- a/docs/technical-guide/getting-started.md
+++ b/docs/technical-guide/getting-started.md
@@ -280,6 +280,55 @@ Postgres database and another one for the assets uploaded by your users (images 
 clips). There may be more volumes if you enable other features, as explained in the file
 itself.
 
+### Configure the proxy
+
+Your host configuration needs to make a proxy to http://localhost:9001.
+
+#### Example with NGINX
+
+```bash
+server {
+  listen 80;
+  server_name penpot.mycompany.com;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  server_name penpot.mycompany.com;
+
+  # This value should be in sync with the corresponding in the docker-compose.yml
+  # PENPOT_HTTP_SERVER_MAX_BODY_SIZE: 31457280
+  client_max_body_size 31457280;
+
+  # Logs: Configure your logs following the best practices inside your company
+  access_log /path/to/penpot.access.log;
+  error_log /path/to/penpot.error.log;
+
+  # TLS: Configure your TLS following the best practices inside your company
+  ssl_certificate /path/to/fullchain;
+  ssl_certificate_key /path/to/privkey;
+
+  # Websockets
+  location /ws/notifications {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_pass http://localhost:9001/ws/notifications;
+  }
+
+  # Proxy pass
+  location / {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_redirect off;
+    proxy_pass http://localhost:9001/;
+  }
+}
+```
+
 ### Troubleshooting
 
 Knowing how to do Penpot troubleshooting can be very useful; on the one hand, it helps to create issues easier to resolve, since they include relevant information from the beginning which also makes them get solved faster; on the other hand, many times troubleshooting gives the necessary information to resolve a problem autonomously, without even creating an issue.
@@ -349,7 +398,6 @@ you need.
 
 Therefore, your prerequisite will be to have a Kubernetes cluster on which we can install
 Helm.
-
 
 ### What is Helm
 

--- a/docs/technical-guide/getting-started.md
+++ b/docs/technical-guide/getting-started.md
@@ -329,6 +329,18 @@ server {
 }
 ```
 
+#### Example with CADDY SERVER
+
+```bash
+penpot.mycompany.com {
+        reverse_proxy :9001
+        tls /path/to/fullchain.pem /path/to/privkey.pem
+        log {
+            output file /path/to/penpot.log
+        }
+}
+```
+
 ### Troubleshooting
 
 Knowing how to do Penpot troubleshooting can be very useful; on the one hand, it helps to create issues easier to resolve, since they include relevant information from the beginning which also makes them get solved faster; on the other hand, many times troubleshooting gives the necessary information to resolve a problem autonomously, without even creating an issue.


### PR DESCRIPTION
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWgzb2Zlbjc3ZXZ5ZDNmczY0eTlwbDZhb2k1Mnd1YnlnbTZvZnFseCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xVurSXSjNiifP8qLXy/giphy.gif)

This PR adds examples of reverse proxy with nginx and caddy server. They are not meant as comprehensive examples about nginx or caddy (or how a proxy works), just to illustrate how to proxy Penpot in a docker deployment.

To test it:
- run penpot with docker compose as explained in the documentation
- install nginx locally and use the given configuration - test it works as expected (including exporting and websockets)
- stop nginx, install caddy and use the configuration - test it works as expected (including exporting and websockets)