### PR TITLE
:bug: Fix Google Fonts load by parsing italic variant ids correctly

### DIFF
--- a/frontend/src/app/main/fonts.clj
+++ b/frontend/src/app/main/fonts.clj
@@ -22,10 +22,12 @@
     {:id "italic" :name "italic" :weight "400" :style "italic" :ttf-url (get files "italic")}
 
     :else
-    (when-let [[a b c] (re-find #"^(\d+)(.*)$" variant)]
-      (if (str/empty? c)
-        {:id a :name b :weight b :style "normal" :ttf-url (get files a)}
-        {:id a :name (str b " (" c ")") :weight b :style c :ttf-url (get files c)}))))
+    (when-let [[id weight style] (re-find #"^(\d+)(.*)$" variant)]
+      {:id id
+       :name variant
+       :weight weight
+       :style (if (str/empty? style) "normal" style)
+       :ttf-url (get files id)})))
 
 (defn- parse-gfont
   [font]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10528

### Summary

This is a follow-up for https://github.com/penpot/penpot/pull/6178 to render google fonts using directly the variant style.

There were two issues:

1. We're not correctly getting italic variants when the google font has a different weight + italic. By default, we're always returning the italic TTF instead of the bold + italic TTFs.
2. Apart from that, we were not loading styles properly in the new render from the variant ids, so bold styles were not being rendered

* Before 
![image](https://github.com/user-attachments/assets/18c31b41-06cd-4085-9956-a57f71f50cce)

* After
![image(3)](https://github.com/user-attachments/assets/fe6a3585-ad9a-4acd-bf5c-2ef094c1908d)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
