### PR TITLE
:bug: Fix tooltip update when set changes

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -240,10 +240,11 @@
         ;; FIXME: missing deps
         on-hover
         (mf/use-fn
-         (mf/deps selected-shapes is-viewer?)
+         (mf/deps selected-shapes is-viewer? active-theme-tokens token half-applied? no-valid-value ref-not-in-active-set)
          (fn [event]
            (let [node  (dom/get-current-target event)
-                 title (generate-tooltip is-viewer? (first selected-shapes) token
+                 theme-token (get active-theme-tokens (:name token))
+                 title (generate-tooltip is-viewer? (first selected-shapes) theme-token
                                          half-applied? no-valid-value ref-not-in-active-set)]
              (dom/set-attribute! node "title" title))))]
 


### PR DESCRIPTION
### Related Ticket

This Pr closes [this issue](https://tree.taiga.io/project/penpot/issue/10439)

### Summary

token pill tooltip should update on set change.

### Steps to reproduce 

1. Import json provided on issue
2. Activate all sets
3. Create a rectangle and apply "background" token to fill
4. Check tooltip on token pill
![Screenshot from 2025-03-11 16-51-07](https://github.com/user-attachments/assets/2fbebecd-7cde-4b59-86b9-00aaedb44ed9)
5. Now toggle off Dark theme and check tooltip again

Tooltip must show the updated value
![Screenshot from 2025-03-11 16-51-54](https://github.com/user-attachments/assets/0efc60a6-4728-48b9-9e5b-48cf670e74be)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
