### PR TITLE
:bug: Fix wasm state warning

### DIFF
--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -138,11 +138,9 @@ pub extern "C" fn use_shape(a: u32, b: u32, c: u32, d: u32) {
 
 #[no_mangle]
 pub unsafe extern "C" fn set_parent(a: u32, b: u32, c: u32, d: u32) {
-    with_state!(state, {
+    with_current_shape!(state, |shape: &mut Shape| {
         let id = uuid_from_u32_quartet(a, b, c, d);
-        with_current_shape!(state, |shape: &mut Shape| {
-            shape.set_parent(id);
-        });
+        shape.set_parent(id);
     });
 }
 


### PR DESCRIPTION
Solving this warning: 

```
   --> src/main.rs:141:17
    |
141 |     with_state!(state, {
    |                 ^^^^^
    |
help: `state` is captured in macro and introduced a unused variable
   --> src/main.rs:25:13
    |
25  |           let $state = unsafe {
    |               ^^^^^^
...
141 | /     with_state!(state, {
142 | |         let id = uuid_from_u32_quartet(a, b, c, d);
143 | |         with_current_shape!(state, |shape: &mut Shape| {
144 | |             shape.set_parent(id);
145 | |         });
146 | |     });
    | |______- in this macro invocation
    = note: `#[warn(unused_variables)]` on by default
    = note: this warning originates in the macro `with_state` (in Nightly builds, run with -Z macro-backtrace for more info)
```