### PR TITLE
:sparkles: Handle token name errors on import

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/errors.cljs
@@ -12,6 +12,11 @@
    {:error/code :error.import/invalid-json-data
     :error/fn #(tr "workspace.token.invalid-json")}
 
+   :error.import/invalid-token-name
+   {:error/code :error.import/invalid-json-data
+    :error/fn #(tr "workspace.token.invalid-json-token-name")
+    :error/detail #(tr "workspace.token.invalid-json-token-name-detail" %)}
+
    :error.import/style-dictionary-reference-errors
    {:error/code :error.import/style-dictionary-reference-errors
     :error/fn #(str (tr "workspace.token.import-error") "\n\n" (first %))

--- a/frontend/src/app/main/ui/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/errors.cljs
@@ -80,4 +80,6 @@
   (->> errors
        (map (fn [err]
               (when (:error/detail err)
-                ((:error/detail err) (:error/value err)))))))
+                ((:error/detail err) (:error/value err)))))
+       (filter some?)
+       (seq)))

--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -10,7 +10,6 @@
    [app.main.ui.workspace.tokens.tinycolor :as tinycolor]
    [app.main.ui.workspace.tokens.token :as wtt]
    [app.main.ui.workspace.tokens.warnings :as wtw]
-   [app.util.i18n :refer [tr]]
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]
@@ -265,6 +264,16 @@
            (= header-2 "Reference Errors:"))
       errors)))
 
+(defn name-error
+  "Extracts name error out of malli schema error during import."
+  [err]
+  (let [schema-error (some-> (ex-data err)
+                             (get-in [:app.common.schema/explain :errors])
+                             (first))
+        name-error? (= (:in schema-error) [:name])]
+    (when name-error?
+      (wte/error-ex-info :error.import/invalid-token-name (:value schema-error) err))))
+
 (defn process-json-stream
   ([data-stream]
    (process-json-stream nil data-stream))
@@ -296,7 +305,9 @@
                           (ctob/decode-dtcg-json (ctob/ensure-tokens-lib nil) json-data))
 
                         (catch js/Error e
-                          (throw (wte/error-ex-info :error.import/invalid-json-data json-data e)))))))
+                          (let [err (or (name-error e)
+                                        (wte/error-ex-info :error.import/invalid-json-data json-data e))]
+                            (throw err)))))))
           (rx/mapcat (fn [tokens-lib]
                        (try
                          (-> (ctob/get-all-tokens tokens-lib)

--- a/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/style_dictionary.cljs
@@ -311,17 +311,6 @@
                          (catch js/Error e
                            (p/rejected (wte/error-ex-info :error.import/style-dictionary-unknown-error "" e))))))))))
 
-;; === Errors
-
-(defn humanize-errors [{:keys [errors] :as token}]
-  (->> (map (fn [err]
-              (case (:error/code err)
-                ;; TODO: This needs translations
-                :error.style-dictionary/missing-reference (tr "workspace.token.token-not-resolved" (:error/value err))
-                nil))
-            errors)
-       (str/join "\n")))
-
 ;; === Hooks
 
 (defonce !tokens-cache (atom nil))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6754,6 +6754,17 @@ msgstr "Invalid color value: %s"
 msgid "workspace.token.invalid-json"
 msgstr "Import Error: Invalid token data in JSON."
 
+#: src/app/main/ui/workspace/tokens/errors.cljs:16
+msgid "workspace.token.invalid-json-token-name"
+msgstr "Import Error: Invalid token name in in JSON."
+
+#: src/app/main/ui/workspace/tokens/errors.cljs:18
+msgid "workspace.token.invalid-json-token-name-detail"
+msgstr ""
+"\"%s\" is not a valid token name.\n"
+"Token names should only contain letters and digits separated by . "
+"characters and must not start with a $ sign."
+
 #: src/app/main/ui/workspace/tokens/errors.cljs:41, src/app/main/ui/workspace/tokens/errors.cljs:45
 msgid "workspace.token.invalid-value"
 msgstr "Invalid token value: %s"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/99

### Summary

Gives more info to the user when json token import fails.
The biggest restriction is the token name right now, as we are more selective about which token names are allowed in penpot.

This error will be shown:

![image](https://github.com/user-attachments/assets/8c557313-8078-4765-b851-30ebfeced2d7)

For an invalid json like

```json
{
  "global": {
    "foo/bar": {
      "value": "1",
      "type": "borderRadius",
      "value": "1px"
    },
    "@foo": {
      "value": "1",
      "type": "borderRadius",
      "value": "1px"
    }
  }
}
```

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

