### PR TITLE
:bug: Fix max lenght on assets inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,7 +46,7 @@
 - Fix incorrect handling of background task result (now task rows are properly marked as completed)
 - Fix available size of resize handler [Taiga #10639](https://tree.taiga.io/project/penpot/issue/10639)
 - Internal error when install a plugin by penpothub - Try plugin [Taiga #10542](https://tree.taiga.io/project/penpot/issue/10542)
-
+- Add character limitation to asset inputs [Taiga #10669](https://tree.taiga.io/project/penpot/issue/10669)
 
 ## 2.5.4
 

--- a/frontend/src/app/main/ui/components/editable_label.cljs
+++ b/frontend/src/app/main/ui/components/editable_label.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data.macros :as dm]
+   [app.main.constants :refer [max-input-length]]
    [app.main.ui.icons :as i]
    [app.util.dom :as dom]
    [app.util.keyboard :as kbd]
@@ -93,6 +94,7 @@
          :default-value value
          :on-key-up on-key-up
          :on-double-click on-dbl-click
+         :max-length max-input-length
          :on-blur cancel-edition}]
 
        [:span {:class (stl/css :editable-label-close)

--- a/frontend/src/app/main/ui/inspect/attributes/text.scss
+++ b/frontend/src/app/main/ui/inspect/attributes/text.scss
@@ -20,6 +20,8 @@
 
 .text-row {
   @extend .attr-row;
+  height: unset;
+  min-height: $s-32;
   :global(.attr-value) {
     align-items: center;
   }

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/colors.cljs
@@ -10,6 +10,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
+   [app.main.constants :refer [max-input-length]]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.data.workspace :as dw]
@@ -220,6 +221,7 @@
          :on-blur input-blur
          :on-key-down input-key-down
          :auto-focus true
+         :max-length max-input-length
          :default-value (cfh/merge-path-item (:path color) (:name color))}]
 
        [:div {:title (if (= (:name color) default-name)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -12,6 +12,7 @@
    [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
    [app.common.text :as txt]
+   [app.main.constants :refer [max-input-length]]
    [app.main.data.common :as dcm]
    [app.main.data.fonts :as fts]
    [app.main.data.shortcuts :as dsc]
@@ -483,6 +484,7 @@
              :type "text"
              :ref name-input-ref
              :default-value (:name typography)
+             :max-length max-input-length
              :on-key-down on-key-down
              :on-blur on-name-blur}]
 
@@ -615,6 +617,7 @@
            :type "text"
            :ref name-input-ref
            :default-value (:name typography)
+           :max-length max-input-length
            :on-key-down on-key-down
            :on-blur on-name-blur}]]
         [:div


### PR DESCRIPTION
### Related Ticket

This PR solves[ this issue](https://tree.taiga.io/project/penpot/issue/10669)

### Summary

Do not allow the creation of assets with names longer than 250 characters.

### Steps to reproduce 

1. Create an asset
2. Set a very long name
3. The name must be clipped to 250 char max.
4. UI must be correct

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
