### PR TITLE
:sparkles: Improve copy on inactive set warning title

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6952,7 +6952,7 @@ msgstr "Inactive"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:340
 msgid "workspace.token.inactive-set-description"
-msgstr "This set is not active. Change theme or activate the set / theme to see changes in the canvas"
+msgstr "This set is not active. Change theme or activate this set to see changes in the viewport"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:405
 msgid "workspace.token.tools"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6930,7 +6930,7 @@ msgstr "Inactivo"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:340
 msgid "workspace.token.inactive-set-description"
-msgstr "Set inactivo. Cambia el tema o activa el set para ver los cambios en el canvas."
+msgstr "Este set no está activo. Cambia el tema o activa este set para ver los cambios en el viewport"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:405
 msgid "workspace.token.tools"


### PR DESCRIPTION
### Related Ticket

This PR fixes a review on https://tree.taiga.io/project/penpot/issue/10668
See Comments

### Summary

The tooltip message should be the same as in this description (my fault, the design was not updated):

“This set is not active. Change theme or activate this set to see changes in the viewport”        
"Este set no está activo. Cambia el tema o activa este set para ver los cambios en el viewport"

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
