### PR TITLE
:bug: Fix long file names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fix SVG `stroke-linecap` property when importing SVGs [Taiga #9489](https://tree.taiga.io/project/penpot/issue/9489)
 - Fix position problems cutting-pasting a component [Taiga #10677](https://tree.taiga.io/project/penpot/issue/10677)
 - Fix design tab has a horizontal scroll [Taiga #10660](https://tree.taiga.io/project/penpot/issue/10660)
+- Fix long file names being clipped when longer than allowed length [Taiga #10662](https://tree.taiga.io/project/penpot/issue/10662)
 
 ## 2.6.0 (Unreleased)
 

--- a/common/src/app/common/data/macros.cljc
+++ b/common/src/app/common/data/macros.cljc
@@ -6,7 +6,7 @@
 
 (ns app.common.data.macros
   "Data retrieval & manipulation specific macros."
-  (:refer-clojure :exclude [get-in select-keys str with-open min max])
+  (:refer-clojure :exclude [get-in select-keys str with-open max])
   #?(:cljs (:require-macros [app.common.data.macros]))
   (:require
    #?(:clj [clojure.core :as c]
@@ -144,3 +144,8 @@
                  (str "expr assert: " (pr-str expr)))]
      (when *assert*
        `(runtime-assert ~hint (fn [] ~expr))))))
+
+(defn truncate
+  "Truncates a string to a certain length"
+  [s max-length]
+  (subs s 0 (min max-length (count s))))

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -706,7 +706,7 @@
 (defn rename-file
   [id name]
   {:pre [(uuid? id) (string? name)]}
-  (let [name (str/prune name 200)]
+  (let [name (dm/truncate name 200)]
     (ptk/reify ::rename-file
       IDeref
       (-deref [_]

--- a/frontend/src/app/main/ui/exports/assets.scss
+++ b/frontend/src/app/main/ui/exports/assets.scss
@@ -304,6 +304,7 @@
     }
     .file-name-label {
       @include bodyLargeTypography;
+      @include textEllipsis;
     }
   }
   &.loading {

--- a/frontend/src/app/main/ui/exports/files.scss
+++ b/frontend/src/app/main/ui/exports/files.scss
@@ -199,6 +199,7 @@
 .file-entry {
   .file-name {
     @include flexRow;
+
     .file-icon {
       @include flexCenter;
       height: $s-16;
@@ -211,6 +212,7 @@
     }
     .file-name-label {
       @include bodyLargeTypography;
+      @include textEllipsis;
     }
   }
   &.loading {

--- a/frontend/src/app/main/ui/workspace/left_header.cljs
+++ b/frontend/src/app/main/ui/workspace/left_header.cljs
@@ -132,7 +132,7 @@
             :saved i/status-tick
             :error i/status-wrong
             nil)]
-         file-name])]
+         [:div {:class (stl/css :file-name-label)} file-name]])]
      (when ^boolean shared?
        [:span {:class (stl/css :shared-badge)} i/library])
      [:div {:class (stl/css :menu-section)}

--- a/frontend/src/app/main/ui/workspace/left_header.scss
+++ b/frontend/src/app/main/ui/workspace/left_header.scss
@@ -37,7 +37,6 @@
 .project-name,
 .file-name {
   @include uppercaseTitleTipography;
-  @include textEllipsis;
   height: $s-16;
   width: 100%;
   padding-bottom: $s-2;
@@ -52,6 +51,10 @@
   align-items: center;
   display: flex;
   flex-direction: row;
+}
+
+.file-name-label {
+  @include textEllipsis;
 }
 
 .file-name-input {

--- a/frontend/src/app/main/ui/workspace/left_header.scss
+++ b/frontend/src/app/main/ui/workspace/left_header.scss
@@ -37,6 +37,7 @@
 .project-name,
 .file-name {
   @include uppercaseTitleTipography;
+  @include textEllipsis;
   height: $s-16;
   width: 100%;
   padding-bottom: $s-2;


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10662

### Summary

There are two types of issues regarding this bug:

1. When saving "long" file names, we were using the "prune" util from the `cuerdas` library. This method removes the original name when is longer than the given max length and changes it to "...", which is the file name that was being actually used.
2. For long names (up to 200 chars, which seems to be the max file name allowed at that point, although we have another check for max 250 name length), the styles break, so we need to use ellipsis on text-overflow when needed.

### Steps to reproduce 

1. Rename a file with a name longer than 200 characters (`loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremi`) 
2. Check the file is saved with 200 chars
3. Check that the file name label is correctly clipped using ellipsis on the left head sidebar
4. Check that the file name label is correctly clipped using ellipsis in the export modal

![image](https://github.com/user-attachments/assets/dcc8c984-fdd0-4531-b95d-14a69242ba92)
![image](https://github.com/user-attachments/assets/2b82c177-de90-4bb3-b738-9b1e25860c47)
![image](https://github.com/user-attachments/assets/6e6d11d3-422c-4443-8494-75a64b7120d7)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
