### PR TITLE
:sparkles: Add dynamic properties modifiers to WASM

### DIFF
--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -108,106 +108,135 @@
 
 ;; --- SHAPE IMPL
 
-(defn- set-wasm-attrs
+(defn set-wasm-single-attr!
+  [shape k]
+  (let [v (get shape k)]
+    (case k
+      :parent-id    (api/set-parent-id v)
+      :type         (api/set-shape-type v)
+      :bool-type    (api/set-shape-bool-type v)
+      :selrect      (api/set-shape-selrect v)
+      :show-content (if (= (:type shape) :frame)
+                      (api/set-shape-clip-content (not v))
+                      (api/set-shape-clip-content false))
+      :rotation     (api/set-shape-rotation v)
+      :transform    (api/set-shape-transform v)
+      :fills        (into [] (api/set-shape-fills v))
+      :strokes      (into [] (api/set-shape-strokes v))
+      :blend-mode   (api/set-shape-blend-mode v)
+      :opacity      (api/set-shape-opacity v)
+      :hidden       (api/set-shape-hidden v)
+      :shapes       (api/set-shape-children v)
+      :blur         (api/set-shape-blur v)
+      :shadow       (api/set-shape-shadows v)
+      :constraints-h (api/set-constraints-h v)
+      :constraints-v (api/set-constraints-v v)
+
+      :svg-attrs
+      (when (= (:type shape) :path)
+        (api/set-shape-path-attrs v))
+
+      :masked-group
+      (when (and (= (:type shape) :group) (:masked-group shape))
+        (api/set-masked (:masked-group shape)))
+
+      :content
+      (cond
+        (or (= (:type shape) :path)
+            (= (:type shape) :bool))
+        (api/set-shape-path-content v)
+
+        (= (:type shape) :svg-raw)
+        (api/set-shape-svg-raw-content (api/get-static-markup shape))
+
+        (= (:type shape) :text)
+        (into [] (api/set-shape-text-content v)))
+
+      (:layout-item-margin
+       :layout-item-margin-type
+       :layout-item-h-sizing
+       :layout-item-v-sizing
+       :layout-item-max-h
+       :layout-item-min-h
+       :layout-item-max-w
+       :layout-item-min-w
+       :layout-item-absolute
+       :layout-item-z-index)
+      (api/set-layout-child shape)
+
+      :layout-grid-rows
+      (api/set-grid-layout-rows v)
+
+      :layout-grid-columns
+      (api/set-grid-layout-columns v)
+
+      :layout-grid-cells
+      (api/set-grid-layout-cells v)
+
+      (:layout
+       :layout-flex-dir
+       :layout-gap-type
+       :layout-gap
+       :layout-align-items
+       :layout-align-content
+       :layout-justify-items
+       :layout-justify-content
+       :layout-wrap-type
+       :layout-padding-type
+       :layout-padding)
+      (cond
+        (ctl/grid-layout? shape)
+        (api/set-grid-layout-data shape)
+
+        (ctl/flex-layout? shape)
+        (api/set-flex-layout shape))
+
+      nil)))
+
+(defn set-wasm-multi-attrs!
+  [shape properties]
+  (api/use-shape (:id shape))
+  (let [pending
+        (->> properties
+             (mapcat #(set-wasm-single-attr! shape %)))]
+    (if (and pending (seq pending))
+      (->> (rx/from pending)
+           (rx/mapcat identity)
+           (rx/reduce conj [])
+           (rx/subs!
+            (fn [_]
+              (api/update-shape-tiles)
+              (api/clear-drawing-cache)
+              (api/request-render "set-wasm-attrs-pending"))))
+      (do
+        (api/update-shape-tiles)
+        (api/request-render "set-wasm-attrs")))))
+
+(defn set-wasm-attrs!
+  [shape k v]
+  (let [shape (assoc shape k v)]
+    (api/use-shape (:id shape))
+    (let [pending (set-wasm-single-attr! shape k)]
+      ;; TODO: set-wasm-attrs is called twice with every set
+      (if (and pending (seq pending))
+        (->> (rx/from pending)
+             (rx/mapcat identity)
+             (rx/reduce conj [])
+             (rx/subs!
+              (fn [_]
+                (api/update-shape-tiles)
+                (api/clear-drawing-cache)
+                (api/request-render "set-wasm-attrs-pending"))))
+        (do
+          (api/update-shape-tiles)
+          (api/request-render "set-wasm-attrs"))))))
+
+(defn- impl-assoc
   [self k v]
   (when ^boolean shape/*wasm-sync*
     (binding [shape/*wasm-sync* false]
-      (let [self (assoc self k v)]
-        (api/use-shape (:id self))
-        (let [pending (case k
-                        :parent-id    (api/set-parent-id v)
-                        :type         (api/set-shape-type v)
-                        :bool-type    (api/set-shape-bool-type v)
-                        :selrect      (api/set-shape-selrect v)
-                        :show-content (if (= (:type self) :frame)
-                                        (api/set-shape-clip-content (not v))
-                                        (api/set-shape-clip-content false))
-                        :rotation     (api/set-shape-rotation v)
-                        :transform    (api/set-shape-transform v)
-                        :fills        (into [] (api/set-shape-fills v))
-                        :strokes      (into [] (api/set-shape-strokes v))
-                        :blend-mode   (api/set-shape-blend-mode v)
-                        :opacity      (api/set-shape-opacity v)
-                        :hidden       (api/set-shape-hidden v)
-                        :shapes       (api/set-shape-children v)
-                        :blur         (api/set-shape-blur v)
-                        :shadow       (api/set-shape-shadows v)
-                        :constraints-h (api/set-constraints-h v)
-                        :constraints-v (api/set-constraints-v v)
+      (set-wasm-attrs! self k v)))
 
-                        :svg-attrs
-                        (when (= (:type self) :path)
-                          (api/set-shape-path-attrs v))
-
-                        :masked-group
-                        (when (and (= (:type self) :group) (:masked-group self))
-                          (api/set-masked (:masked-group self)))
-
-                        :content
-                        (cond
-                          (or (= (:type self) :path)
-                              (= (:type self) :bool))
-                          (api/set-shape-path-content v)
-
-                          (= (:type self) :svg-raw)
-                          (api/set-shape-svg-raw-content (api/get-static-markup self))
-
-                          (= (:type self) :text)
-                          (into [] (api/set-shape-text-content v)))
-
-                        (:layout-item-margin
-                         :layout-item-margin-type
-                         :layout-item-h-sizing
-                         :layout-item-v-sizing
-                         :layout-item-max-h
-                         :layout-item-min-h
-                         :layout-item-max-w
-                         :layout-item-min-w
-                         :layout-item-absolute
-                         :layout-item-z-index)
-                        (api/set-layout-child self)
-
-                        (:layout-grid-rows
-                         :layout-grid-columns
-                         :layout-grid-cells)
-                        (when (ctl/grid-layout? self)
-                          (api/set-grid-layout self))
-
-                        (:layout
-                         :layout-flex-dir
-                         :layout-gap-type
-                         :layout-gap
-                         :layout-align-items
-                         :layout-align-content
-                         :layout-justify-items
-                         :layout-justify-content
-                         :layout-wrap-type
-                         :layout-padding-type
-                         :layout-padding)
-                        (cond
-                          (ctl/grid-layout? self)
-                          (api/set-grid-layout self)
-
-                          (ctl/flex-layout? self)
-                          (api/set-flex-layout self))
-
-                        nil)]
-
-          ;; TODO: set-wasm-attrs is called twice with every set
-          (if (and pending (seq pending))
-            (->> (rx/from pending)
-                 (rx/mapcat identity)
-                 (rx/reduce conj [])
-                 (rx/subs! (fn [_]
-                             (api/update-shape-tiles)
-                             (api/clear-drawing-cache)
-                             (api/request-render "set-wasm-attrs-pending"))))
-            (do
-              (api/update-shape-tiles)
-              (api/request-render "set-wasm-attrs"))))))))
-(defn- impl-assoc
-  [self k v]
-  (set-wasm-attrs self k v)
   (case k
     :id
     (ShapeProxy. v
@@ -228,7 +257,10 @@
 
 (defn- impl-dissoc
   [self k]
-  (set-wasm-attrs self k nil)
+  (when ^boolean shape/*wasm-sync*
+    (binding [shape/*wasm-sync* false]
+      (set-wasm-attrs! self k nil)))
+
   (case k
     :id
     (ShapeProxy. nil

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -279,6 +279,7 @@ pub fn propagate_modifiers(state: &State, modifiers: Vec<TransformEntry>) -> Vec
                     grid_data,
                     shapes,
                     &mut bounds,
+                    &state.structure,
                 );
                 entries.append(&mut children);
             }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10832

### Summary

Dynamic properties modifiers in WASM

### Steps to reproduce 

Move a shape into a grid layout. Should be repositioned dinamically.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
