### PR TITLE
:bug: Fix incorrect undo handling on path edition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,12 @@
 # CHANGELOG
 
-## 2.6.2
+## 2.6.2 (Unreleased)
 
 ### :bug: Bugs fixed
 
 - Increase the height of the right sidebar dropdowns [Taiga #10615](https://tree.taiga.io/project/penpot/issue/10615)
 - Fix scroll on token themes modal [Taiga #10745](https://tree.taiga.io/project/penpot/issue/10745)
+- Fix unexpected exception on path editor on merge segments when undo stack is empty
 
 ## 2.6.1
 

--- a/common/src/app/common/data/undo_stack.cljc
+++ b/common/src/app/common/data/undo_stack.cljc
@@ -47,7 +47,7 @@
 
 (defn undo
   [stack]
-  (update stack :index dec))
+  (update stack :index #(max 0 (dec %))))
 
 (defn redo
   [{index :index items :items :as stack}]


### PR DESCRIPTION
### Related Ticket

No tickets

### Summary

An issue found by accident on refactoring paths

### Steps to reproduce 

- Create a path with some lines and some curves
- Deselect the shape
- Enter shape editor again with curve editor (draw nodes)  with double click on path (the first time it enters on move nodes, so ESC and double click again)
- Draw a new curve with click and drag -> BOOM!

