### PR TITLE
:bug: Fix not active sets on json import

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1301,7 +1301,7 @@ Will return a value that matches this schema:
                                             :tokens (flatten-nested-tokens-json tokens ""))))
                             lib))
           lib' (cond-> lib'
-                 (and (seq active-sets) (empty? active-themes))
+                 (and (seq active-sets) (= #{hidden-token-theme-path} active-themes))
                  (update-theme hidden-token-theme-group hidden-token-theme-name
                                #(assoc % :sets active-sets)))]
       (if-let [themes-data (seq themes-data)]
@@ -1382,10 +1382,10 @@ Will return a value that matches this schema:
    ;; with pages and pages-index.
    (make-tokens-lib :sets (d/ordered-map)
                     :themes (d/ordered-map)
-                    :active-themes #{}))
+                    :active-themes #{hidden-token-theme-path}))
 
   ([& {:keys [sets themes active-themes]}]
-   (let [active-themes (d/nilv active-themes #{})
+   (let [active-themes (d/nilv active-themes #{hidden-token-theme-path})
          themes (if (empty? themes)
                   (update themes hidden-token-theme-group d/oassoc hidden-token-theme-name (make-hidden-token-theme))
                   themes)]


### PR DESCRIPTION
### Related Ticket

This PR closes [this issue](https://tree.taiga.io/project/penpot/issue/10521)

### Summary

When importing a JSON with active sets and without active themes, this must be reflected on the UI after json import.

### Steps to reproduce 

See steps on issue

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
