### PR TITLE
:sparkles: Add a default 256 maxlength value to all input fields

### DIFF
--- a/frontend/src/app/main/constants.cljs
+++ b/frontend/src/app/main/constants.cljs
@@ -192,3 +192,5 @@
     :height 720}])
 
 (def zoom-half-pixel-precision 8)
+
+(def max-input-length 255)

--- a/frontend/src/app/main/ui/ds/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/ds/controls/combobox.cljs
@@ -10,6 +10,7 @@
    [app.main.style :as stl])
   (:require
    [app.common.data :as d]
+   [app.main.constants :refer [max-input-length]]
    [app.main.ui.ds.controls.shared.options-dropdown :refer [options-dropdown*]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon* icon-list] :as i]
    [app.util.array :as array]
@@ -60,6 +61,7 @@
    [:id {:optional true} :string]
    [:options [:vector schema:combobox-option]]
    [:class {:optional true} :string]
+   [:max-length {:optional true} :int]
    [:placeholder {:optional true} :string]
    [:disabled {:optional true} :boolean]
    [:default-selected {:optional true} :string]
@@ -69,7 +71,7 @@
 (mf/defc combobox*
   {::mf/props :obj
    ::mf/schema schema:combobox}
-  [{:keys [id options class placeholder disabled has-error default-selected on-change] :rest props}]
+  [{:keys [id options class placeholder disabled has-error default-selected on-change max-length] :rest props}]
   (let [open* (mf/use-state false)
         open  (deref open*)
 
@@ -240,6 +242,7 @@
                 :aria-activedescendant focused
                 :class (stl/css :input)
                 :data-testid "combobox-input"
+                :maxlength (d/nilv max-length max-input-length)
                 :disabled disabled
                 :value selected
                 :on-change on-input-change

--- a/frontend/src/app/main/ui/ds/controls/input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/input.cljs
@@ -10,6 +10,7 @@
    [app.main.style :as stl])
   (:require
    [app.common.data :as d]
+   [app.main.constants :refer [max-input-length]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon* icon-list]]
    [app.util.dom :as dom]
    [rumext.v2 :as mf]))
@@ -20,13 +21,14 @@
    [:icon {:optional true}
     [:and :string [:fn #(contains? icon-list %)]]]
    [:type {:optional true} :string]
+   [:max-length {:optional true} :int]
    [:variant {:optional true} :string]])
 
 (mf/defc input*
   {::mf/props :obj
    ::mf/forward-ref true
    ::mf/schema schema:input}
-  [{:keys [icon class type variant] :rest props} ref]
+  [{:keys [icon class type max-length variant] :rest props} ref]
   (let [ref   (or ref (mf/use-ref))
         type  (d/nilv type "text")
         props (mf/spread-props props
@@ -34,6 +36,7 @@
                                         :input true
                                         :input-with-icon (some? icon))
                                 :ref ref
+                                :maxlength (d/nilv max-length (str max-input-length))
                                 :type type})
 
         on-icon-click

--- a/frontend/src/app/main/ui/workspace/tokens/components/controls/input_tokens.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/components/controls/input_tokens.cljs
@@ -7,7 +7,9 @@
 (ns app.main.ui.workspace.tokens.components.controls.input-tokens
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.main.constants :refer [max-input-length]]
    [app.main.ui.ds.controls.input :refer [input*]]
    [rumext.v2 :as mf]))
 
@@ -18,6 +20,7 @@
    [:placeholder {:optional true} :string]
    [:default-value {:optional true} [:maybe :string]]
    [:class {:optional true} :string]
+   [:max-length {:optional true} :int]
    [:error {:optional true} :boolean]
    [:value {:optional true} :string]])
 
@@ -25,12 +28,13 @@
   {::mf/props :obj
    ::mf/forward-ref true
    ::mf/schema schema::input-tokens}
