### PR TITLE
:sparkles: Load emoji font dynamically when initializing

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -283,6 +283,7 @@
     ;;       canvas, even though we are not using `page-id` inside the hook.
     ;;       We think moving this out to a handler will make the render code
     ;;       harder to follow through.
+
     (mf/with-effect [page-id]
       (when-let [canvas (mf/ref-val canvas-ref)]
         (->> wasm.api/module

--- a/frontend/src/app/render_wasm/api/texts.cljs
+++ b/frontend/src/app/render_wasm/api/texts.cljs
@@ -20,13 +20,12 @@
 (defn write-shape-text
   ;; buffer has the following format:
   ;; [<num-leaves> <paragraph_attributes> <leaves_attributes> <text>]
-  [leaves paragraph]
+  [leaves paragraph text]
   (let [leaves (filter #(not (str/blank? (:text %))) leaves)
         num-leaves (count leaves)
         paragraph-attr-size 48
         leaf-attr-size 52
         metadata-size (+ 1 paragraph-attr-size (* num-leaves leaf-attr-size))
-        text (apply str (map :text leaves))
         text-buffer (utf8->buffer text)
         text-size (.-byteLength text-buffer)
         buffer (js/ArrayBuffer. (+ metadata-size text-size))
@@ -106,3 +105,8 @@
       (.set heap (js/Uint8Array. buffer) metadata-offset)))
 
   (h/call wasm/internal-module "_set_shape_text_content"))
+
+(def emoji-pattern #"[\uD83C-\uDBFF][\uDC00-\uDFFF]")
+
+(defn contains-emoji? [s]
+  (boolean (re-find emoji-pattern s)))

--- a/render-wasm/src/wasm/fonts.rs
+++ b/render-wasm/src/wasm/fonts.rs
@@ -6,14 +6,24 @@ use crate::STATE;
 use crate::shapes::FontFamily;
 
 #[no_mangle]
-pub extern "C" fn store_font(a: u32, b: u32, c: u32, d: u32, weight: u32, style: u8) {
+pub extern "C" fn store_font(
+    a: u32,
+    b: u32,
+    c: u32,
+    d: u32,
+    weight: u32,
+    style: u8,
+    is_emoji: bool,
+) {
     with_state!(state, {
         let id = uuid_from_u32_quartet(a, b, c, d);
         let font_bytes = mem::bytes();
-
         let family = FontFamily::new(id, weight, style.into());
+        let res = state
+            .render_state()
+            .fonts_mut()
+            .add(family, &font_bytes, is_emoji);
 
-        let res = state.render_state().fonts_mut().add(family, &font_bytes);
         match res {
             Err(msg) => {
                 eprintln!("{}", msg);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10892

### Summary

Instead of loading the default emoji font directly in wasm, we can request it it is a google font. With this, we avoid to include the font in the build. Also, this opens the door to choose and load a custom emoji font in the future.

Ideally, we should detect when the paragraph uses emoji and load the font instead of loading it always by default on initialization.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
