### PR TITLE
:bug: Fix calculate zoom to avoid bubbles to get outside viewbox

### DIFF
--- a/frontend/src/app/main/data/workspace/viewport.cljs
+++ b/frontend/src/app/main/data/workspace/viewport.cljs
@@ -96,17 +96,12 @@
 
 (defn update-viewport-position-center
   [position]
-
-  (dm/assert!
-   "expected a point instance for `position` param"
-   (gpt/point? position))
+  (assert (gpt/point? position) "expected a point instance for `position` param")
 
   (ptk/reify ::update-viewport-position-center
     ptk/UpdateEvent
     (update [_ state]
-      (update state :workspace-local
-              (fn [local]
-                (calculate-centered-viewbox local position))))))
+      (update state :workspace-local calculate-centered-viewbox position))))
 
 (defn update-viewport-position
   [{:keys [x y] :or {x identity y identity}}]

--- a/frontend/src/app/main/data/workspace/viewport.cljs
+++ b/frontend/src/app/main/data/workspace/viewport.cljs
@@ -10,6 +10,7 @@
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.geom.align :as gal]
+   [app.common.geom.point :as gpt]
    [app.common.geom.rect :as gpr]
    [app.common.geom.shapes :as gsh]
    [app.common.math :as mth]
@@ -82,6 +83,30 @@
         (update state :workspace-local
                 (fn [local]
                   (setup state local)))))))
+
+(defn calculate-centered-viewbox
+  "Updates the viewbox coordinates for a given center position"
+  [local position]
+  (let [vbox (:vbox local)
+        nw   (/ (:width vbox) 2)
+        nh   (/ (:height vbox) 2)
+        nx   (- (:x position) nw)
+        ny   (- (:y position) nh)]
+    (update local :vbox assoc :x nx :y ny)))
+
+(defn update-viewport-position-center
+  [position]
+
+  (dm/assert!
+   "expected a point instance for `position` param"
+   (gpt/point? position))
+
+  (ptk/reify ::update-viewport-position-center
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :workspace-local
+              (fn [local]
+                (calculate-centered-viewbox local position))))))
 
 (defn update-viewport-position
   [{:keys [x y] :or {x identity y identity}}]

--- a/frontend/src/app/main/data/workspace/zoom.cljs
+++ b/frontend/src/app/main/data/workspace/zoom.cljs
@@ -20,7 +20,7 @@
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
-(defn- impl-update-zoom
+(defn impl-update-zoom
   [{:keys [vbox] :as local} center zoom]
   (let [new-zoom (if (fn? zoom) (zoom (:zoom local)) zoom)
         old-zoom (:zoom local)

--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -1121,9 +1121,10 @@
         num-grouped-threads (count grouped-threads)
         zoom-scale-step     1.75
         scaled-zoom         (* zoom zoom-scale-step)
-        zoomed-wl           (dwz/impl-update-zoom wl position scaled-zoom)]
+        zoomed-wl           (dwz/impl-update-zoom wl position scaled-zoom)
+        outside-vbox?       (complement inside-vbox?)]
     (if (or (= num-threads num-grouped-threads)
-            (some #((comp not inside-vbox?) % zoomed-wl) grouped-threads))
+            (some #(outside-vbox? % zoomed-wl) grouped-threads))
       zoom
       (calculate-zoom-scale position scaled-zoom threads zoomed-wl))))
 
@@ -1144,13 +1145,12 @@
 
         test-id     (str/join "-" (map :seqn (sort-by :seqn thread-group)))
 
-        wl          (mf/deref refs/workspace-local)
-
         on-click
         (mf/use-fn
-         (mf/deps thread-group position zoom wl)
+         (mf/deps thread-group position zoom)
          (fn []
-           (let [centered-wl  (dwv/calculate-centered-viewbox wl position)
+           (let [wl           (deref refs/workspace-local)
+                 centered-wl  (dwv/calculate-centered-viewbox wl position)
                  updated-zoom (calculate-zoom-scale position zoom thread-group centered-wl)
                  scale-zoom   (/ updated-zoom zoom)]
              (st/emit! (dwv/update-viewport-position-center position)


### PR DESCRIPTION
### Related Ticket

Fixes Taiga issue [#10563](https://tree.taiga.io/project/penpot/issue/10563)

### Summary

Sometimes, when clicking on a bubble group,  the zoom scale we need to apply in order to separate it into bubbles is so big that some or all the bubbles go outside the viewbox, and we need to zoom out again to see any of them, making this confusing for the user. This typically happens when some of the bubbles of the group are very close and some others are far away.

We have adapted the algorithm that calculates the zoom level. In each iteration, we also check that all the bubbles remain inside the viewbox. If any of them gets outside, then we stop the iteration and take the zoom level, even if there are still grouped bubbles. The user can still click in the remaining groups to get them separated recursively.

This may sometimes make the process of separating bubbles a multi-step process rather of doing it at once, but the result is more intuitive for the user.