### PR TITLE
:bug: Fix drop shadows viewport clipping

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -187,6 +187,9 @@ impl RenderState {
 
     pub fn reset_canvas(&mut self) {
         self.surfaces.canvas(SurfaceId::Fills).restore_to_count(1);
+        self.surfaces
+            .canvas(SurfaceId::DropShadows)
+            .restore_to_count(1);
         self.surfaces.canvas(SurfaceId::Strokes).restore_to_count(1);
         self.surfaces.canvas(SurfaceId::Current).restore_to_count(1);
 
@@ -195,6 +198,7 @@ impl RenderState {
                 SurfaceId::Fills,
                 SurfaceId::Strokes,
                 SurfaceId::Current,
+                SurfaceId::DropShadows,
                 SurfaceId::Shadow,
                 SurfaceId::Overlay,
             ],
@@ -220,6 +224,16 @@ impl RenderState {
     pub fn apply_drawing_to_render_canvas(&mut self, shape: &Shape) {
         self.surfaces
             .flush_and_submit(&mut self.gpu_state, SurfaceId::Fills);
+
+        self.surfaces
+            .flush_and_submit(&mut self.gpu_state, SurfaceId::DropShadows);
+
+        self.surfaces.draw_into(
+            SurfaceId::DropShadows,
+            SurfaceId::Current,
+            Some(&skia::Paint::default()),
+        );
+
         self.surfaces.draw_into(
             SurfaceId::Fills,
             SurfaceId::Current,
@@ -263,6 +277,7 @@ impl RenderState {
         self.surfaces.apply_mut(
             &[
                 SurfaceId::Shadow,
+                SurfaceId::DropShadows,
                 SurfaceId::Overlay,
                 SurfaceId::Fills,
                 SurfaceId::Strokes,
@@ -285,17 +300,19 @@ impl RenderState {
         modifiers: Option<&Matrix>,
         clip_bounds: Option<(Rect, Option<Corners>, Matrix)>,
     ) {
-        let surface_ids = &[SurfaceId::Fills, SurfaceId::Strokes];
+        let surface_ids = &[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::DropShadows];
         self.surfaces.apply_mut(surface_ids, |s| {
             s.canvas().save();
         });
 
         // set clipping
         if let Some((bounds, corners, transform)) = clip_bounds {
-            self.surfaces
-                .apply_mut(&[SurfaceId::Fills, SurfaceId::Strokes], |s| {
+            self.surfaces.apply_mut(
+                &[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::DropShadows],
+                |s| {
                     s.canvas().concat(&transform);
-                });
+                },
+            );
 
             if let Some(corners) = corners {
                 let rrect = RRect::new_rect_radii(bounds, &corners);
@@ -362,10 +379,12 @@ impl RenderState {
                 text::render(self, text_content);
             }
             _ => {
-                self.surfaces
-                    .apply_mut(&[SurfaceId::Fills, SurfaceId::Strokes], |s| {
+                self.surfaces.apply_mut(
+                    &[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::DropShadows],
+                    |s| {
                         s.canvas().concat(&matrix);
-                    });
+                    },
+                );
 
                 for fill in shape.fills().rev() {
                     fills::render(self, &shape, fill);
@@ -384,21 +403,17 @@ impl RenderState {
                     );
                 }
 
-                for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
-                    shadows::render_drop_shadow(
-                        self,
-                        shadow,
-                        self.viewbox.zoom * self.options.dpr(),
-                    );
-                }
+                shadows::render_drop_shadows(self, &shape);
             }
         };
 
         self.apply_drawing_to_render_canvas(&shape);
-        self.surfaces
-            .apply_mut(&[SurfaceId::Fills, SurfaceId::Strokes], |s| {
+        self.surfaces.apply_mut(
+            &[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::DropShadows],
+            |s| {
                 s.canvas().restore();
-            });
+            },
+        );
     }
 
     pub fn start_render_loop(
@@ -407,22 +422,23 @@ impl RenderState {
         modifiers: &HashMap<Uuid, Matrix>,
         timestamp: i32,
     ) -> Result<(), String> {
-        let surface_ids = &[SurfaceId::Fills, SurfaceId::Strokes];
-
         if self.render_in_progress {
             if let Some(frame_id) = self.render_request_id {
                 self.cancel_animation_frame(frame_id);
             }
         }
         self.reset_canvas();
-        self.surfaces.apply_mut(surface_ids, |s| {
-            s.canvas().scale((
-                self.viewbox.zoom * self.options.dpr(),
-                self.viewbox.zoom * self.options.dpr(),
-            ));
-            s.canvas()
-                .translate((self.viewbox.pan_x, self.viewbox.pan_y));
-        });
+        self.surfaces.apply_mut(
+            &[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::DropShadows],
+            |s| {
+                s.canvas().scale((
+                    self.viewbox.zoom * self.options.dpr(),
+                    self.viewbox.zoom * self.options.dpr(),
+                ));
+                s.canvas()
+                    .translate((self.viewbox.pan_x, self.viewbox.pan_y));
+            },
+        );
 
         self.pending_nodes = vec![NodeRenderState {
             id: Uuid::nil(),
@@ -514,6 +530,7 @@ impl RenderState {
         self.surfaces.canvas(SurfaceId::Target).save();
         self.surfaces.canvas(SurfaceId::Fills).save();
         self.surfaces.canvas(SurfaceId::Strokes).save();
+        self.surfaces.canvas(SurfaceId::DropShadows).save();
 
         let navigate_zoom = self.viewbox.zoom / cached.viewbox.zoom;
         let navigate_x = cached.viewbox.zoom * (self.viewbox.pan_x - cached.viewbox.pan_x);
@@ -536,6 +553,7 @@ impl RenderState {
         self.surfaces.canvas(SurfaceId::Target).restore();
         self.surfaces.canvas(SurfaceId::Fills).restore();
         self.surfaces.canvas(SurfaceId::Strokes).restore();
+        self.surfaces.canvas(SurfaceId::DropShadows).restore();
 
         self.flush();
 

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -1,17 +1,50 @@
 use skia_safe::{self as skia};
 
 use super::{RenderState, SurfaceId};
-use crate::shapes::Shadow;
+use crate::shapes::{Shadow, Shape, Type};
 
-pub fn render_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
-    let shadow_paint = shadow.to_paint(scale);
+pub fn render_drop_shadows(render_state: &mut RenderState, shape: &Shape) {
+    if shape.fills().len() > 0 {
+        for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+            render_fill_drop_shadow(render_state, &shape, &shadow);
+        }
+    } else {
+        let scale = render_state.viewbox.zoom * render_state.options.dpr();
+        for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+            render_stroke_drop_shadow(render_state, &shadow, scale);
+        }
+    }
+}
+
+fn render_fill_drop_shadow(render_state: &mut RenderState, shape: &Shape, shadow: &Shadow) {
+    let paint = &shadow.get_drop_shadow_paint();
+
+    match &shape.shape_type {
+        Type::Rect(_) | Type::Frame(_) => {
+            render_state
+                .surfaces
+                .draw_rect_to(SurfaceId::DropShadows, shape, paint);
+        }
+        Type::Circle => {
+            render_state
+                .surfaces
+                .draw_circle_to(SurfaceId::DropShadows, shape, paint);
+        }
+        Type::Path(_) | Type::Bool(_) => {
+            render_state
+                .surfaces
+                .draw_path_to(SurfaceId::DropShadows, shape, paint);
+        }
+        _ => {}
+    }
+}
+
+fn render_stroke_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
+    let shadow_paint = &shadow.to_paint(scale);
+
     render_state
         .surfaces
-        .draw_into(SurfaceId::Fills, SurfaceId::Shadow, Some(&shadow_paint));
-
-    render_state
-        .surfaces
-        .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(&shadow_paint));
+        .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(shadow_paint));
 
     render_state.surfaces.draw_into(
         SurfaceId::Shadow,

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -646,6 +646,21 @@ impl Shape {
         }
     }
 
+    pub fn get_skia_path(&self) -> Option<skia::Path> {
+        if let Some(path) = self.shape_type.path() {
+            let mut skia_path = path.to_skia_path();
+            if let Some(path_transform) = self.to_path_transform() {
+                skia_path.transform(&path_transform);
+            }
+            if let Some("evenodd") = self.svg_attrs.get("fill-rule").map(String::as_str) {
+                skia_path.set_fill_type(skia::PathFillType::EvenOdd);
+            }
+            Some(skia_path)
+        } else {
+            None
+        }
+    }
+
     fn transform_selrect(&mut self, transform: &Matrix) {
         let mut center = self.selrect.center();
         center = transform.map_point(center);

--- a/render-wasm/src/shapes/shadows.rs
+++ b/render-wasm/src/shapes/shadows.rs
@@ -123,4 +123,33 @@ impl Shadow {
 
         filter
     }
+
+    // New methods for DropShadow
+    pub fn get_drop_shadow_paint(&self) -> skia::Paint {
+        let mut paint = skia::Paint::default();
+
+        let image_filter = self.get_drop_shadow_filter();
+
+        paint.set_image_filter(image_filter);
+        paint.set_anti_alias(true);
+
+        paint
+    }
+
+    fn get_drop_shadow_filter(&self) -> Option<ImageFilter> {
+        let mut filter = image_filters::drop_shadow_only(
+            (self.offset.0, self.offset.1),
+            (self.blur, self.blur),
+            self.color,
+            None,
+            None,
+            None,
+        );
+
+        if self.spread > 0. {
+            filter = image_filters::dilate((self.spread, self.spread), filter, None);
+        }
+
+        filter
+    }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10516

### Summary

When rendering shadows, the shadows painted on the shadow surface only display the visible part of the original shape. This can cause cropping in certain situations when the shadow offset causes an intersection with the viewport.

This PR aims to resolve the issue for drop shadows (only "fill" shadows for now) to determine whether this approach makes sense or if we should consider a different solution. This change may conflict with the new tiling feature, so we need to align accordingly.

### Changes

This PR introduces (_yet_) another surface named `DropShadow`, but this is meant to be temporary. In order to split these changes in different PRs, I needed to create this different surface to keep supporting border shadows in _the old way_.

With this approach, shadows are rendered one by one directly in its destination surface (`DropShadow`) by applying directly the paint filter, instead of copying the surface + applying the filter.

### What does PR this fix? 

- [x] Drop shadows are not clipped anymore when the shape intersects the viewport (this does not apply on stroke shadows)
- [x] Drop shadows are correctly clipped when the shape is in a board (again: this does not apply to stroke shadows)
- [x] Stroke shadows only appear when the shape has no fill, as it is in production

![Screenshot from 2025-03-18 15-55-49](https://github.com/user-attachments/assets/4d15297d-4278-4961-a5dd-5bcc16240c1f)
 
### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.