### PR TITLE
:bug: Fix wrong path to list all icons in storybook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@
 - Fix available size of resize handler [Taiga #10639](https://tree.taiga.io/project/penpot/issue/10639)
 - Internal error when install a plugin by penpothub - Try plugin [Taiga #10542](https://tree.taiga.io/project/penpot/issue/10542)
 - Add character limitation to asset inputs [Taiga #10669](https://tree.taiga.io/project/penpot/issue/10669)
+- Fix Storybook link 'list of all available icons' wrong path [Taiga #10705](https://tree.taiga.io/project/penpot/issue/10705)
 
 ## 2.5.4
 

--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.mdx
@@ -5,7 +5,7 @@ import * as IconStories from "./icon.stories"
 
 # Iconography
 
-See the [list of all available icons](?path=/story/foundations-icons--all-icons).
+See the [list of all available icons](?path=/story/foundations-assets-icon--all).
 
 ## Variants
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10705

### Summary
Updated wrong path to icons

### Steps to reproduce 
1. https://help.penpot.app/technical-guide/developer/ui/#storybook
2. [hourly.penpot.dev/storybook](https://hourly.penpot.dev/storybook) 
3. Navigate to Assets -> Icons -> Docs
4. Click in See the [list of all available icons](https://hourly.penpot.dev/storybook/iframe.html?path=/story/foundations-icons--all-icons).

It'll point to `?path=/story/foundations-icons--all-icons` and should point to `?path=/story/foundations-assets-icon--all`

Now:
![image](https://github.com/user-attachments/assets/2b81ad4c-5d14-4378-880b-cf8cad0e1e90)

Expected:
![image](https://github.com/user-attachments/assets/ccebe486-27e7-4081-94b6-0cde94b111ea)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
