### PR TITLE
:bug: Fix incorrect task result handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,9 @@
 - Fix problem with constraints when creating group [Taiga #10455](https://tree.taiga.io/project/penpot/issue/10455)
 - Fix opening pen with shortcut multiple times breaks toolbar [Taiga #10566](https://tree.taiga.io/project/penpot/issue/10566)
 - Fix actions when workspace is visited first time [Taiga #10548](https://tree.taiga.io/project/penpot/issue/10548)
-- Chat icon overlaps "Show" button in carrousel section [Taiga #10542](https://tree.taiga.io/project/penpot/issue/10542)
+- Fix chat icon overlaps "Show" button in carrousel section [Taiga #10542](https://tree.taiga.io/project/penpot/issue/10542)
+- Fix incorrect handling of background task result (now task rows are properly marked as completed)
+
 
 ## 2.5.4
 


### PR DESCRIPTION
### Summary

That caused that many task rows in a table not properly marked as completed and leaved just as scheduled.

### Steps to reproduce 

- Schedule a task to be executed (per example password recovery or new register)
- Check that task is executed correctly
- On DB the task row appears as scheduled state with no completion date

