### PR TITLE
:sparkles: Implement token multi-file import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Duplicate token sets [Taiga #10694](https://tree.taiga.io/project/penpot/issue/10694)
 - Add set selection in create Token themes flow [Taiga #10746](https://tree.taiga.io/project/penpot/issue/10746)
 - Display indicator on not active sets [Taiga #10668](https://tree.taiga.io/project/penpot/issue/10668)
+- Allow multi file token import [Github #27](https://github.com/tokens-studio/penpot/issues/27)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -33,6 +33,7 @@
    [app.main.ui.workspace.sidebar.collapsable-button :refer [collapsed-button]]
    [app.main.ui.workspace.sidebar.history :refer [history-toolbox*]]
    [app.main.ui.workspace.tokens.modals]
+   [app.main.ui.workspace.tokens.modals.import]
    [app.main.ui.workspace.tokens.modals.themes]
    [app.main.ui.workspace.viewport :refer [viewport*]]
    [app.util.debug :as dbg]

--- a/frontend/src/app/main/ui/workspace/tokens/modals/import.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/import.cljs
@@ -1,0 +1,167 @@
+(ns app.main.ui.workspace.tokens.modals.import
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [app.common.files.helpers :as cfh]
+   [app.main.data.event :as ev]
+   [app.main.data.modal :as modal]
+   [app.main.data.notifications :as ntf]
+   [app.main.data.style-dictionary :as sd]
+   [app.main.data.workspace.tokens.errors :as wte]
+   [app.main.data.workspace.tokens.library-edit :as dwtl]
+   [app.main.store :as st]
+   [app.main.ui.ds.buttons.button :refer [button*]]
+   [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
+   [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
+   [app.main.ui.ds.foundations.typography.text :refer [text*]]
+   [app.util.dom :as dom]
+   [app.util.i18n :refer [tr]]
+   [app.util.webapi :as wapi]
+   [beicon.v2.core :as rx]
+   [cuerdas.core :as str]
+   [potok.v2.core :as ptk]
+   [rumext.v2 :as mf]))
+
+(defn drop-parent-directory [path]
+  (->> (cfh/split-path path)
+       (rest)
+       (str/join "/")))
+
+(defn remove-path-extension [path]
+  (-> (str/split path ".")
+      (butlast)
+      (str/join)))
+
+(defn file-path->set-name
+  [path]
+  (-> path
+      (drop-parent-directory)
+      (remove-path-extension)))
+
+(defn on-import-stream [tokens-lib-stream]
+  (rx/sub!
+   tokens-lib-stream
+   (fn [lib]
+     (st/emit! (ptk/data-event ::ev/event {::ev/name "import-tokens"})
+               (dwtl/import-tokens-lib lib))
+     (modal/hide!))
+   (fn [err]
+     (js/console.error err)
+     (st/emit! (ntf/show {:content (wte/humanize-errors [(ex-data err)])
+                          :detail (wte/detail-errors [(ex-data err)])
+                          :type :toast
+                          :level :error})))))
+
+(mf/defc import-modal-body*
+  {::mf/private true}
+  []
+  (let [file-input-ref (mf/use-ref)
+        dir-input-ref (mf/use-ref)
+
+        on-display-file-explorer
+        (mf/use-fn #(dom/click (mf/ref-val file-input-ref)))
+
+        on-display-dir-explorer
+        (mf/use-fn #(dom/click (mf/ref-val dir-input-ref)))
+
+        on-import-directory
+        (mf/use-fn
+         (fn [event]
+           (let [files (->> (dom/get-target event)
+                            (dom/get-files)
+                            ;; Read files as text, ignore files with json parse errors
+                            (map (fn [file]
+                                   (->> (wapi/read-file-as-text file)
+                                        (rx/mapcat (fn [json]
+                                                     (let [path (.-webkitRelativePath file)]
+                                                       (rx/of
+                                                        (try
+                                                          {(file-path->set-name path) (sd/parse-json json)}
+                                                          (catch js/Error e
+                                                            {:path path :error e}))))))))))]
+
+             (->> (apply rx/merge files)
+                  (rx/reduce (fn [acc cur]
+                               (if (:error cur)
+                                 acc
+                                 (conj acc cur)))
+                             {})
+                  (rx/map #(sd/decode-json-data (if (= 1 (count %))
+                                                  (val (first %))
+                                                  %)
+                                                (ffirst %)))
+                  (on-import-stream))
+
+             (-> (mf/ref-val dir-input-ref)
+                 (dom/set-value! "")))))
+
+        on-import
+        (mf/use-fn
+         (fn [event]
+           (let [file (-> (dom/get-target event)
+                          (dom/get-files)
+                          (first))
+                 file-name (remove-path-extension (.-name file))]
+             (->> (wapi/read-file-as-text file)
+                  (sd/process-json-stream {:file-name file-name})
+                  (on-import-stream))
+
+             (-> (mf/ref-val file-input-ref)
+                 (dom/set-value! "")))))]
+
+    [:div {:class (stl/css :import-modal-wrapper)}
+     [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :import-modal-title)}
+      (tr "workspace.token.import-tokens")]
+
+     [:div {:class (stl/css :import-modal-content)}
+      [:> text* {:as "div" :typography "body-medium" :class (stl/css :import-description)}
+       [:ul
+        [:li (tr "workspace.token.import-single-file")]
+        [:li (tr "workspace.token.import-multiple-files")]]]
+
+      [:div {:class (stl/css :import-warning)}
+       [:> icon* {:icon-id i/msg-neutral}]
+       [:> text* {:as "div" :typography "body-medium"}
+        (tr "workspace.token.import-warning")]]
+
+      [:div {:class (stl/css :import-actions)}
+       [:input {:type "file"
+                :ref file-input-ref
+                :style {:display "none"}
+                :accept ".json"
+                :on-change on-import}]
+       [:input {:type "file"
+                :ref dir-input-ref
+                :style {:display "none"}
+                :accept ""
+                :webkitdirectory "true"
+                :on-change on-import-directory}]
+       [:> button* {:variant "secondary"
+                    :type "button"
+                    :on-click modal/hide!}
+        (tr "labels.cancel")]
+       [:> button* {:variant "primary"
+                    :type "button"
+                    :on-click on-display-file-explorer}
+        [:> icon* {:icon-id i/document}]
+        (tr "workspace.token.choose-file")]
+       [:> button* {:variant "primary"
+                    :type "button"
+                    :on-click on-display-dir-explorer}
+        ;; TODO Add folder icon
+        [:> icon* {:icon-id i/document}]
+        (tr "workspace.token.choose-folder")]]]]))
+
+(mf/defc import-modal
+  {::mf/wrap-props false
+   ::mf/register modal/components
+   ::mf/register-as :tokens/import}
+  []
+  [:div {:class (stl/css :modal-overlay)}
+   [:div {:class (stl/css :modal-dialog)}
+    [:> icon-button* {:class (stl/css :close-btn)
+                      :on-click modal/hide!
+                      :aria-label (tr "labels.close")
+                      :variant "action"
+                      :icon "close"}]
+    [:> import-modal-body*]]])

--- a/frontend/src/app/main/ui/workspace/tokens/modals/import.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/import.scss
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+@use "../../../ds/typography.scss" as t;
+@use "../../../ds/_sizes.scss" as *;
+
+@import "refactor/common-refactor.scss";
+
+.modal-overlay {
+  @extend .modal-overlay-base;
+}
+
+.modal-dialog {
+  @extend .modal-container-base;
+  width: 100%;
+  max-width: $s-512;
+  max-height: unset;
+  user-select: none;
+  background-color: var(--color-background-primary);
+  border-radius: $s-8;
+}
+
+.import-modal-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: $s-24;
+}
+
+.import-modal-title {
+  color: var(--color-foreground-primary);
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.import-modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: $s-24;
+}
+
+.import-description {
+  color: var(--color-foreground-secondary);
+
+  ul {
+    list-style: disc;
+    padding-left: $s-12;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $s-8;
+  }
+}
+
+.import-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: $s-8;
+  padding: $s-12;
+  border-radius: $s-8;
+  border: 1px solid var(--color-accent-primary-muted);
+  background: var(--color-accent-select);
+  color: var(--color-foreground-primary);
+}
+
+.import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: $s-8;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    gap: $s-4;
+  }
+}
+
+.close-btn {
+  position: absolute;
+  top: $s-8;
+  right: $s-8;
+}

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -12,14 +12,13 @@
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
-   [app.main.data.notifications :as ntf]
    [app.main.data.style-dictionary :as sd]
    [app.main.data.workspace.tokens.application :as dwta]
