### PR TITLE
:bug: Fix not enough surfaces

### DIFF
--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -7,6 +7,7 @@ use super::{gpu_state::GpuState, tiles::Tile};
 use base64::{engine::general_purpose, Engine as _};
 use std::collections::HashMap;
 
+const POOL_CAPACITY_MINIMUM: i32 = 32;
 const POOL_CAPACITY_THRESHOLD: i32 = 4;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -68,7 +69,9 @@ impl Surfaces {
         let debug = target.new_surface_with_dimensions((width, height)).unwrap();
 
         let pool_capacity =
-            (width / tile_dims.width) * (height / tile_dims.height) * POOL_CAPACITY_THRESHOLD;
+            ((width / tile_dims.width) * (height / tile_dims.height) * POOL_CAPACITY_THRESHOLD)
+                .max(POOL_CAPACITY_MINIMUM);
+
         let pool = SurfacePool::with_capacity(&mut target, tile_dims, pool_capacity as usize);
         let tiles = TileSurfaceCache::new(pool);
         Surfaces {


### PR DESCRIPTION
Sometimes when the viewport is small the SurfacePool capacity is too low, this adds a reasonable minimum of previously allocated surfaces.