### PR TITLE
:bug: Fix bytes-alloc-32

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -215,11 +215,11 @@
          (rx/map :body)
          (rx/mapcat wapi/read-file-as-array-buffer)
          (rx/map (fn [image]
-                   (let [size (.-byteLength image)
+                   (let [size    (.-byteLength image)
                          offset  (mem/alloc-bytes size)
-                         heap       (mem/get-heap-u8)
-                         mem        (js/Uint8Array. (.-buffer heap) offset size)]
-                     (.set heap mem offset)
+                         heap    (mem/get-heap-u8)
+                         data    (js/Uint8Array. image)]
+                     (.set heap data offset)
                      (h/call wasm/internal-module "_store_image"
                              (aget buffer 0)
                              (aget buffer 1)

--- a/frontend/src/app/render_wasm/mem.cljs
+++ b/frontend/src/app/render_wasm/mem.cljs
@@ -38,7 +38,7 @@
   [size]
   (when (= size 0)
     (js/console.trace "Tried to allocate 0 bytes"))
-  (h/call wasm/internal-module "_alloc_bytes" size))
+  (ptr8->ptr32 (h/call wasm/internal-module "_alloc_bytes" size)))
 
 (defn get-heap-u8
   "Returns a Uint8Array view of the heap"


### PR DESCRIPTION
Fixes an error that returned a 8-bit aligned pointer when allocating a 32-bit aligned pointer