### PR TITLE
:sparkles: Design improvements to the Invitations page with an empty state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 - Update board presets with a newer devices [Taiga #10610](https://tree.taiga.io/project/penpot/us/10610)
 - Propagate "sharing a prototype" to editors and viewers [Taiga #8853](https://tree.taiga.io/project/penpot/us/8853)
+- Design improvements to the Invitations page with an empty state [Taiga #4554](https://tree.taiga.io/project/penpot/us/4554)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/dashboard/team.scss
+++ b/frontend/src/app/main/ui/dashboard/team.scss
@@ -310,6 +310,12 @@
   color: var(--dashboard-list-text-foreground-color);
 }
 
+.btn-empty-invitations {
+  @extend .button-primary;
+  margin-block-start: $s-16;
+  padding-inline: $s-12;
+}
+
 .title-field-status {
   position: relative;
   cursor: default;

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2152,9 +2152,8 @@ msgid "labels.no-invitations"
 msgstr "No pending invitations."
 
 #: src/app/main/ui/dashboard/team.cljs:742
-#, markdown
-msgid "labels.no-invitations-hint"
-msgstr "Click the **Invite people** button to invite people to this team."
+msgid "labels.no-invitations-gather-people"
+msgstr "Gather your people and build great things together."
 
 #: src/app/main/ui/static.cljs
 #, unused

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2175,9 +2175,8 @@ msgid "labels.no-invitations"
 msgstr "No hay invitaciones pendientes."
 
 #: src/app/main/ui/dashboard/team.cljs:742
-#, markdown
-msgid "labels.no-invitations-hint"
-msgstr "Pulsa el botón 'Invitar al equipo' para añadir más integrantes al equipo."
+msgid "labels.no-invitations-gather-people"
+msgstr "Reúne a tu gente y construid juntos grandes cosas."
 
 #: src/app/main/ui/static.cljs
 #, unused


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/4554

### Summary
When the invitations page is empty, the invite button on the top bar shouldn't be visible. In that case it should be in the bottom of the empty message.
When there are invitations the button should be on the top bar menu.

### Screenshots
Empty state
![image](https://github.com/user-attachments/assets/7770f2d2-46be-4278-b657-f6c82ca45eec)

With invitations state
![image](https://github.com/user-attachments/assets/0863e117-fecd-493f-9b16-44d1cdf4b151)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
