### PR TITLE
:bug: Fix problem with constraints when creating group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - Fix hidden toolbar click event still available [Taiga #10437](https://tree.taiga.io/project/penpot/us/10437)
 - Fix hovering over templates [Taiga #10545](https://tree.taiga.io/project/penpot/issue/10545)
 - Fix problem with default shadows value in plugins [Plugins #191](https://github.com/penpot/penpot-plugins/issues/191)
+- Fix problem with constraints when creating group [Taiga #10455](https://tree.taiga.io/project/penpot/issue/10455)
 
 ## 2.5.4
 

--- a/frontend/src/app/main/data/workspace/groups.cljs
+++ b/frontend/src/app/main/data/workspace/groups.cljs
@@ -120,6 +120,14 @@
                       (pcb/with-page-id page-id)
                       (pcb/with-objects objects)
                       (pcb/add-object group {:index group-idx})
+
+                      ;; Create a group needs to reset the constraints to scale/scale
+                      (pcb/update-shapes
+                       (map :id shapes)
+                       (fn [shape]
+                         (-> shape
+                             (d/assoc-when :constraints-h :scale)
+                             (d/assoc-when :constraints-v :scale))))
                       (pcb/update-shapes (map :id shapes) ctl/remove-layout-item-data)
                       (pcb/change-parent (:id group) (reverse shapes))
                       (pcb/update-shapes (map :id shapes-to-detach) ctk/detach-shape)


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/10455

### Summary
When creating a group it's not reseting the constraints when they have a previous value.

### Steps to reproduce 
- Create a board
- Create a rectangle **outside the board**
- Move the rectangle into the board an create a group with it (ctrl+g or menu > create group)
- Resizing the group will leave the shape without change (because the constraints are wrong)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
