### PR TITLE
:bug: Add migration for fix old broken root shapes (file migration)

### DIFF
--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -121,9 +121,9 @@
                                (into [] shapes)
                                shapes))))
           (update-page [page]
-            (update page :objects update-vals update-object))]
+            (update page :objects d/update-vals update-object))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 (defmethod migrate-data "legacy-3"
   [data _]
@@ -174,9 +174,9 @@
               (fix-empty-points)))
 
           (update-page [page]
-            (update page :objects update-vals update-object))]
+            (update page :objects d/update-vals update-object))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 ;; Put the id of the local file in :component-file in instances of
 ;; local components
@@ -189,9 +189,9 @@
               object))
 
           (update-page [page]
-            (update page :objects update-vals update-object))]
+            (update page :objects d/update-vals update-object))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 ;; Fixes issues with selrect/points for shapes with width/height =
 ;; 0 (line-like paths)
@@ -214,11 +214,11 @@
               shape))
 
           (update-container [container]
-            (update container :objects update-vals fix-line-paths))]
+            (update container :objects d/update-vals fix-line-paths))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 ;; Remove interactions pointing to deleted frames
 (defmethod migrate-data "legacy-7"
@@ -229,9 +229,9 @@
                              (filterv #(get-in page [:objects (:destination %)]) interactions))))
 
           (update-page [page]
-            (update page :objects update-vals (partial update-object page)))]
+            (update page :objects d/update-vals (partial update-object page)))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 ;; Remove groups without any shape, both in pages and components
 (defmethod migrate-data "legacy-8"
@@ -271,8 +271,8 @@
                   (assoc container :objects objects)))))]
 
     (-> data
-        (update :pages-index update-vals clean-container)
-        (d/update-when :components update-vals clean-container))))
+        (update :pages-index d/update-vals clean-container)
+        (d/update-when :components d/update-vals clean-container))))
 
 (defmethod migrate-data "legacy-9"
   [data _]
@@ -306,7 +306,7 @@
   [data _]
   (letfn [(update-page [page]
             (d/update-in-when page [:objects uuid/zero] dissoc :points :selrect))]
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 (defmethod migrate-data "legacy-11"
   [data _]
@@ -320,7 +320,7 @@
             (update page :objects (fn [objects]
                                     (update-vals objects (partial update-object objects)))))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 (defmethod migrate-data "legacy-12"
   [data _]
@@ -330,9 +330,9 @@
               (assoc :size nil)))
 
           (update-page [page]
-            (d/update-in-when page [:options :saved-grids] update-vals update-grid))]
+            (d/update-in-when page [:options :saved-grids] d/update-vals update-grid))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 ;; Add rx and ry to images
 (defmethod migrate-data "legacy-13"
@@ -350,9 +350,9 @@
               (fix-radius)))
 
           (update-page [page]
-            (update page :objects update-vals update-object))]
+            (update page :objects d/update-vals update-object))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 (defmethod migrate-data "legacy-14"
   [data _]
@@ -382,8 +382,8 @@
               container))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-16"
   [data _]
@@ -425,11 +425,11 @@
               (assign-fills)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-17"
   [data _]
@@ -454,11 +454,11 @@
               (assoc :fills [])))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 ;; Remove position-data to solve a bug with the text positioning
 (defmethod migrate-data "legacy-18"
@@ -469,11 +469,11 @@
               (dissoc :position-data)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-19"
   [data _]
@@ -485,11 +485,11 @@
               (dissoc :position-data)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-25"
   [data _]
@@ -501,10 +501,10 @@
                   (update :selrect grc/make-rect)
                   (cts/create-shape))))
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-26"
   [data _]
@@ -517,11 +517,11 @@
               (assoc :transform-inverse (gmt/matrix))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-27"
   [data _]
@@ -548,11 +548,11 @@
                   (dissoc :saved-component-root?))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-28"
   [data _]
