### PR TITLE
:bug: Fix stroke image rendering

### DIFF
--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -451,7 +451,13 @@ fn draw_image_stroke_in_container(
     // Compute scaled rect and clip to it
     let dest_rect = calculate_scaled_rect(size, container, stroke.delta());
     canvas.clip_rect(dest_rect, skia::ClipOp::Intersect, antialias);
-    canvas.draw_image_rect(image.unwrap(), None, dest_rect, &image_paint);
+    canvas.draw_image_rect_with_sampling_options(
+        image.unwrap(),
+        None,
+        dest_rect,
+        render_state.sampling_options,
+        &image_paint,
+    );
 
     // Clear outer stroke for paths if necessary. When adding an outer stroke we need to empty the stroke added too in the inner area.
     if let Type::Path(p) = &shape.shape_type {

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -116,8 +116,8 @@ impl Stroke {
     pub fn delta(&self) -> f32 {
         match self.kind {
             StrokeKind::InnerStroke => 0.,
-            StrokeKind::CenterStroke => self.width / 2.,
-            StrokeKind::OuterStroke => self.width,
+            StrokeKind::CenterStroke => self.width,
+            StrokeKind::OuterStroke => self.width * 2.,
         }
     }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10651

### Summary

Stroke fill images on paths were not correctly rendered and differed from the current render. This PR fixes this, including using the correct sampling_options from the render state.

### Steps to reproduce 

- Create a custom path shape with stroke
- Fill the stroke with an image
- Test different strokes (center, inside, outside) are correctly filled with the image

* Before
![Screenshot 2025-03-28 at 14-37-43 test_stroke_fill - Penpot](https://github.com/user-attachments/assets/a278b7fc-c6ee-4f3c-bb4a-df34c7769b26)

* After
![Screenshot 2025-03-28 at 14-38-12 test_stroke_fill - Penpot](https://github.com/user-attachments/assets/d946edee-325b-45a5-8074-15a75b190dca)

* For reference: production current render
![Screenshot 2025-03-28 at 14-38-39 test_stroke_fill - Penpot](https://github.com/user-attachments/assets/f0dc9512-ca88-465f-b861-f1a89fb2335c)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
