### PR TITLE
:bug: Fix tooltip with only one set and no active

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -103,8 +103,9 @@
 (defn- generate-tooltip
   "Generates a tooltip for a given token"
   [is-viewer shape theme-token token half-applied no-valid-value ref-not-in-active-set]
-  (let [{:keys [name value type]} token
-        {:keys [resolved-value]} theme-token
+  (let [{:keys [name value type resolved-value]} token
+        resolved-value-theme (:resolved-value theme-token)
+        resolved-value (or resolved-value-theme resolved-value)
         {:keys [title] :as token-props} (wtch/get-token-properties theme-token)
         applied-tokens (:applied-tokens shape)
         app-token-vals (set (vals applied-tokens))


### PR DESCRIPTION
### Related Ticket

[Issue 10561](https://tree.taiga.io/project/penpot/issue/10561)

### Summary

When only one set and set not active, tooltip should show resolved value

### Steps to reproduce 

See comment on that issue

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