@@ -577,8 +577,8 @@
             (d/update-when container :objects #(update-vals % (partial update-object %))))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-29"
   [data _]
@@ -609,11 +609,11 @@
                 (update :content #(txt/transform-nodes invalid-node? fix-node %)))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-31"
   [data _]
@@ -624,10 +624,10 @@
                   (dissoc :use-for-thumbnail?))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-32"
   [data _]
@@ -642,11 +642,11 @@
                 object)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-33"
   [data _]
@@ -664,9 +664,9 @@
               object))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
     (-> data
-        (update :pages-index update-vals update-container))))
+        (update :pages-index d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-34"
   [data _]
@@ -676,10 +676,10 @@
               (dissoc object :x :y :width :height)
               object))
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-36"
   [data _]
@@ -689,8 +689,8 @@
                                                   (dissoc objects nil)
                                                   objects))))]
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-37"
   [data _]
@@ -718,11 +718,11 @@
                 shape)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-shape))]
+            (d/update-when container :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-39"
   [data _]
@@ -740,11 +740,11 @@
               shape))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-shape))]
+            (d/update-when container :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-40"
   [data _]
@@ -764,11 +764,11 @@
               shape))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-shape))]
+            (d/update-when container :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-41"
   [data _]
@@ -797,11 +797,11 @@
               shape))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-shape))]
+            (d/update-when container :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-42"
   [data _]
@@ -814,11 +814,11 @@
               object))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (def ^:private valid-fill?
   (sm/lazy-validator ::cts/fill))
@@ -843,11 +843,11 @@
               object))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-44"
   [data _]
@@ -864,10 +864,10 @@
               (d/update-when object :shadow #(into [] xform %))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-45"
   [data _]
@@ -880,9 +880,9 @@
                      :parent-id parent-id)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals fix-shape))]
+            (d/update-when container :objects d/update-vals fix-shape))]
     (-> data
-        (update :pages-index update-vals update-container))))
+        (update :pages-index d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-46"
   [data _]
@@ -890,10 +890,10 @@
             (dissoc object :thumbnail))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-47"
   [data _]
@@ -914,9 +914,9 @@
                 shape)))
 
           (update-page [page]
-            (d/update-when page :objects update-vals (partial fix-shape page)))]
+            (d/update-when page :objects d/update-vals (partial fix-shape page)))]
     (-> data
-        (update :pages-index update-vals update-page))))
+        (update :pages-index d/update-vals update-page))))
 
 (defmethod migrate-data "legacy-48"
   [data _]
@@ -928,9 +928,9 @@
                 shape)))
 
           (update-page [page]
-            (d/update-when page :objects update-vals fix-shape))]
+            (d/update-when page :objects d/update-vals fix-shape))]
     (-> data
-        (update :pages-index update-vals update-page))))
+        (update :pages-index d/update-vals update-page))))
 
 ;; Remove hide-in-viewer for shapes that are origin or destination of an interaction
 (defmethod migrate-data "legacy-49"
@@ -948,9 +948,9 @@
                                     (mapcat :interactions)
                                     (map :destination)
                                     (set))]
-              (update page :objects update-vals (partial update-object destinations))))]
+              (update page :objects d/update-vals (partial update-object destinations))))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 ;; This migration mainly fixes paths with curve-to segments
 ;; without :c1x :c1y :c2x :c2y properties. Additionally, we found a
@@ -993,11 +993,11 @@
 
         update-container
         (fn [page]
-          (d/update-when page :objects update-vals update-shape))]
+          (d/update-when page :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (def ^:private valid-color?
   (sm/lazy-validator ::ctc/color))
@@ -1017,9 +1017,9 @@
               shape))
 
           (update-page [page]
-            (d/update-when page :objects update-vals update-shape))]
+            (d/update-when page :objects d/update-vals update-shape))]
 
