### PR TITLE
:sparkles: Fix single set import

### DIFF
--- a/common/test/common_tests/types/data/legacy-single-set.json
+++ b/common/test/common_tests/types/data/legacy-single-set.json
@@ -1,0 +1,6 @@
+{"color":
+ {"red":
+  {"100":
+   {"value":"red",
+    "type":"color",
+    "description":""}}}}

--- a/common/test/common_tests/types/data/single-set.json
+++ b/common/test/common_tests/types/data/single-set.json
@@ -1,0 +1,6 @@
+{"color":
+ {"red":
+  {"100":
+   {"$value":"red",
+    "$type":"color",
+    "$description":""}}}}

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1372,6 +1372,30 @@
          (t/is (nil? (get-set-token "typography" "H1.Bold")))))))
 
 #?(:clj
+   (t/deftest single-set-legacy-json-decoding
+     (let [json (-> (slurp "test/common_tests/types/data/legacy-single-set.json")
+                    (tr/decode-str))
+           lib (ctob/decode-single-set-legacy-json (ctob/ensure-tokens-lib nil) "single_set" json)
+           get-set-token (fn [set-name token-name]
+                           (some-> (ctob/get-set lib set-name)
+                                   (ctob/get-token token-name)))]
+       (t/is (= '("single_set") (ctob/get-ordered-set-names lib)))
+       (t/testing "token added"
+         (t/is (some? (get-set-token "single_set" "color.red.100")))))))
+
+#?(:clj
+   (t/deftest single-set-dtcg-json-decoding
+     (let [json (-> (slurp "test/common_tests/types/data/single-set.json")
+                    (tr/decode-str))
+           lib (ctob/decode-single-set-json (ctob/ensure-tokens-lib nil) "single_set" json)
+           get-set-token (fn [set-name token-name]
+                           (some-> (ctob/get-set lib set-name)
+                                   (ctob/get-token token-name)))]
+       (t/is (= '("single_set") (ctob/get-ordered-set-names lib)))
+       (t/testing "token added"
+         (t/is (some? (get-set-token "single_set" "color.red.100")))))))
+
+#?(:clj
    (t/deftest dtcg-encoding-decoding-json
      (let [json (-> (slurp "test/common_tests/types/data/tokens-multi-set-example.json")
                     (tr/decode-str))

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -40,6 +40,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.webapi :as wapi]
    [beicon.v2.core :as rx]
+   [cuerdas.core :as str]
    [okulary.core :as l]
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]
@@ -367,9 +368,10 @@
          (fn [event]
            (let [file (-> (dom/get-target event)
                           (dom/get-files)
-                          (first))]
+                          (first))
+                 file-name (str/replace (.-name file) ".json" "")]
              (->> (wapi/read-file-as-text file)
-                  (sd/process-json-stream)
+                  (sd/process-json-stream {:file-name file-name})
                   (rx/subs! (fn [lib]
                               (st/emit! (ptk/data-event ::ev/event {::ev/name "import-tokens"})
                                         (dt/import-tokens-lib lib)))


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/penpot/issues/93

Files to test the changes:
- Legacy single set - [legacy_single_set.json](https://github.com/user-attachments/files/19535508/legacy_single_set.json)
- DTCG single set - [single_set.json](https://github.com/user-attachments/files/19535528/single_set.json)
- Invalid JSON file - [invalid_json.json](https://github.com/user-attachments/files/19535534/invalid_json.json)
- Legacy tokens file - [legacy_tokens.json](https://github.com/user-attachments/files/19535539/legacy_tokens.json)
- DTCG tokens file - [tokens.json](https://github.com/user-attachments/files/19535542/tokens.json)


