### PR TITLE
:bug: Override default SamplingOptions for ImageFill and set FilterMo…

### DIFF
--- a/render-wasm/src/render/fills.rs
+++ b/render-wasm/src/render/fills.rs
@@ -1,5 +1,5 @@
 use crate::shapes::{Fill, ImageFill, Shape, Type};
-use skia_safe::{self as skia, RRect, SamplingOptions};
+use skia_safe::{self as skia, RRect};
 
 use super::RenderState;
 use crate::math::Rect;
@@ -85,8 +85,13 @@ fn draw_image_fill_in_container(
 
     // Draw the image with the calculated destination rectangle
     if let Some(image) = image {
-        let sampling = SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Linear);
-        canvas.draw_image_rect_with_sampling_options(image, None, dest_rect, sampling, &paint);
+        canvas.draw_image_rect_with_sampling_options(
+            image,
+            None,
+            dest_rect,
+            render_state.sampling_options,
+            &paint,
+        );
     }
 
     // Restore the canvas to remove the clipping

--- a/render-wasm/src/render/fills.rs
+++ b/render-wasm/src/render/fills.rs
@@ -1,5 +1,5 @@
 use crate::shapes::{Fill, ImageFill, Shape, Type};
-use skia_safe::{self as skia, RRect};
+use skia_safe::{self as skia, RRect, SamplingOptions};
 
 use super::RenderState;
 use crate::math::Rect;
@@ -85,7 +85,8 @@ fn draw_image_fill_in_container(
 
     // Draw the image with the calculated destination rectangle
     if let Some(image) = image {
-        canvas.draw_image_rect(image, None, dest_rect, &paint);
+        let sampling = SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Linear);
+        canvas.draw_image_rect_with_sampling_options(image, None, dest_rect, sampling, &paint);
     }
 
     // Restore the canvas to remove the clipping


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/task/10347

I followed @belen-albeza's suggestion on using `Linear` instead of  `Nearest` as sampling options for `ImageFill` shapes and it seems to be smoother.

Taking a look, we can reuse the sampling_options from the render state:

* Before:

![image](https://github.com/user-attachments/assets/46a7d5da-e8da-4f02-98da-051e090366d9)

* After:

![image](https://github.com/user-attachments/assets/b7399bc3-a935-4ee1-be22-9db4edc96f33)

