### PR TITLE
:sparkles: Add a warning tooltip over import tokens button

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -22,6 +22,7 @@
    [app.main.ui.context :as ctx]
    [app.main.ui.ds.buttons.button :refer [button*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.foundations.assets.icon :as i]
    [app.main.ui.ds.foundations.typography.text :refer [text*]]
    [app.main.ui.hooks :as h]
    [app.main.ui.hooks.resize :refer [use-resize-hook]]
@@ -408,7 +409,10 @@
       (when can-edit?
         [:> dropdown-menu-item* {:class (stl/css :import-export-menu-item)
                                  :on-click on-display-file-explorer}
-         (tr "labels.import")])
+         [:div {:class (stl/css :import-menu-item)}
+          [:div (tr "labels.import")]
+          [:div {:class (stl/css :import-export-menu-item-icon) :title (tr "workspace.token.import-tooltip")}
+           [:> i/icon* {:icon-id i/info :aria-label (tr "workspace.token.import-tooltip")}]]]])
       [:> dropdown-menu-item* {:class (stl/css :import-export-menu-item)
                                :on-click on-export}
        (tr "labels.export")]]]))

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
@@ -129,6 +129,19 @@
   }
 }
 
+.import-export-menu-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.import-menu-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1;
+}
+
 .theme-select-wrapper {
   display: grid;
   grid-template-columns: 1fr 0.28fr;

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6789,6 +6789,10 @@ msgstr "TOKENS -  %s"
 msgid "workspace.token.tools"
 msgstr "Tools"
 
+#: src/app/main/ui/workspace/tokens/sidebar.cljs:415
+msgid "workspace.token.import-tooltip"
+msgstr "Importing a JSON file will override all your current tokens, sets and themes"
+
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:123
 msgid "workspace.token.value-not-valid"
 msgstr "The value is not valid"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6782,6 +6782,10 @@ msgstr "Valor"
 msgid "workspace.token.tools"
 msgstr "Herramientas"
 
+#: src/app/main/ui/workspace/tokens/sidebar.cljs:415
+msgid "workspace.token.import-tooltip"
+msgstr "Al importar un fichero JSON sobreescribirás todos tus tokens, sets y themes"
+
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:123
 msgid "workspace.token.value-not-valid"
 msgstr "El valor no es válido"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10527

### Summary

Display an info icon with a tooltip to warn the user that importing a JSON will override all their stuff, tokens, themes, sets, etc.

![import-icon](https://github.com/user-attachments/assets/b4c16e37-b024-4fb5-95ce-6474d1beec16)

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
