### PR TITLE
:bug: Fix take new lines into account when rendering text

### DIFF
--- a/frontend/src/app/render_wasm/api/texts.cljs
+++ b/frontend/src/app/render_wasm/api/texts.cljs
@@ -10,7 +10,8 @@
    [app.render-wasm.helpers :as h]
    [app.render-wasm.mem :as mem]
    [app.render-wasm.serializers :as sr]
-   [app.render-wasm.wasm :as wasm]))
+   [app.render-wasm.wasm :as wasm]
+   [clojure.string :as str]))
 
 (defn utf8->buffer [text]
   (let [encoder (js/TextEncoder.)]
@@ -20,7 +21,8 @@
   ;; buffer has the following format:
   ;; [<num-leaves> <paragraph_attributes> <leaves_attributes> <text>]
   [leaves paragraph]
-  (let [num-leaves (count leaves)
+  (let [leaves (filter #(not (str/blank? (:text %))) leaves)
+        num-leaves (count leaves)
         paragraph-attr-size 48
         leaf-attr-size 52
         metadata-size (+ 1 paragraph-attr-size (* num-leaves leaf-attr-size))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10656 

### Summary

After changing the text node parsing, we introduced this "regression". However, there are still other steps to fix, like the fact that when having new lines, these don't have the expected height.

This PR fix at least to be able to have new lines and "empty" text fields to avoid it breaks

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully