### PR TITLE
:bug: Fix stroke width validation

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/errors.cljs
@@ -44,6 +44,10 @@
    {:error/code :error.style-dictionary/invalid-token-value-opacity
     :error/fn #(str/join "\n" [(str (tr "workspace.token.invalid-value" %) ".") (tr "workspace.token.opacity-range")])}
 
+   :error.style-dictionary/invalid-token-value-stroke-width
+   {:error/code :error.style-dictionary/invalid-token-value-stroke-width
+    :error/fn #(str/join "\n" [(str (tr "workspace.token.invalid-value" %) ".") (tr "workspace.token.stroke-width-range")])}
+
    :error/unknown
    {:error/code :error/unknown
     :error/fn #(tr "labels.unknown-error")}})

--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -87,8 +87,34 @@
       (and (not has-references?) out-of-scope)
       {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value-opacity value)]}
 
-      (and has-references? out-of-scope)
-      (assoc parsed-value :warnings [(wtw/warning-with-value :warning.style-dictionary/invalid-referenced-token-value value)])
+      (and has-references? out-of-scope parsed-value)
+      (assoc parsed-value :warnings [(wtw/warning-with-value :warning.style-dictionary/invalid-referenced-token-value-opacity value)])
+
+      :else {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value value)]})))
+
+
+(defn- parse-sd-token-stroke-width-value
+  "Parses `value` of a dimensions `sd-token` into a map like `{:value 1 :unit \"px\"}`.
+  If the `value` is not parseable and/or has missing references returns a map with `:errors`.
+  If the `value` is parseable but is out of range returns a map with `warnings`."
+  [value has-references?]
+
+  (let [parsed-value (wtt/parse-token-value value)
+        out-of-scope (< (:value parsed-value) 0)
+        references (seq (ctob/find-token-value-references value))]
+    (cond
+      (and parsed-value (not out-of-scope))
+      parsed-value
+
+      references
+      {:errors [(wte/error-with-value :error.style-dictionary/missing-reference references)]
+       :references references}
+
+      (and (not has-references?) out-of-scope)
+      {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value-stroke-width value)]}
+
+      (and has-references? out-of-scope parsed-value)
+      (assoc parsed-value :warnings [(wtw/warning-with-value :warning.style-dictionary/invalid-referenced-token-value-stroke-width value)])
 
       :else {:errors [(wte/error-with-value :error.style-dictionary/invalid-token-value value)]})))
 
@@ -132,6 +158,7 @@
            parsed-token-value (case (:type origin-token)
                                 :color (parse-sd-token-color-value value)
                                 :opacity (parse-sd-token-opacity-value value has-references?)
+                                :stroke-width (parse-sd-token-stroke-width-value value has-references?)
                                 (parse-sd-token-numeric-value value))
            output-token (cond (:errors parsed-token-value)
                               (merge origin-token parsed-token-value)

--- a/frontend/src/app/main/ui/workspace/tokens/warnings.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/warnings.cljs
@@ -1,11 +1,16 @@
 (ns app.main.ui.workspace.tokens.warnings
   (:require
+   [app.util.i18n :refer [tr]]
    [cuerdas.core :as str]))
 
 (def warning-codes
-  {:warning.style-dictionary/invalid-referenced-token-value
-   {:warning/code :warning.style-dictionary/invalid-referenced-token-value
-    :warning/fn (fn [value] (str/join "\n" [(str "Resolved value " value ".") "Opacity must be between 0 and 100% or 0 and 1  (e.g. 50% or 0.5)"]))}
+  {:warning.style-dictionary/invalid-referenced-token-value-opacity
+   {:warning/code :warning.style-dictionary/invalid-referenced-token-value-opacity
+    :warning/fn (fn [value] (str/join "\n" [(str (tr "workspace.token.resolved-value" value) ".") (tr "workspace.token.opacity-range")]))}
+
+   :warning.style-dictionary/invalid-referenced-token-value-stroke-width
+   {:warning/code :warning.style-dictionary/invalid-referenced-token-value-stroke-width
+    :warning/fn (fn [value] (str/join "\n" [(str (tr "workspace.token.resolved-value" value) ".") (tr "workspace.token.stroke-width-range")]))}
 
    :warning/unknown
    {:warning/code :warning/unknown

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6675,6 +6675,10 @@ msgstr "Invalid token value: %s"
 msgid "workspace.token.opacity-range"
 msgstr "Opacity must be between 0 and 100% or 0 and 1 (e.g. 50% or 0.5)."
 
+#: src/app/main/ui/workspace/tokens/errors.cljs
+msgid "workspace.token.stroke-width-range"
+msgstr "Stroke width must be between equal or bigger than 0."
+
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs:179
 msgid "workspace.token.label.group"
 msgstr "Group"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6677,6 +6677,10 @@ msgstr "Valor de token no válido: %s"
 msgid "workspace.token.opacity-range"
 msgstr "La opacidad debe estar entre 0 y 100% o 0 y 1 (p.e. 50% o 0.5)."
 
+#: src/app/main/ui/workspace/tokens/errors.cljs
+msgid "workspace.token.stroke-width-range"
+msgstr "Stroke width debe ser mayor o igual a 0."
+
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs:179
 msgid "workspace.token.label.group"
 msgstr "Grupo"


### PR DESCRIPTION
### Related Ticket

This PR fixes [this issue](https://tree.taiga.io/project/penpot/issue/10580)

### Summary

We have added a validation for stroke-width token creation. 

This value could be only equal or bigger than 0.

### Steps to reproduce 

1. Create a file, and go to "tokens". 
2. Create a stroke-width token with value -2. 
3. An error must appear
4. Create a token with a valid value (e.g. 10)
5. Create a new token which refer the previous one and apply an operation to it (e.g {previous} * -1}) the result for this operation must be out of scope
6. A warning should appear

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
