### PR TITLE
:bug: Fix stroke shadows

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -211,13 +211,7 @@ impl RenderState {
 
     pub fn apply_drawing_to_render_canvas(&mut self, shape: Option<&Shape>) {
         self.surfaces
-            .flush_and_submit(&mut self.gpu_state, SurfaceId::Fills);
-
-        self.surfaces
             .flush_and_submit(&mut self.gpu_state, SurfaceId::DropShadows);
-
-        self.surfaces
-            .flush_and_submit(&mut self.gpu_state, SurfaceId::InnerShadows);
 
         self.surfaces.draw_into(
             SurfaceId::DropShadows,
@@ -225,28 +219,26 @@ impl RenderState {
             Some(&skia::Paint::default()),
         );
 
+        self.surfaces
+            .flush_and_submit(&mut self.gpu_state, SurfaceId::Fills);
+
         self.surfaces.draw_into(
             SurfaceId::Fills,
             SurfaceId::Current,
             Some(&skia::Paint::default()),
         );
 
-        self.surfaces.draw_into(
-            SurfaceId::InnerShadows,
-            SurfaceId::Current,
-            Some(&skia::Paint::default()),
-        );
-
         let mut render_overlay_below_strokes = false;
         if let Some(shape) = shape {
-            render_overlay_below_strokes = shape.fills().len() > 0;
+            render_overlay_below_strokes = shape.has_fills();
         }
 
         if render_overlay_below_strokes {
             self.surfaces
-                .flush_and_submit(&mut self.gpu_state, SurfaceId::Overlay);
+                .flush_and_submit(&mut self.gpu_state, SurfaceId::InnerShadows);
+
             self.surfaces.draw_into(
-                SurfaceId::Overlay,
+                SurfaceId::InnerShadows,
                 SurfaceId::Current,
                 Some(&skia::Paint::default()),
             );
@@ -254,6 +246,7 @@ impl RenderState {
 
         self.surfaces
             .flush_and_submit(&mut self.gpu_state, SurfaceId::Strokes);
+
         self.surfaces.draw_into(
             SurfaceId::Strokes,
             SurfaceId::Current,
@@ -262,25 +255,22 @@ impl RenderState {
 
         if !render_overlay_below_strokes {
             self.surfaces
-                .flush_and_submit(&mut self.gpu_state, SurfaceId::Overlay);
+                .flush_and_submit(&mut self.gpu_state, SurfaceId::InnerShadows);
+
             self.surfaces.draw_into(
-                SurfaceId::Overlay,
+                SurfaceId::InnerShadows,
                 SurfaceId::Current,
                 Some(&skia::Paint::default()),
             );
         }
 
         self.surfaces
-            .draw_into(SurfaceId::Overlay, SurfaceId::Current, None);
-        self.surfaces
             .flush_and_submit(&mut self.gpu_state, SurfaceId::Current);
 
         self.surfaces.apply_mut(
             &[
-                SurfaceId::Shadow,
-                SurfaceId::InnerShadows,
                 SurfaceId::DropShadows,
-                SurfaceId::Overlay,
+                SurfaceId::InnerShadows,
                 SurfaceId::Fills,
                 SurfaceId::Strokes,
             ],
@@ -400,11 +390,13 @@ impl RenderState {
                 }
 
                 for stroke in shape.strokes().rev() {
-                    strokes::render(self, &shape, stroke, antialias);
+                    shadows::render_stroke_drop_shadows(self, &shape, stroke, antialias);
+                    strokes::render(self, &shape, stroke, None, None, antialias);
+                    shadows::render_stroke_inner_shadows(self, &shape, stroke, antialias);
                 }
 
-                shadows::render_inner_shadows(self, &shape, antialias);
-                shadows::render_drop_shadows(self, &shape, antialias);
+                shadows::render_fill_inner_shadows(self, &shape, antialias);
+                shadows::render_fill_drop_shadows(self, &shape, antialias);
             }
         };
 

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -1,17 +1,13 @@
 use super::{RenderState, SurfaceId};
-use crate::shapes::{Shadow, Shape, Type};
-use skia_safe::{self as skia, Paint};
+use crate::render::strokes;
+use crate::shapes::{Shadow, Shape, Stroke, Type};
+use skia_safe::Paint;
 
-// Drop Shadows
-pub fn render_drop_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
+// Fill Shadows
+pub fn render_fill_drop_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
     if shape.has_fills() {
         for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
             render_fill_drop_shadow(render_state, &shape, &shadow, antialias);
-        }
-    } else {
-        let scale = render_state.get_scale();
-        for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
-            render_stroke_drop_shadow(render_state, &shadow, scale, antialias);
         }
     }
 }
@@ -26,41 +22,10 @@ fn render_fill_drop_shadow(
     render_shadow_paint(render_state, shape, paint, SurfaceId::DropShadows);
 }
 
-// TODO: Stroke shadows
-fn render_stroke_drop_shadow(
-    render_state: &mut RenderState,
-    shadow: &Shadow,
-    scale: f32,
-    antialias: bool,
-) {
-    let shadow_paint = &shadow.to_paint(scale, antialias);
-
-    render_state
-        .surfaces
-        .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(shadow_paint));
-
-    render_state.surfaces.draw_into(
-        SurfaceId::Shadow,
-        SurfaceId::Current,
-        Some(&skia::Paint::default()),
-    );
-
-    render_state
-        .surfaces
-        .canvas(SurfaceId::Shadow)
-        .clear(skia::Color::TRANSPARENT);
-}
-
-// Inner Shadows
-pub fn render_inner_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
+pub fn render_fill_inner_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
     if shape.has_fills() {
         for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
             render_fill_inner_shadow(render_state, &shape, &shadow, antialias);
-        }
-    } else {
-        let scale = render_state.get_scale();
-        for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
-            render_stroke_inner_shadow(render_state, &shadow, scale, antialias);
         }
     }
 }
