### PR TITLE
:bug: Calculate text-length in bytes correctly

### DIFF
--- a/frontend/src/app/render_wasm/api/texts.cljs
+++ b/frontend/src/app/render_wasm/api/texts.cljs
@@ -72,7 +72,8 @@
               font-id (f/serialize-font-id (:font-id leaf))
               font-family (hash (:font-family leaf))
               font-variant-id (sr/serialize-uuid (:font-variant-id leaf))
-              text-length (count (:text leaf))]
+              text-buffer (utf8->buffer (:text leaf))
+              text-length (.-byteLength text-buffer)]
 
           (.setUint8 dview offset font-style)
           (.setFloat32 dview (+ offset 4) font-size)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10382

### Summary

This is related to the changes to parse text leaves all at once https://github.com/penpot/penpot/pull/6337 

The text-length is not correctly calculated as it should calculate the bytes length. This problem made, for instance, emoji not being properly rendered.

### Steps to reproduce 

Add text and check it works fine using emoji

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.