### PR TITLE
:sparkles: Split rendering of fills and strokes in separate surfaces

### DIFF
--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -1,7 +1,7 @@
 use crate::shapes::Shape;
 use skia_safe as skia;
 
-use super::RenderState;
+use super::{RenderState, SurfaceId};
 
 fn render_debug_view(render_state: &mut RenderState) {
     let mut paint = skia::Paint::default();
@@ -18,13 +18,12 @@ fn render_debug_view(render_state: &mut RenderState) {
 
     render_state
         .surfaces
-        .debug
-        .canvas()
+        .canvas(SurfaceId::Debug)
         .draw_rect(scaled_rect, &paint);
 }
 
 pub fn render_wasm_label(render_state: &mut RenderState) {
-    let canvas = render_state.surfaces.current.canvas();
+    let canvas = render_state.surfaces.canvas(SurfaceId::Current);
 
     let skia::ISize { width, height } = canvas.base_layer_size();
     let p = skia::Point::new(width as f32 - 100.0, height as f32 - 25.0);
@@ -59,18 +58,13 @@ pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, inter
 
     render_state
         .surfaces
-        .debug
-        .canvas()
+        .canvas(SurfaceId::Debug)
         .draw_rect(scaled_rect, &paint);
 }
 
 pub fn render(render_state: &mut RenderState) {
-    let paint = skia::Paint::default();
     render_debug_view(render_state);
-    render_state.surfaces.debug.draw(
-        &mut render_state.surfaces.current.canvas(),
-        (0.0, 0.0),
-        render_state.sampling_options,
-        Some(&paint),
-    );
+    render_state
+        .surfaces
+        .draw_into(SurfaceId::Debug, SurfaceId::Current, None);
 }

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -64,7 +64,9 @@ pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, inter
 
 pub fn render(render_state: &mut RenderState) {
     render_debug_view(render_state);
-    render_state
-        .surfaces
-        .draw_into(SurfaceId::Debug, SurfaceId::Current, None);
+    render_state.surfaces.draw_into(
+        SurfaceId::Debug,
+        SurfaceId::Current,
+        Some(&skia::Paint::default()),
+    );
 }

--- a/render-wasm/src/render/fills.rs
+++ b/render-wasm/src/render/fills.rs
@@ -16,7 +16,7 @@ fn draw_image_fill_in_container(
     }
 
     let size = image_fill.size();
-    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
+    let canvas = render_state.surfaces.canvas(SurfaceId::Fills);
     let container = &shape.selrect;
     let path_transform = shape.to_path_transform();
     let paint = fill.to_paint(container);
@@ -96,7 +96,7 @@ fn draw_image_fill_in_container(
  * This SHOULD be the only public function in this module.
  */
 pub fn render(render_state: &mut RenderState, shape: &Shape, fill: &Fill) {
-    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
+    let canvas = render_state.surfaces.canvas(SurfaceId::Fills);
     let selrect = shape.selrect;
     let path_transform = shape.to_path_transform();
 

--- a/render-wasm/src/render/fills.rs
+++ b/render-wasm/src/render/fills.rs
@@ -1,8 +1,8 @@
-use crate::shapes::{Fill, ImageFill, Shape, Type};
 use skia_safe::{self as skia, RRect};
 
-use super::RenderState;
+use super::{RenderState, SurfaceId};
 use crate::math::Rect;
+use crate::shapes::{Fill, ImageFill, Shape, Type};
 
 fn draw_image_fill_in_container(
     render_state: &mut RenderState,
@@ -16,7 +16,7 @@ fn draw_image_fill_in_container(
     }
 
     let size = image_fill.size();
-    let canvas = render_state.surfaces.shape.canvas();
+    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
     let container = &shape.selrect;
     let path_transform = shape.to_path_transform();
     let paint = fill.to_paint(container);
@@ -96,7 +96,7 @@ fn draw_image_fill_in_container(
  * This SHOULD be the only public function in this module.
  */
 pub fn render(render_state: &mut RenderState, shape: &Shape, fill: &Fill) {
-    let canvas = render_state.surfaces.shape.canvas();
+    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
     let selrect = shape.selrect;
     let path_transform = shape.to_path_transform();
 

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -1,51 +1,37 @@
 use skia_safe::{self as skia};
 
-use super::RenderState;
+use super::{RenderState, SurfaceId};
 use crate::shapes::Shadow;
 
 pub fn render_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
     let shadow_paint = shadow.to_paint(scale);
-    render_state.surfaces.shape.draw(
-        &mut render_state.surfaces.shadow.canvas(),
-        (0.0, 0.0),
-        render_state.sampling_options,
-        Some(&shadow_paint),
-    );
-
-    render_state.surfaces.shadow.draw(
-        &mut render_state.surfaces.current.canvas(),
-        (0.0, 0.0),
-        render_state.sampling_options,
-        Some(&skia::Paint::default()),
-    );
+    render_state
+        .surfaces
+        .draw_into(SurfaceId::Shape, SurfaceId::Shadow, Some(&shadow_paint));
 
     render_state
         .surfaces
-        .shadow
-        .canvas()
+        .draw_into(SurfaceId::Shadow, SurfaceId::Current, None);
+
+    render_state
+        .surfaces
+        .canvas(SurfaceId::Shadow)
         .clear(skia::Color::TRANSPARENT);
 }
 
 pub fn render_inner_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
     let shadow_paint = shadow.to_paint(scale);
 
-    render_state.surfaces.shape.draw(
-        render_state.surfaces.shadow.canvas(),
-        (0.0, 0.0),
-        render_state.sampling_options,
-        Some(&shadow_paint),
-    );
-
-    render_state.surfaces.shadow.draw(
-        &mut render_state.surfaces.overlay.canvas(),
-        (0.0, 0.0),
-        render_state.sampling_options,
-        None,
-    );
+    render_state
+        .surfaces
+        .draw_into(SurfaceId::Shape, SurfaceId::Shadow, Some(&shadow_paint)); // , ShadowPaint
 
     render_state
         .surfaces
-        .shadow
-        .canvas()
+        .draw_into(SurfaceId::Shadow, SurfaceId::Overlay, None); // , None
+
+    render_state
+        .surfaces
+        .canvas(SurfaceId::Shadow)
         .clear(skia::Color::TRANSPARENT);
 }

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -7,11 +7,16 @@ pub fn render_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale
     let shadow_paint = shadow.to_paint(scale);
     render_state
         .surfaces
-        .draw_into(SurfaceId::Shape, SurfaceId::Shadow, Some(&shadow_paint));
-
+        .draw_into(SurfaceId::Fills, SurfaceId::Shadow, Some(&shadow_paint));
     render_state
         .surfaces
-        .draw_into(SurfaceId::Shadow, SurfaceId::Current, None);
+        .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(&shadow_paint));
+
+    render_state.surfaces.draw_into(
+        SurfaceId::Shadow,
+        SurfaceId::Current,
+        Some(&skia::Paint::default()),
+    );
 
     render_state
         .surfaces
@@ -24,7 +29,7 @@ pub fn render_inner_shadow(render_state: &mut RenderState, shadow: &Shadow, scal
 
     render_state
         .surfaces
-        .draw_into(SurfaceId::Shape, SurfaceId::Shadow, Some(&shadow_paint)); // , ShadowPaint
+        .draw_into(SurfaceId::Fills, SurfaceId::Shadow, Some(&shadow_paint));
 
     render_state
         .surfaces

--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -5,7 +5,7 @@ use crate::math::{Matrix, Point, Rect};
 use crate::shapes::{Corners, Fill, ImageFill, Path, Shape, Stroke, StrokeCap, StrokeKind, Type};
 use skia_safe::{self as skia, RRect};
 
-use super::RenderState;
+use super::{RenderState, SurfaceId};
 
 fn draw_stroke_on_rect(
     canvas: &skia::Canvas,
@@ -330,7 +330,7 @@ fn draw_image_stroke_in_container(
     }
 
     let size = image_fill.size();
-    let canvas = render_state.surfaces.shape.canvas();
+    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
     let container = &shape.selrect;
     let path_transform = shape.to_path_transform();
     let svg_attrs = &shape.svg_attrs;
@@ -432,7 +432,7 @@ fn draw_image_stroke_in_container(
  * This SHOULD be the only public function in this module.
  */
 pub fn render(render_state: &mut RenderState, shape: &Shape, stroke: &Stroke) {
-    let canvas = render_state.surfaces.shape.canvas();
+    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
     let dpr_scale = render_state.viewbox.zoom * render_state.options.dpr();
     let selrect = shape.selrect;
     let path_transform = shape.to_path_transform();

--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -330,7 +330,7 @@ fn draw_image_stroke_in_container(
     }
 
     let size = image_fill.size();
-    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
+    let canvas = render_state.surfaces.canvas(SurfaceId::Fills);
     let container = &shape.selrect;
     let path_transform = shape.to_path_transform();
     let svg_attrs = &shape.svg_attrs;
@@ -432,7 +432,7 @@ fn draw_image_stroke_in_container(
  * This SHOULD be the only public function in this module.
  */
 pub fn render(render_state: &mut RenderState, shape: &Shape, stroke: &Stroke) {
-    let canvas = render_state.surfaces.canvas(SurfaceId::Shape);
+    let canvas = render_state.surfaces.canvas(SurfaceId::Strokes);
     let dpr_scale = render_state.viewbox.zoom * render_state.options.dpr();
     let selrect = shape.selrect;
     let path_transform = shape.to_path_transform();

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -1,23 +1,38 @@
 use super::gpu_state::GpuState;
 use skia_safe as skia;
 
+pub enum SurfaceId {
+    Target,
+    Current,
+    Shape,
+    Shadow,
+    Overlay,
+    Debug,
+}
+
 pub struct Surfaces {
     // is the final destination surface, the one that it is represented in the canvas element.
-    pub target: skia::Surface,
+    target: skia::Surface,
     // keeps the current render
-    pub current: skia::Surface,
+    current: skia::Surface,
     // keeps the current shape
-    pub shape: skia::Surface,
+    shape: skia::Surface,
     // used for rendering shadows
-    pub shadow: skia::Surface,
+    shadow: skia::Surface,
     // for drawing the things that are over shadows.
-    pub overlay: skia::Surface,
+    overlay: skia::Surface,
     // for drawing debug info.
-    pub debug: skia::Surface,
+    debug: skia::Surface,
+
+    sampling_options: skia::SamplingOptions,
 }
 
 impl Surfaces {
-    pub fn new(gpu_state: &mut GpuState, (width, height): (i32, i32)) -> Self {
+    pub fn new(
+        gpu_state: &mut GpuState,
+        (width, height): (i32, i32),
+        sampling_options: skia::SamplingOptions,
+    ) -> Self {
         let mut target = gpu_state.create_target_surface(width, height);
         let current = target.new_surface_with_dimensions((width, height)).unwrap();
         let shadow = target.new_surface_with_dimensions((width, height)).unwrap();
@@ -32,20 +47,53 @@ impl Surfaces {
             overlay,
             shape,
             debug,
+            sampling_options,
         }
     }
 
-    pub fn set(&mut self, new_surface: skia::Surface) {
-        let dim = (new_surface.width(), new_surface.height());
-        self.target = new_surface;
+    pub fn resize(&mut self, gpu_state: &mut GpuState, new_width: i32, new_height: i32) {
+        self.reset_from_target(gpu_state.create_target_surface(new_width, new_height));
+    }
+
+    pub fn snapshot(&mut self, id: SurfaceId) -> skia::Image {
+        self.get_mut(id).image_snapshot()
+    }
+
+    pub fn canvas(&mut self, id: SurfaceId) -> &skia::Canvas {
+        self.get_mut(id).canvas()
+    }
+
+    pub fn flush_and_submit(&mut self, gpu_state: &mut GpuState, id: SurfaceId) {
+        let surface = self.get_mut(id);
+        gpu_state.context.flush_and_submit_surface(surface, None);
+    }
+
+    pub fn draw_into(&mut self, from: SurfaceId, to: SurfaceId, paint: Option<&skia::Paint>) {
+        let sampling_options = self.sampling_options;
+
+        self.get_mut(from)
+            .clone()
+            .draw(self.canvas(to), (0.0, 0.0), sampling_options, paint);
+    }
+
+    fn get_mut(&mut self, id: SurfaceId) -> &mut skia::Surface {
+        match id {
+            SurfaceId::Target => &mut self.target,
+            SurfaceId::Current => &mut self.current,
+            SurfaceId::Shadow => &mut self.shadow,
+            SurfaceId::Overlay => &mut self.overlay,
+            SurfaceId::Shape => &mut self.shape,
+            SurfaceId::Debug => &mut self.debug,
+        }
+    }
+
+    fn reset_from_target(&mut self, target: skia::Surface) {
+        let dim = (target.width(), target.height());
+        self.target = target;
         self.current = self.target.new_surface_with_dimensions(dim).unwrap();
         self.overlay = self.target.new_surface_with_dimensions(dim).unwrap();
         self.shadow = self.target.new_surface_with_dimensions(dim).unwrap();
         self.shape = self.target.new_surface_with_dimensions(dim).unwrap();
         self.debug = self.target.new_surface_with_dimensions(dim).unwrap();
-    }
-
-    pub fn resize(&mut self, gpu_state: &mut GpuState, new_width: i32, new_height: i32) {
-        self.set(gpu_state.create_target_surface(new_width, new_height));
     }
 }


### PR DESCRIPTION
Closes https://tree.taiga.io/project/penpot/task/10321

This is a refactor needed so we can [change the order of rendering for inner shadows](https://tree.taiga.io/project/penpot/task/10199).

I also introduced a bit of refactoring to make dealing with surfaces easier, specially when we need to apply the same operation to multiple surfaces at a time.