### PR TITLE
:recycle: Create hidden theme on token lib creation

### DIFF
--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -371,21 +371,10 @@
       [:type [:= :del-typography]]
       [:id ::sm/uuid]]]
 
-    [:add-temporary-token-theme
-     [:map {:title "AddTemporaryTokenThemeChange"}
-      [:type [:= :add-temporary-token-theme]]
-      [:token-theme ::ctot/token-theme]]]
-
     [:update-active-token-themes
      [:map {:title "UpdateActiveTokenThemes"}
       [:type [:= :update-active-token-themes]]
       [:theme-ids [:set :string]]]]
-
-    [:delete-temporary-token-theme
-     [:map {:title "DeleteTemporaryTokenThemeChange"}
-      [:type [:= :delete-temporary-token-theme]]
-      [:id ::sm/uuid]
-      [:name :string]]]
 
     [:add-token-theme
      [:map {:title "AddTokenThemeChange"}
@@ -1044,22 +1033,10 @@
                 (ctob/update-token-in-set lib' set-name token-name (fn [prev-token]
                                                                      (ctob/make-token (merge prev-token token)))))))))
 
-(defmethod process-change :add-temporary-token-theme
-  [data {:keys [token-theme]}]
-  (update data :tokens-lib #(-> %
-                                (ctob/ensure-tokens-lib)
-                                (ctob/add-theme (ctob/make-token-theme token-theme)))))
-
 (defmethod process-change :update-active-token-themes
   [data {:keys [theme-ids]}]
   (update data :tokens-lib #(-> % (ctob/ensure-tokens-lib)
                                 (ctob/set-active-themes theme-ids))))
-
-(defmethod process-change :delete-temporary-token-theme
-  [data {:keys [group name]}]
-  (update data :tokens-lib #(-> %
-                                (ctob/ensure-tokens-lib)
-                                (ctob/delete-theme group name))))
 
 (defmethod process-change :add-token-theme
   [data {:keys [token-theme]}]

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -767,13 +767,6 @@
         (update :undo-changes conj {:type :add-typography :typography prev-typography})
         (apply-changes-local))))
 
-(defn add-temporary-token-theme
-  [changes token-theme]
-  (-> changes
-      (update :redo-changes conj {:type :add-temporary-token-theme :token-theme token-theme})
-      (update :undo-changes conj {:type :delete-temporary-token-theme :id (:id token-theme) :name (:name token-theme)})
-      (apply-changes-local)))
-
 (defn update-active-token-themes
   [changes token-active-theme-ids prev-token-active-theme-ids]
   (-> changes

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -29,6 +29,7 @@
    [app.common.types.file :as ctf]
    [app.common.types.shape :as cts]
    [app.common.types.shape.shadow :as ctss]
+   [app.common.types.tokens-lib :as ctob]
    [app.common.uuid :as uuid]
    [clojure.set :as set]
    [cuerdas.core :as str]))
@@ -1225,6 +1226,17 @@
         (update :pages-index update-vals update-container)
         (update :components update-vals update-container))))
 
+(defmethod migrate-data "Add hidden theme"
+  [data _]
+  (letfn [(update-tokens-lib [tokens-lib]
+            (let [hidden-theme (ctob/get-hidden-theme tokens-lib)]
+              (if (nil? hidden-theme)
+                (ctob/add-theme tokens-lib (ctob/make-hidden-token-theme))
+                tokens-lib)))]
+    (if (contains? data :tokensLib)
+      (update data :tokens-lib update-tokens-lib)
+      data)))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1278,4 +1290,5 @@
          "legacy-62"
          "legacy-65"
          "legacy-66"
-         "legacy-67"]))
+         "legacy-67"
+         "Add hidden theme"]))

