### PR TITLE
:sparkles: Add horizontal scroll on nested layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 - Fix color gradient on texts [Taiga Issue #7488](https://tree.taiga.io/project/penpot/issue/7488)
 - Add support for self mentions [Taiga #10809](https://tree.taiga.io/project/penpot/issue/10809)
 - Fix team info settings alignment [Taiga #10869](https://tree.taiga.io/project/penpot/issue/10869)
+- Fix left sidebar horizontal scroll on nested layers [Taiga #10791](https://tree.taiga.io/project/penpot/issue/10791)
 
 ## 2.6.2 (Unreleased)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -355,18 +355,14 @@
             first-child-node (dom/get-first-child parent-node)
 
             subid
-            (when (and single? selected?)
-              (let [scroll-to @scroll-to-middle?]
-                (ts/schedule
-                 100
-                 #(when (and node scroll-node)
-                    (let [scroll-distance-ratio (dom/get-scroll-distance-ratio node scroll-node)
-                          scroll-behavior (if (> scroll-distance-ratio 1) "instant" "smooth")]
-                      (if scroll-to
-                        (dom/scroll-into-view! first-child-node #js {:block "center" :behavior scroll-behavior  :inline "start"})
-                        (do
-                          (dom/scroll-into-view-if-needed! first-child-node #js {:block "center" :behavior scroll-behavior :inline "start"})
-                          (reset! scroll-to-middle? true))))))))]
+            (when (and single? selected? @scroll-to-middle?)
+              (ts/schedule
+               100
+               #(when (and node scroll-node)
+                  (let [scroll-distance-ratio (dom/get-scroll-distance-ratio node scroll-node)
+                        scroll-behavior (if (> scroll-distance-ratio 1) "instant" "smooth")]
+                    (dom/scroll-into-view-if-needed! first-child-node #js {:block "center" :behavior scroll-behavior :inline "start"})
+                    (reset! scroll-to-middle? true)))))]
 
         #(when (some? subid)
            (rx/dispose! subid))))

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.scss
@@ -91,6 +91,9 @@
 .element-actions {
   display: none;
   height: 100%;
+  display: flex;
+  align-items: end;
+
   &.selected {
     display: flex;
   }

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -102,7 +102,8 @@
     (if ^boolean edition?
       [:input
        {:class (stl/css :element-name
-                        :element-name-input)
+                        :element-name-input
+                        :selected is-selected)
         :style {"--depth" depth "--parent-size" parent-size}
         :type "text"
         :ref ref

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.scss
@@ -11,6 +11,7 @@
   @include bodySmallTypography;
   flex-grow: 1;
   color: var(--context-hover-color, var(--layer-row-foreground-color));
+
   &.selected {
     color: var(--layer-row-foreground-color-selected);
   }
@@ -25,6 +26,7 @@
     opacity: var(--context-hover-opacity, $op-7);
   }
 }
+
 .element-name-input {
   @include textEllipsis;
   @include bodySmallTypography;
@@ -37,7 +39,12 @@
   border-radius: $br-8;
   border: $s-1 solid var(--input-border-color-focus);
   color: var(--layer-row-foreground-color);
+
+  &.selected {
+    min-width: $s-88;
+  }
 }
+
 .element-name-touched {
   color: var(--layer-row-component-foreground-color);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.scss
@@ -226,11 +226,13 @@
   display: flex;
   flex-direction: column;
   height: calc(100vh - var(--calculated-height));
-  width: 100%;
-  overflow-x: hidden;
+  width: calc(var(--width) + var(--depth) * var(--layer-indentation-size));
+  overflow-x: scroll;
   overflow-y: overlay;
   scrollbar-gutter: stable;
+
   .element-list {
-    width: 100%;
+    width: var(--width);
+    display: grid;
   }
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
@@ -38,11 +38,14 @@
   display: flex;
   flex-direction: column;
   height: calc(-38px + var(--height, $s-200));
-  width: 100%;
-  overflow-x: hidden;
+  width: var(--width);
+  overflow-x: scroll;
   overflow-y: overlay;
   scrollbar-gutter: stable;
-  max-width: var(--width);
+
+  .element-list {
+    display: grid;
+  }
 }
 
 .pages-list {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10791

### Summary

When having multiple nested layers, it's hard to manipulate them since it's not possible to scroll horizontally in a proper way. The aim of this PR is to make it possible to manipulate nested elements in a smooth way, being able to interact with all the levels, while keeping the default behavior as it is.

### Steps to reproduce 

- Open or create a file with many nested layers and components (or import these ones [nested_layers.zip](https://github.com/user-attachments/files/19864584/nested_layers.zip), [dashboard.zip](https://github.com/user-attachments/files/19867205/dashboard.zip))


- Navigate through the left sidebar
- Make sure you can edit the elements (if they're not blocked) 
- Check the scroll works smoothly

### Demo

[screen-recorder-wed-apr-23-2025-11-17-22.webm](https://github.com/user-attachments/assets/ff56c486-feaf-4e5e-ac42-a9378802a297)

[screen-recorder-wed-apr-23-2025-14-20-52.webm](https://github.com/user-attachments/assets/74a80f22-9241-4926-a55c-8634de05a559)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

