### PR TITLE
:bug: Fix last shape removal

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -190,8 +190,8 @@
 (defn set-shape-children
   [shape-ids]
   (let [num-shapes (count shape-ids)]
+    (perf/begin-measure "set-shape-children")
     (when (> num-shapes 0)
-      (perf/begin-measure "set-shape-children")
       (let [offset (mem/alloc-bytes (* CHILD-ENTRY-SIZE num-shapes))
             heap (mem/get-heap-u32)]
 
@@ -200,11 +200,11 @@
           (when-not (empty? entries)
             (let [id (first entries)]
               (sr/heapu32-set-uuid id heap (mem/ptr8->ptr32 current-offset))
-              (recur (rest entries) (+ current-offset CHILD-ENTRY-SIZE)))))
+              (recur (rest entries) (+ current-offset CHILD-ENTRY-SIZE)))))))
 
-        (let [result (h/call wasm/internal-module "_set_children")]
-          (perf/end-measure "set-shape-children")
-          result)))))
+    (let [result (h/call wasm/internal-module "_set_children")]
+      (perf/end-measure "set-shape-children")
+      result)))
 
 (defn- get-string-length [string] (+ (count string) 1))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10756

### Summary

This was already fixed, it's a regression introduced in another PR.

* It was fixed [here](https://github.com/penpot/penpot/pull/6258)
* But it seems it was introduced again [here](https://github.com/penpot/penpot/pull/6229/files#diff-06acc13fe862acb1d9c7c7c41d522295630162091fad049283a120143673ace9R203)
