### PR TITLE
:sparkles: Remove automatic cascade on file_change table fk constraint

### DIFF
--- a/backend/src/app/migrations.clj
+++ b/backend/src/app/migrations.clj
@@ -435,7 +435,10 @@
     :fn (mg/resource "app/migrations/sql/0137-add-file-migration-table.sql")}
 
    {:name "0138-mod-file-data-fragment-table.sql"
-    :fn (mg/resource "app/migrations/sql/0138-mod-file-data-fragment-table.sql")}])
+    :fn (mg/resource "app/migrations/sql/0138-mod-file-data-fragment-table.sql")}
+
+   {:name "0139-mod-file-change-table.sql"
+    :fn (mg/resource "app/migrations/sql/0139-mod-file-change-table.sql")}])
 
 (defn apply-migrations!
   [pool name migrations]

--- a/backend/src/app/migrations/sql/0139-mod-file-change-table.sql
+++ b/backend/src/app/migrations/sql/0139-mod-file-change-table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE file_change
+ DROP CONSTRAINT file_change_file_id_fkey,
+ DROP CONSTRAINT file_change_profile_id_fkey,
+  ADD FOREIGN KEY (file_id) REFERENCES file(id) DEFERRABLE,
+  ADD FOREIGN KEY (profile_id) REFERENCES profile(id) ON DELETE SET NULL DEFERRABLE;

--- a/backend/src/app/tasks/delete_object.clj
+++ b/backend/src/app/tasks/delete_object.clj
@@ -40,6 +40,11 @@
                   :file-id id
                   :cause cause))))
 
+    ;; Mark file change to be deleted
+    (db/update! conn :file-change
+                {:deleted-at deleted-at}
+                {:file-id id})
+
     ;; Mark file media objects to be deleted
     (db/update! conn :file-media-object
                 {:deleted-at deleted-at}


### PR DESCRIPTION
No sepecial test  needed, only code review.

Prevents accidental cascades of file_change table on deleting file rows by throwing error.