@@ -75,29 +40,46 @@ fn render_fill_inner_shadow(
     render_shadow_paint(render_state, shape, paint, SurfaceId::InnerShadows);
 }
 
-// TODO: Stroke shadows
-fn render_stroke_inner_shadow(
+pub fn render_stroke_drop_shadows(
     render_state: &mut RenderState,
-    shadow: &Shadow,
-    scale: f32,
+    shape: &Shape,
+    stroke: &Stroke,
     antialias: bool,
 ) {
-    let shadow_paint = &shadow.to_paint(scale, antialias);
+    if !shape.has_fills() {
+        for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+            let filter = shadow.get_drop_shadow_filter();
+            strokes::render(
+                render_state,
+                &shape,
+                stroke,
+                Some(SurfaceId::Strokes), // FIXME
+                filter.as_ref(),
+                antialias,
+            )
+        }
+    }
+}
 
-    render_state
-        .surfaces
-        .draw_into(SurfaceId::Strokes, SurfaceId::Shadow, Some(shadow_paint));
-
-    render_state.surfaces.draw_into(
-        SurfaceId::Shadow,
-        SurfaceId::Overlay,
-        Some(&skia::Paint::default()),
-    );
-
-    render_state
-        .surfaces
-        .canvas(SurfaceId::Shadow)
-        .clear(skia::Color::TRANSPARENT);
+pub fn render_stroke_inner_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    stroke: &Stroke,
+    antialias: bool,
+) {
+    if !shape.has_fills() {
+        for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+            let filter = shadow.get_inner_shadow_filter();
+            strokes::render(
+                render_state,
+                &shape,
+                stroke,
+                Some(SurfaceId::Strokes), // FIXME
+                filter.as_ref(),
+                antialias,
+            )
+        }
+    }
 }
 
 fn render_shadow_paint(

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -13,10 +13,8 @@ pub enum SurfaceId {
     Current,
     Fills,
     Strokes,
-    Shadow,
     DropShadows,
     InnerShadows,
-    Overlay,
     Debug,
 }
 
@@ -30,12 +28,9 @@ pub struct Surfaces {
     // keeps the current shape's strokes
     shape_strokes: skia::Surface,
     // used for rendering shadows
-    shadow: skia::Surface,
-    // used for new shadow rendering
     drop_shadows: skia::Surface,
+    // used fo rendering over shadows.
     inner_shadows: skia::Surface,
-    // for drawing the things that are over shadows.
-    overlay: skia::Surface,
     // for drawing debug info.
     debug: skia::Surface,
     // for drawing tiles.
@@ -63,10 +58,8 @@ impl Surfaces {
 
         let mut target = gpu_state.create_target_surface(width, height);
         let current = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
-        let shadow = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let drop_shadows = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let inner_shadows = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
-        let overlay = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let shape_fills = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let shape_strokes = target.new_surface_with_dimensions(extra_tile_dims).unwrap();
         let debug = target.new_surface_with_dimensions((width, height)).unwrap();
@@ -79,10 +72,8 @@ impl Surfaces {
         Surfaces {
             target,
             current,
-            shadow,
             drop_shadows,
             inner_shadows,
-            overlay,
             shape_fills,
             shape_strokes,
             debug,
@@ -176,10 +167,8 @@ impl Surfaces {
         match id {
             SurfaceId::Target => &mut self.target,
             SurfaceId::Current => &mut self.current,
-            SurfaceId::Shadow => &mut self.shadow,
             SurfaceId::DropShadows => &mut self.drop_shadows,
             SurfaceId::InnerShadows => &mut self.inner_shadows,
-            SurfaceId::Overlay => &mut self.overlay,
             SurfaceId::Fills => &mut self.shape_fills,
             SurfaceId::Strokes => &mut self.shape_strokes,
             SurfaceId::Debug => &mut self.debug,
@@ -225,8 +214,6 @@ impl Surfaces {
                 SurfaceId::Current,
                 SurfaceId::DropShadows,
                 SurfaceId::InnerShadows,
-                SurfaceId::Shadow,
-                SurfaceId::Overlay,
             ],
             |s| {
                 s.canvas().clear(color).reset_matrix();

--- a/render-wasm/src/shapes/shadows.rs
+++ b/render-wasm/src/shapes/shadows.rs
@@ -1,4 +1,4 @@
-use skia_safe::{self as skia, image_filters, ImageFilter};
+use skia_safe::{self as skia, image_filters, ImageFilter, Paint};
 
 use super::Color;
 
@@ -62,75 +62,8 @@ impl Shadow {
         self.hidden
     }
 
-    pub fn to_paint(&self, scale: f32, antialias: bool) -> skia::Paint {
-        let mut paint = skia::Paint::default();
-
-        let image_filter = match self.style {
-            ShadowStyle::Drop => self.drop_shadow_filters(scale),
-            ShadowStyle::Inner => self.inner_shadow_filters(scale),
-        };
-
-        paint.set_image_filter(image_filter);
-        paint.set_anti_alias(antialias);
-
-        paint
-    }
-
-    // To be removed: Old methods for Drop Shadows and Inner Shadows (now used opnly for stroke shadows)
-
-    fn drop_shadow_filters(&self, scale: f32) -> Option<ImageFilter> {
-        let mut filter = image_filters::drop_shadow_only(
-            (self.offset.0 * scale, self.offset.1 * scale),
-            (self.blur * scale, self.blur * scale),
-            self.color,
-            None,
-            None,
-            None,
-        );
-
-        if self.spread > 0. {
-            filter =
-                image_filters::dilate((self.spread * scale, self.spread * scale), filter, None);
-        }
-
-        filter
-    }
-
-    fn inner_shadow_filters(&self, scale: f32) -> Option<ImageFilter> {
-        let sigma = self.blur * 0.5;
-        let mut filter = skia::image_filters::drop_shadow_only(
-            (self.offset.0 * scale, self.offset.1 * scale), // DPR?
-            (sigma * scale, sigma * scale),
-            skia::Color::BLACK,
-            None,
-            None,
-            None,
-        );
-
-        filter = skia::image_filters::color_filter(
-            skia::color_filters::blend(self.color, skia::BlendMode::SrcOut).unwrap(),
-            filter,
-            None,
-        );
-
-        if self.spread > 0. {
-            filter = skia::image_filters::dilate(
-                (self.spread * scale, self.spread * scale),
-                filter,
-                None,
-            );
-        }
-
-        filter = skia::image_filters::blend(skia::BlendMode::SrcIn, None, filter, None);
-
-        filter
-    }
-
-    // New methods for Drop Shadows
-
-    pub fn get_drop_shadow_paint(&self, antialias: bool) -> skia::Paint {
-        let mut paint = skia::Paint::default();
-
+    pub fn get_drop_shadow_paint(&self, antialias: bool) -> Paint {
+        let mut paint = Paint::default();
         let image_filter = self.get_drop_shadow_filter();
 
         paint.set_image_filter(image_filter);
@@ -139,7 +72,7 @@ impl Shadow {
         paint
     }
 
-    fn get_drop_shadow_filter(&self) -> Option<ImageFilter> {
+    pub fn get_drop_shadow_filter(&self) -> Option<ImageFilter> {
         let mut filter = image_filters::drop_shadow_only(
             (self.offset.0, self.offset.1),
             (self.blur, self.blur),
@@ -156,10 +89,8 @@ impl Shadow {
         filter
     }
 
-    // New methods for Inner Shadows
-
-    pub fn get_inner_shadow_paint(&self, antialias: bool) -> skia::Paint {
-        let mut paint = skia::Paint::default();
+    pub fn get_inner_shadow_paint(&self, antialias: bool) -> Paint {
+        let mut paint = Paint::default();
 
         let image_filter = self.get_inner_shadow_filter();
 
@@ -169,12 +100,12 @@ impl Shadow {
         paint
     }
 
-    fn get_inner_shadow_filter(&self) -> Option<ImageFilter> {
+    pub fn get_inner_shadow_filter(&self) -> Option<ImageFilter> {
         let sigma = self.blur * 0.5;
         let mut filter = skia::image_filters::drop_shadow_only(
             (self.offset.0, self.offset.1), // DPR?
             (sigma, sigma),
-            skia::Color::BLACK,
+            skia::Color::WHITE,
             None,
             None,
             None,

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -232,13 +232,13 @@ impl Stroke {
         match self.render_kind(is_open) {
             StrokeKind::InnerStroke => {
                 paint.set_stroke_width(2. * paint.stroke_width());
-                paint
             }
-            StrokeKind::CenterStroke => paint,
+            StrokeKind::CenterStroke => {}
             StrokeKind::OuterStroke => {
                 paint.set_stroke_width(2. * paint.stroke_width());
-                paint
             }
         }
+
+        paint
     }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10516

### Summary

This is the third step for fixing shadows rendering. We fixed [Fill drop shadows](https://github.com/penpot/penpot/pull/6077) and [Fill inner shadows](https://github.com/penpot/penpot/pull/6122) previously.

### Changes

- This PR deprecates the old `Shadow` and `Overlay` surfaces, that we kept to be able to fix this issue in different PRs.
- We now use `DropShadows` and `InnerShadows` surfaces for "shape" shadows (fills, not strokes), while the `Strokes` surface is being used for stroke shadows, which makes it easier to make sure the different stroke "layers" behave correctly when having shadows.

### What does PR this fix?

- [x] Drop and Inner stroke shadows in borders are not clipped anymore when the shape intersects the viewport or the tiles

![current_inner_stroke_shadows](https://github.com/user-attachments/assets/2e810704-6ba9-4710-b156-a731f4a716cc)
![new_inner_stroke_shadows](https://github.com/user-attachments/assets/30e13d72-8502-40fc-a912-81c4cd722ba2)

- [x] Inner stroke shadows work correctly when a shape has multiple strokes.

This final point requires a more detailed explanation. To test strokes and inner shadows, we must consider that there are three types of stroke positioning: inside, outside, and center. In the following screenshots, I applied these strokes in different orders and compared the individual strokes to the final solution to clarify how it should appear in certain cases:

#### Setup

- Strokes: 
![Screenshot 2025-03-25 at 14-55-02 shadows_default - Penpot](https://github.com/user-attachments/assets/a49ea181-9116-47ab-8d30-967d720a0d9e)

- Inner shadow:
![Screenshot 2025-03-25 at 14-48-39 shadows_default - Penpot](https://github.com/user-attachments/assets/534c76ac-154a-4e5e-a2fd-50dc412680a7)

##### Case 1: outside + inside 

![Screenshot 2025-03-25 at 14-49-59 shadows_default - Penpot](https://github.com/user-attachments/assets/e70e7d99-2bb2-4b64-88e1-84031eefdf72)

##### Case 2: outside + inside + center

![Screenshot 2025-03-25 at 14-50-04 shadows_default - Penpot](https://github.com/user-attachments/assets/182834bd-8970-4284-93c1-a47d5d5e7038)

#### Case 3: outside + center + inside

![Screenshot 2025-03-25 at 14-50-08 shadows_default - Penpot](https://github.com/user-attachments/assets/81d495b0-570f-495d-bc78-ae44a0c0a474)

#### Case 4: center + outside + inside

![Screenshot 2025-03-25 at 14-50-14 shadows_default - Penpot](https://github.com/user-attachments/assets/62ef7b73-877e-41e7-9443-18dbcf2488c2)

This approach differs from the current production render, so we should discuss if this is the correct approach we'd like to follow.