### PR TITLE
:sparkles: Don't override user provided color format

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/components/controls/input_token_color_bullet.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/components/controls/input_token_color_bullet.cljs
@@ -20,7 +20,8 @@
   {::mf/props :obj
    ::mf/schema schema::input-token-color-bullet}
   [{:keys [color on-click]}]
-  [:div {:class (stl/css :input-token-color-bullet)
+  [:div {:data-testid "token-form-color-bullet"
+         :class (stl/css :input-token-color-bullet)
          :on-click on-click}
    (if-let [color' (wtt/color-bullet-color color)]
      [:> color-bullet {:color color' :mini true}]

--- a/frontend/src/app/main/ui/workspace/tokens/tinycolor.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/tinycolor.cljs
@@ -32,16 +32,23 @@
     (let [tc (tinycolor color-str)]
       (str/starts-with? (.getFormat tc) "hex"))))
 
-(defn ->string [^js tc]
-  (.toString tc))
+(defn ->string
+  "Stringify `tc` to `format`, uses `hex` as per default."
+  [^js tc format]
+  (let [format' (case format
+                  ;; Tinycolor `.toString` doesnt support the `a` suffix it gives you via `.getFormat`
+                  "rgba" "rgb"
+                  "hsva" "hsv"
+                  ;; Keep these formats
+                  "rgb"  "rgb"
+                  "hsv"  "hsv"
+                  ;; Fall back to hex as the default
+                  "hex")]
+    (.toString tc format')))
 
 (defn ->hex-string [^js tc]
   (assert (tinycolor? tc))
   (.toHexString tc))
-
-(defn ->rgba-string [^js tc]
-  (assert (tinycolor? tc))
-  (.toRgbString tc))
 
 (defn color-format [^js tc]
   (assert (tinycolor? tc))


### PR DESCRIPTION
Respects the users color format when changing a color via the color picker for token colors.


https://github.com/user-attachments/assets/90b2d31c-3fbf-48df-9be0-8c96e8c4d876

