### PR TITLE
:bug: Fix issues on file data migration handling

### DIFF
--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -15,6 +15,7 @@
    [app.common.data.macros :as dm]
    [app.common.exceptions :as ex]
    [app.common.features :as cfeat]
+   [app.common.files.migrations :as-alias fmg]
    [app.common.json :as json]
    [app.common.logging :as l]
    [app.common.schema :as sm]
@@ -745,7 +746,14 @@
                    (assoc :name file-name)
                    (assoc :project-id project-id)
                    (dissoc :options)
-                   (bfc/process-file))]
+                   (bfc/process-file)
+
+                   ;; NOTE: this is necessary because when we just
+                   ;; creating a new file from imported artifact,
+                   ;; there are no migrations registered on the
+                   ;; database, so we need to persist all of them, not
+                   ;; only the applied
+                   (vary-meta dissoc ::fmg/migrated))]
 
 
       (bfm/register-pending-migrations! cfg file)

--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -238,7 +238,6 @@
       (db/update! conn :file
                   {:data (blob/encode (:data file))
                    :version (:version file)
-                   :modified-at (dt/now)
                    :features (db/create-array conn "text" (:features file))}
                   {:id id})
 
@@ -293,7 +292,7 @@
 
 (defn get-file-etag
   [{:keys [::rpc/profile-id]} {:keys [modified-at revn vern permissions]}]
-  (str profile-id "/" revn "/" vern "/"
+  (str profile-id "/" revn "/" vern "/" (hash fmg/available-migrations) "/"
        (dt/format-instant modified-at :iso)
        "/"
        (uri/map->query-string permissions)))

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -37,8 +37,6 @@
 #?(:cljs (l/set-level! :info))
 
 (declare ^:private available-migrations)
-(declare ^:private migration-up-index)
-(declare ^:private migration-down-index)
 
 (def version cfd/version)
 

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -36,7 +36,7 @@
 
 #?(:cljs (l/set-level! :info))
 
-(declare ^:private available-migrations)
+(declare available-migrations)
 
 (def version cfd/version)
 
@@ -48,7 +48,10 @@
   [file]
   (or (nil? (:version file))
       (not= cfd/version (:version file))
-      (not= available-migrations (:migrations file))))
+      (boolean
+       (->> (:migrations file #{})
+            (set/difference available-migrations)
+            (not-empty)))))
 
 (def xf:map-name
   (map :name))


### PR DESCRIPTION
### Summary

This PR comes with 3 changes:

1. Make the HTTP cache aware of pending migrations

This replaces the previous ineffective approach of updating the file modified-at column by adding the hash of current migrations to the etag, triggering cache invalidation in case of availability of different set of migrations on file.

2. Fixes the  incorrect migration handling on importing binfile

Previous to this PR, on importing binfile, only new one migrations were stored on database and once file is imported, making all old (mainly legacy) migrations available to execute on the next file open/retrieval operation. That is incorrect because that migrations should not be executed, they should be marked as migrated without execution on the importation process. This PR fixes this, now the file is imported with all migrations already set and only necessary migrations executes directly on the importation process.

3. Add safer check if file needs migration

Previously: it checks if file migrations and available migrations are different.
Now: it checks if there are some migrations of available set are missing on file. This is necessary because the file can have some migrations applied that are now not available.

#### How to test

It is a bit difficult to setup test scene for all 3 cases.

Case 1:

- Close devtools (that enables cache)
- Open a file and close (populate cache)
- Add dummy migration and restart backend
- Open the file, and check that migration is properly applied independently of the cache

Case 2:

- Create a simple file and export it
- Modify the zip internal and remove all migrations from the file json
- Import the  .penpot file (don't click on accept once impoted, for NOT load the file)
- Look on the database, you will see only a small set of migrations is applied without this PR, and all migrations with this PR

Case 3:

A difficult to setup test scene. But the code is pretty evident
