### PR TITLE
:recycle: Simplifies RPC pattern for token sets

### DIFF
--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -447,6 +447,13 @@
       [:type [:= :set-tokens-lib]]
       [:tokens-lib :any]]]
 
+    [:set-token-set
+     [:map {:title "SetTokenSetChange"}
+      [:type [:= :set-token-set]]
+      [:set-name :string]
+      [:group? :boolean]
+      [:token-set :any #_[:maybe ::ctob/token-set]]]]
+
     [:set-token
      [:map {:title "SetTokenChange"}
       [:type [:= :set-token]]
@@ -1032,6 +1039,24 @@
                 :else
                 (ctob/update-token-in-set lib' set-name token-name (fn [prev-token]
                                                                      (ctob/make-token (merge prev-token token)))))))))
+
+(defmethod process-change :set-token-set
+  [data {:keys [set-name group? token-set]}]
+  (update data :tokens-lib
+          (fn [lib]
+            (let [lib' (ctob/ensure-tokens-lib lib)]
+              (cond
+                (not token-set)
+                (if group?
+                  (ctob/delete-set-group lib' set-name)
+                  (ctob/delete-set lib' set-name))
+
+                (not (ctob/get-set lib' set-name))
+                (ctob/add-set lib' (ctob/make-token-set token-set))
+
+                :else
+                (ctob/update-set lib' set-name (fn [prev-token-set]
+                                                 (ctob/make-token-set (merge prev-token-set token-set)))))))))
 
 (defmethod process-change :update-active-token-themes
   [data {:keys [theme-ids]}]

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -394,11 +394,6 @@
       [:group :string]
       [:name :string]]]
 
-    [:add-token-set
-     [:map {:title "AddTokenSetChange"}
-      [:type [:= :add-token-set]]
-      [:token-set ::ctot/token-set]]]
-
     [:add-token-sets
      [:map {:title "AddTokenSetsChange"}
       [:type [:= :add-token-sets]]
@@ -410,11 +405,6 @@
       [:set-group-path [:vector :string]]
       [:set-group-fname :string]]]
 
-    [:mod-token-set
-     [:map {:title "ModTokenSetChange"}
-      [:type [:= :mod-token-set]]
-      [:name :string]
-      [:token-set ::ctot/token-set]]]
 
     [:move-token-set-before
      [:map {:title "MoveTokenSetBefore"}
@@ -432,16 +422,6 @@
       [:before-path [:maybe [:vector :string]]]
       [:before-group? [:maybe :boolean]]]]
 
-    [:del-token-set
-     [:map {:title "DelTokenSetChange"}
-      [:type [:= :del-token-set]]
-      [:name :string]]]
-
-    [:del-token-set-path
-     [:map {:title "DelTokenSetPathChange"}
-      [:type [:= :del-token-set-path]]
-      [:path :string]]]
-
     [:set-tokens-lib
      [:map {:title "SetTokensLib"}
       [:type [:= :set-tokens-lib]]
@@ -452,7 +432,7 @@
       [:type [:= :set-token-set]]
       [:set-name :string]
       [:group? :boolean]
-      [:token-set :any #_[:maybe ::ctob/token-set]]]]
+      [:token-set [:maybe ::ctot/token-set]]]]
 
     [:set-token
      [:map {:title "SetTokenChange"}
@@ -1084,12 +1064,6 @@
                                 (ctob/ensure-tokens-lib)
                                 (ctob/delete-theme group name))))
 
-(defmethod process-change :add-token-set
-  [data {:keys [token-set]}]
-  (update data :tokens-lib #(-> %
-                                (ctob/ensure-tokens-lib)
-                                (ctob/add-set (ctob/make-token-set token-set)))))
-
 (defmethod process-change :add-token-sets
   [data {:keys [token-sets]}]
   (update data :tokens-lib #(-> %
@@ -1103,14 +1077,6 @@
                                  (ctob/ensure-tokens-lib)
                                  (ctob/rename-set-group set-group-path set-group-fname)))))
 
-(defmethod process-change :mod-token-set
-  [data {:keys [name token-set]}]
-  (update data :tokens-lib (fn [lib]
-                             (-> lib
-                                 (ctob/ensure-tokens-lib)
-                                 (ctob/update-set name (fn [prev-set]
-                                                         (merge prev-set (dissoc token-set :tokens))))))))
-
 (defmethod process-change :move-token-set-before
   [data {:keys [from-path to-path before-path before-group?] :as changes}]
   (update data :tokens-lib #(-> %
@@ -1122,18 +1088,6 @@
   (update data :tokens-lib #(-> %
                                 (ctob/ensure-tokens-lib)
                                 (ctob/move-set-group from-path to-path before-path before-group?))))
-
-(defmethod process-change :del-token-set
-  [data {:keys [name]}]
-  (update data :tokens-lib #(-> %
-                                (ctob/ensure-tokens-lib)
-                                (ctob/delete-set-path name))))
-
-(defmethod process-change :del-token-set-path
-  [data {:keys [path]}]
-  (update data :tokens-lib #(-> %
-                                (ctob/ensure-tokens-lib)
-                                (ctob/delete-set-path path))))
 
 ;; === Operations
 

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -908,6 +908,32 @@
                                       :token nil}))
         (apply-changes-local))))
 
