### PR TITLE
:bug: Add migration for decoding and cleaning shape interactions

### DIFF
--- a/backend/src/app/binfile/cleaner.clj
+++ b/backend/src/app/binfile/cleaner.clj
@@ -1,0 +1,44 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.binfile.cleaner
+  "A collection of helpers for perform cleaning of artifacts; mainly
+  for recently imported shapes."
+  (:require
+   [app.common.data :as d]
+   [app.common.uuid :as uuid]))
+
+(defn- fix-shape-shadow-color
+  "Some shapes can come with invalid `id` property on shadow colors
+  caused by incorrect uuid parsing bug that should be already fixed;
+  this function removes the invalid id from the data structure."
+  [shape]
+  (let [fix-color
+        (fn [{:keys [id] :as color}]
+          (if (uuid? id)
+            color
+            (if (and (string? id)
+                     (re-matches uuid/regex id))
+              (assoc color :id (uuid/uuid id))
+              (dissoc color :id))))
+
+        fix-shadow
+        (fn [shadow]
+          (d/update-when shadow :color fix-color))
+
+        xform
+        (map fix-shadow)]
+
+    (d/update-when shape :shadow
+                   (fn [shadows]
+                     (into [] xform shadows)))))
+
+(defn clean-shape-post-decode
+  "A shape procesor that expected to be executed after schema decoding
+  process but before validation."
+  [shape]
+  (-> shape
+      (fix-shape-shadow-color)))

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -238,6 +238,7 @@
       (db/update! conn :file
                   {:data (blob/encode (:data file))
                    :version (:version file)
+                   :modified-at (dt/now)
                    :features (db/create-array conn "text" (:features file))}
                   {:id id})
 

--- a/backend/src/app/rpc/commands/files_thumbnails.clj
+++ b/backend/src/app/rpc/commands/files_thumbnails.clj
@@ -180,8 +180,7 @@
 (def ^:private
   schema:get-file-data-for-thumbnail
   [:map {:title "get-file-data-for-thumbnail"}
-   [:file-id ::sm/uuid]
-   [:features {:optional true} ::cfeat/features]])
+   [:file-id ::sm/uuid]])
 
 (def ^:private
   schema:partial-file
@@ -211,7 +210,6 @@
                                       (fmg/migrate-file)))]
 
                    (-> (cfeat/get-team-enabled-features cf/flags team)
-                       (cfeat/check-client-features! (:features params))
                        (cfeat/check-file-features! (:features file)))
 
                    {:file-id file-id

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1207,11 +1207,11 @@
               object))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (update :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-67"
   [data _]
@@ -1222,8 +1222,8 @@
             (d/update-when container :objects update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (update :components d/update-vals update-container))))
 
 (defmethod migrate-data "0001-remove-tokens-from-groups"
   [data _]
@@ -1237,8 +1237,10 @@
               (dissoc :applied-tokens)))
 
           (update-page [page]
-            (d/update-when page :objects update-vals update-object))]
-    (update data :pages-index update-vals update-page)))
+            (d/update-when page :objects d/update-vals update-object))]
+
+    (update data :pages-index d/update-vals update-page)))
+
 
 (def available-migrations
   (into (d/ordered-set)

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -848,9 +848,6 @@
         (update :pages-index update-vals update-container)
         (update :components update-vals update-container))))
 
-(def ^:private valid-shadow?
-  (sm/lazy-validator ::ctss/shadow))
-
 (defmethod migrate-data "legacy-44"
   [data _]
   (letfn [(fix-shadow [shadow]
@@ -862,7 +859,7 @@
 
           (update-object [object]
             (let [xform (comp (map fix-shadow)
-                              (filter valid-shadow?))]
+                              (filter ctss/valid-shadow?))]
               (d/update-when object :shadow #(into [] xform %))))
 
           (update-container [container]
@@ -1037,7 +1034,7 @@
 
           (update-shape [shape]
             (let [xform (comp (map fix-shadow)
-                              (filter valid-shadow?))]
+                              (filter ctss/valid-shadow?))]
               (d/update-when shape :shadow #(into [] xform %))))
 
           (update-container [container]

--- a/common/src/app/common/schema.cljc
+++ b/common/src/app/common/schema.cljc
@@ -864,7 +864,7 @@
                                     choices))]
                {:pred pred
                 :type-properties
-                {:title "contains"
+                {:title "contains any"
                  :description "contains predicate"}}))})
 
 (register!

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -211,7 +211,7 @@
    [:interactions {:optional true}
     [:vector {:gen/max 2} ::ctsi/interaction]]
    [:shadow {:optional true}
-    [:vector {:gen/max 1} ::ctss/shadow]]
+    [:vector {:gen/max 1} ctss/schema:shadow]]
    [:blur {:optional true} ::ctsb/blur]
    [:grow-type {:optional true}
     [::sm/one-of grow-types]]

--- a/common/src/app/common/types/shape/shadow.cljc
+++ b/common/src/app/common/types/shape/shadow.cljc
@@ -26,7 +26,9 @@
    [:hidden :boolean]
    [:color ::ctc/color]])
 
