### PR TITLE
:bug: Fix token color reference issue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,7 @@
     "@penpot/mousetrap": "portal:./vendor/mousetrap",
     "@penpot/svgo": "penpot/svgo#v3.1",
     "@penpot/text-editor": "portal:./text-editor",
-    "@tokens-studio/sd-transforms": "1.2.11",
+    "@tokens-studio/sd-transforms": "1.2.12",
     "compression": "^1.7.5",
     "date-fns": "^4.1.0",
     "eventsource-parser": "^3.0.0",

--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -25,7 +25,11 @@
   "Initiates the StyleDictionary instance.
   Setup transforms from tokens-studio used to parse and resolved token values."
   (do
+    ;; Create a custom transform group based on tokens-studio transforms
+    ;; Excluding the css transforms which dont work well with this runtime implementation
     (sd-transforms/register sd)
+    (.registerTransformGroup sd #js {:name "runtime"
+                                     :transforms (sd-transforms/getTransforms #js {:platform "none"})})
     (.registerFormat sd #js {:name "custom/json"
                              :format (fn [^js res]
                                        (.-tokens (.-dictionary res)))})
@@ -33,7 +37,7 @@
 
 (def default-config
   {:platforms {:json
-               {:transformGroup "tokens-studio"
+               {:transformGroup "runtime"
                 ;; Required: The StyleDictionary API is focused on files even when working in the browser
                 :files [{:format "custom/json" :destination "penpot"}]}}
    :preprocessors ["tokens-studio"]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2443,9 +2443,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tokens-studio/sd-transforms@npm:1.2.11":
-  version: 1.2.11
-  resolution: "@tokens-studio/sd-transforms@npm:1.2.11"
+"@tokens-studio/sd-transforms@npm:1.2.12":
+  version: 1.2.12
+  resolution: "@tokens-studio/sd-transforms@npm:1.2.12"
   dependencies:
     "@bundled-es-modules/deepmerge": "npm:^4.3.1"
     "@bundled-es-modules/postcss-calc-ast-parser": "npm:^0.1.6"
@@ -2454,8 +2454,8 @@ __metadata:
     expr-eval-fork: "npm:^2.0.2"
     is-mergeable-object: "npm:^1.1.1"
   peerDependencies:
-    style-dictionary: ">=4.3.0 < 6"
-  checksum: 10c0/58c278a2d738bb2f84e0e01c84d2a96191495440a9a52087cf9ee0e51ae272392cb93d17a3978e1f814e4a4c885aa349227bc0c7f0998a21cfc308988687c0e9
+    style-dictionary: ^4.3.0 || ^5.0.0-rc.0
+  checksum: 10c0/971a09c7d17e3aca621bc2982be5dddd90294ce82a0780ffc48eec0752126ee02bbcbdd0b92eca948499a40d16a9261beb072356ad72e5f606661ba942d0c57b
   languageName: node
   linkType: hard
 
@@ -5888,7 +5888,7 @@ __metadata:
     "@storybook/react-vite": "npm:^8.5.2"
     "@storybook/test": "npm:^8.5.2"
     "@storybook/test-runner": "npm:^0.21.0"
-    "@tokens-studio/sd-transforms": "npm:1.2.11"
+    "@tokens-studio/sd-transforms": "npm:1.2.12"
     "@types/node": "npm:^22.12.0"
     autoprefixer: "npm:^10.4.20"
     compression: "npm:^1.7.5"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/58

### Summary

The [sd-transforms](https://github.com/tokens-studio/sd-transforms) package comes with some default transforms that are buggy for our use-case of a runtime resolver.
We'll fix it in the package as well, but we don't need the CSS transforms for our needs, so I've removed it from the transforms.

Here's the Issue in sd-transforms: https://github.com/tokens-studio/sd-transforms/issues/353

I've Updated sd-transforms package as well while visiting it.

### Steps to reproduce 

1. Create two sets `Foo` & `Bar`
2. Create a color token in `Foo` called `color.foo` with the value of `black`
3. Create a color token in `Bar` called `background` with the value of `{color.foo}`
4. Try to rename `color.foo` to `color.foo.100` or something else after the `foo` group and it wouldn't work

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.