### PR TITLE
:bug: Fix set with spaces not being rename-able via context menu

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -149,7 +149,7 @@
 
         on-context-menu
         (mf/use-fn
-         (mf/deps is-editing can-edit?)
+         (mf/deps is-editing id tree-path can-edit?)
          (fn [event]
            (dom/prevent-default event)
            (dom/stop-propagation event)
@@ -157,6 +157,7 @@
              (st/emit! (dt/assign-token-set-context-menu
                         {:position (dom/get-client-position event)
                          :is-group true
+                         :id id
                          :path tree-path})))))
 
         on-collapse-click
@@ -247,7 +248,7 @@
 
         on-context-menu
         (mf/use-fn
-         (mf/deps is-editing tree-path can-edit?)
+         (mf/deps is-editing id tree-path can-edit?)
          (fn [event]
            (dom/prevent-default event)
            (dom/stop-propagation event)
@@ -255,6 +256,7 @@
              (st/emit! (dt/assign-token-set-context-menu
                         {:position (dom/get-client-position event)
                          :is-group false
+                         :id id
                          :path tree-path})))))
 
         on-double-click

--- a/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
@@ -8,7 +8,6 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data.macros :as dm]
-   [app.common.types.tokens-lib :as ctob]
    [app.main.data.tokens :as dt]
    [app.main.refs :as refs]
    [app.main.store :as st]
@@ -35,16 +34,15 @@
 
 (mf/defc menu*
   {::mf/private true}
-  [{:keys [is-group path]}]
+  [{:keys [is-group id path]}]
   (let [create-set-at-path
         (mf/use-fn (mf/deps path) #(st/emit! (dt/start-token-set-creation path)))
 
         on-edit
         (mf/use-fn
-         (mf/deps path)
+         (mf/deps id)
          (fn []
-           (let [name (ctob/join-set-path path)]
-             (st/emit! (dt/start-token-set-edition name)))))
+           (st/emit! (dt/start-token-set-edition id))))
 
         on-delete
         (mf/use-fn
@@ -59,7 +57,7 @@
 
 (mf/defc token-set-context-menu*
   []
-  (let [{:keys [position is-group path]}
+  (let [{:keys [position is-group id path]}
         (mf/deref ref:token-sets-context-menu)
 
         position-top
@@ -78,4 +76,6 @@
             :style {:top position-top
                     :left position-left}
             :on-context-menu prevent-default}
-      [:> menu* {:is-group is-group :path path}]]]))
+      [:> menu* {:is-group is-group
+                 :id id
+                 :path path}]]]))


### PR DESCRIPTION
Closes https://github.com/tokens-studio/penpot/issues/82

Uses set / group `id` instead of constructing the `id` from path leading to issues where spaces got trimmed in the `path`
https://github.com/tokens-studio/penpot/blob/2cf0054debc262388a26af7e002fc70686656c44/common/src/app/common/types/tokens_lib.cljc#L29-L31