-(sm/register! ::shadow schema:shadow)
-
 (def check-shadow
   (sm/check-fn schema:shadow))
+
+(def valid-shadow?
+  (sm/validator schema:shadow))
+

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -89,14 +89,16 @@
 
     (mf/with-effect [file-id revn visible? thumbnail-id]
       (when (and visible? (not thumbnail-id))
-        (->> (ask-for-thumbnail file-id revn)
-             (rx/subs! (fn [thumbnail-id]
-                         (st/emit! (dd/set-file-thumbnail file-id thumbnail-id)))
-                       (fn [cause]
-                         (log/error :hint "unable to render thumbnail"
-                                    :file-if file-id
-                                    :revn revn
-                                    :message (ex-message cause)))))))
+        (let [subscription
+              (->> (ask-for-thumbnail file-id revn)
+                   (rx/subs! (fn [thumbnail-id]
+                               (st/emit! (dd/set-file-thumbnail file-id thumbnail-id)))
+                             (fn [cause]
+                               (log/error :hint "unable to render thumbnail"
+                                          :file-if file-id
+                                          :revn revn
+                                          :message (ex-message cause)))))]
+          (partial rx/dispose! subscription))))
 
     [:div {:class (stl/css :grid-item-th)
            :style {:background-color bg-color}

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -432,7 +432,7 @@
               (let [id (obj/get self "$id")
                     value (mapv #(shadow-defaults (parser/parse-shadow %)) value)]
                 (cond
-                  (not (sm/validate [:vector ::ctss/shadow] value))
+                  (not (sm/validate [:vector ctss/schema:shadow] value))
                   (u/display-not-valid :shadows value)
 
                   (not (r/check-permission plugin-id "content:write"))

--- a/frontend/src/app/util/http.cljs
+++ b/frontend/src/app/util/http.cljs
@@ -50,7 +50,8 @@
   [headers]
   (into {} (map vec) (seq (.entries ^js headers))))
 
-(def default-headers
+(defn default-headers
+  []
   {"x-frontend-version" (:full cfg/version)})
 
 (defn fetch
@@ -74,7 +75,7 @@
 
            headers       (cond-> headers
                            (not omit-default-headers)
-                           (d/merge default-headers))
+                           (merge (default-headers)))
 
            headers       (-update-headers body headers)
 

--- a/frontend/src/app/worker/thumbnails.cljs
+++ b/frontend/src/app/worker/thumbnails.cljs
@@ -42,12 +42,11 @@
                :http-body body})))
 
 (defn- request-data-for-thumbnail
-  [file-id revn features]
+  [file-id revn]
   (let [path    "api/rpc/command/get-file-data-for-thumbnail"
         params   {:file-id file-id
                   :revn revn
-                  :strip-frames-with-thumbnails true
-                  :features features}
+                  :strip-frames-with-thumbnails true}
         request  {:method :get
                   :uri (u/join cf/public-uri path)
                   :credentials "include"
@@ -86,6 +85,6 @@
       nil)))
 
 (defmethod impl/handler :thumbnails/generate-for-file
-  [{:keys [file-id revn features] :as message} _]
-  (->> (request-data-for-thumbnail file-id revn features)
+  [{:keys [file-id revn] :as message} _]
+  (->> (request-data-for-thumbnail file-id revn)
        (rx/map render-thumbnail)))


### PR DESCRIPTION
How to test it the migration

- Create a file with interactions
- Go to this PR branch
- Restart backend
- Open files, the migrations are still there and migration is applied

How to test the shadow cleaning:

- Create a file with single shape with shadow
- Export it
- Edit the .penpot file and add `"id": "1"` to the shadow on the shape
- Try to import it;

The rest of the commits, there are nothing to manually test, the bugs are very hard to reproduce and almost all changes  only simplifies or removes unnecessary logic.