### PR TITLE
:sparkles: Recalculate token context-menu submenu position

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.scss
@@ -33,12 +33,12 @@
   overflow-y: auto;
 }
 
-.token-context-submenu[data-direction="up"] {
-  bottom: var(--dist);
+.token-context-submenu {
+  display: none;
 }
 
-.token-context-submenu[data-direction="down"] {
-  top: var(--dist);
+.token-context-submenu-top {
+  bottom: 80px;
 }
 
 .token-context-submenu {


### PR DESCRIPTION
Fixed:

- The parent component calculated if it fit the screen and set a position in the CSS accordingly, then passed this position to the children. The problem was that even if the parent did fit, sometimes the children did not, and the submenu was displayed off-screen.

This PR recalculates the position of the token context menu submenu.

- It calculates its position independently of the position of the submenu 
- it checks whether the menu fits on the screen or not, and recalculates its position.

More info: [tg-10380](https://tree.taiga.io/project/penpot/issue/10380)