### PR TITLE
:bug: Add lost spanish translation

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1171,7 +1171,7 @@ msgstr "Theme Option with the same name exists"
 
 #: src/app/main/data/tokens.cljs:198
 msgid "errors.token-set-exists-on-drop"
-msgstr "Cannot complete drop, a set with same name already exists at path %s."
+msgstr "Cannot complete drop, a set with same name already exists at path."
 
 #: src/app/main/data/tokens.cljs:294
 msgid "workspace.token.duplicate-suffix"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7188,3 +7188,7 @@ msgstr "Ya existe un set con el mismo nombre"
 
 msgid "errors.token-theme-already-exists"
 msgstr "Ya existe un theme con este nombre"
+
+#: src/app/main/data/tokens.cljs:198
+msgid "errors.token-set-exists-on-drop"
+msgstr "No se ha podido mover el set, un set con el mismo nombre ya existe en la esa ruta."


### PR DESCRIPTION
### Related Ticket

This PR fixes what was commented on a thread.

### Summary

The line "Cannot complete drop, a set with same name already exists at path ." Was not trasnlated to spanish

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
