### PR TITLE
:bug: Fix _build_env release EMCC_CFLAGS

### DIFF
--- a/render-wasm/_build_env
+++ b/render-wasm/_build_env
@@ -28,6 +28,7 @@ _CARGO_PARAMS="--target=wasm32-unknown-emscripten";
 
 if [ "$_BUILD_MODE" = "release" ]; then
     _CARGO_PARAMS="--release $_CARGO_PARAMS"
+    EMCC_CFLAGS="-Os $EMCC_CFLAGS"
 else
     EMCC_CFLAGS="$EMCC_CFLAGS -sMALLOC=emmalloc-debug"
 fi


### PR DESCRIPTION
There was a problem with the _build_env release EMCC_CFLAGS making the production build to fail.