### PR TITLE
:bug: Fix lost resolved value on tooltip

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -266,6 +266,10 @@
             (ctob/get-active-themes-set-tokens tokens-lib)
             {}))
 
+        ;; Resolve tokens as second step
+        active-theme-tokens'
+        (sd/use-resolved-tokens* active-theme-tokens)
+
         ;; This only checks for the currently explicitly selected set
         ;; name, it is ephimeral and can be nil
         selected-token-set-name
@@ -323,14 +327,14 @@
                            :is-open (get open-status type false)
                            :type type
                            :selected-shapes selected-shapes
-                           :active-theme-tokens active-theme-tokens
+                           :active-theme-tokens active-theme-tokens'
                            :tokens tokens}]))
 
      (for [type empty-group]
        [:> token-group* {:key (name type)
                          :type type
                          :selected-shapes selected-shapes
-                         :active-theme-tokens active-theme-tokens
+                         :active-theme-tokens active-theme-tokens'
                          :tokens []}])]))
 
 (mf/defc import-export-button*


### PR DESCRIPTION
### Related Ticket

This PR closes [this issue](https://tree.taiga.io/project/penpot/issue/10561)

### Summary

This line of code was removed because the `sd/use-resolved-tokens*` function was being applied twice on the `active-set-tokens`.
https://github.com/penpot/penpot/pull/6086/files
The line of code has been reinstated but the variable is being redefined to avoid applying the function twice. 

The raw value is used on line 290 where the function `sd/use-resolved-tokens*` is applied,  and the redefined variable is used in lines 332 and 339. 

### Steps to reproduce 

See issue 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
