### PR TITLE
:sparkles: Filter variant by name on layers panel

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -145,6 +145,7 @@
                   (conj :rect :circle :path :bool))]
     (or (= uuid/zero id)
         (and (or (str/includes? (str/lower (:name shape)) (str/lower search))
+                 (str/includes? (str/lower (:variant-name shape)) (str/lower search))
                  ;; Only for local development we allow search for ids. Otherwise will be hard
                  ;; search for numbers or single letter shape names (ie: "A")
                  (and *assert*


### PR DESCRIPTION
### Related Ticket

Implements Taiga [#10599](https://tree.taiga.io/project/penpot/task/10599)

### Summary

When the user filters by name in the layer tab, they must also filter by variant name, so the variants are displayed.