### PR TITLE
:tada: Avoid setting token to group shapes

### DIFF
--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1251,6 +1251,21 @@
       (update data :tokens-lib update-tokens-lib)
       data)))
 
+(defmethod migrate-data "Remove tokens from groups"
+  [data _]
+  (letfn [(update-object [object]
+            (cond-> object
+              (and (= :group (:type object))
+                   (contains? (:applied-tokens object) :fill))
+              (assoc :fills [])
+              (and (= :group (:type object))
+                   (contains? object :applied-tokens))
+              (dissoc :applied-tokens)))
+
+          (update-page [page]
+            (d/update-when page :objects update-vals update-object))]
+    (update data :pages-index update-vals update-page)))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1306,4 +1321,5 @@
          "legacy-66"
          "legacy-67"
          "Ensure hidden theme"
-         "Add token theme id"]))
+         "Add token theme id"
+         "Remove tokens from groups"]))

--- a/frontend/src/app/main/ui/workspace/tokens/changes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/changes.cljs
@@ -55,11 +55,13 @@
                    (st/emit! (ptk/event ::ev/event {::ev/name "apply-tokens"}))
                    (dwu/start-undo-transaction undo-id)
                    (dwsh/update-shapes shape-ids (fn [shape]
-                                                   (cond-> shape
-                                                     attributes-to-remove
-                                                     (update :applied-tokens #(apply (partial dissoc %) attributes-to-remove))
-                                                     :always
-                                                     (update :applied-tokens merge tokenized-attributes))))
+                                                   (if (= :group (:type shape))
+                                                     shape
+                                                     (cond-> shape
+                                                       attributes-to-remove
+                                                       (update :applied-tokens #(apply (partial dissoc %) attributes-to-remove))
+                                                       :always
+                                                       (update :applied-tokens merge tokenized-attributes)))))
                    (when on-update-shape
                      (on-update-shape resolved-value shape-ids attributes))
                    (dwu/commit-undo-transaction undo-id))))))))))

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -371,8 +371,10 @@
 
 (mf/defc menu-tree
   [{:keys [selected-shapes submenu-offset type errors] :as context-data}]
-  (let [entries (if (and (not (some? errors))
-                         (seq selected-shapes))
+  (let [shape-types (into #{} (map :type selected-shapes))
+        entries (if (and (not (some? errors))
+                         (seq selected-shapes)
+                         (not= shape-types #{:group}))
                   (if (some? type)
                     (submenu-actions-selection-actions context-data)
                     (selection-actions context-data))


### PR DESCRIPTION
### Related Ticket

This PR closes [This issue](https://tree.taiga.io/project/penpot/issue/10443)

### Summary

We do not allow apply a token to a group on the MVP

### Steps to reproduce 

1. Create a color token
2. Create some shapes
3. Group them
4. Select group and apply the token to it by clicking on the token pill
5. Applying a token by context menu is not posible either

Token should not be applied
Color should be visible on selected colors


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
