### PR TITLE
:bug: Eva Fix context menu for viewer role

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -160,7 +160,7 @@
          (fn [event]
            (dom/prevent-default event)
            (dom/stop-propagation event)
-           (when-not is-editing
+           (when (and can-edit? (not is-editing))
              (st/emit! (dt/assign-token-set-context-menu
                         {:position (dom/get-client-position event)
                          :is-group true


### PR DESCRIPTION
### Related Ticket

This PR fixes [this issue](https://tree.taiga.io/project/penpot/issue/10618)

### Summary

Viewer user can not open the context menu on set group element

### Steps to reproduce 

1. Create a team with a owner and a viewer user
2. Create some sets and place them inside a group (e.g. group/set1 and group/set2) with the owner user
3. With the viewer user try to open the context menu of the group row. 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
