### PR TITLE
:sparkles: Normalize the content prop from bool type

### DIFF
--- a/common/src/app/common/files/builder.cljc
+++ b/common/src/app/common/files/builder.cljc
@@ -283,14 +283,14 @@
 
           :else
           (let [objects (lookup-objects file)
-                bool-content (gsh/calc-bool-content bool objects)
-                bool' (gsh/update-bool-selrect bool children objects)]
+                content (gsh/calc-bool-content bool objects)
+                bool'   (gsh/update-bool-selrect bool children objects)]
             (commit-change
              file
              {:type :mod-obj
               :id bool-id
               :operations
-              [{:type :set :attr :bool-content :val bool-content :ignore-touched true}
+              [{:type :set :attr :content :val content :ignore-touched true}
                {:type :set :attr :selrect :val (:selrect bool') :ignore-touched true}
                {:type :set :attr :points  :val (:points bool') :ignore-touched true}
                {:type :set :attr :x       :val (-> bool' :selrect :x) :ignore-touched true}

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1240,6 +1240,24 @@
             (d/update-when page :objects update-vals update-object))]
     (update data :pages-index update-vals update-page)))
 
+(defmethod migrate-data "0002-normalize-bool-content"
+  [data _]
+  (letfn [(update-object [object]
+            ;; NOTE: we still preserve the previous value for possible
+            ;; rollback, we still need to perform an other migration
+            ;; for properly delete the bool-content prop from shapes
+            ;; once the know the migration was OK
+            (if-let [content (:bool-content object)]
+              (assoc object :content content)
+              object))
+
+          (update-container [container]
+            (d/update-when container :objects update-vals update-object))]
+
+    (-> data
+        (update :pages-index update-vals update-container)
+        (update :components update-vals update-container))))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1294,4 +1312,5 @@
          "legacy-65"
          "legacy-66"
          "legacy-67"
-         "0001-remove-tokens-from-groups"]))
+         "0001-remove-tokens-from-groups"
+         "0002-normalize-bool-content"]))

--- a/common/src/app/common/svg/path/bool.cljc
+++ b/common/src/app/common/svg/path/bool.cljc
@@ -312,14 +312,14 @@
         content-a-split (->> content-a-split add-previous (filter is-segment?))
         content-b-split (->> content-b-split add-previous (filter is-segment?))
 
-        bool-content
+        content
         (case bool-type
           :union        (create-union        content-a content-a-split content-b content-b-split sr-a sr-b)
           :difference   (create-difference   content-a content-a-split content-b content-b-split sr-a sr-b)
           :intersection (create-intersection content-a content-a-split content-b content-b-split sr-a sr-b)
           :exclude      (create-exclusion    content-a-split content-b-split))]
 
-    (->> (fix-move-to bool-content)
+    (->> (fix-move-to content)
          (ups/close-subpaths))))
 
 (defn content-bool

--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -93,8 +93,8 @@
    :constraints-h           :constraints-group
    :constraints-v           :constraints-group
    :fixed-scroll            :constraints-group
-   :bool-type               :bool-group
-   :bool-content            :bool-group
+   :bool-type               :content-group
+   :bool-content            :content-group
    :exports                 :exports-group
    :grids                   :grids-group
 

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -234,7 +234,7 @@
   [:map {:title "BoolAttrs"}
    [:shapes [:vector {:gen/max 10 :gen/min 1} ::sm/uuid]]
    [:bool-type [::sm/one-of bool-types]]
-   [:bool-content ::ctsp/content]])
+   [:content ::ctsp/content]])
 
 (def ^:private schema:rect-attrs
   [:map {:title "RectAttrs"}])

--- a/frontend/src/app/main/ui/shapes/bool.cljs
+++ b/frontend/src/app/main/ui/shapes/bool.cljs
@@ -24,7 +24,7 @@
 
           metadata? (mf/use-ctx use/include-metadata-ctx)
           content   (mf/with-memo [shape child-objs]
-                      (let [content (:bool-content shape)]
+                      (let [content (:content shape)]
                         (cond
                           (some? content)
                           content

--- a/frontend/src/app/main/ui/workspace/shapes/bool.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/bool.cljs
@@ -35,7 +35,7 @@
 
             shape      (cond-> shape
                          ^boolean child-sel?
-                         (dissoc :bool-content))]
+                         (dissoc :content))]
 
         [:> shape-container {:shape shape}
          [:& bool-shape {:shape shape

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -420,9 +420,11 @@
   [bool-type]
   (h/call internal-module "_set_shape_bool_type" (sr/translate-bool-type bool-type)))
 
-(defn set-shape-bool-content
-  [content]
-  (set-shape-path-content content))
+(defn- translate-blur-type
+  [blur-type]
+  (case blur-type
+    :layer-blur 1
+    0))
 
 (defn set-shape-blur
   [blur]
@@ -800,7 +802,6 @@
                                   (dm/get-prop shape :r2)
                                   (dm/get-prop shape :r3)
                                   (dm/get-prop shape :r4)])
-                  bool-content (dm/get-prop shape :bool-content)
                   svg-attrs    (dm/get-prop shape :svg-attrs)
                   shadows      (dm/get-prop shape :shadow)]
 
@@ -821,12 +822,13 @@
                 (set-masked masked))
               (when (some? blur)
                 (set-shape-blur blur))
-              (when (and (some? content) (= type :path))
+              (when (and (some? content)
+                         (or (= type :path)
+                             (= type :bool)))
                 (set-shape-path-attrs svg-attrs)
                 (set-shape-path-content content))
               (when (and (some? content) (= type :svg-raw))
                 (set-shape-svg-raw-content (get-static-markup shape)))
-              (when (some? bool-content) (set-shape-bool-content bool-content))
               (when (some? corners) (set-shape-corners corners))
               (when (some? shadows) (set-shape-shadows shadows))
               (when (and (= type :text) (some? content))

--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -114,7 +114,6 @@
       :parent-id    (api/set-parent-id v)
       :type         (api/set-shape-type v)
       :bool-type    (api/set-shape-bool-type v)
-      :bool-content (api/set-shape-bool-content v)
       :selrect      (api/set-shape-selrect v)
       :show-content (if (= (:type self) :frame)
                       (api/set-shape-clip-content (not v))


### PR DESCRIPTION
### Summary

Make it the same as path shape, because they are essentially the same data type

### How to test

Check that boolean types still work as before, in svg render and wasm render
