### PR TITLE
:wrench: Fix Rust tests

### DIFF
--- a/render-wasm/_build_env
+++ b/render-wasm/_build_env
@@ -39,4 +39,4 @@ fi
 export EMCC_CFLAGS;
 export _CARGO_PARAMS;
 
-export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.81.0-1/skia-binaries-24dee32a277b6c7b5357-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache.tar.gz"
+export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.82.0-1/skia-binaries-24dee32a277b6c7b5357-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache.tar.gz"

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -1,6 +1,7 @@
 use skia_safe as skia;
 
 mod debug;
+#[cfg(target_arch = "wasm32")]
 mod emscripten;
 mod math;
 mod mem;
@@ -840,5 +841,6 @@ pub extern "C" fn set_grid_cells() {
 }
 
 fn main() {
+    #[cfg(target_arch = "wasm32")]
     init_gl!();
 }

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -3,6 +3,7 @@ use skia_safe::{self as skia, Rect};
 
 use super::{tiles, RenderState, SurfaceId};
 
+#[cfg(target_arch = "wasm32")]
 use crate::run_script;
 
 const DEBUG_SCALE: f32 = 0.2;
@@ -170,19 +171,25 @@ pub fn render(render_state: &mut RenderState) {
     );
 }
 
+#[cfg(target_arch = "wasm32")]
 #[allow(dead_code)]
 pub fn console_debug_tile_surface(render_state: &mut RenderState, tile: tiles::Tile) {
     let base64_image = render_state.surfaces.base64_snapshot_tile(tile);
+
+    #[cfg(target_arch = "wasm32")]
     run_script!(format!("console.log('%c ', 'font-size: 1px; background: url(data:image/png;base64,{base64_image}) no-repeat; padding: 100px; background-size: contain;')"))
 }
 
+#[cfg(target_arch = "wasm32")]
 #[allow(dead_code)]
 pub fn console_debug_surface(render_state: &mut RenderState, id: SurfaceId) {
     let base64_image = render_state.surfaces.base64_snapshot(id);
+
     run_script!(format!("console.log('%c ', 'font-size: 1px; background: url(data:image/png;base64,{base64_image}) no-repeat; padding: 100px; background-size: contain;')"))
 }
 
 #[allow(dead_code)]
+#[cfg(target_arch = "wasm32")]
 pub fn console_debug_surface_rect(render_state: &mut RenderState, id: SurfaceId, rect: skia::Rect) {
     let int_rect = skia::IRect::from_ltrb(
         rect.left as i32,
@@ -190,7 +197,9 @@ pub fn console_debug_surface_rect(render_state: &mut RenderState, id: SurfaceId,
         rect.right as i32,
         rect.bottom as i32,
     );
+
     let base64_image = render_state.surfaces.base64_snapshot_rect(id, int_rect);
+
     if let Some(base64_image) = base64_image {
         run_script!(format!("console.log('%c ', 'font-size: 1px; background: url(data:image/png;base64,{base64_image}) no-repeat; padding: 100px; background-size: contain;')"))
     }

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -337,7 +337,7 @@ mod tests {
         shapes.insert(parent_id, parent.clone());
 
         let bounds =
-            calculate_group_bounds(&parent, &shapes, HashMap::<Uuid, Bounds>::new()).unwrap();
+            calculate_group_bounds(&parent, &shapes, &HashMap::<Uuid, Bounds>::new()).unwrap();
 
         assert_eq!(bounds.width(), 3.0);
         assert_eq!(bounds.height(), 3.0);

--- a/render-wasm/src/shapes/transform.rs
+++ b/render-wasm/src/shapes/transform.rs
@@ -101,12 +101,11 @@ impl SerializableResult for TransformEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::uuid::Uuid;
 
     #[test]
     fn test_serialization() {
         let entry = TransformEntry::new(
-            uuid!("550e8400-e29b-41d4-a716-446655440000"),
+            Uuid::new_v4(),
             Matrix::new_all(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 0.0, 1.0),
         );
 

--- a/render-wasm/src/uuid.rs
+++ b/render-wasm/src/uuid.rs
@@ -30,6 +30,17 @@ impl Uuid {
     pub fn from_u64_pair(high: u64, low: u64) -> Self {
         Self(ExternalUuid::from_u64_pair(high, low))
     }
+
+    #[cfg(test)]
+    pub fn new_v4() -> Self {
+        Self(ExternalUuid::new_v4())
+    }
+}
+
+impl From<ExternalUuid> for Uuid {
+    fn from(uuid: ExternalUuid) -> Self {
+        Self(uuid)
+    }
 }
 
 impl fmt::Display for Uuid {

--- a/render-wasm/test
+++ b/render-wasm/test
@@ -4,7 +4,8 @@ pushd $_SCRIPT_DIR;
 
 . ./_build_env
 
-# export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.81.0-1/skia-binaries-24dee32a277b6c7b5357-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache.tar.gz"
+export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.81.0-2/skia-binaries-24dee32a277b6c7b5357-aarch64-unknown-linux-gnu-gl-svg-textlayout-binary-cache.tar.gz"
+export _CARGO_PARAMS="--target=aarch64-unknown-linux-gnu";
 
 cargo test $_CARGO_PARAMS --bin render_wasm -- --show-output
 popd

--- a/render-wasm/test
+++ b/render-wasm/test
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 _SCRIPT_DIR=$(dirname $0);
-
-export SKIA_BINARIES_URL="https://github.com/rust-skia/skia-binaries/releases/download/0.80.0/skia-binaries-9e7d2684a17084095aef-x86_64-unknown-linux-gnu-egl-gl-svg-textlayout-vulkan-wayland-webpd-webpe-x11.tar.gz"
-
 pushd $_SCRIPT_DIR;
-cargo test --bin render_wasm -- --show-output
+
+. ./_build_env
+
+# export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.81.0-1/skia-binaries-24dee32a277b6c7b5357-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache.tar.gz"
+
+cargo test $_CARGO_PARAMS --bin render_wasm -- --show-output
 popd


### PR DESCRIPTION
This PRs makes `./test` work again.

- :wrench: Fix test script (rust wasm)
- :wrench: Make code compile in test mode + using aarch64 as a target for tests

Changes that were made:

- Point the `./test` scripts to our custom Skia binaries.
- Fix the UUID-related code in the tests that was not compiling.
- Change the tests to run in `aarch64-linux` (not `wasm32`) until we find a way to run those with `cargo test`. That involved excluding some code bits (i.e. those related to emscripten) from non-wasm32 targets.

I added a new tag in [our skia binaries repo](https://github.com/penpot/skia-binaries/releases/tag/0.81.0-2) to contain a custom skia build for aarch64.
