### PR TITLE
:sparkles: Add a maxlenght to input CRUD tokens

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -492,6 +492,7 @@
            :auto-focus true
            :label (tr "workspace.token.token-name")
            :default-value @name-ref
+           :maxlength 256
            :on-blur on-blur-name
            :on-change on-update-name}])
 
@@ -514,6 +515,7 @@
         {:id "token-value"
          :placeholder (tr "workspace.token.enter-token-value")
          :label (tr "workspace.token.token-value")
+         :maxlength 256
          :default-value @value-ref
          :ref value-input-ref
          :on-change on-update-value
@@ -532,6 +534,7 @@
         {:id "token-description"
          :placeholder (tr "workspace.token.enter-token-description")
          :label (tr "workspace.token.token-description")
+         :maxlength 256
          :default-value @description-ref
          :on-blur on-update-description
          :on-change on-update-description}]


### PR DESCRIPTION
### Related Ticket

- https://tree.taiga.io/project/penpot/issue/10447
- https://tree.taiga.io/project/penpot/issue/10441

### Summary

On tokens crud, add a max lenght of 256 characters to the name and value input in order to avoid blocking the UI with extreme large character values

Once the user reach the max lenght, the input stop accepting characters.   
If the user paste a large number, cut it. 

### How to reproduce

Explained here: https://tree.taiga.io/project/penpot/issue/10441
