### PR TITLE
:bug: Fix restore component restore layout

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -581,11 +581,14 @@
             changes (-> (pcb/empty-changes it)
                         (cll/generate-restore-component ldata component-id library-id page objects))
 
+            page-id
+            (->> changes :redo-changes (keep :page-id) first)
+
             frames
             (->> changes :redo-changes (keep :frame-id))]
 
         (rx/of (dch/commit-changes changes)
-               (ptk/data-event :layout/update {:ids frames}))))))
+               (ptk/data-event :layout/update {:page-id page-id :ids frames}))))))
 
 
 (defn restore-components


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10637

### Summary

The flex wasn't updating when the restore was in another page.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
