### PR TITLE
:recycle: Use rx streams for style dictionary interface

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -45,7 +45,7 @@
       (when-let [tokens (some-> (dsh/lookup-file-data state)
                                 (get :tokens-lib)
                                 (ctob/get-active-themes-set-tokens))]
-        (->> (rx/from (sd/resolve-tokens+ tokens))
+        (->> (sd/resolve-tokens tokens)
              (rx/mapcat
               (fn [resolved-tokens]
                 (let [undo-id (js/Symbol)

--- a/frontend/src/app/main/data/workspace/tokens/propagation.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/propagation.cljs
@@ -185,12 +185,11 @@
     (watch [_ state _]
       (when-let [tokens-lib (-> (dsh/lookup-file-data state)
                                 (get :tokens-lib))]
-        (let [tokens (-> (ctob/get-active-themes-set-tokens tokens-lib)
-                         (sd/resolve-tokens+))]
-          (->> (rx/from tokens)
-               (rx/mapcat (fn [sd-tokens]
-                            (let [undo-id (js/Symbol)]
-                              (rx/concat
-                               (rx/of (dwu/start-undo-transaction undo-id :timeout false))
-                               (propagate-tokens state sd-tokens)
-                               (rx/of (dwu/commit-undo-transaction undo-id))))))))))))
+        (->> (ctob/get-active-themes-set-tokens tokens-lib)
+             (sd/resolve-tokens)
+             (rx/mapcat (fn [sd-tokens]
+                          (let [undo-id (js/Symbol)]
+                            (rx/concat
+                             (rx/of (dwu/start-undo-transaction undo-id :timeout false))
+                             (propagate-tokens state sd-tokens)
+                             (rx/of (dwu/commit-undo-transaction undo-id)))))))))))

--- a/frontend/test/frontend_tests/tokens/helpers/state.cljs
+++ b/frontend/test/frontend_tests/tokens/helpers/state.cljs
@@ -30,9 +30,9 @@
     ptk/WatchEvent
     (watch [_ state _]
       (let [data (dsh/lookup-file-data state)]
-        (->> (rx/from (-> (get data :tokens-lib)
-                          (ctob/get-active-themes-set-tokens)
-                          (sd/resolve-tokens+)))
+        (->> (get data :tokens-lib)
+             (ctob/get-active-themes-set-tokens)
+             (sd/resolve-tokens)
              (rx/mapcat #(rx/of (end))))))))
 
 (defn stop-on

--- a/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
+++ b/frontend/test/frontend_tests/tokens/style_dictionary_test.cljs
@@ -10,8 +10,7 @@
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.style-dictionary :as sd]
    [beicon.v2.core :as rx]
-   [cljs.test :as t :include-macros true]
-   [promesa.core :as p]))
+   [cljs.test :as t :include-macros true]))
 
 (t/deftest resolve-tokens-test
   (t/async
@@ -35,23 +34,23 @@
                                                                        :value "{borderRadius.sm} * 200000000"
                                                                        :type :border-radius}))
                        (ctob/get-all-tokens))]
-        (-> (sd/resolve-tokens+ tokens)
-            (p/finally
-              (fn [resolved-tokens]
-                (t/is (= 12 (get-in resolved-tokens ["borderRadius.sm" :resolved-value])))
-                (t/is (= "px" (get-in resolved-tokens ["borderRadius.sm" :unit])))
-                (t/is (= 24 (get-in resolved-tokens ["borderRadius.md-with-dashes" :resolved-value])))
-                (t/is (= "px" (get-in resolved-tokens ["borderRadius.md-with-dashes" :unit])))
-                (t/is (nil? (get-in resolved-tokens ["borderRadius.large" :resolved-value])))
-                (t/is (= :error.token/number-too-large
-                         (get-in resolved-tokens ["borderRadius.large" :errors 0 :error/code])))
-                (t/is (nil? (get-in resolved-tokens ["borderRadius.largePx" :resolved-value])))
-                (t/is (= :error.token/number-too-large
-                         (get-in resolved-tokens ["borderRadius.largePx" :errors 0 :error/code])))
-                (t/is (nil? (get-in resolved-tokens ["borderRadius.largeFn" :resolved-value])))
-                (t/is (= :error.token/number-too-large
-                         (get-in resolved-tokens ["borderRadius.largeFn" :errors 0 :error/code])))
-                (done))))))))
+        (-> (sd/resolve-tokens tokens)
+            (rx/sub!
+             (fn [resolved-tokens]
+               (t/is (= 12 (get-in resolved-tokens ["borderRadius.sm" :resolved-value])))
+               (t/is (= "px" (get-in resolved-tokens ["borderRadius.sm" :unit])))
+               (t/is (= 24 (get-in resolved-tokens ["borderRadius.md-with-dashes" :resolved-value])))
+               (t/is (= "px" (get-in resolved-tokens ["borderRadius.md-with-dashes" :unit])))
+               (t/is (nil? (get-in resolved-tokens ["borderRadius.large" :resolved-value])))
+               (t/is (= :error.token/number-too-large
+                        (get-in resolved-tokens ["borderRadius.large" :errors 0 :error/code])))
+               (t/is (nil? (get-in resolved-tokens ["borderRadius.largePx" :resolved-value])))
+               (t/is (= :error.token/number-too-large
+                        (get-in resolved-tokens ["borderRadius.largePx" :errors 0 :error/code])))
+               (t/is (nil? (get-in resolved-tokens ["borderRadius.largeFn" :resolved-value])))
+               (t/is (= :error.token/number-too-large
+                        (get-in resolved-tokens ["borderRadius.largeFn" :errors 0 :error/code])))
+               (done))))))))
 
 (t/deftest process-json-stream-test
   (t/async


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/21

### Summary

Refactors StyleDictionary bindings to use rx streams instead of promises.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
