### PR TITLE
:bug: Fix initial value of color bullet in form

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1233,7 +1233,8 @@ Will return a value that matches this schema:
           (fn [tokens' cur]
             (merge tokens' (:tokens (get-set this cur))))
           tokens (order-theme-set theme)))
-       (d/ordered-map) active-themes)))
+       (d/ordered-map)
+       active-themes)))
 
   (encode-dtcg [this]
     (let [themes-xform

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -312,6 +312,7 @@
 
         token-resolve-result* (mf/use-state (get resolved-tokens (wtt/token-identifier token)))
         token-resolve-result (deref token-resolve-result*)
+
         set-resolve-value
         (mf/use-fn
          (fn [token-or-err]
@@ -320,12 +321,15 @@
                  v (cond
                      error?
                      token-or-err
+
                      warnings?
                      (:warnings {:warnings token-or-err})
+
                      :else
                      (:resolved-value token-or-err))]
              (when color? (reset! color (if error? nil v)))
              (reset! token-resolve-result* v))))
+
         on-update-value-debounced (use-debonced-resolve-callback name-ref token active-theme-tokens set-resolve-value)
         on-update-value (mf/use-fn
                          (mf/deps on-update-value-debounced)
@@ -459,10 +463,10 @@
            (when (k/enter? e)
              (on-submit e))))]
 
-    ;; Clear form token cache on mount
+    ;; Clear form token cache on unmount
     (mf/use-effect
      (fn []
-       (reset! form-token-cache-atom nil)))
+       #(reset! form-token-cache-atom nil)))
 
     ;; Update the value when editing an existing token
     ;; so the user doesn't have to interact with the form to validate the token


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10552

### Steps to reproduce 

See issue

### Technical notes

If cache is reset on component mount, the reset comes too late, since it's asynchronous and there are some effects that read it immediately. Better to reset it in unmount, for a later run of the form.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