-    (update data :pages-index update-vals update-page)))
+    (update data :pages-index d/update-vals update-page)))
 
 
 (defmethod migrate-data "legacy-53"
@@ -1039,11 +1039,11 @@
               (d/update-when shape :shadow #(into [] xform %))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-shape))]
+            (d/update-when container :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 ;; This migration moves page options to the page level
 (defmethod migrate-data "legacy-55"
@@ -1095,11 +1095,11 @@
                   (update :content (partial txt/transform-nodes identity fix-fills)))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 
 (defmethod migrate-data "legacy-57"
@@ -1126,7 +1126,7 @@
     (-> data
         (update :pages (fn [pages] (into [] (remove nil?) pages)))
         (update :pages-index dissoc nil)
-        (update :pages-index update-vals update-page))))
+        (update :pages-index d/update-vals update-page))))
 
 (defmethod migrate-data "legacy-59"
   [data _]
@@ -1137,11 +1137,11 @@
             (d/update-when shape :touched #(into #{} (map fix-touched) %)))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-shape))]
+            (d/update-when container :objects d/update-vals update-shape))]
 
     (-> data
-        (update :pages-index update-vals update-container)
-        (d/update-when :components update-vals update-container))))
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-62"
   [data _]
@@ -1174,7 +1174,7 @@
           ;; so the relevant objects are inside the component
           (d/update-when component :objects remove-cycles))]
 
-    (d/update-when data :components update-vals update-component)))
+    (d/update-when data :components d/update-vals update-component)))
 
 (defmethod migrate-data "legacy-65"
   [data _]
@@ -1185,14 +1185,14 @@
         update-page
         (fn [page]
           (-> (update-object page)
-              (update :objects update-vals update-object)))]
+              (update :objects d/update-vals update-object)))]
 
     (-> data
         (update-object)
-        (update :pages-index update-vals update-page)
-        (d/update-when :colors update-vals update-object)
-        (d/update-when :typographies update-vals update-object)
-        (d/update-when :components update-vals update-object))))
+        (update :pages-index d/update-vals update-page)
+        (d/update-when :colors d/update-vals update-object)
+        (d/update-when :typographies d/update-vals update-object)
+        (d/update-when :components d/update-vals update-object))))
 
 (defmethod migrate-data "legacy-66"
   [data _]
@@ -1218,7 +1218,7 @@
             (d/update-when object :shadow #(into [] (reverse %))))
 
           (update-container [container]
-            (d/update-when container :objects update-vals update-object))]
+            (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
         (update :pages-index d/update-vals update-container)

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1264,6 +1264,28 @@
         (update :pages-index d/update-vals update-container)
         (d/update-when :components d/update-vals update-container))))
 
+(defmethod migrate-data "0003-fix-root-shape"
+  [data _]
+  (letfn [(update-object [shape]
+            (if (= (:id shape) uuid/zero)
+              (-> shape
+                  (assoc :parent-id uuid/zero)
+                  (assoc :frame-id uuid/zero)
+                  ;; We explicitly dissoc them and let the shape-setup
+                  ;; to regenerate it with valid values.
+                  (dissoc :selrect)
+                  (dissoc :points)
+                  (cts/setup-shape))
+              shape))
+
+          (update-container [container]
+            (d/update-when container :objects d/update-vals update-object))]
+
+    (-> data
+        (update :pages-index d/update-vals update-container)
+        (d/update-when :components d/update-vals update-container)
+        (d/without-nils))))
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1319,4 +1341,5 @@
          "legacy-66"
          "legacy-67"
          "0001-remove-tokens-from-groups"
-         "0002-clean-shape-interactions"]))
+         "0002-clean-shape-interactions"
+         "0003-fix-root-shape"]))

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -218,7 +218,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 ;; Remove interactions pointing to deleted frames
 (defmethod migrate-data "legacy-7"
@@ -272,7 +272,7 @@
 
     (-> data
         (update :pages-index update-vals clean-container)
-        (update :components update-vals clean-container))))
+        (d/update-when :components update-vals clean-container))))
 
 (defmethod migrate-data "legacy-9"
   [data _]
@@ -383,7 +383,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-16"
   [data _]
@@ -429,7 +429,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-17"
   [data _]
@@ -458,7 +458,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 ;; Remove position-data to solve a bug with the text positioning
 (defmethod migrate-data "legacy-18"
@@ -473,7 +473,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-19"
   [data _]
@@ -489,7 +489,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-25"
   [data _]
@@ -504,7 +504,7 @@
             (d/update-when container :objects update-vals update-object))]
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-26"
   [data _]
