### PR TITLE
:bug: Fix problem with readonly and inspect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
   tab [Taiga #10377](https://tree.taiga.io/project/penpot/issue/10377)
 - Fix minor inconsistencies on RPC `get-file-libraries` and `get-file`
   methods (add missing team-id prop)
-
+- Fix problem with viewer role and inspect mode [Taiga #9751](https://tree.taiga.io/project/penpot/issue/9751)
 
 ## 2.5.3
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options.cljs
@@ -197,16 +197,25 @@
                     :id "inspect"
                     :content inspect-content}])]
 
-    (mf/with-effect [permissions]
-      (when-not (:can-edit permissions)
-        (on-change-tab :inspect)))
-
     [:div {:class (stl/css :tool-window)}
-     [:> tab-switcher* {:tabs tabs
-                        :default-selected "info"
-                        :on-change-tab on-change-tab
-                        :selected (name options-mode)
-                        :class (stl/css :options-tab-switcher)}]]))
+     (if (:can-edit permissions)
+       [:> tab-switcher* {:tabs tabs
+                          :default-selected "info"
+                          :on-change-tab on-change-tab
+                          :selected (name options-mode)
+                          :class (stl/css :options-tab-switcher)}]
+
+       [:div {:class (stl/css-case :element-options true
+                                   :inspect-options true
+                                   :read-only true)}
+        [:& hrs/right-sidebar {:page-id           page-id
+                               :objects           objects
+                               :file-id           file-id
+                               :frame             shape-parent-frame
+                               :shapes            selected-shapes
+                               :on-change-section on-change-section
+                               :on-expand         on-expand
+                               :from              :workspace}]])]))
 
 ;; TODO: this need optimizations, selected-objects and
 ;; selected-objects-with-children are derefed always but they only

--- a/frontend/src/app/main/ui/workspace/sidebar/options.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options.scss
@@ -33,6 +33,11 @@
   padding-top: $s-8;
 }
 
+.read-only {
+  grid-template-areas: "right-sidebar";
+  padding: var(--sp-s);
+}
+
 .design-options,
 .interaction-options {
   overflow: auto;

--- a/frontend/src/app/main/ui/workspace/viewport.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport.cljs
@@ -231,7 +231,7 @@
         show-selrect?            (and selrect (empty? drawing) (not text-editing?))
         show-measures?           (and (not transform)
                                       (not node-editing?)
-                                      (or show-distances? mode-inspect?))
+                                      (or show-distances? mode-inspect? read-only?))
         show-artboard-names?     (contains? layout :display-artboard-names)
         hide-ui?                 (contains? layout :hide-ui)
         show-rulers?             (and (contains? layout :rulers) (not hide-ui?))


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/9751

### Summary
Changes to the read-only mode so it shows the assets panel.
(This is already in `develop` this is a backport to staging)

### Steps to reproduce 
Login with a user with only read-only permission into a file. The user should be able to see the assets.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
