### PR TITLE
:tada: Add text shadows

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -375,7 +375,12 @@ impl RenderState {
                 self.surfaces.apply_mut(&[SurfaceId::Fills], |s| {
                     s.canvas().concat(&matrix);
                 });
-                text::render(self, &shape, text_content);
+
+                let paragraphs = text_content.to_skia_paragraphs(&self.fonts.font_collection());
+
+                shadows::render_text_drop_shadows(self, &shape, &paragraphs, antialias);
+                text::render(self, &shape, &paragraphs, None, None);
+                shadows::render_text_inner_shadows(self, &shape, &paragraphs, antialias);
             }
             _ => {
                 self.surfaces.apply_mut(

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -1,7 +1,8 @@
 use super::{RenderState, SurfaceId};
 use crate::render::strokes;
+use crate::render::text::{self};
 use crate::shapes::{Shadow, Shape, Stroke, Type};
-use skia_safe::Paint;
+use skia_safe::{textlayout::Paragraph, Paint};
 
 // Fill Shadows
 pub fn render_fill_drop_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
@@ -80,6 +81,64 @@ pub fn render_stroke_inner_shadows(
             )
         }
     }
+}
+
+pub fn render_text_drop_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paragraphs: &[Paragraph],
+    antialias: bool,
+) {
+    for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+        render_text_drop_shadow(render_state, &shape, &shadow, &paragraphs, antialias);
+    }
+}
+
+pub fn render_text_drop_shadow(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    shadow: &Shadow,
+    paragraphs: &[Paragraph],
+    antialias: bool,
+) {
+    let paint = &shadow.get_drop_shadow_paint(antialias);
+
+    text::render(
+        render_state,
+        shape,
+        &paragraphs,
+        Some(SurfaceId::DropShadows),
+        Some(paint),
+    );
+}
+
+pub fn render_text_inner_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paragraphs: &[Paragraph],
+    antialias: bool,
+) {
+    for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+        render_text_inner_shadow(render_state, &shape, &shadow, &paragraphs, antialias);
+    }
+}
+
+pub fn render_text_inner_shadow(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    shadow: &Shadow,
+    paragraphs: &[Paragraph],
+    antialias: bool,
+) {
+    let paint = &shadow.get_inner_shadow_paint(antialias);
+
+    text::render(
+        render_state,
+        shape,
+        &paragraphs,
+        Some(SurfaceId::InnerShadows),
+        Some(paint),
+    );
 }
 
 fn render_shadow_paint(

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -1,13 +1,25 @@
 use super::{RenderState, Shape, SurfaceId};
-use crate::shapes::TextContent;
+use skia_safe::{self as skia, canvas::SaveLayerRec, paint, textlayout::Paragraph};
 
-pub fn render(render_state: &mut RenderState, shape: &Shape, text: &TextContent) {
+pub fn render(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paragraphs: &[Paragraph],
+    surface_id: Option<SurfaceId>,
+    paint: Option<&paint::Paint>,
+) {
     let mut offset_y = 0.0;
-    for mut skia_paragraph in text.to_paragraphs(&render_state.fonts().font_collection()) {
-        skia_paragraph.layout(shape.width());
+    let default_paint = skia::Paint::default();
+    let mask = SaveLayerRec::default().paint(&paint.unwrap_or(&default_paint));
+    let canvas = render_state
+        .surfaces
+        .canvas(surface_id.unwrap_or(SurfaceId::Fills));
 
+    canvas.save_layer(&mask);
+    for skia_paragraph in paragraphs {
         let xy = (shape.selrect().x(), shape.selrect.y() + offset_y);
-        skia_paragraph.paint(render_state.surfaces.canvas(SurfaceId::Fills), xy);
+        skia_paragraph.paint(canvas, xy);
         offset_y += skia_paragraph.height();
     }
+    canvas.restore();
 }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -549,6 +549,7 @@ impl Shape {
         self.hidden
     }
 
+    #[allow(dead_code)]
     pub fn width(&self) -> f32 {
         self.selrect.width()
     }

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -65,6 +65,15 @@ impl TextContent {
             })
             .collect()
     }
+
+    pub fn to_skia_paragraphs(&self, fonts: &FontCollection) -> Vec<skia::textlayout::Paragraph> {
+        let mut paragraphs = Vec::new();
+        for mut skia_paragraph in self.to_paragraphs(fonts) {
+            skia_paragraph.layout(self.width());
+            paragraphs.push(skia_paragraph);
+        }
+        paragraphs
+    }
 }
 
 impl Default for TextContent {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10828

### Summary

This PR applies a similar strategy as we did with strokes to add text shadows, both drop and inner shadows. It uses a mask to draw them directly to its surface applying the shadow paint, which is the same as we use for the rest of shadows

[screen-recorder-mon-apr-21-2025-14-40-22.webm](https://github.com/user-attachments/assets/81d257b4-c7ce-4a7c-8712-ecc4b46482b3)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.