### PR TITLE
:bug: Fix wrong path to list all icons in storybook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fix SVG `stroke-linecap` property when importing SVGs [Taiga #9489](https://tree.taiga.io/project/penpot/issue/9489)
 - Fix position problems cutting-pasting a component [Taiga #10677](https://tree.taiga.io/project/penpot/issue/10677)
 - Fix design tab has a horizontal scroll [Taiga #10660](https://tree.taiga.io/project/penpot/issue/10660)
+- Fix Storybook link 'list of all available icons' wrong path [Taiga #10705](https://tree.taiga.io/project/penpot/issue/10705)
 
 ## 2.6.0 (Unreleased)
 

--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.mdx
@@ -5,7 +5,7 @@ import * as IconStories from "./icon.stories"
 
 # Iconography
 
-See the [list of all available icons](?path=/story/foundations-icons--all-icons).
+See the [list of all available icons](?path=/story/foundations-assets-icon--all).
 
 ## Variants
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10705

### Summary
Updated wrong path to icons

### Steps to reproduce 
1. https://help.penpot.app/technical-guide/developer/ui/#storybook
2. [hourly.penpot.dev/storybook](https://hourly.penpot.dev/storybook) 
3. Navigate to Assets -> Icons -> Docs
4. Click in See the [list of all available icons](https://hourly.penpot.dev/storybook/iframe.html?path=/story/foundations-icons--all-icons).

It'll point to `?path=/story/foundations-icons--all-icons` and should point to `?path=/story/foundations-assets-icon--all`

Now:
![image](https://github.com/user-attachments/assets/2b81ad4c-5d14-4378-880b-cf8cad0e1e90)

Expected:
![image](https://github.com/user-attachments/assets/ccebe486-27e7-4081-94b6-0cde94b111ea)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
