### PR TITLE
:bug: Fix viewer style in fullscreen mode

### DIFF
--- a/frontend/src/app/main/ui/viewer.cljs
+++ b/frontend/src/app/main/ui/viewer.cljs
@@ -565,7 +565,7 @@
       [:section#viewer-section {:ref viewer-section-ref
                                 :data-viewer-section true
                                 :class (stl/css-case :viewer-section true
-                                                     :fulscreen fullscreen?)
+                                                     :fullscreen fullscreen?)
                                 :on-click click-on-screen}
        (cond
          (empty? frames)

--- a/frontend/src/app/main/ui/viewer.scss
+++ b/frontend/src/app/main/ui/viewer.scss
@@ -206,6 +206,15 @@
   transform: translateX(-$s-40);
 }
 
+[data-fullscreen="true"] .viewer-content {
+  transform: translateY(-$s-48);
+  height: 100vh;
+}
+
+[data-fullscreen="true"] .viewer-section {
+  height: 100vh;
+}
+
 [data-force-visible="true"] .viewer-go-next {
   transform: translateX(0);
 }


### PR DESCRIPTION
https://tree.taiga.io/project/penpot/issue/7723

## Context

On fullscreen mode, the viewer shows the top-bar as "empty" when the bar is hidden