### PR TITLE
:bug: Fix comment loading crash (new renderer viewport)

### DIFF
--- a/frontend/playwright/data/get-teams-render-wasm.json
+++ b/frontend/playwright/data/get-teams-render-wasm.json
@@ -1,0 +1,26 @@
+[
+  {
+    "~:features": {
+      "~#set": [
+        "render-wasm",
+        "layout/grid",
+        "styles/v2",
+        "fdata/pointer-map",
+        "fdata/objects-map",
+        "components/v2",
+        "fdata/shape-data-type"
+      ]
+    },
+    "~:permissions": {
+      "~:type": "~:membership",
+      "~:is-owner": true,
+      "~:is-admin": true,
+      "~:can-edit": true
+    },
+    "~:name": "Default",
+    "~:modified-at": "~m1713533116375",
+    "~:id": "~uc7ce0794-0992-8105-8004-38e630f7920a",
+    "~:created-at": "~m1713533116375",
+    "~:is-default": true
+  }
+]

--- a/frontend/playwright/ui/specs/render-wasm.spec.js
+++ b/frontend/playwright/ui/specs/render-wasm.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+import { WorkspacePage } from "../pages/WorkspacePage";
+import { BaseWebSocketPage } from "../pages/BaseWebSocketPage";
+
+test.beforeEach(async ({ page }) => {
+  await WorkspacePage.init(page);
+  await BaseWebSocketPage.mockRPC(
+    page,
+    "get-teams",
+    "get-teams-render-wasm.json",
+  );
+});
+
+test("BUG 10867 - Crash when loading comments", async ({ page }) => {
+  const workspacePage = new WorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.goToWorkspace();
+
+  await workspacePage.showComments();
+  await expect(
+    workspacePage.rightSidebar.getByText("Show all comments"),
+  ).toBeVisible();
+});

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -105,6 +105,7 @@
         workspace-editor-state (mf/deref refs/workspace-editor-state)
         workspace-v2-editor-state (mf/deref refs/workspace-v2-editor-state)
 
+        file-id           (get file :id)
         objects           (get page :objects)
         page-id           (get page :id)
         background        (get page :background clr/canvas)
@@ -341,6 +342,7 @@
       (when show-comments?
         [:> comments/comments-layer* {:vbox vbox
                                       :page-id page-id
+                                      :file-id file-id
                                       :vport vport
                                       :zoom zoom}])
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10867

> **:warning: This only happens with the new renderer enabled**.

### Summary

Fixes the crash when clicking on the comments button in the workspace.

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~
