### PR TITLE
:bug: Fix problem with default shadows in plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - The plugin list in the navigation menu lacks scrolling, some plugins are not visible when a large number are installed [Taiga #9360](https://tree.taiga.io/project/penpot/us/9360)
 - Fix hidden toolbar click event still available [Taiga #10437](https://tree.taiga.io/project/penpot/us/10437)
 - Fix hovering over templates [Taiga #10545](https://tree.taiga.io/project/penpot/issue/10545)
+- Fix problem with default shadows value in plugins [Plugins #191](https://github.com/penpot/penpot-plugins/issues/191)
 
 ## 2.5.4
 

--- a/frontend/src/app/plugins/format.cljs
+++ b/frontend/src/app/plugins/format.cljs
@@ -176,8 +176,9 @@
 
 (defn format-shadows
   [shadows]
-  (when (some? shadows)
-    (format-array format-shadow shadows)))
+  (if (some? shadows)
+    (format-array format-shadow shadows)
+    (array)))
 
 ;;export interface Fill {
 ;;  fillColor?: string;


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/10263

### Summary
Default value for shadows is null when should be an empty array.

### Steps to reproduce 
- Create board
- Access the shape's shadows via penpot.selection.shapes[id].shadows

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