+(defn set-token-set [changes set-name group? token-set]
+  (assert-library! changes)
+  (let [library-data (::library-data (meta changes))
+        prev-token-set (some-> (get library-data :tokens-lib)
+                               (ctob/get-set set-name))]
+    (-> changes
+        (update :redo-changes conj {:type :set-token-set
+                                    :set-name set-name
+                                    :token-set token-set
+                                    :group? group?})
+        (update :undo-changes conj (if prev-token-set
+                                     {:type :set-token-set
+                                      :set-name (or
+                                                 ;; Undo of edit
+                                                 (:name token-set)
+                                                 ;; Undo of delete
+                                                 set-name)
+                                      :token-set prev-token-set
+                                      :group? group?}
+                                     ;; Undo of create
+                                     {:type :set-token-set
+                                      :set-name set-name
+                                      :token-set nil
+                                      :group? group?}))
+        (apply-changes-local))))
+
 (defn add-component
   ([changes id path name new-shapes updated-shapes main-instance-id main-instance-page]
    (add-component changes id path name new-shapes updated-shapes main-instance-id main-instance-page nil nil nil))

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -803,13 +803,6 @@
         (update :undo-changes conj {:type :add-token-theme :token-theme prev-token-theme})
         (apply-changes-local))))
 
-(defn add-token-set
-  [changes token-set]
-  (-> changes
-      (update :redo-changes conj {:type :add-token-set :token-set token-set})
-      (update :undo-changes conj {:type :del-token-set :name (:name token-set)})
-      (apply-changes-local)))
-
 (defn rename-token-set-group
   [changes set-group-path set-group-fname]
   (let [undo-path (ctob/replace-last-path-name set-group-path set-group-fname)
@@ -817,29 +810,6 @@
     (-> changes
         (update :redo-changes conj {:type :rename-token-set-group :set-group-path set-group-path :set-group-fname set-group-fname})
         (update :undo-changes conj {:type :rename-token-set-group :set-group-path undo-path :set-group-fname undo-fname})
-        (apply-changes-local))))
-
-(defn update-token-set
-  [changes token-set prev-token-set]
-  (-> changes
-      (update :redo-changes conj {:type :mod-token-set :name (:name prev-token-set) :token-set token-set})
-      (update :undo-changes conj {:type :mod-token-set :name (:name token-set) :token-set (or prev-token-set token-set)})
-      (apply-changes-local)))
-
-(defn delete-token-set-path
-  [changes group? path]
-  (assert-library! changes)
-  (let [;; TODO Move leaking prefix to library
-        prefixed-path (if group?
-                        (ctob/set-group-path->set-group-prefixed-path path)
-                        (ctob/set-full-path->set-prefixed-full-path path))
-        prefixed-path-str (ctob/join-set-path prefixed-path)
-        library-data (::library-data (meta changes))
-        prev-token-sets (some-> (get library-data :tokens-lib)
-                                (ctob/get-path-sets prefixed-path-str))]
-    (-> changes
-        (update :redo-changes conj {:type :del-token-set-path :path prefixed-path-str})
-        (update :undo-changes conj {:type :add-token-sets :token-sets prev-token-sets})
         (apply-changes-local))))
 
 (defn move-token-set-before

--- a/common/src/app/common/types/token_theme.cljc
+++ b/common/src/app/common/types/token_theme.cljc
@@ -24,4 +24,4 @@
   [:name :string]
   [:description {:optional true} [:maybe :string]]
   [:modified-at {:optional true} ::sm/inst]
-  [:tokens :any]])
+  [:tokens {:optional true} :any]])

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -152,7 +152,7 @@
 (defn update-token-set [set-name token-set]
   (ptk/reify ::update-token-set
     ptk/WatchEvent
-    (watch [it state _]
+    (watch [it _ _]
       (let [changes (-> (pcb/empty-changes it)
                         (pcb/set-token-set set-name false token-set))]
         (rx/of

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -152,8 +152,10 @@
 (defn update-token-set [set-name token-set]
   (ptk/reify ::update-token-set
     ptk/WatchEvent
-    (watch [it _ _]
-      (let [changes (-> (pcb/empty-changes it)
+    (watch [it state _]
+      (let [data (dsh/lookup-file-data state)
+            changes (-> (pcb/empty-changes it)
+                        (pcb/with-library-data data)
                         (pcb/set-token-set set-name false token-set))]
         (rx/of
          (set-selected-token-set-name (:name token-set))
@@ -249,8 +251,10 @@
   [token]
   (ptk/reify ::create-token-and-set
     ptk/WatchEvent
-    (watch [_ _ _]
+    (watch [_ state _]
       (let [set-name   "Global"
+
+            data    (dsh/lookup-file-data state)
 
             token-set
             (-> (ctob/make-token-set :name set-name)
@@ -263,7 +267,9 @@
             (ctob/enable-set hidden-theme set-name)
 
             changes
-            (pcb/set-token-set (pcb/empty-changes) set-name false token-set)
+            (-> (pcb/empty-changes)
+                (pcb/with-library-data data)
+                (pcb/set-token-set set-name false token-set))
 
             changes
             (-> changes

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -127,10 +127,12 @@
       (update state :workspace-tokens dissoc :token-set-new-path))
 
     ptk/WatchEvent
-    (watch [it _ _]
-      (let [token-set (update token-set :name #(if (empty? %) set-name (ctob/join-set-path [% set-name])))
+    (watch [it state _]
+      (let [data (dsh/lookup-file-data state)
+            token-set-name #(if (empty? %) set-name (ctob/join-set-path [% set-name]))
             changes   (-> (pcb/empty-changes it)
-                          (pcb/add-token-set token-set))]
+                          (pcb/with-library-data data)
+                          (pcb/set-token-set token-set false token-set-name))]
         (rx/of (set-selected-token-set-name (:name token-set))
                (dch/commit-changes changes))))))
 

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -263,7 +263,7 @@
             (ctob/enable-set hidden-theme set-name)
 
             changes
-            (pcb/add-token-set (pcb/empty-changes) token-set)
+            (pcb/set-token-set (pcb/empty-changes) set-name false token-set)
 
             changes
             (-> changes

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -492,7 +492,7 @@
            :auto-focus true
            :label (tr "workspace.token.token-name")
            :default-value @name-ref
-           :maxlength 256
+           :max-length 256
            :on-blur on-blur-name
            :on-change on-update-name}])
 
@@ -515,7 +515,7 @@
         {:id "token-value"
          :placeholder (tr "workspace.token.enter-token-value")
          :label (tr "workspace.token.token-value")
-         :maxlength 256
+         :max-length 256
          :default-value @value-ref
          :ref value-input-ref
          :on-change on-update-value
@@ -534,7 +534,7 @@
         {:id "token-description"
          :placeholder (tr "workspace.token.enter-token-description")
          :label (tr "workspace.token.token-description")
-         :maxlength 256
+         :max-length 256
          :default-value @description-ref
          :on-blur on-update-description
          :on-change on-update-description}]


### PR DESCRIPTION
Closes https://github.com/tokens-studio/penpot/issues/73 of parent issue: https://github.com/tokens-studio/penpot/issues/66