### PR TITLE
:sparkles: Add, edit and delete variant properties from layer panel

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -59,14 +59,14 @@
 
 
 (defn generate-add-new-property
-  [changes variant-id & {:keys [fill-values?]}]
+  [changes variant-id & {:keys [fill-values? property-name]}]
   (let [data               (pcb/get-library-data changes)
         objects            (pcb/get-objects changes)
         related-components (cfv/find-variant-components data objects variant-id)
 
         props              (-> related-components first :variant-properties)
         next-prop-num      (ctv/next-property-number props)
-        property-name      (str ctv/property-prefix next-prop-num)
+        property-name      (d/nilv property-name (str ctv/property-prefix next-prop-num))
 
         [_ changes]
         (reduce (fn [[num changes] component]

--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -66,7 +66,7 @@
 
         props              (-> related-components first :variant-properties)
         next-prop-num      (ctv/next-property-number props)
-        property-name      (d/nilv property-name (str ctv/property-prefix next-prop-num))
+        property-name      (or property-name (str ctv/property-prefix next-prop-num))
 
         [_ changes]
         (reduce (fn [[num changes] component]

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -111,5 +111,35 @@
 (defn valid-properties-string?
   "Checks if a string of properties has a processable format or not"
   [s]
-  (let [pattern #"^(\w+=\w+)(,\s*\w+=\w+)*$"]
+  (let [pattern #"^([a-zA-Z0-9\s]+=[a-zA-Z0-9\s]+)(,\s*[a-zA-Z0-9\s]+=[a-zA-Z0-9\s]+)*$"]
     (not (nil? (re-matches pattern s)))))
+
+
+(defn find-properties-to-remove
+  "Compares two property maps to find which properties should be removed"
+  [prev-props upd-props]
+  (let [upd-names (set (map :name upd-props))]
+    (filterv #(not (contains? upd-names (:name %))) prev-props)))
+
+
+(defn find-properties-to-update
+  "Compares two property maps to find which properties should be updated"
+  [prev-props upd-props]
+  (filterv #(some (fn [prop] (and (= (:name %) (:name prop))
+                                  (not= (:value %) (:value prop)))) prev-props) upd-props))
+
+
+(defn find-properties-to-add
+  "Compares two property maps to find which properties should be added"
+  [prev-props upd-props]
+  (let [prev-names (set (map :name prev-props))]
+    (filterv #(not (contains? prev-names (:name %))) upd-props)))
+
+
+(defn find-index-for-property-name
+  "Finds the index of a name in a property map"
+  [props name]
+  (some (fn [[idx prop]]
+          (when (= (:name prop) name)
+            idx))
+        (map-indexed vector props)))

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -86,3 +86,30 @@
         new-properties (map-indexed (fn [i v] {:name (str property-prefix (+ next-prop-num i))
                                                :value v}) remaining)]
     (into assigned new-properties)))
+
+
+(defn properties-map-to-string
+  "Transforms a map of properties to a string of properties omitting the empty ones"
+  [properties]
+  (->> properties
+       (keep (fn [{:keys [name value]}]
+               (when (not (str/blank? value))
+                 (str name "=" value))))
+       (str/join ", ")))
+
+
+(defn properties-string-to-map
+  "Transforms a string of properties to a map of properties"
+  [s]
+  (->> (str/split s ",")
+       (mapv #(str/split % "="))
+       (mapv (fn [[k v]]
+               {:name (str/trim k)
+                :value (str/trim v)}))))
+
+
+(defn valid-properties-string?
+  "Checks if a string of properties has a processable format or not"
+  [s]
+  (let [pattern #"^(\w+=\w+)(,\s*\w+=\w+)*$"]
+    (not (nil? (re-matches pattern s)))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -1,0 +1,32 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.variant-test
+  (:require
+   [app.common.types.variant :as ctv]
+   [clojure.test :as t]))
+
+(t/deftest convert-between-variant-properties-maps-and-strings
+  (let [map-with-two-props           [{:name "border" :value "yes"} {:name "color" :value "gray"}]
+        map-with-two-props-one-blank [{:name "border" :value "no"} {:name "color" :value ""}]
+        map-with-one-prop            [{:name "border" :value "no"}]
+
+        string-valid-with-two-props  "border=yes, color=gray"
+        string-valid-with-one-prop   "border=no"
+        string-invalid               "border=yes, color="]
+
+    (t/testing "convert map to string"
+      (t/is (= (ctv/properties-map-to-string map-with-two-props) string-valid-with-two-props))
+      (t/is (= (ctv/properties-map-to-string map-with-two-props-one-blank) string-valid-with-one-prop)))
+
+    (t/testing "convert string to map"
+      (t/is (= (ctv/properties-string-to-map string-valid-with-two-props) map-with-two-props))
+      (t/is (= (ctv/properties-string-to-map string-valid-with-one-prop) map-with-one-prop)))
+
+    (t/testing "check if a string is valid"
+      (t/is (= (ctv/valid-properties-string? string-valid-with-two-props) true))
+      (t/is (= (ctv/valid-properties-string? string-valid-with-one-prop) true))
+      (t/is (= (ctv/valid-properties-string? string-invalid) false)))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -13,20 +13,69 @@
   (let [map-with-two-props           [{:name "border" :value "yes"} {:name "color" :value "gray"}]
         map-with-two-props-one-blank [{:name "border" :value "no"} {:name "color" :value ""}]
         map-with-one-prop            [{:name "border" :value "no"}]
+        map-with-spaces              [{:name "border 1" :value "of course"} {:name "color 2" :value "dark gray"}]
 
         string-valid-with-two-props  "border=yes, color=gray"
         string-valid-with-one-prop   "border=no"
+        string-valid-with-spaces     "border 1=of course, color 2=dark gray"
         string-invalid               "border=yes, color="]
 
     (t/testing "convert map to string"
       (t/is (= (ctv/properties-map-to-string map-with-two-props) string-valid-with-two-props))
-      (t/is (= (ctv/properties-map-to-string map-with-two-props-one-blank) string-valid-with-one-prop)))
+      (t/is (= (ctv/properties-map-to-string map-with-two-props-one-blank) string-valid-with-one-prop))
+      (t/is (= (ctv/properties-map-to-string map-with-spaces) string-valid-with-spaces)))
 
     (t/testing "convert string to map"
       (t/is (= (ctv/properties-string-to-map string-valid-with-two-props) map-with-two-props))
-      (t/is (= (ctv/properties-string-to-map string-valid-with-one-prop) map-with-one-prop)))
+      (t/is (= (ctv/properties-string-to-map string-valid-with-one-prop) map-with-one-prop))
+      (t/is (= (ctv/properties-string-to-map string-valid-with-spaces) map-with-spaces)))
 
     (t/testing "check if a string is valid"
       (t/is (= (ctv/valid-properties-string? string-valid-with-two-props) true))
       (t/is (= (ctv/valid-properties-string? string-valid-with-one-prop) true))
+      (t/is (= (ctv/valid-properties-string? string-valid-with-spaces) true))
       (t/is (= (ctv/valid-properties-string? string-invalid) false)))))
+
+
+(t/deftest compare-property-maps
+  (let [prev-props  [{:name "border" :value "yes"} {:name "color" :value "gray"}]
+        upd-props-1 [{:name "border" :value "yes"}]
+        upd-props-2 [{:name "border" :value "yes"} {:name "color" :value "blue"}]
+        upd-props-3 [{:name "border" :value "yes"} {:name "color" :value "gray"} {:name "shadow" :value "large"}]
+        upd-props-4 [{:name "color" :value "yellow"} {:name "shadow" :value "large"}]]
+
+    (t/testing "a property to remove"
+      (t/is (= (ctv/find-properties-to-remove prev-props upd-props-1)
+               [{:name "color" :value "gray"}]))
+      (t/is (= (ctv/find-properties-to-update prev-props upd-props-1)
+               []))
+      (t/is (= (ctv/find-properties-to-add prev-props upd-props-1)
+               [])))
+
+    (t/testing "a property to update"
+      (t/is (= (ctv/find-properties-to-remove prev-props upd-props-2)
+               []))
+      (t/is (= (ctv/find-properties-to-update prev-props upd-props-2)
+               [{:name "color" :value "blue"}]))
+      (t/is (= (ctv/find-properties-to-add prev-props upd-props-2)
+               [])))
+
+    (t/testing "a property to add"
+      (t/is (= (ctv/find-properties-to-remove prev-props upd-props-3)
+               []))
+      (t/is (= (ctv/find-properties-to-update prev-props upd-props-3)
+               []))
+      (t/is (= (ctv/find-properties-to-add prev-props upd-props-3)
+               [{:name "shadow" :value "large"}])))
+
+    (t/testing "properties to remove, update & add"
+      (t/is (= (ctv/find-properties-to-remove prev-props upd-props-4)
+               [{:name "border" :value "yes"}]))
+      (t/is (= (ctv/find-properties-to-update prev-props upd-props-4)
+               [{:name "color" :value "yellow"}]))
+      (t/is (= (ctv/find-properties-to-add prev-props upd-props-4)
+               [{:name "shadow" :value "large"}])))
+
+    (t/testing "find property index"
+      (t/is (= (ctv/find-index-for-property-name prev-props "border") 0))
+      (t/is (= (ctv/find-index-for-property-name prev-props "color") 1)))))

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -62,8 +62,8 @@
         variant-id            (when is-variant? (:variant-id item))
         variant-name          (when is-variant? (:variant-name item))
 
-        fdata                 (:data (deref refs/file))
-        component             (ctkl/get-component fdata (:component-id item))
+        workspace-data        (deref refs/workspace-data)
+        component             (ctkl/get-component workspace-data (:component-id item))
         variant-properties    (:variant-properties component)]
     [:*
      [:div {:id id

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -62,8 +62,8 @@
         variant-id            (when is-variant? (:variant-id item))
         variant-name          (when is-variant? (:variant-name item))
 
-        workspace-data        (deref refs/workspace-data)
-        component             (ctkl/get-component workspace-data (:component-id item))
+        data                  (deref refs/workspace-data)
+        component             (ctkl/get-component data (:component-id item))
         variant-properties    (:variant-properties component)]
     [:*
      [:div {:id id

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -11,6 +11,7 @@
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.types.component :as ctk]
+   [app.common.types.components-list :as ctkl]
    [app.common.types.container :as ctn]
    [app.common.types.shape.layout :as ctl]
    [app.common.uuid :as uuid]
@@ -23,7 +24,7 @@
    [app.main.ui.context :as ctx]
    [app.main.ui.hooks :as hooks]
    [app.main.ui.icons :as i]
-   [app.main.ui.workspace.sidebar.layer-name :refer [layer-name]]
+   [app.main.ui.workspace.sidebar.layer-name :refer [layer-name*]]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.keyboard :as kbd]
@@ -54,10 +55,16 @@
                                    (= uuid/zero (:parent-id item)))
         absolute?             (ctl/item-absolute? item)
         main-instance?        (:main-instance item)
+
         variants?             (features/use-feature "variants/v1")
         is-variant?           (when variants? (ctk/is-variant? item))
+        is-variant-container? (when variants? (ctk/is-variant-container? item))
+        variant-id            (when is-variant? (:variant-id item))
         variant-name          (when is-variant? (:variant-name item))
-        is-variant-container? (when variants? (ctk/is-variant-container? item))]
+
+        fdata                 (:data (deref refs/file))
+        component             (ctkl/get-component fdata (:component-id item))
+        variant-properties    (:variant-properties component)]
     [:*
      [:div {:id id
             :ref dref
@@ -121,21 +128,24 @@
             {:shape item
              :main-instance? main-instance?}]]])
 
-       [:& layer-name {:ref name-ref
-                       :shape-id id
-                       :shape-name name
-                       :is-shape-touched touched?
-                       :disabled-double-click read-only?
-                       :on-start-edit on-disable-drag
-                       :on-stop-edit on-enable-drag
-                       :depth depth
-                       :is-blocked blocked?
-                       :parent-size parent-size
-                       :is-selected selected?
-                       :type-comp (or component-tree? is-variant-container?)
-                       :type-frame (cfh/frame-shape? item)
-                       :variant-name variant-name
-                       :is-hidden hidden?}]
+       [:> layer-name* {:ref name-ref
+                        :shape-id id
+                        :shape-name name
+                        :is-shape-touched touched?
+                        :disabled-double-click read-only?
+                        :on-start-edit on-disable-drag
+                        :on-stop-edit on-enable-drag
+                        :depth depth
+                        :is-blocked blocked?
+                        :parent-size parent-size
+                        :is-selected selected?
+                        :type-comp (or component-tree? is-variant-container?)
+                        :type-frame (cfh/frame-shape? item)
+                        :variant-id variant-id
+                        :variant-name variant-name
+                        :variant-properties variant-properties
+                        :component-id (:id component)
+                        :is-hidden hidden?}]
 
        (when (not read-only?)
          [:div {:class (stl/css-case

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -60,7 +60,7 @@
 
         accept-edit
         (mf/use-fn
-         (mf/deps shape-id on-stop-edit variant-properties)
+         (mf/deps shape-id on-stop-edit component-id variant-id variant-name variant-properties)
          (fn []
            (let [name-input     (mf/ref-val ref)
                  name           (str/trim (dom/get-value name-input))]

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -9,7 +9,9 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.types.variant :as ctv]
    [app.main.data.workspace :as dw]
+   [app.main.data.workspace.variants :as dwv]
    [app.main.store :as st]
    [app.util.debug :as dbg]
    [app.util.dom :as dom]
@@ -24,12 +26,13 @@
   (-> (l/in [:workspace-local :shape-for-rename])
       (l/derived st/state)))
 
-(mf/defc layer-name
+(mf/defc layer-name*
   {::mf/wrap-props false
    ::mf/forward-ref true}
   [{:keys [shape-id shape-name is-shape-touched disabled-double-click
            on-start-edit on-stop-edit depth parent-size is-selected
-           type-comp type-frame variant-name is-hidden is-blocked]} external-ref]
+           type-comp type-frame variant-id variant-name variant-properties
+           component-id is-hidden is-blocked]} external-ref]
   (let [edition*         (mf/use-state false)
         edition?         (deref edition*)
 
@@ -39,6 +42,9 @@
         shape-for-rename (mf/deref lens:shape-for-rename)
 
         shape-name       (d/nilv variant-name shape-name)
+        default-value    (if variant-id
+                           (ctv/properties-map-to-string variant-properties)
+                           shape-name)
 
         has-path?        (str/includes? shape-name "/")
 
@@ -54,13 +60,17 @@
 
         accept-edit
         (mf/use-fn
-         (mf/deps shape-id on-stop-edit)
+         (mf/deps shape-id on-stop-edit variant-properties)
          (fn []
            (let [name-input     (mf/ref-val ref)
                  name           (str/trim (dom/get-value name-input))]
              (on-stop-edit)
              (reset! edition* false)
-             (st/emit! (dw/end-rename-shape shape-id name)))))
+             (if variant-name
+               (let [valid? (ctv/valid-properties-string? name)
+                     props  (if valid? (ctv/properties-string-to-map name) {})]
+                 (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties props)))
+               (st/emit! (dw/end-rename-shape shape-id name))))))
 
         cancel-edit
         (mf/use-fn
@@ -99,7 +109,7 @@
         :on-blur accept-edit
         :on-key-down on-key-down
         :auto-focus true
-        :default-value (d/nilv shape-name "")}]
+        :default-value (d/nilv default-value "")}]
       [:*
        [:span
         {:class (stl/css-case


### PR DESCRIPTION
### Related Ticket

Implements Taiga task [#10665](https://tree.taiga.io/project/penpot/task/10665).

### Summary

The user is now able to update the variant properties from the layers panel, using the formula `[property_name]=[value]`. This implies removing a value, editing a value and add a property with a value. 

If the formula is malformed, all the values of the properties for this component will be set to a blank value. The error management will be addressed in a different task.