### PR TITLE
:bug: Fix clicking on a comment at the viewer's sidebar is not opening threads

### DIFF
--- a/frontend/src/app/main/ui/workspace/comments.cljs
+++ b/frontend/src/app/main/ui/workspace/comments.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.main.data.comments :as dcmt]
+   [app.main.data.event :as ev]
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.comments :as dwcm]
    [app.main.refs :as refs]
@@ -112,9 +113,11 @@
 
         on-thread-click
         (mf/use-fn
-         (mf/deps page-id)
+         (mf/deps page-id from-viewer)
          (fn [thread]
-           (st/emit! (dwcm/navigate-to-comment thread))))]
+           (if from-viewer
+             (st/emit! (with-meta (dcmt/open-thread thread) {::ev/origin "viewer"}))
+             (st/emit! (dwcm/navigate-to-comment thread)))))]
 
     [:div  {:class (stl/css-case :comments-section true
                                  :from-viewer  from-viewer)}


### PR DESCRIPTION
### Related Ticket

Fixes Taiga issue [#10465](https://tree.taiga.io/project/penpot/issue/10465)

### Summary

Clicking on a comment in the viewer's comment sidebar causes an error in the application (it shows the screen to request access). This is because it tries to redirect the user to the workspace, and it does not have any info about the current user and their privileges.

With this fix, the redirection is avoided and  the thread is opened in the viewer, exactly the same way as it is done in the workspace.