### PR TITLE
:sparkles: Render text properly while dragging and resizing the text Shape

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -380,7 +380,10 @@ impl RenderState {
                 }
             }
             Type::Text(text_content) => {
-                text::render(self, text_content);
+                self.surfaces.apply_mut(&[SurfaceId::Fills], |s| {
+                    s.canvas().concat(&matrix);
+                });
+                text::render(self, &shape, text_content);
             }
             _ => {
                 self.surfaces.apply_mut(
@@ -594,6 +597,7 @@ impl RenderState {
         }
         let scale = self.get_scale();
         let mut should_stop = false;
+
         while !should_stop {
             if let Some(current_tile) = self.current_tile {
                 if self.surfaces.has_cached_tile_surface(current_tile) {

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -1,13 +1,11 @@
-use super::{RenderState, SurfaceId};
+use super::{RenderState, Shape, SurfaceId};
 use crate::shapes::TextContent;
 
-pub fn render(render_state: &mut RenderState, text: &TextContent) {
-    let mut offset_y = 0.0;
+pub fn render(render_state: &mut RenderState, shape: &Shape, text: &TextContent) {
     for mut skia_paragraph in text.to_paragraphs(&render_state.fonts().font_collection()) {
-        skia_paragraph.layout(text.width());
+        skia_paragraph.layout(shape.width());
 
-        let xy = (text.x(), text.y() + offset_y);
+        let xy = (shape.selrect().x(), shape.selrect.y());
         skia_paragraph.paint(render_state.surfaces.canvas(SurfaceId::Fills), xy);
-        offset_y += skia_paragraph.height();
     }
 }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -575,6 +575,10 @@ impl Shape {
         self.hidden
     }
 
+    pub fn width(&self) -> f32 {
+        self.selrect.width()
+    }
+
     pub fn visually_insignificant(&self, scale: f32) -> bool {
         self.selrect.width() * scale < MIN_VISIBLE_SIZE
             || self.selrect.height() * scale < MIN_VISIBLE_SIZE

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -26,14 +26,17 @@ impl TextContent {
         self.bounds = Rect::from_xywh(x, y, w, h);
     }
 
+    #[allow(dead_code)]
     pub fn width(&self) -> f32 {
         self.bounds.width()
     }
 
+    #[allow(dead_code)]
     pub fn x(&self) -> f32 {
         self.bounds.x()
     }
 
+    #[allow(dead_code)]
     pub fn y(&self) -> f32 {
         self.bounds.y()
     }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10530

### Summary

This PR uses the shape bounds to render the text position, and also uses it as the paragraph layout, so it's both dragged and resized properly

### Steps to reproduce 
- Add a text
- Drag it around the file
- Check it's correctly rendered when the shape is resized

[screen-recorder-thu-mar-27-2025-13-06-34.webm](https://github.com/user-attachments/assets/bf5f4b96-35f1-4e5d-a54a-9b7dbbbfca78)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