-  [{:keys [class label id error value children] :rest props} ref]
+  [{:keys [class label id max-length error value children] :rest props} ref]
   (let [ref   (or ref (mf/use-ref))
         props (mf/spread-props props {:id id
                                       :type "text"
                                       :class (stl/css :input)
                                       :aria-invalid error
+                                      :max-length (d/nilv max-length max-input-length)
                                       :value value
                                       :ref ref})]
     [:div {:class (dm/str class " " (stl/css-case :wrapper true

--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
@@ -106,9 +106,9 @@
            [:> heading* {:level 3
                          :class (stl/css :theme-group-label)
                          :typography "body-large"}
-            [:span {:class (stl/css :group-title) :title (tr "workspace.token.group-name")}
-             [:> icon* {:icon-id "group"}]
-             group]])
+            [:div {:class (stl/css :group-title) :title (str (tr "workspace.token.group-name") ": " group)}
+             [:> icon* {:icon-id "group" :class (stl/css :group-title-icon)}]
+             [:> text* {:as "span" :typography "body-medium" :class (stl/css :group-title-name)} group]]])
          [:ul {:class (stl/css :theme-group-rows-wrapper)}
           (for [[_ {:keys [group name] :as theme}] themes
                 :let [theme-id (ctob/theme-path theme)
@@ -126,7 +126,7 @@
                                             :theme-path [(:id theme) (:group theme) (:name theme)]})))]]
             [:li {:key theme-id
                   :class (stl/css :theme-row)}
-             [:div {:class (stl/css :theme-row-left)}
+             [:div {:class (stl/css :theme-switch-row)}
 
               ;; FIXME: FIREEEEEEEEEE THIS
               [:div {:on-click (fn [e]
@@ -135,11 +135,12 @@
                                  (st/emit! (wdt/toggle-token-theme-active? group name)))}
                [:& switch {:name (tr "workspace.token.theme-name" name)
                            :on-change (constantly nil)
-                           :selected? selected?}]]
-              [:> text* {:as "span"  :typography "body-medium" :class (stl/css :theme-name)} name]]
+                           :selected? selected?}]]]
+             [:div {:class (stl/css :theme-name-row)}
+              [:> text* {:as "span"  :typography "body-medium" :class (stl/css :theme-name) :title name} name]]
 
 
-             [:div {:class (stl/css :theme-row-right)}
+             [:div {:class (stl/css :theme-actions-row)}
               (let [sets-count (some-> theme :sets seq count)]
                 [:> button* {:class (stl/css-case :sets-count-button sets-count
                                                   :sets-count-empty-button (not sets-count))

--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.cljs
@@ -205,6 +205,7 @@
       [:> input-tokens* {:id "theme-input"
                          :label (tr "workspace.token.label.theme")
                          :type "text"
+                         :max-length 256
                          :placeholder (tr "workspace.token.label.theme-placeholder")
                          :on-change on-update-name
                          :value (mf/ref-val theme-name-ref)

--- a/frontend/src/app/main/ui/workspace/tokens/modals/themes.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/themes.scss
@@ -32,8 +32,8 @@
 }
 
 .themes-modal-wrapper {
-  display: grid;
-  grid-template-rows: 0fr minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: $s-16;
   max-height: $s-688;
 }
@@ -120,6 +120,15 @@
   gap: $s-4;
 }
 
+.group-title-icon {
+  flex-shrink: 0;
+}
+
+.group-title-name {
+  flex-grow: 1;
+  @include textEllipsis;
+}
+
 .theme-group-rows-wrapper {
   display: flex;
   flex-direction: column;
@@ -136,26 +145,26 @@
 }
 
 .theme-row {
-  display: flex;
   align-items: center;
-  gap: $s-12;
+  display: flex;
   justify-content: space-between;
+  gap: $s-16;
 }
 
-.theme-row-left {
-  display: flex;
-  align-items: center;
-  gap: $s-16;
+.theme-name-row {
+  @include textEllipsis;
+  flex-grow: 1;
 }
 
 .theme-name {
   color: var(--color-foreground-primary);
 }
 
-.theme-row-right {
-  display: flex;
+.theme-actions-row {
   align-items: center;
+  display: flex;
   gap: $s-6;
+  flex-shrink: 0;
 }
 
 .sets-count-button {

--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -227,6 +227,7 @@
          :on-submit on-edit-submit'}]
        [:*
         [:div {:class (stl/css :set-name)
+               :title label
                :on-double-click on-double-click
                :id label-id}
          label]
@@ -499,7 +500,7 @@
            (when (fn? on-start-edition)
              (on-start-edition v))))]
 
-    [:fieldset {:class (stl/css :sets-list)}
+    [:div {:class (stl/css :sets-list)}
      (if ^boolean empty-state?
        [:> text* {:as "span" :typography "body-small" :class (stl/css :empty-state-message-sets)}
         (tr "workspace.token.no-sets-create")]

--- a/frontend/src/app/main/ui/workspace/tokens/sets.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.cljs
@@ -94,6 +94,7 @@
       :type "text"
       :on-blur on-submit
       :on-key-down on-key-down
+      :maxlength "256"
       :auto-focus true
       :placeholder (tr "workspace.token.set-edit-placeholder")
       :default-value default-value}]))

--- a/frontend/src/app/main/ui/workspace/tokens/sets.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sets.scss
@@ -70,6 +70,7 @@
 }
 
 .icon {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   width: $s-20;
@@ -82,6 +83,7 @@
 }
 
 .checkbox-style {
+  flex-shrink: 0;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -319,8 +319,7 @@
 
     [:*
      [:& token-context-menu]
-     [:& title-bar {:all-clickable true
-                    :title (tr "workspace.token.tokens-section-title" selected-token-set-name)}]
+     [:span {:class (stl/css :sets-header)} (tr "workspace.token.tokens-section-title" selected-token-set-name)]
 
      (for [type filled-group]
        (let [tokens (get tokens-by-type type)]

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
@@ -44,6 +44,11 @@
   margin-bottom: $s-8;
   padding-left: $s-8;
   color: var(--title-foreground-color);
+  word-break: break-word;
+}
+
+.sets-header {
+  margin-block-start: $s-8;
 }
 
 .themes-wrapper {

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
@@ -38,11 +38,11 @@
   padding-block-end: $s-16;
 }
 
-.themes-header {
+.themes-header,
+.sets-header {
   @include use-typography("headline-small");
   display: block;
-  margin-bottom: $s-8;
-  padding-left: $s-8;
+  padding: $s-8;
   color: var(--title-foreground-color);
   word-break: break-word;
 }

--- a/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
@@ -41,7 +41,7 @@
                      :sub-item grouped?
                      :is-selected selected?)
              :on-click select-theme}
-        [:> text* {:as "span" :typography "body-small" :class (stl/css :label)} name]
+        [:> text* {:as "span" :typography "body-small" :class (stl/css :label) :title name} name]
         [:> icon* {:icon-id i/tick
                    :aria-hidden true
                    :class (stl/css-case :check-icon true
@@ -58,7 +58,7 @@
                :aria-labelledby (dm/str group "-label")
                :role "group"}
           (when (seq group)
-            [:> text* {:as "span" :typography "headline-small" :class (stl/css :group) :id (dm/str group "-label")} group])
+            [:> text* {:as "span" :typography "headline-small" :class (stl/css :group) :id (dm/str (str/kebab group) "-label") :title group} group])
           [:& themes-list {:themes themes
                            :active-theme-paths active-theme-paths
                            :on-close on-close

--- a/frontend/src/app/main/ui/workspace/tokens/theme_select.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/theme_select.scss
@@ -41,6 +41,7 @@
 }
 
 .group {
+  @include textEllipsis;
   display: block;
   padding: $s-8;
   color: var(--color-foreground-secondary);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10614

### Summary

This PR must be composed of two commits

1. Should set a maxlenght to all inputs (ds and tokens)
2. Should fix wrong interface behavior when themes and sets names are too long

### Steps to reproduce 

Defined on the issue

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
