### PR TITLE
:bug: Fix Fill Inner Shadow rendering

### DIFF
--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -1,10 +1,10 @@
-use skia_safe::{self as skia};
-
 use super::{RenderState, SurfaceId};
 use crate::shapes::{Shadow, Shape, Type};
+use skia_safe::{self as skia, Paint};
 
+// Drop Shadows
 pub fn render_drop_shadows(render_state: &mut RenderState, shape: &Shape) {
-    if shape.fills().len() > 0 {
+    if shape.has_fills() {
         for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
             render_fill_drop_shadow(render_state, &shape, &shadow);
         }
@@ -18,27 +18,10 @@ pub fn render_drop_shadows(render_state: &mut RenderState, shape: &Shape) {
 
 fn render_fill_drop_shadow(render_state: &mut RenderState, shape: &Shape, shadow: &Shadow) {
     let paint = &shadow.get_drop_shadow_paint();
-
-    match &shape.shape_type {
-        Type::Rect(_) | Type::Frame(_) => {
-            render_state
-                .surfaces
-                .draw_rect_to(SurfaceId::DropShadows, shape, paint);
-        }
-        Type::Circle => {
-            render_state
-                .surfaces
-                .draw_circle_to(SurfaceId::DropShadows, shape, paint);
-        }
-        Type::Path(_) | Type::Bool(_) => {
-            render_state
-                .surfaces
-                .draw_path_to(SurfaceId::DropShadows, shape, paint);
-        }
-        _ => {}
-    }
+    render_shadow_paint(render_state, shape, paint, SurfaceId::DropShadows);
 }
 
+// TODO: Stroke shadows
 fn render_stroke_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
     let shadow_paint = &shadow.to_paint(scale);
 
@@ -58,30 +41,63 @@ fn render_stroke_drop_shadow(render_state: &mut RenderState, shadow: &Shadow, sc
         .clear(skia::Color::TRANSPARENT);
 }
 
-pub fn render_inner_shadow(
-    render_state: &mut RenderState,
-    shadow: &Shadow,
-    scale: f32,
-    render_over_fills: bool,
-) {
-    let shadow_paint = shadow.to_paint(scale);
-
-    if render_over_fills {
-        render_state
-            .surfaces
-            .draw_into(SurfaceId::Fills, SurfaceId::Shadow, Some(&shadow_paint));
+// Inner Shadows
+pub fn render_inner_shadows(render_state: &mut RenderState, shape: &Shape) {
+    if shape.has_fills() {
+        for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+            render_fill_inner_shadow(render_state, &shape, &shadow);
+        }
     } else {
-        render_state
-            .surfaces
-            .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(&shadow_paint));
+        let scale = render_state.get_scale();
+        for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+            render_stroke_inner_shadow(render_state, &shadow, scale);
+        }
     }
+}
+
+fn render_fill_inner_shadow(render_state: &mut RenderState, shape: &Shape, shadow: &Shadow) {
+    let paint = &shadow.get_inner_shadow_paint();
+    render_shadow_paint(render_state, shape, paint, SurfaceId::InnerShadows);
+}
+
+// TODO: Stroke shadows
+fn render_stroke_inner_shadow(render_state: &mut RenderState, shadow: &Shadow, scale: f32) {
+    let shadow_paint = &shadow.to_paint(scale);
 
     render_state
         .surfaces
-        .draw_into(SurfaceId::Shadow, SurfaceId::Overlay, None);
+        .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(shadow_paint));
+
+    render_state.surfaces.draw_into(
+        SurfaceId::Shadow,
+        SurfaceId::Overlay,
+        Some(&skia::Paint::default()),
+    );
 
     render_state
         .surfaces
         .canvas(SurfaceId::Shadow)
         .clear(skia::Color::TRANSPARENT);
+}
+
+fn render_shadow_paint(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paint: &Paint,
+    surface_id: SurfaceId,
+) {
+    match &shape.shape_type {
+        Type::Rect(_) | Type::Frame(_) => {
+            render_state.surfaces.draw_rect_to(surface_id, shape, paint);
+        }
+        Type::Circle => {
+            render_state
+                .surfaces
+                .draw_circle_to(surface_id, shape, paint);
+        }
+        Type::Path(_) | Type::Bool(_) => {
+            render_state.surfaces.draw_path_to(surface_id, shape, paint);
+        }
+        _ => {}
+    }
 }

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -9,7 +9,7 @@ pub fn render_drop_shadows(render_state: &mut RenderState, shape: &Shape) {
             render_fill_drop_shadow(render_state, &shape, &shadow);
         }
     } else {
-        let scale = render_state.viewbox.zoom * render_state.options.dpr();
+        let scale = render_state.get_scale();
         for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
             render_stroke_drop_shadow(render_state, &shadow, scale);
         }

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -15,6 +15,7 @@ pub enum SurfaceId {
     Strokes,
     Shadow,
     DropShadows,
+    InnerShadows,
     Overlay,
     Debug,
 }
