### PR TITLE
:lipstick: Fix design review for input component

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/input.cljs
@@ -48,9 +48,9 @@
         props (mf/spread-props props {:ref ref
                                       :type type
                                       :id id
-                                      :hint-type hint-type
                                       :max-length max-length
                                       :has-hint has-hint
+                                      :hint-type hint-type
                                       :variant variant})]
     [:div {:class (dm/str class " " (stl/css-case :input-wrapper true
                                                   :variant-dense (= variant "dense")

--- a/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
@@ -26,7 +26,6 @@
   background: var(--input-bg-color);
   border-radius: $br-8;
   padding: 0 var(--sp-s);
-  outline-offset: #{$b-1};
   outline: $b-1 solid var(--input-outline-color);
 
   &:hover {
@@ -112,7 +111,7 @@
   margin-inline-start: var(--sp-xxs);
 }
 
-.hint-type-error:has(.has-hint) {
+.hint-type-error {
   --input-outline-color: var(--color-foreground-error);
 }
 

--- a/frontend/src/app/main/ui/ds/controls/utilities/label.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/label.scss
@@ -19,6 +19,11 @@
   align-items: center;
 }
 
+.label-text,
+.label-optional {
+  line-height: inherit;
+}
+
 .label-text {
   color: var(--label-color);
 }

--- a/frontend/src/app/main/ui/workspace/tokens/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/form.cljs
@@ -536,6 +536,7 @@
                      :variant "comfortable"
                      :auto-focus true
                      :default-value @token-name-ref
+                     :hint-type (when (seq (:errors @name-errors)) "error")
                      :ref name-ref
                      :on-blur on-blur-name
                      :on-change on-update-name}])


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10968

### Summary

Minor fixes to the input:

- Line-height from label elements was different from other input elements
- Input outline had an offset and block size was perceived as bigger than other input elements
- Display a red border when warning is type error

### Steps to reproduce 

Test on storybook

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
