### PR TITLE
:bug: Fix update layout on component restore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fix several issues with internal srepl helpers
 - Fix unexpected exception on template import from libraries
 - Fix incorrect uuid parsing from different parts of code
+- Fix update layout on component restore [Taiga #10637](https://tree.taiga.io/project/penpot/issue/10637)
 
 ## 2.6.1
 

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -586,8 +586,13 @@
             ldata   (dsh/lookup-file-data state library-id)
 
             changes (-> (pcb/empty-changes it)
-                        (cll/generate-restore-component ldata component-id library-id page objects))]
-        (rx/of (dch/commit-changes changes))))))
+                        (cll/generate-restore-component ldata component-id library-id page objects))
+
+            frames
+            (->> changes :redo-changes (keep :frame-id))]
+
+        (rx/of (dch/commit-changes changes)
+               (ptk/data-event :layout/update {:ids frames}))))))
 
 
 (defn restore-components


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10637

### Summary

Update layout when restoring component

### Steps to reproduce 

- Create a frame with flex and fit content
- Add two rects to the flex
- Convert one rect into a component
- Make a copy of the component (outside the flex)
- Delete the component main
- The flex shrinks, becuse now it only have one element
- Restore the component

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