@@ -521,7 +521,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-27"
   [data _]
@@ -552,7 +552,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-28"
   [data _]
@@ -578,7 +578,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-29"
   [data _]
@@ -613,7 +613,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-31"
   [data _]
@@ -627,7 +627,7 @@
             (d/update-when container :objects update-vals update-object))]
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-32"
   [data _]
@@ -646,7 +646,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-33"
   [data _]
@@ -679,7 +679,7 @@
             (d/update-when container :objects update-vals update-object))]
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-36"
   [data _]
@@ -690,7 +690,7 @@
                                                   objects))))]
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-37"
   [data _]
@@ -722,7 +722,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-39"
   [data _]
@@ -744,7 +744,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-40"
   [data _]
@@ -768,7 +768,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-41"
   [data _]
@@ -801,7 +801,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-42"
   [data _]
@@ -818,7 +818,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (def ^:private valid-fill?
   (sm/lazy-validator ::cts/fill))
@@ -847,7 +847,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-44"
   [data _]
@@ -867,7 +867,7 @@
             (d/update-when container :objects update-vals update-object))]
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-45"
   [data _]
@@ -893,7 +893,7 @@
             (d/update-when container :objects update-vals update-object))]
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-47"
   [data _]
@@ -997,7 +997,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (def ^:private valid-color?
   (sm/lazy-validator ::ctc/color))
@@ -1043,7 +1043,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 ;; This migration moves page options to the page level
 (defmethod migrate-data "legacy-55"
@@ -1099,7 +1099,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 
 (defmethod migrate-data "legacy-57"
@@ -1141,7 +1141,7 @@
 
     (-> data
         (update :pages-index update-vals update-container)
-        (update :components update-vals update-container))))
+        (d/update-when :components update-vals update-container))))
 
 (defmethod migrate-data "legacy-62"
   [data _]
@@ -1174,7 +1174,7 @@
           ;; so the relevant objects are inside the component
           (d/update-when component :objects remove-cycles))]
 
-    (update data :components update-vals update-component)))
+    (d/update-when data :components update-vals update-component)))
 
 (defmethod migrate-data "legacy-65"
   [data _]
@@ -1189,7 +1189,7 @@
 
     (-> data
         (update-object)
-        (d/update-when :pages-index update-vals update-page)
+        (update :pages-index update-vals update-page)
         (d/update-when :colors update-vals update-object)
         (d/update-when :typographies update-vals update-object)
         (d/update-when :components update-vals update-object))))
@@ -1210,7 +1210,7 @@
 
     (-> data
         (update :pages-index d/update-vals update-container)
-        (update :components d/update-vals update-container))))
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "legacy-67"
   [data _]
@@ -1222,7 +1222,7 @@
 
     (-> data
         (update :pages-index d/update-vals update-container)
-        (update :components d/update-vals update-container))))
+        (d/update-when :components d/update-vals update-container))))
 
 (defmethod migrate-data "0001-remove-tokens-from-groups"
   [data _]
@@ -1262,7 +1262,7 @@
 
     (-> data
         (update :pages-index d/update-vals update-container)
-        (update :components d/update-vals update-container))))
+        (d/update-when :components d/update-vals update-container))))
 
 (def available-migrations
   (into (d/ordered-set)


### PR DESCRIPTION
### Summary

This PR includes:

1. Replace all update-vals with d/update-vals on migrations. 

It is a consistency fix; d/update-vals in contrary to the update-vals, preserves the type of the map.

2. Add missing usage of `d/update-when` on components key update.

The normal `update` will levale a `nil`  no components and we don't want this nil.

3. Add migration for fix root shape

We have observed several reports on our gc task failing on this issue. 
