### PR TITLE
:bug: Fix rounded corners in image fill

### DIFF
--- a/render-wasm/src/render/fills.rs
+++ b/render-wasm/src/render/fills.rs
@@ -1,8 +1,8 @@
 use skia_safe::{self as skia, RRect};
 
 use super::{RenderState, SurfaceId};
-use crate::math::Rect;
-use crate::shapes::{Fill, ImageFill, Shape, Type};
+use crate::math::Rect as MathRect;
+use crate::shapes::{Fill, Frame, ImageFill, Rect, Shape, Type};
 
 fn draw_image_fill_in_container(
     render_state: &mut RenderState,
@@ -43,7 +43,7 @@ fn draw_image_fill_in_container(
     let scaled_width = width * scale;
     let scaled_height = height * scale;
 
-    let dest_rect = Rect::from_xywh(
+    let dest_rect = MathRect::from_xywh(
         container.left - (scaled_width - container_width) / 2.0,
         container.top - (scaled_height - container_height) / 2.0,
         scaled_width,
@@ -55,6 +55,16 @@ fn draw_image_fill_in_container(
 
     // Set the clipping rectangle to the container bounds
     match &shape.shape_type {
+        Type::Rect(Rect {
+            corners: Some(corners),
+        })
+        | Type::Frame(Frame {
+            corners: Some(corners),
+            ..
+        }) => {
+            let rrect: RRect = RRect::new_rect_radii(container, &corners);
+            canvas.clip_rrect(rrect, skia::ClipOp::Intersect, true);
+        }
         Type::Rect(_) | Type::Frame(_) => {
             canvas.clip_rect(container, skia::ClipOp::Intersect, true);
         }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10436

### Summary

This PR fixes image fill with rect shapes using radius by applying a rounded rect clip when shape has corners.

### Steps to reproduce 

* Create a rect > set radius > fill with an image 
* Before
![image](https://github.com/user-attachments/assets/ff28b0aa-b734-4420-a345-e2ea99ef5a01)

* After
![image](https://github.com/user-attachments/assets/744b5744-0427-4483-aa53-2e42ba1a916d)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
