### PR TITLE
:bug: Fix margin lost on layout creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,7 +45,7 @@
 - Fix chat icon overlaps "Show" button in carrousel section [Taiga #10542](https://tree.taiga.io/project/penpot/issue/10542)
 - Fix incorrect handling of background task result (now task rows are properly marked as completed)
 - Fix available size of resize handler [Taiga #10639](https://tree.taiga.io/project/penpot/issue/10639)
-
+- Fix margin lost on layout creation [taiga #7582](https://tree.taiga.io/project/penpot/issue/7582)
 
 ## 2.5.4
 

--- a/common/src/app/common/files/shapes_helpers.cljc
+++ b/common/src/app/common/files/shapes_helpers.cljc
@@ -38,7 +38,7 @@
     [shape changes]))
 
 (defn prepare-move-shapes-into-frame
-  [changes frame-id shapes objects remove-layout-data?]
+  [changes frame-id shapes objects remove-layou-data]
   (let [parent-id  (dm/get-in objects [frame-id :parent-id])
         shapes     (remove #(= % parent-id) shapes)
         to-move    (->> shapes
@@ -46,7 +46,7 @@
                         (not-empty))]
     (if to-move
       (-> changes
-          (cond-> (and remove-layout-data?
+          (cond-> (and remove-layou-data
                        (not (ctl/any-layout? objects frame-id)))
             (pcb/update-shapes shapes ctl/remove-layout-item-data))
           (pcb/update-shapes shapes #(cond-> % (cfh/frame-shape? %) (assoc :hide-in-viewer true)))


### PR DESCRIPTION
## Related ticket

This PR closes https://tree.taiga.io/project/penpot/issue/7582

## Sumary
When selecting layout items and create with them a new layout board, layout props dissappear. 

## Steps to reproduce

1. Create 2 shapes
2. Select them and press `shift + a` to create a flex board around them.
3. Select one of the shapes and add a margin to it.
4. Select the 2 shapes again and press `shift + a` again. This will create a new flex board inside the first one.

The shape with the margin should keep the margin.
Video on issue

### Checklist

- [x]  Provide a brief summary of the changes introduced
- [x]  Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable
- [x]  Include screenshots or videos, if applicable
- [x]  Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable
- [ ] Add integration test to solve the bug

