### PR TITLE
:sparkles: Add duplicate sets feature

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -9,6 +9,7 @@
    #?(:clj [app.common.fressian :as fres])
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.files.helpers :as cfh]
    [app.common.schema :as sm]
    [app.common.time :as dt]
    [app.common.transit :as t]
@@ -320,6 +321,7 @@
            (assoc-in (concat [:tokens-tree] path) token)
            (assoc-in [:ids temp-id] token))))
    {:tokens-tree {} :ids {}} tokens))
+
 
 (defprotocol ITokenSet
   (update-name [_ set-name] "change a token set name while keeping the path")
@@ -920,6 +922,7 @@ Will return a value that matches this schema:
         this)))
 
 
+
   (delete-set [_ set-name]
     (let [prefixed-path (set-name->prefixed-full-path set-name)]
       (TokensLib. (d/dissoc-in sets prefixed-path)
@@ -1467,6 +1470,14 @@ Will return a value that matches this schema:
    :type-properties
    {:encode/json encode-dtcg
     :decode/json decode-dtcg}})
+
+(defn duplicate-set [set-name lib & {:keys [suffix]}]
+  (let [sets (get-sets lib)
+        unames (map :name sets)
+        copy-name (cfh/generate-unique-name set-name unames :suffix suffix)]
+    (some-> (get-set lib set-name)
+            (assoc :name copy-name)
+            (assoc :modified-at (dt/now)))))
 
 (sm/register! type:tokens-lib)
 

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -320,13 +320,13 @@
                                                                     (ctob/make-token :name "test-token"
                                                                                      :type :boolean
                                                                                      :value true)})))
-        token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
-        token' (get-in token-set-copy' [:tokens "test-token"])]
+        token-set-copy (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
+        token (get-in token-set-copy [:tokens "test-token"])]
 
