### PR TITLE
:sparkles: Allow modifying property name when a variation is selected

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/input_with_values.cljs
+++ b/frontend/src/app/main/ui/ds/controls/input_with_values.cljs
@@ -29,7 +29,7 @@
         input-ref (mf/use-ref)
         input     (mf/ref-val input-ref)
 
-        title     (str name ": " values)
+        title     (if values (str name ": " values) name)
 
         on-edit
         (mf/use-fn
@@ -74,7 +74,8 @@
       [:div {:class (stl/css :input-with-values-edit-container)}
        [:> input* props]]
       [:div {:class (stl/css :input-with-values-container :input-with-values-grid)
-             :title title :on-click on-edit}
+             :title title
+             :on-click on-edit}
        [:span {:class (stl/css :input-with-values-name)} name]
        (when values
          [:span {:class (stl/css :input-with-values-values)} values])])))

--- a/frontend/src/app/main/ui/ds/controls/input_with_values.cljs
+++ b/frontend/src/app/main/ui/ds/controls/input_with_values.cljs
@@ -16,9 +16,8 @@
 (def ^:private schema:input-with-values
   [:map
    [:name :string]
-   [:values :string]
+   [:values {:optional true} :string]
    [:on-blur {:optional true} fn?]])
-
 
 (mf/defc input-with-values*
   {::mf/props :obj
@@ -26,15 +25,19 @@
   [{:keys [name values on-blur] :rest props}]
   (let [editing*  (mf/use-state false)
         editing?  (deref editing*)
+
         input-ref (mf/use-ref)
         input     (mf/ref-val input-ref)
+
         title     (str name ": " values)
+
         on-edit
         (mf/use-fn
          (fn [event]
            (dom/stop-propagation event)
            (reset! editing* true)
            (dom/focus! input)))
+
         on-stop-edit
         (mf/use-fn
          (mf/deps on-blur)
@@ -43,6 +46,7 @@
            (reset! editing* false)
            (when on-blur
              (on-blur event))))
+
         on-focus
         (mf/use-fn
          (fn [event]
@@ -71,5 +75,6 @@
        [:> input* props]]
       [:div {:class (stl/css :input-with-values-container :input-with-values-grid)
              :title title :on-click on-edit}
-       [:span {:class (stl/css :input-with-values-name)}  name]
-       [:span {:class (stl/css :input-with-values-values)} values]])))
+       [:span {:class (stl/css :input-with-values-name)} name]
+       (when values
+         [:span {:class (stl/css :input-with-values-values)} values])])))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -281,25 +281,40 @@
          (fn [pos value]
            (st/emit! (dwv/update-property-value id-component pos value))))
 
+        update-property-name
+        (mf/use-fn
+         (mf/deps variant-id)
+         (fn [event]
+           (let [value (dom/get-target-val event)
+                 pos   (-> (dom/get-current-target event)
+                           (dom/get-data "position")
+                           int)]
+             (st/emit! (dwv/update-property-name variant-id pos value)))))
+
         switch-component
         (mf/use-fn
          (mf/deps shape)
          (fn [id]
            (st/emit! (dwl/component-swap shape (:component-file shape) id))))]
+
     [:*
      (for [[pos prop] (map vector (range) properties)]
 
        [:div {:key (str (:id shape) pos) :class (stl/css :variant-property-container)}
         (if (ctk/main-instance? shape)
           [:*
-           [:span {:class (stl/css :variant-property-name :variant-property-name-bg)} (:name prop)]
+           [:div {:class (stl/css :variant-property-name-width)}
+            [:> input-with-values* {:name (:name prop)
+                                    :data-position pos
+                                    :on-blur update-property-name}]]
            [:> combobox* {:id (str "variant-prop-" (:id shape) pos)
                           :default-selected (if (str/empty? (:value prop)) "--" (:value prop))
                           :options (clj->js (get-options (:name prop)))
                           :on-change (partial change-property-value pos)}]]
 
           [:*
-           [:span {:class (stl/css :variant-property-name)} (:name prop)]
+           [:span {:class (stl/css :variant-property-name :variant-property-name-width)}
+            (:name prop)]
            [:& select {:default-value id-component
                        :options (filter-matching id-component (keyword (:name prop)))
                        :on-change switch-component}]])])]))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -303,7 +303,7 @@
        [:div {:key (str (:id shape) pos) :class (stl/css :variant-property-container)}
         (if (ctk/main-instance? shape)
           [:*
-           [:div {:class (stl/css :variant-property-name-width)}
+           [:div {:class (stl/css :variant-property-name-wrapper)}
             [:> input-with-values* {:name (:name prop)
                                     :data-position pos
                                     :on-blur update-property-name}]]
@@ -313,7 +313,7 @@
                           :on-change (partial change-property-value pos)}]]
 
           [:*
-           [:span {:class (stl/css :variant-property-name :variant-property-name-width)}
+           [:span {:class (stl/css :variant-property-name)}
             (:name prop)]
            [:& select {:default-value id-component
                        :options (filter-matching id-component (keyword (:name prop)))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -719,6 +719,7 @@
 .variant-property-name {
   color: var(--color-foreground-primary);
   height: var(--sp-xxxl);
+  width: $s-104;
 
   display: flex;
   align-items: center;
@@ -729,6 +730,8 @@
   white-space: nowrap;
 }
 
-.variant-property-name-width {
+.variant-property-name-wrapper {
+  display: flex;
+  flex: 0 0 auto;
   width: $s-104;
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -716,22 +716,19 @@
   gap: var(--sp-xs);
 }
 
-.variant-property-name-bg {
-  border-radius: $br-8;
-  background-color: var(--assets-item-background-color);
-}
-
 .variant-property-name {
   color: var(--color-foreground-primary);
-
-  width: $s-104;
+  height: var(--sp-xxxl);
 
   display: flex;
   align-items: center;
   justify-content: center;
-  height: var(--sp-xxxl);
 
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.variant-property-name-width {
+  width: $s-104;
 }


### PR DESCRIPTION
### Related Ticket

Implements Taiga [#10649](https://tree.taiga.io/project/penpot/task/10649)

### Summary

When a variant is selected, the user should be able to edit the name of any of its properties by clicking on them on the right sidebar.