### PR TITLE
:sparkles: Inherit text-align attribute from paragraph

### DIFF
--- a/common/src/app/common/text.cljc
+++ b/common/src/app/common/text.cljc
@@ -69,6 +69,7 @@
 
 (def text-node-attrs
   (d/concat-vec
+   text-align-attrs
    text-typography-attrs
    text-font-attrs
    text-spacing-attrs


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10806

### Summary

Minor change to inherit the text-align attribute by text nodes from its parent paragraph 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
