### PR TITLE
:lipstick: Truncate long file names

### DIFF
--- a/frontend/src/app/main/ui/workspace/left_header.cljs
+++ b/frontend/src/app/main/ui/workspace/left_header.cljs
@@ -110,7 +110,7 @@
           :auto-focus true
           :default-value (:name file "")}]
         [:div
-         {:class (stl/css :file-name)
+         {:class (stl/css :file-name-container)
           :title file-name
           :on-double-click start-editing-name}
           ;;-- Persistende state widget
@@ -126,13 +126,8 @@
                          :saved (tr "workspace.header.saved")
                          :error (tr "workspace.header.save-error")
                          nil)}
-          (case persistence-status
-            :pending i/status-alert
-            :saving i/status-alert
-            :saved i/status-tick
-            :error i/status-wrong
-            nil)]
-         file-name])]
+          ]
+         [:div {:class (stl/css :file-name)} file-name]])]
      (when ^boolean shared?
        [:span {:class (stl/css :shared-badge)} i/library])
      [:div {:class (stl/css :menu-section)}

--- a/frontend/src/app/main/ui/workspace/left_header.scss
+++ b/frontend/src/app/main/ui/workspace/left_header.scss
@@ -34,24 +34,31 @@
   max-width: calc(100% - $s-64);
 }
 
+.file-name-container {
+  display: flex;
+  gap: $s-4;
+  align-items: center;
+}
+
 .project-name,
-.file-name {
+.file-name-container {
   @include uppercaseTitleTipography;
-  @include textEllipsis;
   height: $s-16;
-  width: 100%;
   padding-bottom: $s-2;
   color: var(--title-foreground-color);
   cursor: pointer;
 }
 
+.project-name {
+  @include textEllipsis;
+}
+
 .file-name {
   @include smallTitleTipography;
+  @include textEllipsis;
+  flex: 1;
   text-transform: none;
   color: var(--title-foreground-color-hover);
-  align-items: center;
-  display: flex;
-  flex-direction: row;
 }
 
 .file-name-input {


### PR DESCRIPTION
### Related Ticket

Partially fixes https://tree.taiga.io/project/penpot/issue/10662

### Summary

Long file names are not being truncated correctly.

### Steps to reproduce 

Create a long file name as: 

```
May musical arrival beloved luckily adapted him. Shyness mention married son she his started now. 
```

Expected  in the UI workspace

`May musical a...`

Current

`May musical arr`

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
