### PR TITLE
:bug: Fix relative position application for flex children

### DIFF
--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -859,10 +859,11 @@
           (rx/of (reorder-selected-layout-child direction))
           (rx/of (nudge-selected-shapes direction shift?)))))))
 
-(defn- get-relative-delta [position bbox parent]
-  (let [parent-bbox (-> parent :points grc/points->rect)
+(defn- get-relative-delta [position bbox frame]
+  (let [frame-bbox (-> frame :points grc/points->rect)
         relative-cpos (gpt/subtract (gpt/point (:x bbox) (:y bbox))
-                                    (gpt/point (:x parent-bbox) (:y parent-bbox)))
+                                    (gpt/point (:x frame-bbox)
+                                               (:y frame-bbox)))
         cpos (gpt/point (:x relative-cpos) (:y relative-cpos))
         pos (gpt/point (or (:x position) (:x relative-cpos))
                        (or (:y position) (:y relative-cpos)))]

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -859,12 +859,6 @@
           (rx/of (reorder-selected-layout-child direction))
           (rx/of (nudge-selected-shapes direction shift?)))))))
 
-(defn- get-delta [position bbox]
-  (let [cpos (gpt/point (:x bbox) (:y bbox))
-        pos (gpt/point (or (:x position) (:x bbox))
-                       (or (:y position) (:y bbox)))]
-    (gpt/subtract pos cpos)))
-
 (defn- get-relative-delta [position bbox parent]
   (let [parent-bbox (-> parent :points grc/points->rect)
         relative-cpos (gpt/subtract (gpt/point (:x bbox) (:y bbox))
@@ -888,10 +882,8 @@
              shape      (get objects id)
              ;; FIXME: performance rect
              bbox       (-> shape :points grc/points->rect)
-             parent     (cfh/get-parent objects id)
-             delta      (if-not (:relative? options)
-                          (get-delta position bbox)
-                          (get-relative-delta position bbox parent))
+             frame      (cfh/get-frame objects shape)
+             delta      (get-relative-delta position bbox frame)
              modif-tree (dwm/create-modif-tree [id] (ctm/move-modifiers delta))]
          (rx/of (dwm/apply-modifiers {:modifiers modif-tree
                                       :page-id page-id

--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -859,6 +859,12 @@
           (rx/of (reorder-selected-layout-child direction))
           (rx/of (nudge-selected-shapes direction shift?)))))))
 
+(defn- get-delta [position bbox]
+  (let [cpos (gpt/point (:x bbox) (:y bbox))
+        pos (gpt/point (or (:x position) (:x bbox))
+                       (or (:y position) (:y bbox)))]
+    (gpt/subtract pos cpos)))
+
 (defn- get-relative-delta [position bbox frame]
   (let [frame-bbox (-> frame :points grc/points->rect)
         relative-cpos (gpt/subtract (gpt/point (:x bbox) (:y bbox))
@@ -884,7 +890,9 @@
              ;; FIXME: performance rect
              bbox       (-> shape :points grc/points->rect)
              frame      (cfh/get-frame objects shape)
-             delta      (get-relative-delta position bbox frame)
+             delta      (if (:absolute? options)
+                          (get-delta position bbox)
+                          (get-relative-delta position bbox frame))
              modif-tree (dwm/create-modif-tree [id] (ctm/move-modifiers delta))]
          (rx/of (dwm/apply-modifiers {:modifiers modif-tree
                                       :page-id page-id

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -239,9 +239,8 @@
         do-position-change
         (mf/use-fn
          (mf/deps ids)
-         (fn [shape' frame' value attr]
-           (let [to (+ value (attr frame'))]
-             (st/emit! (udw/update-position (:id shape') {attr to})))))
+         (fn [shape' value attr]
+           (st/emit! (udw/update-position (:id shape') {attr value}))))
 
         on-position-change
         (mf/use-fn
@@ -249,7 +248,7 @@
          (fn [value attr]
            (st/emit! (udw/trigger-bounding-box-cloaking ids))
            (binding [cts/*wasm-sync* true]
-             (doall (map #(do-position-change %1 %2 value attr) shapes frames)))))
+             (doall (map #(do-position-change %1 value attr) shapes)))))
 
         ;; ROTATION
 

--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -290,12 +290,6 @@
                                 {:ignore-touched true
                                  :page-id page-id}))))))))
 
-(defn- immediate-flex-absolute-child? [objects id]
-  (let [shape (get objects id)]
-    (boolean
-     (and (:layout-item-absolute shape)
-          (ctsl/flex-layout-immediate-child? objects shape)))))
-
 (defn update-shape-position
   ([value shape-ids attributes] (update-shape-position value shape-ids attributes nil))
   ([value shape-ids attributes page-id]
@@ -303,21 +297,12 @@
      ptk/WatchEvent
      (watch [_ state _]
        (when (number? value)
-         (let [page-id' (or page-id (get state :current-page-id))
-               objects (dsh/lookup-page-objects state page-id')
-               {canvas-children-ids false
-                flex-children-ids true} (group-by #(immediate-flex-absolute-child? objects %) shape-ids)]
+         (let [page-id' (or page-id (get state :current-page-id))]
            (rx/concat
-            (concat
-             (map #(dwt/update-position % (zipmap attributes (repeat value))
-                                        {:ignore-touched true
-                                         :page-id page-id'})
-                  canvas-children-ids)
-             (map #(dwt/update-position % (zipmap attributes (repeat value))
-                                        {:ignore-touched true
-                                         :page-id page-id'
-                                         :relative? true})
-                  flex-children-ids)))))))))
+            (map #(dwt/update-position % (zipmap attributes (repeat value))
+                                       {:ignore-touched true
+                                        :page-id page-id'})
+                 shape-ids))))))))
 
 
 (defn update-layout-sizing-limits

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -492,7 +492,9 @@
                   (u/display-not-valid :x "Plugin doesn't have 'content:write' permission")
 
                   :else
-                  (st/emit! (dw/update-position id {:x value})))))}
+                  (st/emit! (dw/update-position id
+                                                {:x value}
+                                                {:absolute? true})))))}
 
            :y
            {:this true
@@ -508,7 +510,9 @@
                   (u/display-not-valid :y "Plugin doesn't have 'content:write' permission")
 
                   :else
-                  (st/emit! (dw/update-position id {:y value})))))}
+                  (st/emit! (dw/update-position id
+                                                {:y value}
+                                                {:absolute? true})))))}
 
            :parent
            {:this true
@@ -542,7 +546,9 @@
                       parent-id (-> self u/proxy->shape :parent-id)
                       parent (u/locate-shape (obj/get self "$file") (obj/get self "$page") parent-id)
                       parent-x (:x parent)]
-                  (st/emit! (dw/update-position id {:x (+ parent-x value)})))))}
+                  (st/emit! (dw/update-position id
+                                                {:x (+ parent-x value)}
+                                                {:absolute? true})))))}
 
            :parentY
            {:this true
@@ -567,7 +573,9 @@
                       parent-id (-> self u/proxy->shape :parent-id)
                       parent (u/locate-shape (obj/get self "$file") (obj/get self "$page") parent-id)
                       parent-y (:y parent)]
-                  (st/emit! (dw/update-position id {:y (+ parent-y value)})))))}
+                  (st/emit! (dw/update-position id
+                                                {:y (+ parent-y value)}
+                                                {:absolute? true})))))}
 
            :boardX
            {:this true
@@ -592,7 +600,9 @@
                       frame-id (-> self u/proxy->shape :frame-id)
                       frame (u/locate-shape (obj/get self "$file") (obj/get self "$page") frame-id)
                       frame-x (:x frame)]
-                  (st/emit! (dw/update-position id {:x (+ frame-x value)})))))}
+                  (st/emit! (dw/update-position id
+                                                {:x (+ frame-x value)}
+                                                {:absolute? true})))))}
 
            :boardY
            {:this true
@@ -617,7 +627,9 @@
                       frame-id (-> self u/proxy->shape :frame-id)
                       frame (u/locate-shape (obj/get self "$file") (obj/get self "$page") frame-id)
                       frame-y (:y frame)]
-                  (st/emit! (dw/update-position id {:y (+ frame-y value)})))))}
+                  (st/emit! (dw/update-position id
+                                                {:y (+ frame-y value)}
+                                                {:absolute? true})))))}
 
            :width
            {:this true

--- a/frontend/test/frontend_tests/plugins/context_shapes_test.cljs
+++ b/frontend/test/frontend_tests/plugins/context_shapes_test.cljs
@@ -8,8 +8,6 @@
   (:require
    [app.common.math :as m]
    [app.common.test-helpers.files :as cthf]
-   [app.common.test-helpers.ids-map :as cthi]
-   [app.common.test-helpers.shapes :as cths]
    [app.common.uuid :as uuid]
    [app.main.store :as st]
    [app.plugins.api :as api]
@@ -24,7 +22,6 @@
         ^js context (api/create-context "TEST")
 
         _       (set! st/state store)
-        context (api/create-context "TEST")
 
         ^js file    (. context -currentFile)
         ^js page    (. context -currentPage)


### PR DESCRIPTION
Fixes dimension token application to a shape that is a child of flex layout.

**Before**
Application of a token changes position of a shape relatively to canvas.
**After**
Application of a token changes position of shape relatively to flex container, if shape is a child of it.