### PR TITLE
:bug: Remove children correctly

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -198,9 +198,8 @@
           (when-not (empty? entries)
             (let [id (first entries)]
               (sr/heapu32-set-uuid id heap (mem/ptr8->ptr32 current-offset))
-              (recur (rest entries) (+ current-offset CHILD-ENTRY-SIZE)))))
-
-        (h/call wasm/internal-module "_set_children")))))
+              (recur (rest entries) (+ current-offset CHILD-ENTRY-SIZE)))))))
+    (h/call wasm/internal-module "_set_children")))
 
 (defn- get-string-length [string] (+ (count string) 1))
 

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -219,7 +219,8 @@ pub extern "C" fn add_shape_child(a: u32, b: u32, c: u32, d: u32) {
 
 #[no_mangle]
 pub extern "C" fn set_children() {
-    let bytes = mem::bytes();
+    let bytes = mem::bytes_or_empty();
+
     let entries: IndexSet<Uuid> = bytes
         .chunks(size_of::<<Uuid as SerializableResult>::BytesType>())
         .map(|data| Uuid::from_bytes(data.try_into().unwrap()))
@@ -237,13 +238,10 @@ pub extern "C" fn set_children() {
             state.delete_shape(id);
         }
     });
-}
 
-#[no_mangle]
-pub extern "C" fn clear_shape_children() {
-    with_current_shape!(state, |shape: &mut Shape| {
-        shape.clear_children();
-    });
+    if !bytes.is_empty() {
+        mem::free_bytes();
+    }
 }
 
 #[no_mangle]

--- a/render-wasm/src/mem.rs
+++ b/render-wasm/src/mem.rs
@@ -56,6 +56,12 @@ pub fn bytes() -> Vec<u8> {
         .map_or_else(|| panic!("Buffer is not initialized"), |buffer| *buffer)
 }
 
+pub fn bytes_or_empty() -> Vec<u8> {
+    let mut guard = BUFFERU8.lock().unwrap();
+
+    guard.take().map_or_else(|| Vec::new(), |buffer| *buffer)
+}
+
 pub trait SerializableResult {
     type BytesType;
     fn from_bytes(bytes: Self::BytesType) -> Self;

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -444,10 +444,6 @@ impl Shape {
         (added, removed)
     }
 
-    pub fn clear_children(&mut self) {
-        self.children.clear();
-    }
-
     pub fn fills(&self) -> std::slice::Iter<Fill> {
         self.fills.iter()
     }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10756

### Summary

Minor fix to a change introduced in the [heap usage refactor.](https://github.com/penpot/penpot/pull/6204/files) This calls "set_children" always as before to remove the **all** the needed shapes as necessary

### Steps to reproduce

- Check one single shape is deleted correctly
- Check one single shape inside another shape (i.e. a Board) is deleted correctly

https://github.com/user-attachments/assets/ed585c20-e02f-4206-87c6-5b4dd53d3930

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

