### PR TITLE
:bug: Fix linecap SVG path property

### DIFF
--- a/common/src/app/common/svg/shapes_builder.cljc
+++ b/common/src/app/common/svg/shapes_builder.cljc
@@ -435,16 +435,12 @@
 
         attrs
         (-> attrs
-            (cond-> linecap
-              (dissoc :strokeLinecap))
             (cond-> (some? color)
               (dissoc :stroke :strokeWidth :strokeOpacity))
             (update
              :style
              (fn [style]
                (-> style
-                   (cond-> linecap
-                     (dissoc :strokeLinecap))
                    (cond-> (some? color)
                      (dissoc :stroke :strokeWidth :strokeOpacity)))))
             (d/without-nils))]
@@ -461,12 +457,14 @@
 
       (and (some? linecap) (cfh/path-shape? shape)
            (or (= linecap :round) (= linecap :square)))
+
       (assoc :stroke-cap-start linecap
-             :stroke-cap-end linecap)
+             :stroke-cap-end linecap
+             :stroke-linecap linecap)
 
       (d/any-key? (dm/get-in shape [:strokes 0])
                   :strokeColor :strokeOpacity :strokeWidth
-                  :strokeCapStart :strokeCapEnd)
+                  :strokeLinecap :strokeCapStart :strokeCapEnd)
       (assoc-in [:strokes 0 :stroke-style] :svg))))
 
 (defn setup-opacity [shape]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/9489

### Summary

When importing a SVG with `stroke-linecap` property, it gets removed in favor of `stroke-cap-start` and `stroke-cap-end`, which is not working properly on svg strokes

### Steps to reproduce 

- Import this [SVG image](https://github.com/user-attachments/assets/2d6aa02c-79d3-4590-a98f-9ec19b34e024)
- Check if stroke is rounded

![image](https://github.com/user-attachments/assets/faf7fa80-9250-49d8-b9a3-bd74d84f93c6)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable --> https://github.com/penpot/penpot/pull/6166