### PR TITLE
:bug: Remove values from config that are invalid for Style Dictionary

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -13,6 +13,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
+   [clojure.walk :as walk]
    [cuerdas.core :as str]
    [promesa.core :as p]
    [rumext.v2 :as mf]))
@@ -165,7 +166,13 @@
     config)
 
   (build-dictionary [_]
-    (let [config' (clj->js config)]
+    (let [config' (->> config
+                       (walk/prewalk
+                        (fn [item]
+                          (cond-> item
+                            (and (map? item) (contains? item :error/fn))
+                            (dissoc item :error/fn))))
+                       clj->js)]
       (-> (sd. config')
           (.buildAllPlatforms "json")
           (p/then #(.-allTokens ^js %))))))


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/penpot/issues/85 and [taiga#10456](https://tree.taiga.io/project/penpot/issue/10456)

### Testing
1. Import penpot file from from the original issue
2. Enable a set that would have a token with a reference to an another token in the disabled set.
3. Check that at least one token in the enabled set shows as a broken reference 
4. Check the console doesn't contain exception logs similar to the one in the example below. 

### Error logs example

```error
Uncaught (in promise) DataCloneError: Failed to execute 'structuredClone' on 'Window': function (p1__118454_SHARP_){
return cljs.core.str.cljs$core$IFn$_invoke$arity$1(app.util.i18n.tr.cljs$core$IFn...<omitted>...
} could not be cloned.
```

### Change description
Removes invalid values from Style Dictionary config

### Error explanation

The error happens when SD config contains functions e.g.:
```clojure
{:cfg
 {:platforms
  {:json
   {:transformGroup "tokens-studio",
    :files [{:format "custom/json", :destination "penpot"}]}},
  :preprocessors ["tokens-studio"],
  :log
  {:verbosity "silent",
   :warnings "silent",
   :errors {:brokenReferences "console"}},
  :tokens
  {"color"
   {"err"
    {:name "color.err",
     :type :color,
     :value "{color.red.100}",
     :description "",
     :modified-at #app/instant "2025-03-18T10:11:45.893+01:00",
     :errors
     [{:error/code :error.token/invalid-color,
       :error/fn #object[Function], ;; <- causes StyleDictionary to throw exceptions
       :error/value "{color.red.100}"}]},
    "red"
    {"100"
     {:name "color.red.100",
      :type :color,
      :value "#770c0c",
      :description "",
      :modified-at #app/instant "2025-03-18T10:11:45.892+01:00"}}}}}}
```