### PR TITLE
Fix typos in index.njk

### DIFF
--- a/docs/user-guide/objects/index.njk
+++ b/docs/user-guide/objects/index.njk
@@ -166,7 +166,7 @@ a design.</p>
 
 <h2 id="curves">Curves (freehand)</h2>
 <p>The curve tool allows a path to be created directly in a freehand mode.
-Select the curve tool by clicking on the icon at the toolbar or pressing <kbd>Ctrl/⌘</kbd> + <kbd>c</kbd>.
+Select the curve tool by clicking on the icon at the toolbar or pressing <kbd>Shift/⇧</kbd> + <kbd>c</kbd>.
 <p>The path created will contain a lot of points, but it is edited the same way as any other curve.</p>
 
 <h2 id="paths">Paths (bezier)</h2>

--- a/docs/user-guide/objects/index.njk
+++ b/docs/user-guide/objects/index.njk
@@ -206,7 +206,7 @@ You can choose to edit individual nodes or create new ones. Press <kbd>Esc</kbd>
 <h3>Insert images</h3>
 <p>There are several options for inserting an image into a Penpot file:</p>
 <ul>
-  <li>Use the <strong>image tool</strong> at the toolbar or press <kbd>K</kbd> to inspect images in your file system.</li>
+  <li>Use the <strong>image tool</strong> at the toolbar or press <kbd>K</kbd> to insert images in your file system.</li>
   <li><strong>Drag</strong> an image from your computer to the viewport.</li>
   <li>Copy an image & paste it or drag it right from a <strong>browser</strong>.</li>
   <li>Drag an image from a Penpot <strong>library</strong>.</li>


### PR DESCRIPTION
📚 Curves shortcut corrected.
[body] There was a typo in the curves shortcut. Instead of Ctrl we must type Shift. 
[footer] It was just a typo.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
