### PR TITLE
:sparkles: Selection of several components of a variant ar the same time

### DIFF
--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -231,3 +231,19 @@
          {:props (vec props1) :used-pos (matching-indices props1 props2)}
          props2)
         :props)))
+
+(defn compare-properties
+  "Compares vectors of properties keeping the value if it is the same for all
+   or setting a custom value where their values do not coincide"
+  ([props-list]
+   (compare-properties props-list nil))
+
+  ([props-list distinct-mark]
+   (let [grouped (group-by :name (apply concat props-list))
+         check-values (fn [values]
+                        (if (apply = (map :value values))
+                          (first (map :value values))
+                          distinct-mark))]
+     (mapv (fn [[name values]]
+             {:name name :value (check-values values)})
+           grouped))))

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -241,9 +241,19 @@
   ([props-list distinct-mark]
    (let [grouped (group-by :name (apply concat props-list))
          check-values (fn [values]
-                        (if (apply = (map :value values))
-                          (first (map :value values))
-                          distinct-mark))]
+                        (let [vals (map :value values)]
+                          (if (apply = vals)
+                            (first vals)
+                            distinct-mark)))]
      (mapv (fn [[name values]]
              {:name name :value (check-values values)})
            grouped))))
+
+(defn same-variant?
+  "Determines if all elements belong to the same variant"
+  [components]
+  (let [variant-ids (distinct (map :variant-id components))
+        not-blank?  (complement str/blank?)]
+    (and
+     (= 1 (count variant-ids))
+     (not-blank? (first variant-ids)))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -37,7 +37,7 @@
       (t/is (= (ctv/valid-properties-string? string-invalid) false)))))
 
 
-(t/deftest compare-property-maps
+(t/deftest find-properties
   (let [prev-props  [{:name "border" :value "yes"} {:name "color" :value "gray"}]
         upd-props-1 [{:name "border" :value "yes"}]
         upd-props-2 [{:name "border" :value "yes"} {:name "color" :value "blue"}]
@@ -79,3 +79,17 @@
     (t/testing "find property index"
       (t/is (= (ctv/find-index-for-property-name prev-props "border") 0))
       (t/is (= (ctv/find-index-for-property-name prev-props "color") 1)))))
+
+
+(t/deftest compare-properties
+  (let [props-1  [{:name "border" :value "yes"} {:name "color" :value "gray"}]
+        props-2  [{:name "border" :value "yes"} {:name "color" :value "red"}]
+        props-3  [{:name "border" :value "no"} {:name "color" :value "gray"}]]
+
+    (t/testing "compare properties"
+      (t/is (= (ctv/compare-properties [props-1 props-2])
+               [{:name "border" :value "yes"} {:name "color" :value nil}]))
+      (t/is (= (ctv/compare-properties [props-1 props-2 props-3])
+               [{:name "border" :value nil} {:name "color" :value nil}]))
+      (t/is (= (ctv/compare-properties [props-1 props-2 props-3] "&")
+               [{:name "border" :value "&"} {:name "color" :value "&"}])))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -93,3 +93,16 @@
                [{:name "border" :value nil} {:name "color" :value nil}]))
       (t/is (= (ctv/compare-properties [props-1 props-2 props-3] "&")
                [{:name "border" :value "&"} {:name "color" :value "&"}])))))
+
+
+(t/deftest check-belong-same-variant
+  (let [components-1 [{:variant-id "a variant"} {:variant-id "a variant"}]
+        components-2 [{:variant-id "a variant"} {:variant-id "another variant"}]
+        components-3 [{:variant-id "a variant"} {}]
+        components-4 [{} {}]]
+
+    (t/testing "check-belong-same-variant"
+      (t/is (= (ctv/same-variant? components-1) true))
+      (t/is (= (ctv/same-variant? components-2) false))
+      (t/is (= (ctv/same-variant? components-3) false))
+      (t/is (= (ctv/same-variant? components-4) false)))))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -14,6 +14,7 @@
    [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
    [app.common.types.file :as ctf]
+   [app.common.types.variant :as ctv]
    [app.config :as cf]
    [app.main.data.helpers :as dsh]
    [app.main.data.modal :as modal]
@@ -381,7 +382,7 @@
 
         variants? (features/use-feature "variants/v1")
 
-        same-variant? (= 1 (count (distinct (map :variant-id shapes))))
+        same-variant? (ctv/same-variant? shapes)
 
         do-detach-component
         #(st/emit! (dwl/detach-components (map :id copies)))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -381,6 +381,7 @@
 
         variants? (features/use-feature "variants/v1")
 
+        same-variant? (= 1 (count (distinct (map :variant-id shapes))))
 
         do-detach-component
         #(st/emit! (dwl/detach-components (map :id copies)))
@@ -446,7 +447,7 @@
            (when (= 1 (count comps-to-restore))
              (ts/schedule 1000 do-show-component)))
 
-        menu-entries [(when (and (not multi) main-instance?)
+        menu-entries [(when (and (or (not multi) same-variant?) main-instance?)
                         {:title (tr "workspace.shape.menu.show-in-assets")
                          :action do-show-in-assets})
                       (when (and (not multi) main-instance? local-component? lacks-annotation?)
@@ -470,7 +471,7 @@
                       (when can-update-main?
                         {:title (tr "workspace.shape.menu.update-main")
                          :action do-update-component})
-                      (when (and variants? (not multi) main-instance?)
+                      (when (and variants? (or (not multi) same-variant?) main-instance?)
                         {:title (tr "workspace.shape.menu.add-variant")
                          :shortcut :create-component
                          :action do-add-variant})]]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -669,7 +669,7 @@
                                                       current-file
                                                       libraries
                                                       {:include-deleted? true}) shapes)
-        same-variant?   (= 1 (count (distinct (map :variant-id components))))
+        same-variant?   (ctv/same-variant? components)
 
         toggle-content
         (mf/use-fn #(swap! state* update :show-content not))


### PR DESCRIPTION
### Related Ticket

Implements Taiga [#10664](https://tree.taiga.io/project/penpot/task/10664)

### Summary

When several variant components are selected, the view in the design tab shows all of the properties and their values. If for one property there have mixed values, the combobox showcases the “Mixed” label, and the user can override both by typing a new value or by selecting one from the selector.

This only works when the user is selecting multiple main components belonging to the same variant.