### PR TITLE
:wrench: Log error on process animation frame

### DIFF
--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -95,11 +95,24 @@ pub extern "C" fn render(timestamp: i32) {
 
 #[no_mangle]
 pub extern "C" fn process_animation_frame(timestamp: i32) {
-    with_state!(state, {
-        state
-            .process_animation_frame(timestamp)
-            .expect("Error processing animation frame");
+    let result = std::panic::catch_unwind(|| {
+        with_state!(state, {
+            state
+                .process_animation_frame(timestamp)
+                .expect("Error processing animation frame");
+        });
     });
+
+    match result {
+        Ok(_) => {}
+        Err(err) => {
+            match err.downcast_ref::<String>() {
+                Some(message) => println!("process_animation_frame error: {}", message),
+                None => println!("process_animation_frame error: {:?}", err),
+            }
+            std::panic::resume_unwind(err);
+        }
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10654

### Summary

This PR logs errors on process animation frame, so we can provisionally know what fails
 
### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