-   [app.main.data.workspace.tokens.errors :as wte]
    [app.main.data.workspace.tokens.library-edit :as dwtl]
    [app.main.refs :as refs]
    [app.main.store :as st]
-   [app.main.ui.components.dropdown-menu :refer [dropdown-menu dropdown-menu-item*]]
+   [app.main.ui.components.dropdown-menu :refer [dropdown-menu
+                                                 dropdown-menu-item*]]
    [app.main.ui.components.title-bar :refer [title-bar]]
    [app.main.ui.context :as ctx]
    [app.main.ui.ds.buttons.button :refer [button*]]
@@ -38,8 +37,6 @@
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.webapi :as wapi]
-   [beicon.v2.core :as rx]
-   [cuerdas.core :as str]
    [okulary.core :as l]
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]
@@ -360,9 +357,7 @@
 
 (mf/defc import-export-button*
   []
-  (let [input-ref  (mf/use-ref)
-
-        show-menu* (mf/use-state false)
+  (let [show-menu* (mf/use-state false)
         show-menu? (deref show-menu*)
 
         can-edit?
@@ -380,30 +375,6 @@
            (dom/stop-propagation event)
            (reset! show-menu* false)))
 
-        on-display-file-explorer
-        (mf/use-fn #(dom/click (mf/ref-val input-ref)))
-
-        on-import
-        (mf/use-fn
-         (fn [event]
-           (let [file (-> (dom/get-target event)
-                          (dom/get-files)
-                          (first))
-                 file-name (str/replace (.-name file) ".json" "")]
-             (->> (wapi/read-file-as-text file)
-                  (sd/process-json-stream {:file-name file-name})
-                  (rx/subs! (fn [lib]
-                              (st/emit! (ptk/data-event ::ev/event {::ev/name "import-tokens"})
-                                        (dwtl/import-tokens-lib lib)))
-                            (fn [err]
-                              (js/console.error err)
-                              (st/emit! (ntf/show {:content (wte/humanize-errors [(ex-data err)])
-                                                   :detail (wte/detail-errors [(ex-data err)])
-                                                   :type :toast
-                                                   :level :error})))))
-             (-> (mf/ref-val input-ref)
-                 (dom/set-value! "")))))
-
         on-export
         (mf/use-fn
          (fn []
@@ -415,13 +386,6 @@
                   (dom/trigger-download "tokens.json")))))]
 
     [:div {:class (stl/css :import-export-button-wrapper)}
-     (when can-edit?
-       [:input {:type "file"
-                :ref input-ref
-                :style {:display "none"}
-                :id "file-input"
-                :accept ".json"
-                :on-change on-import}])
      [:> button* {:on-click open-menu
                   :icon "import-export"
                   :variant "secondary"}
@@ -431,11 +395,9 @@
                         :list-class (stl/css :import-export-menu)}
       (when can-edit?
         [:> dropdown-menu-item* {:class (stl/css :import-export-menu-item)
-                                 :on-click on-display-file-explorer}
+                                 :on-click #(modal/show! :tokens/import {})}
          [:div {:class (stl/css :import-menu-item)}
-          [:div (tr "labels.import")]
-          [:div {:class (stl/css :import-export-menu-item-icon) :title (tr "workspace.token.import-tooltip")}
-           [:> i/icon* {:icon-id i/info :aria-label (tr "workspace.token.import-tooltip")}]]]])
+          [:div (tr "labels.import")]]])
       [:> dropdown-menu-item* {:class (stl/css :import-export-menu-item)
                                :on-click on-export}
        (tr "labels.export")]]]))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2069,6 +2069,30 @@ msgstr "Hide resolved comments"
 msgid "labels.import"
 msgstr "Import"
 
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:116
+msgid "workspace.token.import-tokens"
+msgstr "Import tokens"
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:121
+msgid "workspace.token.import-single-file"
+msgstr "In a single JSON file, the first-level keys should be the token set names."
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:122
+msgid "workspace.token.import-multiple-files"
+msgstr "In multiple files, the file name / path are the set names."
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:127
+msgid "workspace.token.import-warning"
+msgstr "Importing tokens will override all your current tokens, sets and themes."
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:149
+msgid "workspace.token.choose-file"
+msgstr "Choose file"
+
+#: src/app/main/ui/workspace/tokens/modals/import.cljs:155
+msgid "workspace.token.choose-folder"
+msgstr "Choose folder"
+
 #: src/app/main/ui/dashboard/team.cljs:1018
 msgid "labels.inactive"
 msgstr "Inactive"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/27

### Summary

- Allows uploading multi-file token folders
- Introduces modal to chose between folder or file upload
- Crude implemplementation of Modal UI from https://chat.kaleidos.net/penpot-partners/pl/6y7fmo1h4i8qtjgdg1babxtcqc
  - Missing icons for the folder and info icon

https://github.com/user-attachments/assets/0a66a6eb-ad0d-464a-bb3b-00ba60f19e07


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