@@ -32,6 +33,7 @@ pub struct Surfaces {
     shadow: skia::Surface,
     // used for new shadow rendering
     drop_shadows: skia::Surface,
+    inner_shadows: skia::Surface,
     // for drawing the things that are over shadows.
     overlay: skia::Surface,
     // for drawing debug info.
@@ -63,6 +65,7 @@ impl Surfaces {
         let current = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let shadow = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let drop_shadows = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
+        let inner_shadows = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let overlay = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let shape_fills = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let shape_strokes = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
@@ -78,6 +81,7 @@ impl Surfaces {
             current,
             shadow,
             drop_shadows,
+            inner_shadows,
             overlay,
             shape_fills,
             shape_strokes,
@@ -154,7 +158,12 @@ impl Surfaces {
             -render_area.top() + self.margins.height as f32 / viewbox.zoom,
         );
         self.apply_mut(
-            &[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::DropShadows],
+            &[
+                SurfaceId::Fills,
+                SurfaceId::Strokes,
+                SurfaceId::DropShadows,
+                SurfaceId::InnerShadows,
+            ],
             |s| {
                 s.canvas().restore();
                 s.canvas().save();
@@ -169,6 +178,7 @@ impl Surfaces {
             SurfaceId::Current => &mut self.current,
             SurfaceId::Shadow => &mut self.shadow,
             SurfaceId::DropShadows => &mut self.drop_shadows,
+            SurfaceId::InnerShadows => &mut self.inner_shadows,
             SurfaceId::Overlay => &mut self.overlay,
             SurfaceId::Fills => &mut self.shape_fills,
             SurfaceId::Strokes => &mut self.shape_strokes,
@@ -205,6 +215,7 @@ impl Surfaces {
     pub fn reset(&mut self, color: skia::Color) {
         self.canvas(SurfaceId::Fills).restore_to_count(1);
         self.canvas(SurfaceId::DropShadows).restore_to_count(1);
+        self.canvas(SurfaceId::InnerShadows).restore_to_count(1);
         self.canvas(SurfaceId::Strokes).restore_to_count(1);
         self.canvas(SurfaceId::Current).restore_to_count(1);
         self.apply_mut(
@@ -213,6 +224,7 @@ impl Surfaces {
                 SurfaceId::Strokes,
                 SurfaceId::Current,
                 SurfaceId::DropShadows,
+                SurfaceId::InnerShadows,
                 SurfaceId::Shadow,
                 SurfaceId::Overlay,
             ],

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -749,6 +749,10 @@ impl Shape {
             _ => false,
         }
     }
+
+    pub fn has_fills(&self) -> bool {
+        !self.fills.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/render-wasm/src/view.rs
+++ b/render-wasm/src/view.rs
@@ -51,4 +51,8 @@ impl Viewbox {
         self.area
             .set_wh(self.width / self.zoom, self.height / self.zoom);
     }
+
+    pub fn zoom(&self) -> f32 {
+        self.zoom
+    }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10516

### Summary

This is the second step of fixing shadows rendering. We fixed [Fill drop shadows](https://github.com/penpot/penpot/pull/6077) in the previous step, in order to split these changes to avoid having a large PR. Here, we aim to fix **Fill inner shadows** (no strokes for the moment, that'd be in the last step)

### Changes

Following the same approach we used for drop shadows, this PR adds the `InnerShadows` Surface. In the last step we aim to deprecate `Shadow` and `Overlay` surfaces, currently used only for stroke shadows. We render the shadows directly into the `InnerShadows` surface by applying the filter.

### What does PR this fix?

- [x] Inner shadows are not clipped anymore when the shape intersects the viewport
- [x] Inner shadows work properly within the new tiles system

* Before
![inner_shadows_before](https://github.com/user-attachments/assets/a0b168fa-c067-45be-9207-276220fe9ce3)


* After
![inner_shadows_after](https://github.com/user-attachments/assets/5ab9f68d-7b36-4f5b-96f7-458c06b9938e)

Other minor refactors:
- New `has_fills` method for Shape
- New `get_scale()` method to RenderState 
