### PR TITLE
:wrench: Use with_state and with_current_state macros allowing static…

### DIFF
--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -1,23 +1,22 @@
 use crate::mem;
+use crate::with_current_shape;
 use crate::STATE;
 
 #[no_mangle]
 pub extern "C" fn clear_shape_text() {
-    let state = unsafe { STATE.as_mut() }.expect("Got an invalid state pointer");
-    if let Some(shape) = state.current_shape() {
+    with_current_shape!(state, |shape: &mut Shape| {
         shape.clear_text();
-    }
+    });
 }
 
 #[no_mangle]
 pub extern "C" fn add_text_paragraph() {
-    let state = unsafe { STATE.as_mut() }.expect("Got an invalid state pointer");
-    if let Some(shape) = state.current_shape() {
+    with_current_shape!(state, |shape: &mut Shape| {
         let res = shape.add_text_paragraph();
         if let Err(err) = res {
             eprintln!("{}", err);
         }
-    }
+    });
 }
 
 #[no_mangle]
@@ -27,11 +26,10 @@ pub extern "C" fn add_text_leaf() {
         String::from_utf8_unchecked(bytes) // TODO: handle this error
     };
 
-    let state = unsafe { STATE.as_mut() }.expect("got an invalid state pointer");
-    if let Some(shape) = state.current_shape() {
+    with_current_shape!(state, |shape: &mut Shape| {
         let res = shape.add_text_leaf(&text);
         if let Err(err) = res {
             eprintln!("{}", err);
         }
-    }
+    });
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10314

### Summary

This is a follow-up for https://github.com/penpot/penpot/pull/5992.

- It removes direct access to STATE and uses only the defined macros to access and manipulate it.
- It adds `#[allow(static_mut_refs)]` only into these macros (for now)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
