### PR TITLE
:sparkles: Allow importing token files with reference errors

### DIFF
--- a/frontend/src/app/main/data/style_dictionary.cljs
+++ b/frontend/src/app/main/data/style_dictionary.cljs
@@ -314,11 +314,11 @@
                              (resolve-tokens-with-errors+)
                              (p/then (fn [_] tokens-lib))
                              (p/catch (fn [sd-error]
-                                        (let [reference-errors (reference-errors sd-error)
-                                              err (if reference-errors
-                                                    (wte/error-ex-info :error.import/style-dictionary-reference-errors reference-errors sd-error)
-                                                    (wte/error-ex-info :error.import/style-dictionary-unknown-error sd-error sd-error))]
-                                          (throw err)))))
+                                        (let [reference-errors (reference-errors sd-error)]
+                                          ;; We allow reference errors for the users to resolve in the ui and throw on any other errors
+                                          (if reference-errors
+                                            (p/resolved tokens-lib)
+                                            (throw (wte/error-ex-info :error.import/style-dictionary-unknown-error sd-error sd-error)))))))
                          (catch js/Error e
                            (p/rejected (wte/error-ex-info :error.import/style-dictionary-unknown-error "" e))))))))))
 

--- a/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
+++ b/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
@@ -117,23 +117,6 @@ color.value tries to reference missing, which is not defined.")))
               (t/is (= :error.import/invalid-json-data (:error/code (ex-data err))))
               (done)))))))
 
-(t/deftest process-missing-references-json-test
-  (t/async
-    done
-    (t/testing "fails on missing references in tokens"
-      (let [json (-> {"core" {"color" {"$value" "{missing}"
-                                       "$type" "color"}}
-                      "$metadata" {"tokenSetOrder" ["core"]}}
-                     (tr/encode-str {:type :json-verbose}))]
-        (->> (rx/of json)
-             (sd/process-json-stream)
-             (rx/subs!
-              (fn []
-                (throw (js/Error. "Should be an error")))
-              (fn [err]
-                (t/is (= :error.import/style-dictionary-reference-errors (:error/code (ex-data err))))
-                (done))))))))
-
 (t/deftest single-set-legacy-json-decoding
   (let [decode-single-set-legacy-json #'sd/decode-single-set-legacy-json
         json {"color" {"red" {"100" {"value" "red"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/103

### Summary

The UI handles missing references, so we shouldn't block users from importing data with missing references inside.

### Steps to reproduce 

1. Import a file with a missing reference [missing-references.json](https://github.com/user-attachments/files/19936065/missing-references.json)
2. It should display in the UI

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
