### PR TITLE
:sparkles: Propagate sharing a prototype to editors and viewers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,9 @@
 ### :heart: Community contributions (Thank you!)
 
 ### :sparkles: New features
+
 - Update board presets with a newer devices [Taiga #10610](https://tree.taiga.io/project/penpot/us/10610)
+- Propagate "sharing a prototype" to editors and viewers [Taiga #8853](https://tree.taiga.io/project/penpot/us/8853)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/viewer/header.cljs
+++ b/frontend/src/app/main/ui/viewer/header.cljs
@@ -198,9 +198,7 @@
              :on-click toggle-fullscreen}
       i/expand]
 
-     (when (and
-            (:in-team permissions)
-            (:is-admin permissions))
+     (when (:in-team permissions)
        [:button {:on-click open-share-dialog
                  :class (stl/css :share-btn)}
         (tr "labels.share")])


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/8853

### Summary
Editors and viewers of a project can share a prototype with people who are not part of the project. This is just like how owners and administrators do it.

### Steps to reproduce 
With a member with editor or viewer role, go to 'View mode' and check if the 'Share' button is visible.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
