### PR TITLE
:bug: Revert offset change to fix paragraph rendering

### DIFF
--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -2,10 +2,12 @@ use super::{RenderState, Shape, SurfaceId};
 use crate::shapes::TextContent;
 
 pub fn render(render_state: &mut RenderState, shape: &Shape, text: &TextContent) {
+    let mut offset_y = 0.0;
     for mut skia_paragraph in text.to_paragraphs(&render_state.fonts().font_collection()) {
         skia_paragraph.layout(shape.width());
 
-        let xy = (shape.selrect().x(), shape.selrect.y());
+        let xy = (shape.selrect().x(), shape.selrect.y() + offset_y);
         skia_paragraph.paint(render_state.surfaces.canvas(SurfaceId::Fills), xy);
+        offset_y += skia_paragraph.height();
     }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10530

### Summary

Put offset back since it's being used for correctly rendering multiple line paragraphs

### Steps to reproduce 

Add a text with multiple lines and check they're all correctly rendered

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
