### PR TITLE
:bug: Fix problem with new buttons on team change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Increase the height of the right sidebar dropdowns [Taiga #10615](https://tree.taiga.io/project/penpot/issue/10615)
 - Fix scroll on token themes modal [Taiga #10745](https://tree.taiga.io/project/penpot/issue/10745)
 - Fix unexpected exception on path editor on merge segments when undo stack is empty
+- Fix problem with new buttons on team change [Taiga #10783](https://tree.taiga.io/project/penpot/issue/10783)
 
 ## 2.6.1
 

--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -133,6 +133,8 @@
       (let [team-id' (get state :current-team-id)]
         (if (= team-id' team-id)
           (-> state
+              (dissoc :files)
+              (dissoc :recent-files)
               (dissoc :current-team-id)
               (dissoc :shared-files)
               (dissoc :fonts))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10783

### Summary

Fixed problem showing old add button on change to an empty team.

### Steps to reproduce 

- Create new team
- The create file button is the old one

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
