### PR TITLE
:wrench: Relax secure cookies requirement when non-https public uri is set

### DIFF
--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -12,6 +12,7 @@
    [app.common.exceptions :as ex]
    [app.common.flags :as flags]
    [app.common.schema :as sm]
+   [app.common.uri :as u]
    [app.common.version :as v]
    [app.util.overrides]
    [app.util.time :as dt]
@@ -230,7 +231,14 @@
 
 (defn- parse-flags
   [config]
-  (flags/parse flags/default (:flags config)))
+  (let [public-uri  (c/get config :public-uri)
+        public-uri  (some-> public-uri (u/uri))
+        extra-flags (if (and public-uri
+                             (= (:scheme public-uri) "http")
+                             (not= (:host public-uri) "localhost"))
+                      #{:disable-secure-session-cookies}
+                      #{})]
+    (flags/parse flags/default extra-flags (:flags config))))
 
 (defn read-env
   [prefix]


### PR DESCRIPTION
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHg4OXVybTR6YTIwaG5nMW81bGtlYWJoaHdpYTNzcjA4NGo1c3A0YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Y8wgPlCWM5jWg/giphy.gif)

This PR enforces the secure session when the public uri is an https address