### PR TITLE
:sparkles: Add cleaner to file-gc

### DIFF
--- a/backend/src/app/binfile/cleaner.clj
+++ b/backend/src/app/binfile/cleaner.clj
@@ -70,13 +70,25 @@
         (cts/setup-shape))
     shape))
 
+(defn- fix-legacy-flex-dir
+  "This operation is only relevant to old data and it is fixed just
+  for convenience."
+  [shape]
+  (d/update-when shape :layout-flex-dir
+                 (fn [dir]
+                   (case dir
+                     :reverse-row :row-reverse
+                     :reverse-column :column-reverse
+                     dir))))
+
 (defn clean-shape-post-decode
   "A shape procesor that expected to be executed after schema decoding
   process but before validation."
   [shape]
   (-> shape
       (fix-shape-shadow-color)
-      (fix-root-shape)))
+      (fix-root-shape)
+      (fix-legacy-flex-dir)))
 
 (defn clean-file
   [file & {:as _opts}]

--- a/backend/src/app/binfile/cleaner.clj
+++ b/backend/src/app/binfile/cleaner.clj
@@ -90,13 +90,18 @@
       (fix-root-shape)
       (fix-legacy-flex-dir)))
 
+(defn- fix-container
+  [container]
+  (-> container
+      ;; Remove possible `nil` keys on objects
+      (d/update-when :objects dissoc nil)
+      (d/update-when :objects d/update-vals clean-shape-post-decode)))
+
 (defn clean-file
   [file & {:as _opts}]
-  (let [update-container
-        (fn [container]
-          (d/update-when container :objects d/update-vals clean-shape-post-decode))]
-    (update file :data
-            (fn [data]
-              (-> data
-                  (update :pages-index d/update-vals update-container)
-                  (update :components d/update-vals update-container))))))
+  (update file :data
+          (fn [data]
+            (-> data
+                (d/update-when :pages-index d/update-vals fix-container)
+                (d/update-when :components d/update-vals fix-container)
+                (d/without-nils)))))

--- a/backend/src/app/tasks/file_gc.clj
+++ b/backend/src/app/tasks/file_gc.clj
@@ -10,6 +10,7 @@
   file is eligible to be garbage collected after some period of
   inactivity (the default threshold is 72h)."
   (:require
+   [app.binfile.cleaner :as bfl]
    [app.binfile.common :as bfc]
    [app.common.files.helpers :as cfh]
    [app.common.files.validate :as cfv]
@@ -258,6 +259,7 @@
   (if-let [file (get-file cfg file-id)]
     (let [file (->> file
                     (bfc/decode-file cfg)
+                    (bfl/clean-file)
                     (clean-media! cfg)
                     (clean-fragments! cfg))
           file (assoc file :has-media-trimmed true)]

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -58,8 +58,7 @@
   [file-id revn]
   (->> (wrk/ask! {:cmd :thumbnails/generate-for-file
                   :revn revn
-                  :file-id file-id
-                  :features (get @st/state :features)})
+                  :file-id file-id})
        (rx/mapcat (fn [{:keys [fonts] :as result}]
                     (->> (fonts/render-font-styles fonts)
                          (rx/map (fn [styles]


### PR DESCRIPTION
### Summary

This PR mainly extends the newly added cleaner mechanism with several fixes for known issues on our database and adds the process to the file-gc task.

There are **no user tests**.

Merge with **merge commit**.
