### PR TITLE
:sparkles: Add a tooltip explanation on themes modal sets

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
@@ -144,6 +144,7 @@
                 [:> button* {:class (stl/css :sets-count-button)
                              :variant "secondary"
                              :type "button"
+                             :title (tr "workspace.token.sets-hint")
                              :on-click on-edit-theme}
                  [:div {:class (stl/css :label-wrapper)}
                   [:> text* {:as "span" :typography "body-medium"}

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6719,6 +6719,10 @@ msgstr "You currently have no themes."
 msgid "workspace.token.num-active-sets"
 msgstr "%s active sets"
 
+#: src/app/main/ui/workspace/tokens/modals/themes.cljs:147
+msgid "workspace.token.sets-hint"
+msgstr "Edit theme and manage sets"
+
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:114
 #, fuzzy
 msgid "workspace.token.original-value"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6723,6 +6723,10 @@ msgstr "Actualmente no existen temas."
 msgid "workspace.token.num-active-sets"
 msgstr "%s sets activos"
 
+#: src/app/main/ui/workspace/tokens/modals/themes.cljs:147
+msgid "workspace.token.sets-hint"
+msgstr "Editar tema y gestionar set"
+
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:114
 #, fuzzy
 msgid "workspace.token.original-value"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10526

### Summary

Add a tooltip over the “active set" button, in theme list modal to better explain how to use it.

![image](https://github.com/user-attachments/assets/b4f3490f-078c-4dcf-b18d-befbb9967e2c)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
