### PR TITLE
:bug: Fix storybook icons list scroll

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fix scroll on storybook docs [taiga #9962](https://tree.taiga.io/project/penpot/issue/9962)
 - Navigate tracking event firing multiple times [Taiga #10415](https://tree.taiga.io/project/penpot/issue/10415)
 - Fix problem with selection colors [Taiga #10376](https://tree.taiga.io/project/penpot/issue/10376)
+- Fix scroll on storybook icons list [taiga #9962](https://tree.taiga.io/project/penpot/issue/9962)
 
 ## 2.5.1
 

--- a/frontend/resources/styles/common/dependencies/storybook.scss
+++ b/frontend/resources/styles/common/dependencies/storybook.scss
@@ -4,6 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
-.sb-show-main.sb-main-fullscreen {
+.sb-show-main.sb-main-fullscreen,
+.sb-show-main.sb-main-padded {
   overflow-y: auto;
 }


### PR DESCRIPTION
### Related Ticket

This PR closes this tasks https://tree.taiga.io/project/penpot/issue/9962

### Summary
Add scroll to icons list on storybook

### Steps to reproduce 
Go to the storybook and check the foundations -> assets -> icon -> all page and check if there is a scroll
![Screenshot from 2025-03-10 14-04-29](https://github.com/user-attachments/assets/a962098e-1629-4419-bf34-86cb64960846)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
