### PR TITLE
:lipstick: Improve context menu scanability

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.scss
@@ -59,7 +59,7 @@
   @include use-typography("body-small");
   display: flex;
   align-items: center;
-  height: $s-28;
+  height: $s-32;
   width: 100%;
   padding: $s-8;
   border-radius: $br-8;
@@ -79,6 +79,42 @@
   &[aria-selected="true"] {
     --context-menu-item-bg-color: var(--color-background-quaternary);
   }
+}
+
+.context-menu-item-hint-wrapper {
+  position: relative;
+}
+
+.context-menu-item-selected {
+  & .icon-wrapper {
+    color: var(--color-accent-primary);
+  }
+}
+
+.context-menu-item-unselected {
+  color: var(--color-foreground-secondary);
+
+  & .icon-wrapper {
+    color: var(--color-background-quaternary);
+  }
+
+  &:hover {
+    color: var(--color-foreground-primary);
+
+    & .icon-wrapper {
+      color: var(--color-foreground-secondary);
+    }
+  }
+}
+
+.context-menu-item-hint {
+  position: absolute;
+  background-color: var(--color-background-primary);
+  border-radius: $br-6;
+  padding: $s-4;
+  inset-inline-end: $s-4;
+  inset-block-start: $s-4;
+  color: var(--color-foreground-secondary);
 }
 
 .item-text {

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6522,6 +6522,42 @@ msgstr "Delete theme"
 msgid "workspace.token.duplicate"
 msgstr "Duplicate token"
 
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.axis"
+msgstr "Axis"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.size"
+msgstr "Size"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.min-size"
+msgstr "Min. size"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.max-size"
+msgstr "Max. size"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.gaps"
+msgstr "Gaps"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.paddings"
+msgstr "Paddings"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.margins"
+msgstr "Margins"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.radius"
+msgstr "Radius"
+
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:235
+msgid "workspace.token.color"
+msgstr "Color"
+
 #: src/app/main/ui/workspace/tokens/context_menu.cljs:218
 msgid "workspace.token.edit"
 msgstr "Edit token"


### PR DESCRIPTION
This PR improves context menu scanability as requested in [tg-10292](https://tree.taiga.io/project/penpot/us/10292?milestone=431233)

- [x] Changes context menu button colors to improve contrast nad interaction
- [x] Adds hints to selection groups 