### PR TITLE
:recycle: Refactor how rAF/cAF are handled

### DIFF
--- a/render-wasm/_build_env
+++ b/render-wasm/_build_env
@@ -7,6 +7,7 @@ else
 fi
 
 EMCC_CFLAGS="--no-entry \
+    --js-library src/js/wapi.js \
     -sASSERTIONS=1 \
     -sALLOW_TABLE_GROWTH=1 \
     -sALLOW_MEMORY_GROWTH=1 \
@@ -33,7 +34,7 @@ else
     #        -gseparate-dwarf
     #        -gsplit-dwarf
     #        -gsource-map
-    EMCC_CFLAGS="-g $EMCC_CFLAGS -sMALLOC=emmalloc-debug"
+    EMCC_CFLAGS="-g $EMCC_CFLAGS -sVERBOSE=1 -sMALLOC=emmalloc-debug"
 fi
 
 export EMCC_CFLAGS;

--- a/render-wasm/src/js/wapi.js
+++ b/render-wasm/src/js/wapi.js
@@ -1,0 +1,8 @@
+addToLibrary({
+  wapi_requestAnimationFrame: function wapi_requestAnimationFrame() {
+    return window.requestAnimationFrame(Module._process_animation_frame);
+  },
+  wapi_cancelAnimationFrame: function wapi_cancelAnimationFrame(frameId) {
+    return window.cancelAnimationFrame(frameId);
+  }
+});

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -12,6 +12,7 @@ mod state;
 mod utils;
 mod uuid;
 mod view;
+mod wapi;
 mod wasm;
 
 use crate::mem::SerializableResult;

--- a/render-wasm/src/wapi.rs
+++ b/render-wasm/src/wapi.rs
@@ -1,0 +1,28 @@
+#[macro_export]
+macro_rules! request_animation_frame {
+    () => {
+        #[cfg(target_arch = "wasm32")]
+        {
+            extern "C" {
+                pub fn wapi_requestAnimationFrame() -> i32;
+            }
+            unsafe { wapi_requestAnimationFrame() }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! cancel_animation_frame {
+    ($frame_id:expr) => {
+        #[cfg(target_arch = "wasm32")]
+        {
+            extern "C" {
+                pub fn wapi_cancelAnimationFrame(frame_id: i32);
+            }
+            unsafe { wapi_cancelAnimationFrame($frame_id) }
+        }
+    };
+}
+
+pub use cancel_animation_frame;
+pub use request_animation_frame;


### PR DESCRIPTION
### Summary

Instead of calling `run_script` or `run_script_int`, we should define our own JS API that's called from Rust code.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
