### PR TITLE
:sparkles: Display tokens contextual menu in body through portal

### DIFF
--- a/frontend/src/app/main/ui/components/portal.cljs
+++ b/frontend/src/app/main/ui/components/portal.cljs
@@ -6,10 +6,11 @@
 
 (ns app.main.ui.components.portal
   (:require
+   [app.util.dom :as dom]
    [rumext.v2 :as mf]))
 
 (mf/defc portal-on-document*
   [{:keys [children]}]
   (mf/portal
    (mf/html [:* children])
-   (.-body js/document)))
+   (dom/get-body)))

--- a/frontend/src/app/main/ui/modal.cljs
+++ b/frontend/src/app/main/ui/modal.cljs
@@ -86,4 +86,4 @@
   (when-let [modal (mf/deref ref:modal)]
     (mf/portal
      (mf/html [:> modal-wrapper* {:data modal :key (dm/str (:id modal))}])
-     (.-body js/document))))
+     (dom/get-body))))

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -446,17 +446,22 @@
             (mf/set-ref-val! dropdown-direction-change* (inc (mf/ref-val dropdown-direction-change*)))))))
 
     ;; FIXME: perf optimization
-    [:& dropdown {:show is-open?
-                  :on-close #(st/emit! (dt/assign-token-context-menu nil))}
-     [:div {:class (stl/css :token-context-menu)
-            :data-testid "tokens-context-menu-for-token"
-            :ref dropdown-ref
-            :data-direction dropdown-direction
-            :style {:--bottom (if (= dropdown-direction "up")
-                                "40px"
-                                "unset")
-                    :--top (dm/str top "px")
-                    :left (dm/str left "px")}
-            :on-context-menu prevent-default}
-      (when mdata
-        [:& token-context-menu-tree (assoc mdata :width @width :direction dropdown-direction)])]]))
+
+    (when is-open?
+      (mf/portal
+       (mf/html
+        [:& dropdown {:show is-open?
+                      :on-close #(st/emit! (dt/assign-token-context-menu nil))}
+         [:div {:class (stl/css :token-context-menu)
+                :data-testid "tokens-context-menu-for-token"
+                :ref dropdown-ref
+                :data-direction dropdown-direction
+                :style {:--bottom (if (= dropdown-direction "up")
+                                    "40px"
+                                    "unset")
+                        :--top (dm/str top "px")
+                        :left (dm/str left "px")}
+                :on-context-menu prevent-default}
+          (when mdata
+            [:& token-context-menu-tree (assoc mdata :width @width :direction dropdown-direction)])]])
+       (dom/get-body)))))

--- a/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
@@ -139,4 +139,4 @@
            [:& theme-options {:active-theme-paths active-theme-paths
                               :themes themes
                               :on-close on-close-dropdown}]]])
-        (.-body js/document)))]))
+        (dom/get-body)))]))


### PR DESCRIPTION
This issue displays the contextual menu in tokens in the body, instead of the tokens context, through a portal. This will avoid common problems of layer priority. See issue

[tg-10381](https://tree.taiga.io/project/penpot/issue/10381)
