### PR TITLE
:wrench: Do not try to set svg path attrs if none

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -349,8 +349,6 @@
                 (h/call wasm/internal-module "_add_shape_stroke_solid_fill" rgba)))))
         strokes))
 
-
-
 (defn set-shape-path-attrs
   [attrs]
   (let [style (:style attrs)
@@ -754,7 +752,8 @@
     (when (and (some? content)
                (or (= type :path)
                    (= type :bool)))
-      (set-shape-path-attrs svg-attrs)
+      (when (some? svg-attrs)
+        (set-shape-path-attrs svg-attrs))
       (set-shape-path-content content))
     (when (and (some? content) (= type :svg-raw))
       (set-shape-svg-raw-content (get-static-markup shape)))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10750

### Summary

Only set path svg-attrs if present 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.