### PR TITLE
:sparkles: Enable WEBGL_debug_renderer_info extension before initiali…

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -742,10 +742,12 @@
   (let [gl      (unchecked-get internal-module "GL")
         flags   (debug-flags)
         context (.getContext ^js canvas "webgl2" canvas-options)
-
         ;; Register the context with emscripten
         handle  (.registerContext ^js gl context #js {"majorVersion" 2})]
     (.makeContextCurrent ^js gl handle)
+
+    ;; Force the WEBGL_debug_renderer_info extension as emscripten does not enable it
+    (.getExtension context "WEBGL_debug_renderer_info")
 
     ;; Initialize Wasm Render Engine
     (h/call internal-module "_init" (/ (.-width ^js canvas) dpr) (/ (.-height ^js canvas) dpr))


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/task/9875

## Context

The `WEBGL_debug_renderer_info` extension in provides access to the GPU vendor and renderer details (e.g: https://gist.github.com/cvan/042b2448fcecefafbb6a91469484cdf8?permalink_comment_id=3898971)

The problem is that emscripten does not enable the "WEBGL_debug_renderer_info" by default, but Skia might need it. For example, in canvaskit, they enforce it:

https://skia.googlesource.com/skia/+/a453fed07c91/modules/canvaskit/webgl.js?autodive=0%2F%2F%2F%2F%2F#52

This seems to come from this part of emscripten in the function: `getEmscriptenSupportedExtensions` (which is what is compiled to our `render_wasm.js`). It filters out all the debug extensions, including `WEBGL_debug_renderer_info` https://github.com/emscripten-core/emscripten/blob/main/src/lib/libwebgl.js#L1254-L1260

This MR enables this extension before initializing the WASM render.

## Others

The only concern I have is that `WEBGL_debug_renderer_info` seems to be going to be deprecated in Firefox (this could be the reason why I could not reproduce the warning in the first place)
