### PR TITLE
:bug: Fix copy on input placeholder

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -513,7 +513,7 @@
       [:div {:class (stl/css :input-row)}
        [:> input-tokens*
         {:id "token-value"
-         :placeholder (tr "workspace.token.enter-token-value")
+         :placeholder (tr "workspace.token.token-value-enter")
          :label (tr "workspace.token.token-value")
          :max-length 256
          :default-value @value-ref

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6615,8 +6615,8 @@ msgid "workspace.token.enter-token-name"
 msgstr "Enter %s token name"
 
 #: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Enter token value or alias"
+msgid "workspace.token.token-value-enter"
+msgstr "Enter a value or alias with {alias}"
 
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6617,8 +6617,8 @@ msgid "workspace.token.enter-token-name"
 msgstr "Introduce un nombre para el token %s"
 
 #: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Introduce un valor o alias"
+msgid "workspace.token.token-value-enter"
+msgstr "Introduce un valor o un alias usando {alias}"
 
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -6402,10 +6402,6 @@ msgstr "הוספת תיאור (רשות)"
 msgid "workspace.token.enter-token-name"
 msgstr "נא למלא את שם האסימון %s"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "נא למלא ערך או כינוי לאסימון"
-
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -6427,10 +6427,6 @@ msgstr "Tambahkan deskripsi (opsional)"
 msgid "workspace.token.enter-token-name"
 msgstr "Masukkan nama token %s"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Masukkan nilai atau alias token"
-
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -6464,10 +6464,6 @@ msgstr "Aggiungi una descrizione (opzionale)"
 msgid "workspace.token.enter-token-name"
 msgstr "Inserisci il nome del token %s"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Inserisci un valore del token o un alias"
-
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -6474,10 +6474,6 @@ msgstr "Voeg een beschrijving toe (optioneel)"
 msgid "workspace.token.enter-token-name"
 msgstr "Voer de tokennaam %s in"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Voer de tokenwaarde of alias in"
-
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -6447,10 +6447,6 @@ msgstr "Lägg till en beskrivning (valfritt)"
 msgid "workspace.token.enter-token-name"
 msgstr "Ange %s tokennamn"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Ange tokenvärde eller alias"
-
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"

--- a/frontend/translations/ukr_UA.po
+++ b/frontend/translations/ukr_UA.po
@@ -6485,10 +6485,6 @@ msgstr "Додайте опис (необов'язково)"
 msgid "workspace.token.enter-token-name"
 msgstr "Введіть %s ім'я токену"
 
-#: src/app/main/ui/workspace/tokens/form.cljs:463
-msgid "workspace.token.enter-token-value"
-msgstr "Введіть значення токену чи його псевдонім"
-
 #: src/app/main/ui/workspace/tokens/sets.cljs
 #, unused
 msgid "workspace.token.grouping-set-alert"


### PR DESCRIPTION
### Related Ticket

This PR solves [this issue](https://tree.taiga.io/project/penpot/issue/10557)

### Summary

We have changed a copy for input placeholder, we have deleted existing translations with old copy. 

### Steps to reproduce 

- Refresh tmux (tab 1)  if reviewing on localhost.
- Open token creation modal
- Check input placeholder
![Screenshot from 2025-03-18 11-07-42](https://github.com/user-attachments/assets/661b218c-1521-408b-9e95-5052a62e5078)

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
