### PR TITLE
:bug: Fix render object with pending status

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -405,7 +405,7 @@
                                                    (filter #(= (:type %) :add-obj))
                                                    (map :obj))]
                                     (doseq [shape added]
-                                      (api/set-object [] shape))))
+                                      (api/process-object shape))))
 
                                 (if (and save-undo? (seq undo-changes))
                                   (let [entry {:undo-changes undo-changes

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -756,6 +756,17 @@
               (set-shape-fills fills)
               (set-shape-strokes strokes)))))
 
+(defn process-object
+  [shape]
+  (let [pending (set-object [] shape)]
+    (when-let [pending (seq pending)]
+      (->> (rx/from pending)
+           (rx/mapcat identity)
+           (rx/reduce conj [])
+           (rx/subs! (fn [_]
+                       (clear-drawing-cache)
+                       (request-render "set-objects")))))))
+
 (defn set-objects
   [objects]
   (let [shapes        (into [] (vals objects))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10692

### Summary

After the refactor to prevent processing all objects on each render, we didn't take into account these situations where we needed to call a render after an async operation (as loading an image)

This PR aims to fix this issue by doing the same as set-objects do: request a render when setting a single object with async behavior

### Steps to reproduce 

  - Open a file or create a new one
  - Add an image
  - It should work as expected

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.