### PR TITLE
:bug: Add tooltip to empty sets button on theme creation modal

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
@@ -140,24 +140,18 @@
 
 
              [:div {:class (stl/css :theme-row-right)}
-              (if-let [sets-count (some-> theme :sets seq count)]
-                [:> button* {:class (stl/css :sets-count-button)
+              (let [sets-count (some-> theme :sets seq count)]
+                [:> button* {:class (stl/css-case :sets-count-button sets-count
+                                                  :sets-count-empty-button (not sets-count))
                              :variant "secondary"
                              :type "button"
                              :title (tr "workspace.token.sets-hint")
                              :on-click on-edit-theme}
                  [:div {:class (stl/css :label-wrapper)}
                   [:> text* {:as "span" :typography "body-medium"}
-                   (tr "workspace.token.num-active-sets" sets-count)]
-                  [:> icon* {:icon-id "arrow-right"}]]]
-
-                [:> button* {:class (stl/css :sets-count-empty-button)
-                             :type "button"
-                             :variant "secondary"
-                             :on-click on-edit-theme}
-                 [:div {:class (stl/css :label-wrapper)}
-                  [:> text* {:as "span" :typography "body-medium"}
-                   (tr "workspace.token.no-active-sets")]
+                   (if sets-count
+                     (tr "workspace.token.num-active-sets" sets-count)
+                     (tr "workspace.token.no-active-sets"))]
                   [:> icon* {:icon-id "arrow-right"}]]])
 
               [:> icon-button* {:on-click delete-theme

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6735,7 +6735,7 @@ msgstr "%s sets activos"
 
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs:147
 msgid "workspace.token.sets-hint"
-msgstr "Editar tema y gestionar set"
+msgstr "Editar tema y gestionar sets"
 
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:114
 #, fuzzy


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10526

### Summary

- [x] Fixes an issue regarding the tooltip on empty sets button was not being displayed
- [x] Fixes an unrelated typo

### Steps to reproduce 

1. Open the themes modal 
2. Ensure that a tooltip is shown on the active sets button without any active set
3. Ensure that a tooltip is shown on the active sets button with active sets

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
