### PR TITLE
:bug: Fix scroll on storybook doc files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,9 @@
 
 ### :bug: Bugs fixed
 
+- Fix scroll on storybook docs [taiga #9962](https://tree.taiga.io/project/penpot/issue/9962)
 - Navigate tracking event firing multiple times [Taiga #10415](https://tree.taiga.io/project/penpot/issue/10415)
-- Fix problem with selection colors [Taiga #](https://tree.taiga.io/project/penpot/issue/10376)
+- Fix problem with selection colors [Taiga #10376](https://tree.taiga.io/project/penpot/issue/10376)
 
 ## 2.5.1
 

--- a/frontend/resources/styles/common/dependencies/storybook.scss
+++ b/frontend/resources/styles/common/dependencies/storybook.scss
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+.sb-show-main.sb-main-fullscreen {
+  overflow-y: auto;
+}

--- a/frontend/resources/styles/main-default.scss
+++ b/frontend/resources/styles/main-default.scss
@@ -13,6 +13,7 @@
 @import "common/dependencies/fonts";
 @import "common/dependencies/animations";
 @import "common/dependencies/highlight.scss";
+@import "common/dependencies/storybook.scss";
 
 @import "common/refactor/themes.scss";
 @import "common/refactor/design-tokens.scss";


### PR DESCRIPTION
### Related ticket

This PR closes https://tree.taiga.io/project/penpot/issue/9962

### Sumary
Doc files on storybook have lost scrollbar after upgrade

### Steps to reproduce
1. Start local enviroment
2. Go to http://localhost:6006/  
3. Check if there is scroll on button docs

### Checklist

- [x]  Provide a brief summary of the changes introduced
- [x]  Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable
- [x]  Include screenshots or videos, if applicable
- [x]  Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable
- [x] CI pass
