### PR TITLE
:tada: Render text while typing

### DIFF
--- a/frontend/src/app/main/fonts.cljs
+++ b/frontend/src/app/main/fonts.cljs
@@ -253,7 +253,6 @@
 
 (defn get-variant
   [{:keys [variants] :as font} font-variant-id]
-  (prn "get-variant" font-variant-id fonts)
   (or (d/seek #(= (:id %) font-variant-id) variants)
       (get-default-variant font)))
 

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -50,6 +50,7 @@
    [app.main.ui.workspace.viewport.widgets :as widgets]
    [app.render-wasm.api :as wasm.api]
    [app.util.debug :as dbg]
+   [app.util.text-editor :as ted]
    [beicon.v2.core :as rx]
    [promesa.core :as p]
    [rumext.v2 :as mf]))
@@ -101,6 +102,9 @@
         drawing           (mf/deref refs/workspace-drawing)
         focus             (mf/deref refs/workspace-focus-selected)
 
+        workspace-editor-state (mf/deref refs/workspace-editor-state)
+        workspace-v2-editor-state (mf/deref refs/workspace-v2-editor-state)
+
         objects           (get page :objects)
         page-id           (get page :id)
         background        (get page :background clr/canvas)
@@ -138,6 +142,7 @@
          on-viewport-ref] (create-viewport-ref)
 
         canvas-ref        (mf/use-ref nil)
+        text-editor-ref   (mf/use-ref nil)
 
         ;; VARS
         disable-paste     (mf/use-var false)
@@ -287,6 +292,18 @@
         (fn []
           (wasm.api/clear-canvas))))
 
+    (mf/with-effect [show-text-editor? workspace-editor-state workspace-v2-editor-state edition]
+      (let [editor-state (get workspace-editor-state edition)
+            v2-editor-state (get workspace-v2-editor-state edition)
+            active-editor-state (or v2-editor-state editor-state)]
+        (when (and show-text-editor? active-editor-state)
+          (let [content (-> active-editor-state
+                            (ted/get-editor-current-content)
+                            (ted/export-content))]
+            (wasm.api/set-shape-text-content content)
+            (wasm.api/clear-drawing-cache)
+            (wasm.api/request-render "content")))))
+
     (mf/with-effect [vport]
       (when @canvas-init?
         (wasm.api/resize-viewbox (:width vport) (:height vport))))
@@ -352,7 +369,6 @@
        :class (dm/str @cursor (when drawing-tool " drawing") " " (stl/css :viewport-controls))
        :style {:touch-action "none"}
        :fill "none"
-
        :on-click         on-click
        :on-context-menu  on-context-menu
        :on-double-click  on-double-click
@@ -378,8 +394,10 @@
        (when show-text-editor?
          (if (features/active-feature? @st/state "text-editor/v2")
            [:& editor-v2/text-editor {:shape editing-shape
+                                      :ref text-editor-ref
                                       :modifiers modifiers}]
            [:& editor-v1/text-editor-svg {:shape editing-shape
+                                          :ref text-editor-ref
                                           :modifiers modifiers}]))
 
        (when show-frame-outline?


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10710

### Summary

This PR triggers a text-render when typing 

[screen-recorder-tue-apr-15-2025-09-59-09.webm](https://github.com/user-attachments/assets/0938f765-c885-4803-9b0b-ea5233c77bc5)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
