### PR TITLE
:wrench: Improve Rust dev env

### DIFF
--- a/docker/devenv/Dockerfile
+++ b/docker/devenv/Dockerfile
@@ -10,6 +10,7 @@ ENV NODE_VERSION=v22.14.0 \
     CLJFMT_VERSION=0.13.0 \
     RUSTUP_VERSION=1.27.1 \
     RUST_VERSION=1.85.0 \
+    EMSCRIPTEN_VERSION=4.0.6 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
@@ -269,8 +270,8 @@ WORKDIR /usr/local
 RUN set -eux; \
   git clone https://github.com/emscripten-core/emsdk.git; \
   cd emsdk; \
-  ./emsdk install latest; \
-  ./emsdk activate latest; \
+  ./emsdk install $EMSCRIPTEN_VERSION; \
+  ./emsdk activate $EMSCRIPTEN_VERSION; \
   rustup target add wasm32-unknown-emscripten;
 
 WORKDIR /home

--- a/render-wasm/_build_env
+++ b/render-wasm/_build_env
@@ -24,7 +24,7 @@ EMSDK_QUIET=1 . /usr/local/emsdk/emsdk_env.sh;
 
 export EM_CACHE="/tmp/emsdk_cache";
 
-_CARGO_PARAMS="--target=wasm32-unknown-emscripten";
+_CARGO_PARAMS="";
 
 if [ "$_BUILD_MODE" = "release" ]; then
     _CARGO_PARAMS="--release $_CARGO_PARAMS"
@@ -40,4 +40,3 @@ fi
 export EMCC_CFLAGS;
 export _CARGO_PARAMS;
 
-export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.81.0-3/skia-binaries-24dee32a277b6c7b5357-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache.tar.gz"

--- a/render-wasm/build
+++ b/render-wasm/build
@@ -4,7 +4,10 @@ set -x
 _SCRIPT_DIR=$(dirname $0);
 pushd $_SCRIPT_DIR;
 
-. ./_build_env 
+. ./_build_env
+
+export CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-"wasm32-unknown-emscripten"};
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL:-"https://github.com/penpot/skia-binaries/releases/download/0.81.0-3/skia-binaries-24dee32a277b6c7b5357-wasm32-unknown-emscripten-gl-svg-textlayout-binary-cache.tar.gz"}
 
 cargo build $_CARGO_PARAMS
 

--- a/render-wasm/test
+++ b/render-wasm/test
@@ -6,10 +6,10 @@ pushd $_SCRIPT_DIR;
 
 . ./_build_env
 
-export SKIA_BINARIES_URL="https://github.com/penpot/skia-binaries/releases/download/0.81.0-3/skia-binaries-24dee32a277b6c7b5357-x86_64-unknown-linux-gnu-gl-svg-textlayout-binary-cache.tar.gz"
-export _CARGO_PARAMS="--target=x86_64-unknown-linux-gnu";
+export SKIA_BINARIES_URL=${SKIA_BINARIES_URL:-"https://github.com/penpot/skia-binaries/releases/download/0.81.0-3/skia-binaries-24dee32a277b6c7b5357-x86_64-unknown-linux-gnu-gl-svg-textlayout-binary-cache.tar.gz"}
+export CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET:-"x86_64-unknown-linux-gnu"};
 
-cargo test $_CARGO_PARAMS --bin render_wasm -- --show-output
+cargo test --bin render_wasm -- --show-output
 
 # Exit with the same status code as cargo test
 exit $?


### PR DESCRIPTION
Closes https://tree.taiga.io/project/penpot/task/10781

- :wrench: Use cargo env variable for target and allow to override it as well as SKIA_BINARIES_URL
- :wrench: Fix emscripten version in devenv
