### PR TITLE
WIP :sparkles: Tokens: Support for shadow opacity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### :heart: Community contributions (Thank you!)
 
+- [DESIGN TOKENS] Types added: Shadows opacity.
+
 ### :sparkles: New features
 
 ### :bug: Bugs fixed

--- a/common/src/app/common/types/shape/shadow.cljc
+++ b/common/src/app/common/types/shape/shadow.cljc
@@ -33,10 +33,10 @@
 
 (defn update-shadow-opacity [shape value]
   (let [updated-shadows (mapv
-                          (fn [shadow]
-                            (let [shadow-color (:color shadow)
-                                  updated-color (assoc shadow-color :opacity value)]
-                              (assoc shadow :color updated-color)))
-                          (:shadow shape))]
+                         (fn [shadow]
+                           (let [shadow-color (:color shadow)
+                                 updated-color (assoc shadow-color :opacity value)]
+                             (assoc shadow :color updated-color)))
+                         (:shadow shape))]
     ;; Update all shadows in the shape
     (assoc shape :shadow updated-shadows)))

--- a/common/src/app/common/types/shape/shadow.cljc
+++ b/common/src/app/common/types/shape/shadow.cljc
@@ -30,3 +30,13 @@
 
 (def check-shadow
   (sm/check-fn schema:shadow))
+
+(defn update-shadow-opacity [shape value]
+  (let [updated-shadows (mapv
+                          (fn [shadow]
+                            (let [shadow-color (:color shadow)
+                                  updated-color (assoc shadow-color :opacity value)]
+                              (assoc shadow :color updated-color)))
+                          (:shadow shape))]
+    ;; Update all shadows in the shape
+    (assoc shape :shadow updated-shadows)))

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -116,7 +116,8 @@
 (sm/register!
  ^{::sm/type ::opacity}
  [:map
-  [:opacity {:optional true} token-name-ref]])
+  [:layer-opacity {:optional true} token-name-ref]
+  [:shadow-opacity {:optional true} token-name-ref]])
 
 (def opacity-keys (schema-keys ::opacity))
 

--- a/docs/user-guide/design-tokens/index.njk
+++ b/docs/user-guide/design-tokens/index.njk
@@ -206,10 +206,15 @@ title: 10· Design Tokens
 <p>The Y property specifies the position of the element on the Y axis of the canvas.</p>
 
 <h3 id="design-tokens-opacity">Opacity</h3>
-<p>Opacity tokens allow you to define the opacity of a layer, ranging from fully opaque to fully transparent.</p>
+<p>Opacity tokens allow you to define the opacity of a layer or shadow, ranging from fully opaque to fully transparent.</p>
 <p>Opacity tokens can be applied to any design element that supports transparency. You can use any decimal value between 0 and 1 to set varying levels of opacity or you can use any value between 0 and 100 with <strong>`%`</strong> sign at the end of the value. For example, you can use <strong>45%</strong> which would resolve to <strong>.45</strong>.</p>
+<p>When applying shadow opacity, the value will be set to all the shadows of the design element.</p>
 <h4>Applying Opacity Tokens</h4>
-<p>To apply the opacity token to an element, select the element and click on the desired token.</p>
+<p>To apply the opacity token to an element, select the element and right-click on the desired token:</p>
+<ul>
+    <li><strong>Layer</strong> to apply the opacity to the layer of the selected element.</li>
+    <li><strong>Shadow</strong> to apply the opacity to all the shadows of the selected element.</li>
+</ul>
 
 <h3 id="design-tokens-rotation">Rotation</h3>
 <p>Rotation tokens are used to define and standardize rotational values within a design system. These tokens represent rotation angles, typically measured in degrees, and can be applied to elements such as icons or images, to ensure consistent rotation throughout a design.</p>

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -243,7 +243,9 @@
      :spacing spacing-attribute-actions
      :sizing sizing-attribute-actions
      :rotation (partial generic-attribute-actions #{:rotation} "Rotation")
-     :opacity (partial generic-attribute-actions #{:opacity} "Opacity")
+     :opacity (fn [context-data]
+          [(generic-attribute-actions #{:layer-opacity} "Layer" (assoc context-data :hint (tr "workspace.token.opacity")))
+           (generic-attribute-actions #{:shadow-opacity} "Shadows" (assoc context-data :on-update-shape wtch/update-opacity))])
      :stroke-width stroke-width
      :dimensions (fn [context-data]
                    (concat

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -25,7 +25,6 @@
 ;; Translation dictionaries
 (def ^:private attribute-dictionary
   {:rotation "Rotation"
-   :opacity "Opacity"
    :stroke-width "Stroke Width"
 
    ;; Spacing
@@ -48,7 +47,11 @@
 
    ;; Color
    :fill "Fill"
-   :stroke-color "Stroke Color"})
+   :stroke-color "Stroke Color"
+
+   ;; Opacity
+   :layer-opacity "Layer"
+   :shadow-opacity "Shadows"})
 
 (def ^:private dimensions-dictionary
   {:stroke-width :stroke-width

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6649,6 +6649,10 @@ msgstr "Back to theme list"
 msgid "workspace.token.color"
 msgstr "Color"
 
+#: src/app/main/ui/workspace/tokens/context_menu.cljs:247
+msgid "workspace.token.opacity"
+msgstr "Opacity"
+
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs:54
 msgid "workspace.token.create-new-theme"
 msgstr "Create your first theme now."


### PR DESCRIPTION
This patch splits the opacity token in two:

1. Layer (the existing opacity token);
2. Shadows (a new one);

I wasn't sure whether to call it Layer or Shape, but the user guide seemed to be calling it Layer, so I went with it,

<img width="325" alt="Screenshot 2025-04-07 at 00 12 22" src="https://github.com/user-attachments/assets/1c75222b-7943-4704-902c-bd8a2a32c976" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.