### PR TITLE
:bug: Fix UI with long named colors

### DIFF
--- a/frontend/src/app/main/ui/inspect/attributes/common.scss
+++ b/frontend/src/app/main/ui/inspect/attributes/common.scss
@@ -70,36 +70,23 @@
     visibility: visible;
   }
 }
+
 .one-line {
   max-height: $s-32;
 }
+
 .two-line {
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: auto 1fr;
+  gap: $s-4;
 }
+
 .color-name-wrapper {
   @include bodySmallTypography;
   @include flexColumn;
   padding: $s-8 $s-4 $s-8 $s-8;
   height: $s-32;
   max-width: $s-80;
-
-  &.gradient-color {
-    color: var(--menu-foreground-color);
-    max-width: $s-124;
-  }
-  .color-name-library {
-    @include bodySmallTypography;
-    @include textEllipsis;
-    text-align: left;
-    height: $s-16;
-    color: var(--menu-foreground-color-rest);
-  }
-  .color-value-wrapper {
-    @include bodySmallTypography;
-    height: $s-16;
-    color: var(--menu-foreground-color);
-  }
 }
 
 .opacity-info {
@@ -152,6 +139,7 @@
 .color-name-library {
   @include inspectValue;
   color: var(--menu-foreground-color-rest);
+  word-break: break-word;
 }
 
 .image-download {


### PR DESCRIPTION
### Related Ticket

This PR closes the comment on [this issue ](https://tree.taiga.io/project/penpot/issue/10630)

### Summary

The UI breaks when the library color has a very long name

### Steps to reproduce 

1. Create a color asset with a very long name
2. Set the color to a shape
3. Go to inspect, info tab
4. Check the UI

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