--- a/common/src/app/common/logic/tokens.cljc
+++ b/common/src/app/common/logic/tokens.cljc
@@ -4,24 +4,21 @@
    [app.common.types.tokens-lib :as ctob]))
 
 (defn generate-update-active-sets
-  "Copy the active sets from the currently active themes and move them to the hidden token theme and update the theme with `update-hidden-theme-fn`.
-
+  "Copy the active sets from the currently active themes and move them to the hidden token theme and update the theme with `update-theme-fn`.
   Use this for managing sets active state without having to modify a user created theme (\"no themes selected\" state in the ui)."
-  [changes tokens-lib update-hidden-theme-fn]
+  [changes tokens-lib update-theme-fn]
   (let [prev-active-token-themes (ctob/get-active-theme-paths tokens-lib)
         active-token-set-names   (ctob/get-active-themes-set-names tokens-lib)
 
-        prev-hidden-token-theme (ctob/get-hidden-theme tokens-lib)
-        hidden-token-theme      (-> (or (some-> prev-hidden-token-theme (ctob/set-sets active-token-set-names))
-                                        (ctob/make-hidden-token-theme :sets active-token-set-names))
-                                    (update-hidden-theme-fn))
+        prev-hidden-token-theme  (ctob/get-hidden-theme tokens-lib)
+
+        hidden-token-theme       (-> (some-> prev-hidden-token-theme (ctob/set-sets active-token-set-names))
+                                     (update-theme-fn))
 
         changes (-> changes
                     (pcb/update-active-token-themes #{ctob/hidden-token-theme-path} prev-active-token-themes))
 
-        changes (if prev-hidden-token-theme
-                  (pcb/update-token-theme changes hidden-token-theme prev-hidden-token-theme)
-                  (pcb/add-token-theme changes hidden-token-theme))]
+        changes (pcb/update-token-theme changes hidden-token-theme prev-hidden-token-theme)]
     changes))
 
 (defn generate-toggle-token-set

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -633,10 +633,6 @@
 (def valid-active-token-themes?
   (sm/validator schema:active-themes))
 
-(defn update-themes
-  [themes token-theme]
-  (update themes (:group token-theme) d/oassoc (:name token-theme) token-theme))
-
 ;; === Import / Export from DTCG format
 
 (def ^:private legacy-node?

--- a/common/test/common_tests/logic/token_test.cljc
+++ b/common/test/common_tests/logic/token_test.cljc
@@ -32,7 +32,6 @@
       (t/is (= #{} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib)))))
 
   (t/testing "toggling an inactive set will switch to hidden theme without user sets"
@@ -51,7 +50,6 @@
       (t/is (= #{} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib)))))
 
   (t/testing "toggling an set with hidden theme already active will toggle set in hidden theme"
@@ -68,12 +66,7 @@
           undo-lib (tht/get-tokens-lib undo)]
       (t/is (= (ctob/get-active-theme-paths redo-lib) (ctob/get-active-theme-paths undo-lib)))
 
-      (t/is (= #{"foo/bar"} (:sets (ctob/get-hidden-theme redo-lib))))
-
-      ;; Undo
-      ;; (t/is (some? (ctob/get-hidden-theme undo-lib)))
-      
-      )))
+      (t/is (= #{"foo/bar"} (:sets (ctob/get-hidden-theme redo-lib)))))))
 
 (t/deftest set-token-test
   (t/testing "delete token"
@@ -157,7 +150,6 @@
       (t/is (= #{"foo/bar/baz" "foo/bar/baz/baz-child"} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib)))))
 
   (t/testing "toggling set group with partially active sets inside will deactivate all child sets"
@@ -179,7 +171,6 @@
       (t/is (= #{ctob/hidden-token-theme-path} (ctob/get-active-theme-paths redo-lib)))
 
       ;; Undo
-      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib))))))
 
 (t/deftest generate-move-token-set-test

--- a/common/test/common_tests/logic/token_test.cljc
+++ b/common/test/common_tests/logic/token_test.cljc
@@ -32,7 +32,7 @@
       (t/is (= #{} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      (t/is (nil? (ctob/get-hidden-theme undo-lib)))
+      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib)))))
 
   (t/testing "toggling an inactive set will switch to hidden theme without user sets"
@@ -51,7 +51,7 @@
       (t/is (= #{} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      (t/is (nil? (ctob/get-hidden-theme undo-lib)))
+      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib)))))
 
   (t/testing "toggling an set with hidden theme already active will toggle set in hidden theme"
@@ -71,7 +71,9 @@
       (t/is (= #{"foo/bar"} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      (t/is (some? (ctob/get-hidden-theme undo-lib))))))
+      ;; (t/is (some? (ctob/get-hidden-theme undo-lib)))
+      
+      )))
 
 (t/deftest set-token-test
   (t/testing "delete token"
@@ -155,7 +157,7 @@
       (t/is (= #{"foo/bar/baz" "foo/bar/baz/baz-child"} (:sets (ctob/get-hidden-theme redo-lib))))
 
       ;; Undo
-      (t/is (nil? (ctob/get-hidden-theme undo-lib)))
+      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib)))))
 
   (t/testing "toggling set group with partially active sets inside will deactivate all child sets"
@@ -177,7 +179,7 @@
       (t/is (= #{ctob/hidden-token-theme-path} (ctob/get-active-theme-paths redo-lib)))
 
       ;; Undo
-      (t/is (nil? (ctob/get-hidden-theme undo-lib)))
+      ;; (t/is (nil? (ctob/get-hidden-theme undo-lib)))
       (t/is (= #{"/theme"} (ctob/get-active-theme-paths undo-lib))))))
 
 (t/deftest generate-move-token-set-test

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -12,7 +12,9 @@
    [app.common.time :as dt]
    [app.common.transit :as tr]
    [app.common.types.tokens-lib :as ctob]
-   [clojure.test :as t]))
+   [clojure.test :as t]
+   [app.common.pprint :as pp]
+   ))
 
 (defn setup-virtual-time
   [next]
@@ -990,7 +992,7 @@
             [node-group0 node-group1 node-group2]
             (ctob/get-children themes-tree)
 
-            [node-theme1]
+            [hidden-theme node-theme1]
             (ctob/get-children (second node-group0))
 
             [node-theme2 node-theme3]
@@ -999,19 +1001,24 @@
             [node-theme4]
             (ctob/get-children (second node-group2))]
 
-        (t/is (= (count themes-list) 4))
-        (t/is (= (:name (nth themes-list 0)) "token-theme-1"))
-        (t/is (= (:name (nth themes-list 1)) "token-theme-2"))
-        (t/is (= (:name (nth themes-list 2)) "token-theme-3"))
-        (t/is (= (:name (nth themes-list 3)) "token-theme-4"))
-        (t/is (= (:group (nth themes-list 0)) ""))
-        (t/is (= (:group (nth themes-list 1)) "group1"))
+        (t/is (= (count themes-list) 5))
+        (t/is (= (:name (nth themes-list 0)) "__PENPOT__HIDDEN__TOKEN__THEME__"))
+        (t/is (= (:name (nth themes-list 1)) "token-theme-1"))
+        (t/is (= (:name (nth themes-list 2)) "token-theme-2"))
+        (t/is (= (:name (nth themes-list 3)) "token-theme-3"))
+        (t/is (= (:name (nth themes-list 4)) "token-theme-4"))
+        (t/is (= (:group (nth themes-list 1)) ""))
         (t/is (= (:group (nth themes-list 2)) "group1"))
-        (t/is (= (:group (nth themes-list 3)) "group2"))
+        (t/is (= (:group (nth themes-list 3)) "group1"))
+        (t/is (= (:group (nth themes-list 4)) "group2"))
 
         (t/is (= (first node-group0) ""))
         (t/is (= (ctob/group? (second node-group0)) true))
-        (t/is (= (count (second node-group0)) 1))
+        (t/is (= (count (second node-group0)) 2))
+
+        (t/is (= (first hidden-theme) "__PENPOT__HIDDEN__TOKEN__THEME__"))
+        (t/is (= (ctob/group? (second hidden-theme)) false))
+        (t/is (= (:name (second hidden-theme)) "__PENPOT__HIDDEN__TOKEN__THEME__"))
 
         (t/is (= (first node-theme1) "token-theme-1"))
         (t/is (= (ctob/group? (second node-theme1)) false))
@@ -1049,10 +1056,12 @@
             themes-tree' (ctob/get-theme-tree tokens-lib')
             group1'      (get themes-tree' "group1")
             token-theme  (get-in themes-tree ["group1" "token-theme-2"])
-            token-theme' (get-in themes-tree' ["group1" "token-theme-2"])]
+            token-theme' (get-in themes-tree' ["group1" "token-theme-2"])
+            _ (pp/pprint group1')]
 
-        (t/is (= (ctob/theme-count tokens-lib') 4))
+        (t/is (= (ctob/theme-count tokens-lib') 5))
         (t/is (= (count group1') 2))
+        ;; Dont understand this change
         (t/is (= (d/index-of (keys group1') "token-theme-2") 0))
         (t/is (= (:name token-theme') "token-theme-2"))
         (t/is (= (:group token-theme') "group1"))
@@ -1088,7 +1097,7 @@
             token-theme  (get-in themes-tree ["group1" "token-theme-2"])
             token-theme' (get-in themes-tree' ["group1" "updated-name"])]
 
-        (t/is (= (ctob/theme-count tokens-lib') 4))
+        (t/is (= (ctob/theme-count tokens-lib') 5))
         (t/is (= (count group1') 2))
         (t/is (= (d/index-of (keys group1') "updated-name") 0))
         (t/is (= (:name token-theme') "updated-name"))
@@ -1117,7 +1126,7 @@
             token-theme  (get-in themes-tree ["group1" "token-theme-2"])
             token-theme' (get-in themes-tree' ["group2" "updated-name"])]
 
-        (t/is (= (ctob/theme-count tokens-lib') 3))
+        (t/is (= (ctob/theme-count tokens-lib') 4))
         (t/is (= (count group1') 1))
         (t/is (= (count group2') 1))
         (t/is (= (d/index-of (keys group2') "updated-name") 0))
@@ -1137,7 +1146,7 @@
             themes-tree' (ctob/get-theme-tree tokens-lib')
             token-theme' (get-in themes-tree' ["group1" "token-theme-2"])]
 
-        (t/is (= (ctob/theme-count tokens-lib') 1))
+        (t/is (= (ctob/theme-count tokens-lib') 2))
         (t/is (= (count themes-tree') 1))
         (t/is (nil? token-theme'))))))
 

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1057,7 +1057,6 @@
 
         (t/is (= (ctob/theme-count tokens-lib') 5))
         (t/is (= (count group1') 2))
-        ;; Dont understand this change
         (t/is (= (d/index-of (keys group1') "token-theme-2") 0))
         (t/is (= (:name token-theme') "token-theme-2"))
         (t/is (= (:group token-theme') "group1"))

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -12,9 +12,7 @@
    [app.common.time :as dt]
    [app.common.transit :as tr]
    [app.common.types.tokens-lib :as ctob]
-   [clojure.test :as t]
-   [app.common.pprint :as pp]
-   ))
+   [clojure.test :as t]))
 
 (defn setup-virtual-time
   [next]
@@ -78,7 +76,6 @@
       (t/is (= (:description token-set1) ""))
       (t/is (some? (:modified-at token-set1)))
       (t/is (empty? (:tokens token-set1)))
-
       (t/is (= (:name token-set2) "test-token-set-2"))
       (t/is (= (:description token-set2) "test description"))
       (t/is (= (:modified-at token-set2) now))
@@ -505,8 +502,8 @@
           token-themes' (ctob/get-themes tokens-lib')
           token-theme'  (ctob/get-theme tokens-lib' "" "test-token-theme")]
 
-      (t/is (= (ctob/theme-count tokens-lib') 1))
-      (t/is (= (first token-themes') token-theme))
+      (t/is (= (ctob/theme-count tokens-lib') 2))
+      (t/is (= (second token-themes') token-theme))
       (t/is (= token-theme' token-theme))))
 
   (t/testing "update-token-theme"
@@ -526,7 +523,7 @@
           token-theme   (ctob/get-theme tokens-lib "" "test-token-theme")
           token-theme'  (ctob/get-theme tokens-lib' "" "test-token-theme")]
 
-      (t/is (= (ctob/theme-count tokens-lib') 1))
+      (t/is (= (ctob/theme-count tokens-lib') 2))
       (t/is (= (:name token-theme') "test-token-theme"))
       (t/is (= (:description token-theme') "some description"))
       (t/is (dt/is-after? (:modified-at token-theme') (:modified-at token-theme)))))
@@ -544,7 +541,7 @@
           token-theme   (ctob/get-theme tokens-lib "" "test-token-theme")
           token-theme'  (ctob/get-theme tokens-lib' "" "updated-name")]
 
-      (t/is (= (ctob/theme-count tokens-lib') 1))
+      (t/is (= (ctob/theme-count tokens-lib') 2))
       (t/is (= (:name token-theme') "updated-name"))
       (t/is (dt/is-after? (:modified-at token-theme') (:modified-at token-theme)))))
 
@@ -558,7 +555,7 @@
 
           token-theme'  (ctob/get-theme tokens-lib' "" "updated-name")]
 
-      (t/is (= (ctob/theme-count tokens-lib') 0))
+      (t/is (= (ctob/theme-count tokens-lib') 1))
       (t/is (nil? token-theme'))))
 
   (t/testing "toggle-set-in-theme"
@@ -592,7 +589,7 @@
 
       (t/is (ctob/valid-tokens-lib? tokens-lib'))
       (t/is (= (ctob/set-count tokens-lib') 1))
-      (t/is (= (ctob/theme-count tokens-lib') 1))))
+      (t/is (= (ctob/theme-count tokens-lib') 2))))
 
   #?(:clj
      (t/testing "fressian-serialization"
@@ -608,7 +605,7 @@
 
          (t/is (ctob/valid-tokens-lib? tokens-lib'))
          (t/is (= (ctob/set-count tokens-lib') 1))
-         (t/is (= (ctob/theme-count tokens-lib') 1))))))
+         (t/is (= (ctob/theme-count tokens-lib') 2))))))
 
 (t/deftest grouping
   (t/testing "split-and-join"
@@ -1056,8 +1053,7 @@
             themes-tree' (ctob/get-theme-tree tokens-lib')
             group1'      (get themes-tree' "group1")
             token-theme  (get-in themes-tree ["group1" "token-theme-2"])
-            token-theme' (get-in themes-tree' ["group1" "token-theme-2"])
-            _ (pp/pprint group1')]
+            token-theme' (get-in themes-tree' ["group1" "token-theme-2"])]
 
         (t/is (= (ctob/theme-count tokens-lib') 5))
         (t/is (= (count group1') 2))

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -253,18 +253,21 @@
                 (ctob/add-token token))
 
             hidden-theme
-            (ctob/make-hidden-token-theme :sets [set-name])
+            (ctob/make-hidden-token-theme)
+
+            hidden-theme-with-set
+            (ctob/enable-set hidden-theme set-name)
 
             changes
             (pcb/add-token-set (pcb/empty-changes) token-set)
 
             changes
             (-> changes
-                (pcb/add-token-theme hidden-theme)
+                (pcb/update-token-theme hidden-theme-with-set hidden-theme)
                 (pcb/update-active-token-themes #{ctob/hidden-token-theme-path} #{}))]
 
-        (rx/of (set-selected-token-set-name set-name)
-               (dch/commit-changes changes))))))
+        (rx/of (dch/commit-changes changes)
+               (set-selected-token-set-name set-name))))))
 
 (defn create-token
   [params]


### PR DESCRIPTION
## Related ticket
This PR closes this task https://tree.taiga.io/project/penpot/task/10360
This PR also closes this task https://github.com/tokens-studio/penpot/issues/74

## Summary
In this PR we remove the creation of the hidden theme from the frontend, and place this creation on the token lib.

## Steps to reproduce and to test
Test code
1. Create a new file
2. Create a token
3. Check file data with `debug.dump_data()`
4. File data should have a token lib with a theme called `"__PENPOT__HIDDEN__TOKEN__THEME__"`


Test migration
1. Go to develop and comment this lines 
common/src/app/common/types/tokens_lib.cljc
![Screenshot from 2025-03-06 12-56-50](https://github.com/user-attachments/assets/83abaaa9-e271-4e16-8a69-642bc06819b7)
5. Create a file
6. Import the [tokens (2).json](https://github.com/user-attachments/files/19108341/tokens.2.json) token library from json
7. Open dev tools and check the file data `debug.dump_data()`
8.  file data should have a token lib but no themes
9. No checkout to this branch and go to the same file
10. without changing anything check file data again
11. Migration should be applied, token lib should have one theme
### Checklist

- [x] Provide a brief summary of the changes introduced
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable
- [x] Include screenshots or videos, if applicable
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->