### PR TITLE
:tada: Add text solid strokes

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -706,11 +706,11 @@
       (set-grid-layout shape))
 
     (let [pending (into [] (concat
+                            (set-shape-strokes strokes)
                             (if (and (= type :text) (some? content))
                               (set-shape-text-content content)
                               [])
-                            (set-shape-fills fills)
-                            (set-shape-strokes strokes)))]
+                            (set-shape-fills fills)))]
       (perf/end-measure "set-object")
       pending)))
 

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -706,11 +706,11 @@
       (set-grid-layout shape))
 
     (let [pending (into [] (concat
-                            (set-shape-strokes strokes)
                             (if (and (= type :text) (some? content))
                               (set-shape-text-content content)
                               [])
-                            (set-shape-fills fills)))]
+                            (set-shape-fills fills)
+                            (set-shape-strokes strokes)))]
       (perf/end-measure "set-object")
       pending)))
 

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -367,15 +367,32 @@ impl RenderState {
                     }
                 }
             }
+
             Type::Text(text_content) => {
                 self.surfaces.apply_mut(&[SurfaceId::Fills], |s| {
                     s.canvas().concat(&matrix);
                 });
 
-                let paragraphs = text_content.to_skia_paragraphs(&self.fonts.font_collection());
+                let paragraphs = text_content.get_skia_paragraphs(&self.fonts.font_collection());
 
                 shadows::render_text_drop_shadows(self, &shape, &paragraphs, antialias);
                 text::render(self, &shape, &paragraphs, None, None);
+
+                for stroke in shape.strokes().rev() {
+                    let stroke_paints = shape.get_text_stroke_paint(&stroke);
+                    let stroke_paragraphs = text_content
+                        .get_skia_stroke_paragraphs(&self.fonts.font_collection(), &stroke_paints);
+                    shadows::render_text_drop_shadows(self, &shape, &stroke_paragraphs, antialias);
+                    text::render(
+                        self,
+                        &shape,
+                        &stroke_paragraphs,
+                        Some(SurfaceId::Strokes),
+                        None,
+                    );
+                    shadows::render_text_inner_shadows(self, &shape, &stroke_paragraphs, antialias);
+                }
+
                 shadows::render_text_inner_shadows(self, &shape, &paragraphs, antialias);
             }
             _ => {

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -86,7 +86,7 @@ pub fn render_stroke_inner_shadows(
 pub fn render_text_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paragraphs: &[Paragraph],
+    paragraphs: &[Vec<Paragraph>],
     antialias: bool,
 ) {
     for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
@@ -98,7 +98,7 @@ pub fn render_text_drop_shadow(
     render_state: &mut RenderState,
     shape: &Shape,
     shadow: &Shadow,
-    paragraphs: &[Paragraph],
+    paragraphs: &[Vec<Paragraph>],
     antialias: bool,
 ) {
     let paint = &shadow.get_drop_shadow_paint(antialias);
@@ -115,7 +115,7 @@ pub fn render_text_drop_shadow(
 pub fn render_text_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paragraphs: &[Paragraph],
+    paragraphs: &[Vec<Paragraph>],
     antialias: bool,
 ) {
     for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
@@ -127,7 +127,7 @@ pub fn render_text_inner_shadow(
     render_state: &mut RenderState,
     shape: &Shape,
     shadow: &Shadow,
-    paragraphs: &[Paragraph],
+    paragraphs: &[Vec<Paragraph>],
     antialias: bool,
 ) {
     let paint = &shadow.get_inner_shadow_paint(antialias);

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -4,11 +4,10 @@ use skia_safe::{self as skia, canvas::SaveLayerRec, paint, textlayout::Paragraph
 pub fn render(
     render_state: &mut RenderState,
     shape: &Shape,
-    paragraphs: &[Paragraph],
+    paragraphs: &[Vec<Paragraph>],
     surface_id: Option<SurfaceId>,
     paint: Option<&paint::Paint>,
 ) {
-    let mut offset_y = 0.0;
     let default_paint = skia::Paint::default();
     let mask = SaveLayerRec::default().paint(&paint.unwrap_or(&default_paint));
     let canvas = render_state
@@ -16,10 +15,13 @@ pub fn render(
         .canvas(surface_id.unwrap_or(SurfaceId::Fills));
 
     canvas.save_layer(&mask);
-    for skia_paragraph in paragraphs {
-        let xy = (shape.selrect().x(), shape.selrect.y() + offset_y);
-        skia_paragraph.paint(canvas, xy);
-        offset_y += skia_paragraph.height();
+    for group in paragraphs {
+        let mut offset_y = 0.0;
+        for skia_paragraph in group {
+            let xy = (shape.selrect().x(), shape.selrect.y() + offset_y);
+            skia_paragraph.paint(canvas, xy);
+            offset_y += skia_paragraph.height();
+        }
     }
     canvas.restore();
 }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1,4 +1,4 @@
-use skia_safe::{self as skia};
+use skia_safe::{self as skia, paint::Paint};
 
 use crate::render::BlendMode;
 use crate::uuid::Uuid;
@@ -810,6 +810,60 @@ impl Shape {
 
     pub fn has_fills(&self) -> bool {
         !self.fills.is_empty()
+    }
+
+    pub fn get_text_stroke_paint(&self, stroke: &Stroke) -> Vec<Paint> {
+        let mut paints = Vec::new();
+
+        match stroke.kind {
+            StrokeKind::InnerStroke => {
+                let mut paint = skia::Paint::default();
+                paint.set_blend_mode(skia::BlendMode::DstOver);
+                paint.set_anti_alias(true);
+                paints.push(paint);
+
+                let mut paint = skia::Paint::default();
+                paint.set_style(skia::PaintStyle::Stroke);
+                paint.set_blend_mode(skia::BlendMode::SrcATop);
+                paint.set_anti_alias(true);
+                paint.set_stroke_width(stroke.width * 2.0);
+                paint.set_color(match &stroke.fill {
+                    Fill::Solid(color) => *color,
+                    _ => Color::BLACK,
+                });
+                paints.push(paint);
+            }
+            StrokeKind::CenterStroke => {
+                let mut paint = skia::Paint::default();
+                paint.set_style(skia::PaintStyle::Stroke);
+                paint.set_anti_alias(true);
+                paint.set_stroke_width(stroke.width);
+                paint.set_color(match &stroke.fill {
+                    Fill::Solid(color) => *color,
+                    _ => Color::BLACK,
+                });
+                paints.push(paint);
+            }
+            StrokeKind::OuterStroke => {
+                let mut paint = skia::Paint::default();
+                paint.set_style(skia::PaintStyle::Stroke);
+                paint.set_blend_mode(skia::BlendMode::DstOver);
+                paint.set_anti_alias(true);
+                paint.set_stroke_width(stroke.width * 2.0);
+                paint.set_color(match &stroke.fill {
+                    Fill::Solid(color) => *color,
+                    _ => Color::BLACK,
+                });
+                paints.push(paint);
+
+                let mut paint = skia::Paint::default();
+                paint.set_blend_mode(skia::BlendMode::Clear);
+                paint.set_anti_alias(true);
+                paints.push(paint);
+            }
+        }
+
+        paints
     }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10899

### Summary

This PR is the first approach for rendering text strokes. Right now, since we're making changes on fills, this only renders solid fills for now. We'll work on introducing other fill types in the next PRs

### Steps to reproduce 

- It's important to check that different stroke combinations (outer, inner, center) work as in production
- Check that text shadows keep working and adapting to the stroke's weight
- File to test: [text_strokes_render_test.zip](https://github.com/user-attachments/files/19979840/text_strokes_render_test.zip)

### Demo

[screen-recorder-wed-apr-30-2025-11-54-24.webm](https://github.com/user-attachments/assets/3ebc1ecb-bc89-49a5-bc5e-fbadf50c8988)

#### New vs Current

![Screenshot from 2025-05-06 17-42-36](https://github.com/user-attachments/assets/e962f428-8bde-4f3e-9531-2e2528166189)

#### New vs Current

![Screenshot from 2025-05-06 17-43-00](https://github.com/user-attachments/assets/1b0a990e-0014-4639-ae7b-40a0adf422d3)

#### New vs Current

![Screenshot from 2025-05-06 17-43-43](https://github.com/user-attachments/assets/602e5dfd-e60b-4769-8bbe-faca9005d652)

#### New vs Current

![Screenshot from 2025-05-06 17-44-51](https://github.com/user-attachments/assets/c2c862ce-7e31-4267-ae4d-ae4ec73f2a1b)

#### New vs Current

![Screenshot from 2025-05-06 17-45-42](https://github.com/user-attachments/assets/b8cb5090-af45-48b5-b8e4-30e2eccb64a0)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