-    (t/is (some? token-set-copy'))
-    (t/is (= (:name token-set-copy') "test-token-set-copy"))
-    (t/is (= (count (:tokens token-set-copy')) 1))
-    (t/is (= (:name token') "test-token"))))
+    (t/is (some? token-set-copy))
+    (t/is (= (:name token-set-copy) "test-token-set-copy"))
+    (t/is (= (count (:tokens token-set-copy)) 1))
+    (t/is (= (:name token) "test-token"))))
 
 (t/deftest duplicate-token-set-twice
   (let [tokens-lib  (-> (ctob/make-tokens-lib)
@@ -350,20 +350,20 @@
   (let [tokens-lib      (-> (ctob/make-tokens-lib)
                             (ctob/add-set (ctob/make-token-set :name "test-token-set")))
 
-        token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
-        tokens'         (get token-set-copy' :tokens)]
+        token-set-copy (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
+        tokens         (get token-set-copy :tokens)]
 
-    (t/is (some? token-set-copy'))
-    (t/is (= (:name token-set-copy') "test-token-set-copy"))
-    (t/is (= (count (:tokens token-set-copy')) 0))
-    (t/is (= (count tokens') 0))))
+    (t/is (some? token-set-copy))
+    (t/is (= (:name token-set-copy) "test-token-set-copy"))
+    (t/is (= (count (:tokens token-set-copy)) 0))
+    (t/is (= (count tokens) 0))))
 
 (t/deftest duplicate-not-existing-token-set
   (let [tokens-lib      (ctob/make-tokens-lib)
 
-        token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})]
+        token-set-copy (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})]
 
-    (t/is (nil? token-set-copy'))))
+    (t/is (nil? token-set-copy))))
 
 (t/deftest active-themes-set-names
   (let [tokens-lib  (-> (ctob/make-tokens-lib)

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -340,18 +340,17 @@
 
         tokens-lib (ctob/add-set tokens-lib (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"}))
 
-        token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
-        token' (get-in token-set-copy' [:tokens "test-token"])]
+        token-set-copy (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
+        token (get-in token-set-copy [:tokens "test-token"])]
 
-    (t/is (some? token-set-copy'))
-    (t/is (= (:name token-set-copy') "test-token-set-copy-2"))
-    (t/is (= (count (:tokens token-set-copy')) 1))
-    (t/is (= (:name token') "test-token"))))
+    (t/is (some? token-set-copy))
+    (t/is (= (:name token-set-copy) "test-token-set-copy-2"))
+    (t/is (= (count (:tokens token-set-copy)) 1))
+    (t/is (= (:name token) "test-token"))))
 
 (t/deftest duplicate-empty-token-set
   (let [tokens-lib      (-> (ctob/make-tokens-lib)
-                            (ctob/add-set (ctob/make-token-set :name "test-token-set"))
-                            (ctob/add-theme (ctob/make-token-theme :name "test-token-theme" :sets #{"test-token-set"})))
+                            (ctob/add-set (ctob/make-token-set :name "test-token-set")))
 
         token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
         tokens'         (get token-set-copy' :tokens)]
@@ -362,8 +361,7 @@
     (t/is (= (count tokens') 0))))
 
 (t/deftest duplicate-not-existing-token-set
-  (let [tokens-lib      (-> (ctob/make-tokens-lib)
-                            (ctob/add-theme (ctob/make-token-theme :name "test-token-theme" :sets #{"test-token-set"})))
+  (let [tokens-lib      (ctob/make-tokens-lib)
 
         token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})]
 

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -319,8 +319,7 @@
                                                            :tokens {"test-token"
                                                                     (ctob/make-token :name "test-token"
                                                                                      :type :boolean
-                                                                                     :value true)}))
-                        (ctob/add-theme (ctob/make-token-theme :name "test-token-theme" :sets #{"test-token-set"})))
+                                                                                     :value true)})))
         token-set-copy' (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"})
         token' (get-in token-set-copy' [:tokens "test-token"])]
 
@@ -335,8 +334,7 @@
                                                            :tokens {"test-token"
                                                                     (ctob/make-token :name "test-token"
                                                                                      :type :boolean
-                                                                                     :value true)}))
-                        (ctob/add-theme (ctob/make-token-theme :name "test-token-theme" :sets #{"test-token-set"})))
+                                                                                     :value true)})))
 
         tokens-lib (ctob/add-set tokens-lib (ctob/duplicate-set "test-token-set" tokens-lib {:suffix "copy"}))
 

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -21,7 +21,6 @@
    [app.main.ui.workspace.tokens.update :as wtu]
    [app.util.i18n :refer [tr]]
    [beicon.v2.core :as rx]
-   [cuerdas.core :as str]
    [potok.v2.core :as ptk]))
 
 (declare set-selected-token-set-name)
@@ -189,6 +188,23 @@
           (let [changes (-> (pcb/empty-changes it)
                             (pcb/with-library-data data)
                             (pcb/rename-token-set (:name token-set) name))]
+            (rx/of (set-selected-token-set-name name)
+                   (dch/commit-changes changes))))))))
+
+(defn duplicate-token-set
+  [is-group id]
+  (ptk/reify ::duplicate-token-set
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [data       (dsh/lookup-file-data state)
+            name       (ctob/normalize-set-name id)
+            tokens-lib (get data :tokens-lib)
+            suffix     (tr "workspace.token.duplicate-suffix")]
+
+        (when-let [set (ctob/duplicate-set name tokens-lib {:suffix suffix})]
+          (let [changes (-> (pcb/empty-changes it)
+                            (pcb/with-library-data data)
+                            (pcb/set-token-set (:name set) is-group set))]
             (rx/of (set-selected-token-set-name name)
                    (dch/commit-changes changes))))))))
 
@@ -385,17 +401,8 @@
         (when-let [token (ctob/get-token token-set token-name)]
           (let [tokens (ctob/get-tokens token-set)
                 unames (map :name tokens)
-
-                suffix-fn
-                (fn [copy-count]
-                  (let [suffix (tr "workspace.token.duplicate-suffix")]
-                    (str/concat "-"
-                                suffix
-                                (when (> copy-count 1)
-                                  (str "-" copy-count)))))
-
-                copy-name
-                (cfh/generate-unique-name token-name unames :suffix-fn suffix-fn)]
+                suffix (tr "workspace.token.duplicate-suffix")
+                copy-name (cfh/generate-unique-name token-name unames :suffix suffix)]
 
             (rx/of (create-token (assoc token :name copy-name)))))))))
 

--- a/frontend/src/app/main/data/tokens.cljs
+++ b/frontend/src/app/main/data/tokens.cljs
@@ -192,7 +192,7 @@
                    (dch/commit-changes changes))))))))
 
 (defn duplicate-token-set
-  [is-group id]
+  [id is-group]
   (ptk/reify ::duplicate-token-set
     ptk/WatchEvent
     (watch [it state _]

--- a/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
@@ -59,7 +59,8 @@
      (when is-group
        [:> menu-entry* {:title (tr "workspace.token.add-set-to-group") :on-click create-set-at-path}])
      [:> menu-entry* {:title (tr "labels.rename") :on-click on-edit}]
-     [:> menu-entry* {:title (tr "labels.duplicate") :on-click on-duplicate}]
+     (when-not is-group
+       [:> menu-entry* {:title (tr "labels.duplicate") :on-click on-duplicate}])
      [:> menu-entry* {:title (tr "labels.delete")  :on-click on-delete}]]))
 
 (mf/defc token-set-context-menu*

--- a/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
@@ -48,7 +48,7 @@
         (mf/use-fn
          (mf/deps is-group id)
          (fn []
-           (st/emit! (dt/duplicate-token-set is-group id))))
+           (st/emit! (dt/duplicate-token-set id is-group))))
 
         on-delete
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets_context_menu.cljs
@@ -44,6 +44,12 @@
          (fn []
            (st/emit! (dt/start-token-set-edition edition-id))))
 
+        on-duplicate
+        (mf/use-fn
+         (mf/deps is-group id)
+         (fn []
+           (st/emit! (dt/duplicate-token-set is-group id))))
+
         on-delete
         (mf/use-fn
          (mf/deps is-group path)
@@ -53,6 +59,7 @@
      (when is-group
        [:> menu-entry* {:title (tr "workspace.token.add-set-to-group") :on-click create-set-at-path}])
      [:> menu-entry* {:title (tr "labels.rename") :on-click on-edit}]
+     [:> menu-entry* {:title (tr "labels.duplicate") :on-click on-duplicate}]
      [:> menu-entry* {:title (tr "labels.delete")  :on-click on-delete}]]))
 
 (mf/defc token-set-context-menu*

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -10,6 +10,7 @@
    [frontend-tests.logic.groups-test]
    [frontend-tests.plugins.context-shapes-test]
    [frontend-tests.tokens.logic.token-actions-test]
+   [frontend-tests.tokens.logic.token-data-test]
    [frontend-tests.tokens.style-dictionary-test]
    [frontend-tests.tokens.token-form-test]
    [frontend-tests.tokens.token-test]
@@ -39,6 +40,7 @@
    'frontend-tests.util-simple-math-test
    'frontend-tests.basic-shapes-test
    'frontend-tests.tokens.logic.token-actions-test
+   'frontend-tests.tokens.logic.token-data-test
    'frontend-tests.tokens.style-dictionary-test
    'frontend-tests.tokens.token-test
    'frontend-tests.tokens.token-form-test))

--- a/frontend/test/frontend_tests/tokens/helpers/tokens.cljs
+++ b/frontend/test/frontend_tests/tokens/helpers/tokens.cljs
@@ -20,3 +20,6 @@
                      :objects shape-id
                      :applied-tokens]
                merge applied-attributes)))
+
+(defn get-tokens-lib [file]
+  (get-in file [:data :tokens-lib]))

--- a/frontend/test/frontend_tests/tokens/logic/token_data_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_data_test.cljs
@@ -20,8 +20,6 @@
   (-> (setup-file)
       (assoc-in [:data :tokens-lib]
                 (-> (ctob/make-tokens-lib)
-                    (ctob/add-theme (ctob/make-token-theme :name "Theme A" :sets #{"Set A"}))
-                    (ctob/set-active-themes #{"/Theme A"})
                     (ctob/add-set (ctob/make-token-set :name "Set A"))))))
 
 (t/deftest duplicate-set

--- a/frontend/test/frontend_tests/tokens/logic/token_data_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_data_test.cljs
@@ -1,0 +1,63 @@
+(ns frontend-tests.tokens.logic.token-data-test
+  (:require
+   [app.common.test-helpers.files :as cthf]
+   [app.common.types.tokens-lib :as ctob]
+   [app.main.data.tokens :as dt]
+   [cljs.test :as t :include-macros true]
+   [frontend-tests.helpers.pages :as thp]
+   [frontend-tests.helpers.state :as ths]
+   [frontend-tests.tokens.helpers.state :as tohs]
+   [frontend-tests.tokens.helpers.tokens :as toht]))
+
+(t/use-fixtures :each
+  {:before thp/reset-idmap!})
+
+(defn setup-file []
+  (cthf/sample-file :file-1 :page-label :page-1))
+
+(defn setup-file-with-token-lib
+  []
+  (-> (setup-file)
+      (assoc-in [:data :tokens-lib]
+                (-> (ctob/make-tokens-lib)
+                    (ctob/add-theme (ctob/make-token-theme :name "Theme A" :sets #{"Set A"}))
+                    (ctob/set-active-themes #{"/Theme A"})
+                    (ctob/add-set (ctob/make-token-set :name "Set A"))))))
+
+(t/deftest duplicate-set
+  (t/async
+    done
+    (let [file   (setup-file-with-token-lib)
+          store  (ths/setup-store file)
+          events [(dt/duplicate-token-set "Set A" false)]]
+
+      (tohs/run-store-async
+       store done events
+       (fn [new-state]
+         (let [file'     (ths/get-file-from-state new-state)
+               token-lib (toht/get-tokens-lib file')
+               sets      (ctob/get-sets token-lib)
+               set       (ctob/get-set token-lib "Set A")]
+
+           (t/testing "Token lib contains two sets"
+             (t/is (= (count sets) 2))
+             (t/is (some? set)))))))))
+
+(t/deftest duplicate-non-exist-set
+  (t/async
+    done
+    (let [file   (setup-file-with-token-lib)
+          store  (ths/setup-store file)
+          events [(dt/duplicate-token-set "Set B" false)]]
+
+      (tohs/run-store-async
+       store done events
+       (fn [new-state]
+         (let [file'     (ths/get-file-from-state new-state)
+               token-lib (toht/get-tokens-lib file')
+               sets      (ctob/get-sets token-lib)
+               set       (ctob/get-set token-lib "Set B")]
+
+           (t/testing "Token lib contains one set"
+             (t/is (= (count sets) 1))
+             (t/is (nil? set)))))))))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1367,6 +1367,10 @@ msgstr "Owner can't leave team, you must reassign the owner role."
 msgid "errors.token-set-already-exists"
 msgstr "A set with the same name already exists"
 
+#: src/app/main/data/tokens.cljs:
+msgid "errors.token-set-doesnt-exists"
+msgstr "Can't duplicate an unkown set"
+
 #: src/app/main/data/tokens.cljs:245
 msgid "errors.token-set-exists-on-drop"
 msgstr "Cannot complete drop, a set with same name already exists at path."
@@ -1895,6 +1899,10 @@ msgstr "Dashboard"
 #: src/app/main/ui/dashboard/file_menu.cljs:326, src/app/main/ui/dashboard/fonts.cljs:261, src/app/main/ui/dashboard/fonts.cljs:337, src/app/main/ui/dashboard/fonts.cljs:351, src/app/main/ui/dashboard/project_menu.cljs:115, src/app/main/ui/dashboard/team.cljs:952, src/app/main/ui/settings/access_tokens.cljs:197, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:216, src/app/main/ui/workspace/sidebar/versions.cljs:136, src/app/main/ui/workspace/tokens/form.cljs:565, src/app/main/ui/workspace/tokens/modals/themes.cljs:414, src/app/main/ui/workspace/tokens/sets_context_menu.cljs:56
 msgid "labels.delete"
 msgstr "Delete"
+
+#: src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+msgid "labels.duplicate"
+msgstr "Duplicate"
 
 #: src/app/main/ui/comments.cljs:976
 msgid "labels.delete-comment"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1385,6 +1385,10 @@ msgstr ""
 msgid "errors.token-set-already-exists"
 msgstr "Ya existe un set con el mismo nombre"
 
+#: src/app/main/data/tokens.cljs:
+msgid "errors.token-set-doesnt-exists"
+msgstr "No se puede duplicar un set que no existe."
+
 #: src/app/main/data/tokens.cljs:245
 msgid "errors.token-set-exists-on-drop"
 msgstr ""
@@ -1918,6 +1922,10 @@ msgstr "Panel"
 #: src/app/main/ui/dashboard/file_menu.cljs:326, src/app/main/ui/dashboard/fonts.cljs:261, src/app/main/ui/dashboard/fonts.cljs:337, src/app/main/ui/dashboard/fonts.cljs:351, src/app/main/ui/dashboard/project_menu.cljs:115, src/app/main/ui/dashboard/team.cljs:952, src/app/main/ui/settings/access_tokens.cljs:197, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:216, src/app/main/ui/workspace/sidebar/versions.cljs:136, src/app/main/ui/workspace/tokens/form.cljs:565, src/app/main/ui/workspace/tokens/modals/themes.cljs:414, src/app/main/ui/workspace/tokens/sets_context_menu.cljs:56
 msgid "labels.delete"
 msgstr "Borrar"
+
+#: src/app/main/ui/workspace/tokens/sets_context_menu.cljs
+msgid "labels.duplicate"
+msgstr "Duplicar"
 
 #: src/app/main/ui/comments.cljs:976
 msgid "labels.delete-comment"
@@ -6712,6 +6720,10 @@ msgstr "Borrar theme"
 #: src/app/main/ui/workspace/tokens/context_menu.cljs:275
 msgid "workspace.token.duplicate"
 msgstr "Duplicar token"
+
+#: src/app/main/data/tokens.cljs:386
+msgid "workspace.token.duplicate-suffix"
+msgstr "copiar"
 
 #: src/app/main/ui/workspace/tokens/context_menu.cljs:262
 msgid "workspace.token.edit"


### PR DESCRIPTION
### Related Ticket

This PR closes[ this task](https://tree.taiga.io/project/penpot/issue/10694)

### Summary

On set context menu there is a new option to duplicate set.

### Steps to reproduce 

1. Create a token set
2. Open context menu
3. Click on duplicate

A new set will appear with the suffix "copy" added to the name, tokens included. 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
