### PR TITLE
:bug: Rewrite active tokens calculation algorithm

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1227,18 +1227,15 @@ Will return a value that matches this schema:
         :none)))
 
   (get-active-themes-set-tokens [this]
-    (let [sets-order (get-ordered-set-names this)
-          active-themes (get-active-themes this)
-          order-theme-set (fn [theme]
-                            (filter #(contains? (set (:sets theme)) %) sets-order))]
-      (reduce
-       (fn [tokens theme]
-         (reduce
-          (fn [tokens' cur]
-            (merge tokens' (:tokens (get-set this cur))))
-          tokens (order-theme-set theme)))
-       (d/ordered-map)
-       active-themes)))
+    (let [theme-set-names  (get-active-themes-set-names this)
+          all-set-names    (get-ordered-set-names this)
+          active-set-names (filter theme-set-names all-set-names)
+          tokens           (reduce (fn [tokens set-name]
+                                     (let [set (get-set this set-name)]
+                                       (merge tokens (:tokens set))))
+                                   (d/ordered-map)
+                                   active-set-names)]
+      tokens))
 
   (encode-dtcg [this]
     (let [themes-xform


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10617

### Summary

(Technical note) The current algorithm to calculate active sets walks themes in a random order, and process sets in the order they are inside the themes, instead of the global set order. This may cause wrong token values are calculated.

I have rewritten it.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
