### PR TITLE
:bug: Fix line height on token pills

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.scss
@@ -26,6 +26,7 @@
 }
 
 .name-wrapper {
+  @include use-typography("code-font");
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -41,6 +42,7 @@
 }
 
 .first-name-wrapper {
+  @include use-typography("code-font");
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -48,6 +50,7 @@
 }
 
 .last-name-wrapper {
+  @include use-typography("code-font");
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
### Related Ticket

This PR fixes [this issue](https://tree.taiga.io/project/penpot/issue/10628)

### Summary

Span elements overwrite line height of its parents, that is why in this element line height was not being correctly setted. 

### Steps to reproduce 

1. Create a token
2. Open dev tools
3. Check line height of the token name. It must be 1.2

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
