### PR TITLE
:bug: Show broken pills when all sets are disabled

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -336,7 +336,7 @@
   [tokens & {:keys [interactive?]}]
   (let [state* (mf/use-state tokens)]
     (mf/with-effect [tokens interactive?]
-      (when (seq tokens)
+      (if (seq tokens)
         (let [tpoint  (dt/tpoint-ms)
               promise (if interactive?
                         (resolve-tokens-interactive+ tokens)
@@ -346,5 +346,6 @@
                (p/fmap (fn [resolved-tokens]
                          (let [elapsed (tpoint)]
                            (l/dbg :hint "use-resolved-tokens*" :elapsed elapsed)
-                           (reset! state* resolved-tokens))))))))
+                           (reset! state* resolved-tokens))))))
+        (reset! state* tokens)))
     @state*))


### PR DESCRIPTION
### Related Ticket

This PR solves [this issue](https://tree.taiga.io/project/penpot/issue/10613)

### Summary

When  we disable a set that has refences for other tokens, those tokens must appear "broken"

### Steps to reproduce 

See issue to step by step

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
