### PR TITLE
:sparkles: Close swap panel after doing a swap

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -346,7 +346,9 @@
         (mf/use-fn
          (mf/deps shapes file-id item)
          #(when-not loop
-            (st/emit! (dwl/component-multi-swap shapes file-id (:id item)))))
+            (st/emit!
+             (dwl/component-multi-swap shapes file-id (:id item))
+             (dwsp/clear-specialized-panel))))
 
         item-ref       (mf/use-ref)
         visible?       (h/use-visible item-ref :once? true)]


### PR DESCRIPTION
Implements: https://tree.taiga.io/project/penpot/task/10882

Also fixes: https://tree.taiga.io/project/penpot/issue/9033 (because that interaction can't be done anymore)