### PR TITLE
:bug: Fix path editing with wrong selrect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix path having a wrong selrect [Taiga #10257](https://tree.taiga.io/project/penpot/issue/10257)
 - Fix SVG `stroke-linecap` property when importing SVGs [Taiga #9489](https://tree.taiga.io/project/penpot/issue/9489)
 
 ## 2.6.0 (Unreleased)

--- a/common/src/app/common/geom/shapes/path.cljc
+++ b/common/src/app/common/geom/shapes/path.cljc
@@ -347,7 +347,11 @@
                move-p nil
                content (seq content)]
           (if content
-            (let [command (first content)
+            (let [last-p (last content)
+                  content (if (= :move-to (:command last-p))
+                            (butlast content)
+                            content)
+                  command (first content)
                   to-p    (command->point command)
 
                   [from-p move-p command-pts]

--- a/common/src/app/common/svg/path/subpath.cljc
+++ b/common/src/app/common/svg/path/subpath.cljc
@@ -126,7 +126,7 @@
   (pt= (:from subpath) (:to subpath)))
 
 (defn close-subpaths
-  "Searches a path for possible supaths that can create closed loops and merge them"
+  "Searches a path for possible subpaths that can create closed loops and merge them"
   [content]
   (let [subpaths (get-subpaths content)
         closed-subpaths


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #10257](https://tree.taiga.io/project/penpot/issue/10257)

### Summary

I've added a check in the path `content->selrect` function that verifies if the last point is a `:move-to` command and in that case, it's excluded from the selrect computation.

### Steps to reproduce 

1. Choose path tool
2. Create an arbitrary path with multiple points
3. Press ESC
4. Add an extra point far from the initial path
5. Press ESC
6. Press ESC again
7. The selrect includes that extra point

[screencast-from-18022025-153036.webm](https://github.com/user-attachments/assets/577082cf-9afb-41ac-a8f6-ad8fecc7bfad)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
