### PR TITLE
:sparkles: Cap gradient stops (wasm)

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -223,7 +223,7 @@
                 (h/call wasm/internal-module "_add_shape_solid_fill" rgba))
 
               (some? gradient)
-              (let [size   (sr-fills/gradient-byte-size gradient)
+              (let [size   sr-fills/GRADIENT-BYTE-SIZE
                     offset (mem/alloc-bytes size)
                     heap   (mem/get-heap-u32)]
                 (sr-fills/write-gradient-fill! offset heap gradient opacity)
@@ -269,7 +269,7 @@
 
             (cond
               (some? gradient)
-              (let [size   (sr-fills/gradient-byte-size gradient)
+              (let [size   sr-fills/GRADIENT-BYTE-SIZE
                     offset (mem/alloc-bytes size)
                     heap   (mem/get-heap-u32)]
                 (sr-fills/write-gradient-fill! offset heap gradient opacity)

--- a/frontend/src/app/render_wasm/serializers/fills.cljs
+++ b/frontend/src/app/render_wasm/serializers/fills.cljs
@@ -2,13 +2,13 @@
   (:require
    [app.render-wasm.serializers.color :as clr]))
 
-(def GRADIENT-STOP-SIZE 8)
-(def GRADIENT-BASE-SIZE 24)
+(def ^:private GRADIENT-STOP-SIZE 8)
+(def ^:private GRADIENT-BASE-SIZE 28)
+;; TODO: Define in shape model
+(def ^:private MAX-GRADIENT-STOPS 8)
 
-(defn gradient-byte-size
-  [gradient]
-  (let [stops (:stops gradient)]
-    (+ GRADIENT-BASE-SIZE (* (count stops) GRADIENT-STOP-SIZE))))
+(def GRADIENT-BYTE-SIZE
+  (+ GRADIENT-BASE-SIZE (* MAX-GRADIENT-STOPS GRADIENT-STOP-SIZE)))
 
 (defn write-gradient-fill!
   [offset heap gradient opacity]
@@ -18,13 +18,14 @@
         end-x   (:end-x gradient)
         end-y   (:end-y  gradient)
         width   (or (:width gradient) 0)
-        stops   (:stops gradient)]
+        stops   (take MAX-GRADIENT-STOPS (:stops gradient))]
     (.setFloat32 dview offset        start-x true)
     (.setFloat32 dview (+ offset 4)  start-y true)
     (.setFloat32 dview (+ offset 8)  end-x true)
     (.setFloat32 dview (+ offset 12) end-y true)
     (.setFloat32 dview (+ offset 16) opacity true)
     (.setFloat32 dview (+ offset 20) width true)
+    (.setUint32  dview (+ offset 24) (count stops) true)
     (loop [stops (seq stops) offset (+ offset GRADIENT-BASE-SIZE)]
       (if (empty? stops)
         offset

--- a/frontend/src/app/render_wasm/serializers/fills.cljs
+++ b/frontend/src/app/render_wasm/serializers/fills.cljs
@@ -5,7 +5,7 @@
 (def ^:private GRADIENT-STOP-SIZE 8)
 (def ^:private GRADIENT-BASE-SIZE 28)
 ;; TODO: Define in shape model
-(def ^:private MAX-GRADIENT-STOPS 8)
+(def ^:private MAX-GRADIENT-STOPS 16)
 
 (def GRADIENT-BYTE-SIZE
   (+ GRADIENT-BASE-SIZE (* MAX-GRADIENT-STOPS GRADIENT-STOP-SIZE)))

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -26,14 +26,14 @@ pub(crate) static mut STATE: Option<Box<State>> = None;
 
 #[macro_export]
 macro_rules! with_state {
-    ($state:ident, $block:block) => {
+    ($state:ident, $block:block) => {{
         let $state = unsafe {
             #[allow(static_mut_refs)]
             STATE.as_mut()
         }
         .expect("Got an invalid state pointer");
         $block
-    };
+    }};
 }
 
 #[macro_export]
@@ -155,7 +155,7 @@ pub extern "C" fn use_shape(a: u32, b: u32, c: u32, d: u32) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn set_parent(a: u32, b: u32, c: u32, d: u32) {
+pub extern "C" fn set_parent(a: u32, b: u32, c: u32, d: u32) {
     with_current_shape!(state, |shape: &mut Shape| {
         let id = uuid_from_u32_quartet(a, b, c, d);
         shape.set_parent(id);
@@ -177,7 +177,7 @@ pub extern "C" fn set_shape_bool_type(raw_bool_type: u8) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn set_shape_type(shape_type: u8) {
+pub extern "C" fn set_shape_type(shape_type: u8) {
     with_current_shape!(state, |shape: &mut Shape| {
         shape.set_shape_type(Type::from(shape_type));
     });
@@ -252,11 +252,8 @@ pub extern "C" fn store_image(a: u32, b: u32, c: u32, d: u32) {
         let id = uuid_from_u32_quartet(a, b, c, d);
         let image_bytes = mem::bytes();
 
-        match state.render_state().add_image(id, &image_bytes) {
-            Err(msg) => {
-                eprintln!("{}", msg);
-            }
-            _ => {}
+        if let Err(msg) = state.render_state().add_image(id, &image_bytes) {
+            eprintln!("{}", msg);
         }
 
         mem::free_bytes();
@@ -267,8 +264,8 @@ pub extern "C" fn store_image(a: u32, b: u32, c: u32, d: u32) {
 pub extern "C" fn is_image_cached(a: u32, b: u32, c: u32, d: u32) -> bool {
     with_state!(state, {
         let id = uuid_from_u32_quartet(a, b, c, d);
-        return state.render_state().has_image(&id);
-    });
+        state.render_state().has_image(&id)
+    })
 }
 
 #[no_mangle]
@@ -390,8 +387,8 @@ pub extern "C" fn propagate_modifiers() -> *mut u8 {
 
     with_state!(state, {
         let result = shapes::propagate_modifiers(state, entries);
-        return mem::write_vec(result);
-    });
+        mem::write_vec(result)
+    })
 }
 
 #[no_mangle]
@@ -405,10 +402,12 @@ pub extern "C" fn set_structure_modifiers() {
 
     with_state!(state, {
         for entry in entries {
-            if !state.structure.contains_key(&entry.parent) {
-                state.structure.insert(entry.parent, Vec::new());
-            }
-            state.structure.get_mut(&entry.parent).unwrap().push(entry);
+            state.structure.entry(entry.parent).or_insert_with(Vec::new);
+            state
+                .structure
+                .get_mut(&entry.parent)
+                .expect("Parent not found for entry")
+                .push(entry);
         }
     });
 

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -3,7 +3,7 @@ use skia_safe::{self as skia, Rect};
 use super::Color;
 use crate::uuid::Uuid;
 
-const MAX_GRADIENT_STOPS: usize = 8;
+const MAX_GRADIENT_STOPS: usize = 16;
 const BASE_GRADIENT_DATA_SIZE: usize = 28;
 const RAW_GRADIENT_DATA_SIZE: usize =
     BASE_GRADIENT_DATA_SIZE + RAW_STOP_DATA_SIZE * MAX_GRADIENT_STOPS;


### PR DESCRIPTION
- :lipstick: Change to more idiomatic code in `main.rs` functions
- :sparkles: Embed stop data into RawGradientData

<img width="468" alt="Screenshot 2025-04-24 at 9 03 50 AM" src="https://github.com/user-attachments/assets/26c967e3-667a-4e3b-831a-fab143ee17d7" />

### Related Ticket

Closes https://tree.taiga.io/project/penpot/task/10755

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] ~~Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.~~
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
