### PR TITLE
:bug: Fix avoid uncacheable tiles

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1,7 +1,7 @@
 use skia_safe::{self as skia, Matrix, RRect, Rect};
 
 use crate::uuid::Uuid;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::performance;
 use crate::view::Viewbox;
@@ -837,21 +837,26 @@ impl RenderState {
 
     pub fn update_tile_for(&mut self, shape: &Shape) {
         let (rsx, rsy, rex, rey) = self.get_tiles_for_rect(shape);
+        let new_tiles: HashSet<(i32, i32)> = (rsx..=rex)
+            .flat_map(|x| (rsy..=rey).map(move |y| (x, y)))
+            .collect();
 
         // Update tiles where the shape was
         if let Some(tiles) = self.tiles.get_tiles_of(shape.id) {
             for tile in tiles.iter() {
                 self.surfaces.remove_cached_tile_surface(*tile);
             }
+            // Remove shape from tiles not used
+            let diff: HashSet<_> = tiles.difference(&new_tiles).cloned().collect();
+            for tile in diff.iter() {
+                self.tiles.remove_shape_at(*tile, shape.id);
+            }
         }
 
         // Update tiles matching the actual selrect
-        for x in rsx..=rex {
-            for y in rsy..=rey {
-                let tile = (x, y);
-                self.tiles.add_shape_at(tile, shape.id);
-                self.surfaces.remove_cached_tile_surface(tile);
-            }
+        for tile in new_tiles {
+            self.tiles.add_shape_at(tile, shape.id);
+            self.surfaces.remove_cached_tile_surface(tile);
         }
     }
 

--- a/render-wasm/src/render/tiles.rs
+++ b/render-wasm/src/render/tiles.rs
@@ -81,6 +81,10 @@ impl TileHashMap {
         if let Some(shapes) = self.grid.get_mut(&tile) {
             shapes.shift_remove(&id);
         }
+
+        if let Some(tiles) = self.index.get_mut(&id) {
+            tiles.remove(&tile);
+        }
     }
 
     pub fn get_tiles_of(&mut self, shape_id: Uuid) -> Option<&HashSet<Tile>> {


### PR DESCRIPTION
Related to: https://tree.taiga.io/project/penpot/task/10790

If a shape is rendered inside a tile that tile is uncacheable even if the shape is moved out of the tile.

In the attached video:

- While the top-left rect is moved inside the -2,0 tile, the rest are marked as cached
- If that rect is moved over the rest of the tiles all of them are uncached
- Ifthat rect is moved again only inside the -2,0 tile the rest keep uncached

Actually in develop:

https://github.com/user-attachments/assets/c7b6f0be-b5ec-4399-b8e2-1ed89cd62591

With the current pull request:

https://github.com/user-attachments/assets/f8b318f6-1a68-47ea-bc46-77b9b6799542

