### PR TITLE
:tada: Add id to token theme

### DIFF
--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1237,6 +1237,20 @@
       (update data :tokens-lib update-tokens-lib)
       data)))
 
+(defmethod migrate-data "Add token theme id"
+  [data _]
+  (letfn [(update-tokens-lib [tokens-lib]
+            (let [themes (ctob/get-themes tokens-lib)]
+              (reduce (fn [lib theme]
+                        (if (:id theme)
+                          lib
+                          (ctob/update-theme lib (:group theme) (:name theme) #(assoc % :id (str (uuid/next))))))
+                      tokens-lib
+                      themes)))]
+    (if (contains? data :tokens-lib)
+      (update data :tokens-lib update-tokens-lib)
+      data)))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1291,4 +1305,5 @@
          "legacy-65"
          "legacy-66"
          "legacy-67"
-         "Add hidden theme"]))
+         "Add hidden theme"
+         "Add token theme id"]))

--- a/common/src/app/common/types/token_theme.cljc
+++ b/common/src/app/common/types/token_theme.cljc
@@ -15,6 +15,7 @@
   [:group :string]
   [:description [:maybe :string]]
   [:is-source :boolean]
+  [:id :string]
   [:modified-at {:optional true} ::sm/inst]
   [:sets :any]])
 

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -600,6 +600,7 @@
   (-> attrs
       (assoc :group hidden-token-theme-group)
       (assoc :name hidden-token-theme-name)
+      (assoc :id (str uuid/zero))
       (make-token-theme)))
 
 ;; === TokenThemes (collection)

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -13,6 +13,7 @@
    [app.common.time :as dt]
    [app.common.transit :as t]
    [app.common.types.token :as cto]
+   [app.common.uuid :as uuid]
    [clojure.set :as set]
    [clojure.walk :as walk]
    [cuerdas.core :as str]))
@@ -496,13 +497,14 @@
   (theme-matches-group-name [_ group name] "if a theme matches the given group & name")
   (hidden-temporary-theme? [_] "if a theme is the (from the user ui) hidden temporary theme"))
 
-(defrecord TokenTheme [name group description is-source modified-at sets]
+(defrecord TokenTheme [name group description is-source id modified-at sets]
   ITokenTheme
   (set-sets [_ set-names]
     (TokenTheme. name
                  group
                  description
                  is-source
+                 id
                  (dt/now)
                  set-names))
 
@@ -529,6 +531,7 @@
                    group
                    description
                    is-source
+                   id
                    (dt/now)
                    (conj (disj sets prev-set-name) set-name))
       this))
@@ -553,6 +556,7 @@
    [:group :string]
    [:description [:maybe :string]]
    [:is-source [:maybe :boolean]]
+   [:id :string]
    [:modified-at ::sm/inst]
    [:sets [:set {:gen/max 5} :string]]])
 
@@ -583,10 +587,11 @@
   [& {:as attrs}]
   (-> attrs
       (update :group d/nilv top-level-theme-group-name)
+      (update :description d/nilv "")
       (update :is-source d/nilv false)
+      (update :id d/nilv (str (uuid/next)))
       (update :modified-at #(or % (dt/now)))
       (update :sets set)
-      (update :description d/nilv "")
       (check-token-theme-attrs)
       (map->TokenTheme)))
 
