### PR TITLE
:bug: Render children in the correct order

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -734,7 +734,7 @@ impl RenderState {
                             }
 
                             for child_id in children_ids.iter().rev() {
-                                self.pending_nodes.push_back(NodeRenderState {
+                                self.pending_nodes.push_front(NodeRenderState {
                                     id: *child_id,
                                     visited_children: false,
                                     clip_bounds: children_clip_bounds,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10914

### Summary

For recursive elements like Groups, we're not sorting the children correctly. 

Before:

![image](https://github.com/user-attachments/assets/ece0c7d7-9903-4465-9a52-5b3a7f755e0e)


After:

![image](https://github.com/user-attachments/assets/7ebdacb7-bb99-4d72-a94c-a676dcd0d477)


### Steps to reproduce 

-   Create a rect
-   Create a smaller rect inside that rect
-   Group the shapes
-   Check the order of the shapes inside the group
-   The smaller rect is on top of the group, but it's drawn behind the bigger rect


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
