### PR TITLE
:bug: Hide inactive warning if sets are empty

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -257,6 +257,14 @@
         selected        (mf/deref refs/selected-shapes)
         open-status     (mf/deref ref:token-type-open-status)
 
+        ;; FIXME: This is an inneficient operation just for being
+        ;; ability to check if there are some sets and lookup the
+        ;; first one when no set is selected, should be REFACTORED; is
+        ;; inneficient because instead of return the sets as-is (tree)
+        ;; it firstly makes it a plain seq from tree.
+        token-sets
+        (some-> tokens-lib (ctob/get-sets))
+
         selected-shapes
         (mf/with-memo [selected objects]
           (into [] (keep (d/getf objects)) selected))
@@ -332,7 +340,7 @@
      [:div {:class (stl/css :sets-header-container)}
       [:span {:class (stl/css :sets-header)} (tr "workspace.token.tokens-section-title" selected-token-set-name)]
       [:div {:class (stl/css :sets-header-status) :title (tr "workspace.token.inactive-set-description")}
-       (when (not (token-set-active? selected-token-set-name))
+       (when (and (seq token-sets) (not (token-set-active? selected-token-set-name)))
          [:*
           [:> i/icon* {:class (stl/css :sets-header-status-icon) :icon-id i/eye-off}]
           [:span {:class (stl/css :sets-header-status-text)}

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -257,14 +257,6 @@
         selected        (mf/deref refs/selected-shapes)
         open-status     (mf/deref ref:token-type-open-status)
 
-        ;; FIXME: This is an inneficient operation just for being
-        ;; ability to check if there are some sets and lookup the
-        ;; first one when no set is selected, should be REFACTORED; is
-        ;; inneficient because instead of return the sets as-is (tree)
-        ;; it firstly makes it a plain seq from tree.
-        token-sets
-        (some-> tokens-lib (ctob/get-sets))
-
         selected-shapes
         (mf/with-memo [selected objects]
           (into [] (keep (d/getf objects)) selected))
@@ -340,7 +332,11 @@
      [:div {:class (stl/css :sets-header-container)}
       [:span {:class (stl/css :sets-header)} (tr "workspace.token.tokens-section-title" selected-token-set-name)]
       [:div {:class (stl/css :sets-header-status) :title (tr "workspace.token.inactive-set-description")}
-       (when (and (seq token-sets) (not (token-set-active? selected-token-set-name)))
+       ;; NOTE: when no set in tokens-lib, the selected-token-set-name
+       ;; will be `nil`, so for properly hide the inactive message we
+       ;; check that at least `selected-token-set-name` has a value
+       (when (and (some? selected-token-set-name)
+                  (not (token-set-active? selected-token-set-name)))
          [:*
           [:> i/icon* {:class (stl/css :sets-header-status-icon) :icon-id i/eye-off}]
           [:span {:class (stl/css :sets-header-status-text)}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10668

### Summary
When there is no set, does not display the indicator.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
