### PR TITLE
🐛 Handle swapped nested instances when detaching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fix incorrect uuid parsing from different parts of code
 - Fix update layout on component restore [Taiga #10637](https://tree.taiga.io/project/penpot/issue/10637)
 - Fix horizontal scroll in viewer [Github #6290](https://github.com/penpot/penpot/issues/6290)
+- Fix detach component in a particular case [Taiga #10837](https://tree.taiga.io/project/penpot/issue/10837)
 
 ## 2.6.1
 

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -36,6 +36,8 @@
 ;; Change this to :info :debug or :trace to debug this module, or :warn to reset to default
 (log/set-level! :warn)
 
+;; Add uuids here to filter logs to only show specific shapes or containers (and all shapes
+;; contained in them).
 (def log-shape-ids #{})
 (def log-container-ids #{})
 
@@ -306,55 +308,67 @@
 (defn- generate-detach-recursive
   [changes container libraries shape-id first component-root?]
   (let [shape (ctn/get-shape container shape-id)]
+    (shape-log :trace shape-id container
+               :msg "  Processing" :shape-id shape-id)
     (if (and (ctk/instance-head? shape) (not first))
       ; Subinstances are not detached
       (cond-> changes
         component-root?
         ; If the initial shape was component-root, first level subinstances are converted in top instances
-        (pcb/update-shapes [shape-id] #(assoc % :component-root true))
+        (pcb/update-shapes [shape-id] #(do (log/trace :msg "  -> promote to root")
+                                           (assoc % :component-root true)))
 
         :always
         ; First level subinstances of a detached component can't have swap-slot
-        (pcb/update-shapes [shape-id] ctk/remove-swap-slot)
+        (pcb/update-shapes [shape-id] #(do (log/trace :msg "  -> remove swap-slot")
+                                           (ctk/remove-swap-slot %)))
 
         (nil? (ctk/get-swap-slot shape))
-        ; Near shape-refs need to be advanced one level (except if the head is already swapped)
+        ; Near shape-ref of shape and children need to be advanced one level
+        ; (except if the head is already swapped)
         (generate-advance-nesting-level nil container libraries (:id shape)))
 
       ;; Otherwise, detach the shape and all children
       (let [children-ids (:shapes shape)]
+        (log/trace :msg "  -> detach")
         (reduce #(generate-detach-recursive %1 container libraries %2 false component-root?)
                 (pcb/update-shapes changes [(:id shape)] ctk/detach-shape)
                 children-ids)))))
 
 (defn- generate-advance-nesting-level
   [changes file container libraries shape-id]
-  (let [children (cfh/get-children-with-self (:objects container) shape-id)
+  (log/trace :msg "  -> advance-nesting-level")
+  (let [children  (cfh/get-children-with-self (:objects container) shape-id)
         skip-near (fn [changes shape]
+                    (shape-log :trace (:id shape) container
+                               :msg "     * advancing" :shape-id (:id shape))
                     (let [ref-shape (ctf/find-ref-shape file container libraries shape {:include-deleted? true})]
                       (cond-> changes
                         (some? (:shape-ref ref-shape))
-                        (pcb/update-shapes [(:id shape)] #(assoc % :shape-ref (:shape-ref ref-shape)))
+                        (pcb/update-shapes [(:id shape)] #(do (log/trace :msg "       (advanced)")
+                                                              (assoc % :shape-ref (:shape-ref ref-shape))))
 
-                        ;; When advancing level, the normal touched groups (not swap slots) of the
-                        ;; ref-shape must be merged into the current shape, because they refer to
-                        ;; the new referenced shape.
+                          ;; When advancing level, the normal touched groups (not swap slots) of the
+                          ;; ref-shape must be merged into the current shape, because they refer to
+                          ;; the new referenced shape.
                         (some? ref-shape)
                         (pcb/update-shapes
                          [(:id shape)]
-                         #(assoc % :touched
-                                 (clojure.set/union (:touched shape)
-                                                    (ctk/normal-touched-groups ref-shape))))
+                         #(do (log/trace :msg "       (merge touched)")
+                              (assoc % :touched
+                                     (clojure.set/union (:touched shape)
+                                                        (ctk/normal-touched-groups ref-shape)))))
 
-                        ;; Swap slot must also be copied if the current shape has not any,
-                        ;; except if this is the first level subcopy.
+                          ;; Swap slot must also be copied if the current shape has not any,
+                          ;; except if this is the first level subcopy.
                         (and (some? (ctk/get-swap-slot ref-shape))
                              (nil? (ctk/get-swap-slot shape))
                              (not= (:id shape) shape-id))
-                        (pcb/update-shapes [(:id shape)] #(ctk/set-swap-slot % (ctk/get-swap-slot ref-shape)))
+                        (pcb/update-shapes [(:id shape)] #((do (log/trace :msg "       (got swap-slot)")
+                                                               (ctk/set-swap-slot % (ctk/get-swap-slot ref-shape)))))
 
-                        ;; If we can't get the ref-shape (e.g. it's in an external library not linked),
-                        ;: we can't do a suitable advance. So it's better to detach the shape
+                          ;; If we can't get the ref-shape (e.g. it's in an external library not linked),
+                          ;: we can't do a suitable advance. So it's better to detach the shape
                         (nil? ref-shape)
                         (pcb/update-shapes [(:id shape)] ctk/detach-shape))))]
 


### PR DESCRIPTION
**DO NOT SQUASH COMMITS WHEN MERGING**

### Related Ticket

[https://tree.taiga.io/project/penpot/issue/10837](https://tree.taiga.io/project/penpot/issue/10837)

### Summary

A bug occurs when user tries to detach a copy and all those things occur:
- The copy has the main instance in a library that is not attached to the file (so the main instance cannot be located).
- There are two levels of nested copies.
- The copies of the second level have been swapped to a component in a library that is attached to the file (so the new main instance can be located).

In this case the algorithm will try to keep the second level instances as copies, but it fails because they are not root copies.

### Steps to reproduce 

See Taiga issue.

### Checklist

- [*] Choose the correct target branch; use `develop` by default.
- [*] Provide a brief summary of the changes introduced.
- [*] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [*] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [*] Check CI passes successfully.
- [*] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