@@ -1269,11 +1274,12 @@ Will return a value that matches this schema:
       (if-let [themes-data (seq themes-data)]
         (as-> lib' $
           (reduce
-           (fn [lib {:strs [name group description is-source modified-at sets]}]
+           (fn [lib {:strs [name group description is-source id modified-at sets]}]
              (add-theme lib (TokenTheme. name
                                          (or group "")
                                          description
                                          (some? is-source)
+                                         (or id (str (uuid/next)))
                                          (or (some-> modified-at
                                                      (dt/parse-instant))
                                              (dt/now))

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1257,7 +1257,7 @@
                                                                           :value "{accent.default}"})}))
                             (ctob/add-theme (ctob/make-token-theme :name "theme-1"
                                                                    :group "group-1"
-                                                                   :id "test-id"
+                                                                   :id "test-id-00"
                                                                    :modified-at now
                                                                    :sets #{"core"})))
              result   (ctob/encode-dtcg tokens-lib)
@@ -1265,7 +1265,7 @@
                                    "group" "group-1"
                                    "is-source" false
                                    "modified-at" now
-                                   "id" "test-id"
+                                   "id" "test-id-00"
                                    "name" "theme-1"
                                    "selectedTokenSets" {"core" "enabled"}}]
                        "$metadata" {"tokenSetOrder" ["core"]
@@ -1288,7 +1288,7 @@
 
      (t/testing "encode-decode-dtcg-json"
        (with-redefs [dt/now (constantly #inst "2024-10-16T12:01:20.257840055-00:00")]
-         (let [tokens-lib (-> (ctob/make-tokens-lib) ;;Aqui se genera un id al default theme
+         (let [tokens-lib (-> (ctob/make-tokens-lib)
                               (ctob/add-set (ctob/make-token-set :name "core"
                                                                  :tokens {"colors.red.600"
                                                                           (ctob/make-token
@@ -1377,7 +1377,7 @@
                                                                           :value "{accent.default}"})}))
                             (ctob/add-theme (ctob/make-token-theme :name "theme-1"
                                                                    :group "group-1"
-                                                                   :id "test-id"
+                                                                   :id "test-id-01"
                                                                    :modified-at now
                                                                    :sets #{"core"}))
                             (ctob/toggle-theme-active? "group-1" "theme-1"))
@@ -1386,7 +1386,7 @@
                                    "group" "group-1"
                                    "is-source" false
                                    "modified-at" now
-                                   "id" "test-id"
+                                   "id" "test-id-01"
                                    "name" "theme-1"
                                    "selectedTokenSets" {"core" "enabled"}}]
                        "$metadata" {"tokenSetOrder" ["core"]

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1257,6 +1257,7 @@
                                                                           :value "{accent.default}"})}))
                             (ctob/add-theme (ctob/make-token-theme :name "theme-1"
                                                                    :group "group-1"
+                                                                   :id "test-id"
                                                                    :modified-at now
                                                                    :sets #{"core"})))
              result   (ctob/encode-dtcg tokens-lib)
@@ -1264,6 +1265,7 @@
                                    "group" "group-1"
                                    "is-source" false
                                    "modified-at" now
+                                   "id" "test-id"
                                    "name" "theme-1"
                                    "selectedTokenSets" {"core" "enabled"}}]
                        "$metadata" {"tokenSetOrder" ["core"]
@@ -1286,7 +1288,7 @@
 
      (t/testing "encode-decode-dtcg-json"
        (with-redefs [dt/now (constantly #inst "2024-10-16T12:01:20.257840055-00:00")]
-         (let [tokens-lib (-> (ctob/make-tokens-lib)
+         (let [tokens-lib (-> (ctob/make-tokens-lib) ;;Aqui se genera un id al default theme
                               (ctob/add-set (ctob/make-token-set :name "core"
                                                                  :tokens {"colors.red.600"
                                                                           (ctob/make-token
@@ -1304,6 +1306,7 @@
                                                                            {:name "button.primary.background"
                                                                             :type :color
                                                                             :value "{accent.default}"})})))
+
                encoded (ctob/encode-dtcg tokens-lib)
                with-prev-tokens-lib (ctob/decode-dtcg-json tokens-lib encoded)
                with-empty-tokens-lib (ctob/decode-dtcg-json (ctob/ensure-tokens-lib nil) encoded)]
@@ -1374,6 +1377,7 @@
                                                                           :value "{accent.default}"})}))
                             (ctob/add-theme (ctob/make-token-theme :name "theme-1"
                                                                    :group "group-1"
+                                                                   :id "test-id"
                                                                    :modified-at now
                                                                    :sets #{"core"}))
                             (ctob/toggle-theme-active? "group-1" "theme-1"))
@@ -1382,6 +1386,7 @@
                                    "group" "group-1"
                                    "is-source" false
                                    "modified-at" now
+                                   "id" "test-id"
                                    "name" "theme-1"
                                    "selectedTokenSets" {"core" "enabled"}}]
                        "$metadata" {"tokenSetOrder" ["core"]

--- a/frontend/playwright/data/workspace/get-file-tokens.json
+++ b/frontend/playwright/data/workspace/get-file-tokens.json
@@ -1748,6 +1748,7 @@
                         "~:group": "Core",
                         "~:description": null,
                         "~:is-source": false,
+                        "~:id": "core-light",
                         "~:modified-at": "~m1737542746842",
                         "~:sets": {
                           "~#set": ["LightDark/light", "theme", "core"]
@@ -1763,6 +1764,7 @@
                         "~:group": "Core",
                         "~:description": null,
                         "~:is-source": false,
+                        "~:id": "core-dark",
                         "~:modified-at": "~m1737542746842",
                         "~:sets": {
                           "~#set": ["LightDark/dark", "theme", "core"]
@@ -1785,6 +1787,7 @@
                         "~:group": "",
                         "~:description": null,
                         "~:is-source": false,
+                        "~:id": "hidden-theme",
                         "~:modified-at": "~m1737542683555",
                         "~:sets": {
                           "~#set": ["LightDark/light", "theme", "core"]


### PR DESCRIPTION
### Related Ticket

This PR closes this tasks https://tree.taiga.io/project/penpot/task/10359

### Summary

In this PR we are adding and ID to each theme in the tokens lib

### Steps to reproduce 
To reproduce, open a file with a token lib and check the file data
1. Open a file with a token lib
2. Open dev tools
3. Write `debug.dump_data()`
4. Check in themes that each theme has an ID

You can also check with an empty file and create a new token or importing a token json. 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
