### PR TITLE
:bug: Fix notification vertical alignment

### DIFF
--- a/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.cljs
+++ b/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.cljs
@@ -37,9 +37,9 @@
   {::mf/props :obj
    ::mf/schema schema:notification-pill}
   [{:keys [level type is-html appearance detail children show-detail on-toggle-detail]}]
-  (let [class (stl/css-case :notification-pill true
-                            :appearance-neutral (= appearance :neutral)
+  (let [class (stl/css-case :appearance-neutral (= appearance :neutral)
                             :appearance-ghost (= appearance :ghost)
+                            :with-detail detail
                             :type-toast (= type :toast)
                             :type-context (= type :context)
                             :level-default  (= level :default)

--- a/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.scss
+++ b/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.scss
@@ -88,6 +88,9 @@
   display: grid;
   max-height: 92vh;
   overflow: hidden;
+}
+
+.with-detail {
   grid-template-rows: auto 1fr;
 }
 


### PR DESCRIPTION
### Related Ticket

This PR fixes [this issue](https://tree.taiga.io/project/penpot/issue/10778)

### Summary

Due recent change notification pill is not vertically align

### Steps to reproduce 

1. Go to storybook
2. Open a notification component (i.e. toast with longer text)
3. Check blank space around text

More space at bottom (BAD)
![Screenshot from 2025-04-10 13-31-22](https://github.com/user-attachments/assets/eaada563-6c5d-48be-bb80-36f2143f35b9)

Same space top and bottom (GOOD)
![Screenshot from 2025-04-10 13-31-29](https://github.com/user-attachments/assets/7dcde9c9-94a4-4c1f-a74c-8e2d1cb91d05)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
