### PR TITLE
:bug: Fix layout context menu width + position

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.scss
@@ -22,7 +22,7 @@
       padding: 0;
       margin: 0;
       .layout-options {
-        width: $s-92;
+        width: fit-content;
       }
       .layout-option {
         white-space: nowrap;
@@ -310,7 +310,7 @@
 .layout-options {
   @extend .dropdown-wrapper;
   @include flexColumn;
-  right: 0;
+  right: var(--sp-s);
   left: initial;
 
   button {


### PR DESCRIPTION
Fixes https://tree.taiga.io/project/penpot/issue/10234

> :warning: Do test with **Firefox**

<img width="299" alt="Screenshot 2025-02-26 at 4 52 41 PM" src="https://github.com/user-attachments/assets/0e8d49a2-5e3f-4822-aede-c5f507e14461" />
