### PR TITLE
:bug: Fix font id serialization

### DIFF
--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -144,12 +144,19 @@
 
 (defn serialize-font-id
   [font-id]
-  (let [google-font? (str/starts-with? font-id "gfont-")]
-    (if google-font?
-      (uuid/get-u32 (google-font-id->uuid font-id))
-      (let [no-prefix (subs font-id (inc (str/index-of font-id "-")))
-            as-uuid (uuid/uuid no-prefix)]
-        (uuid/get-u32 as-uuid)))))
+  (try
+    (if (nil? font-id)
+      (do
+        [uuid/zero])
+      (let [google-font? (str/starts-with? font-id "gfont-")]
+        (if google-font?
+          (uuid/get-u32 (google-font-id->uuid font-id))
+          (let [no-prefix (subs font-id (inc (str/index-of font-id "-")))]
+            (if (or (nil? no-prefix) (not (string? no-prefix)) (str/blank? no-prefix))
+              [uuid/zero]
+              (uuid/get-u32 (uuid/uuid no-prefix)))))))
+    (catch :default _e
+      [uuid/zero])))
 
 (defn serialize-font-weight
   [font-weight]

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -46,10 +46,14 @@
 
 (defn serialize-uuid
   [id]
-  (if (nil? id)
-    [uuid/zero]
-    (let [as-uuid (uuid/uuid id)]
-      (uuid/get-u32 as-uuid))))
+  (try
+    (if (nil? id)
+      (do
+        [uuid/zero])
+      (let [as-uuid (uuid/uuid id)]
+        (uuid/get-u32 as-uuid)))
+    (catch :default _e
+      [uuid/zero])))
 
 (defn heapu32-set-u32
   [value heap offset]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10916

### Summary

Font id serialization fails when there's no associated font-id to the leaf

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
