### PR TITLE
:bug: Fix history panel shortcut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix shortcut for history version panel [Taiga #11006](https://tree.taiga.io/project/penpot/issue/11006)
 - Fix positioning of comment drafts when near the right / bottom edges of viewport [Taiga #10534](https://tree.taiga.io/project/penpot/issue/10534)
 - Fix path having a wrong selrect [Taiga #10257](https://tree.taiga.io/project/penpot/issue/10257)
 - Fix SVG `stroke-linecap` property when importing SVGs [Taiga #9489](https://tree.taiga.io/project/penpot/issue/9489)

--- a/frontend/playwright/ui/specs/versions.spec.js
+++ b/frontend/playwright/ui/specs/versions.spec.js
@@ -4,11 +4,13 @@ import { presenceFixture } from "../../data/workspace/ws-notifications";
 
 test.beforeEach(async ({ page }) => {
   await WorkspacePage.init(page);
+  const workspacePage = new WorkspacePage(page);
+  await workspacePage.setupEmptyFile(page);
 });
 
 test("Save and restore version", async ({ page }) => {
   const workspacePage = new WorkspacePage(page);
-  await workspacePage.setupEmptyFile(page);
+
   await workspacePage.mockRPC(/get\-file\?/, "workspace/versions-init.json");
   await workspacePage.mockRPC(
     "get-file-fragment?file-id=*&fragment-id=406b7b01-d3e2-80e4-8005-3138b7cc5f0b",
@@ -86,4 +88,21 @@ test("Save and restore version", async ({ page }) => {
 
   // check that the history panel is closed after restore
   await expect(page.getByRole("tab", { name: "design" })).toBeVisible();
+});
+
+test("BUG 11006 - Fix history panel shortcut", async ({ page }) => {
+  const workspacePage = new WorkspacePage(page);
+  await workspacePage.mockRPC(/get\-file\?/, "workspace/versions-init.json");
+  await workspacePage.mockRPC(
+    "get-file-snapshots?file-id=*",
+    "workspace/versions-snapshot-1.json",
+  );
+
+  await workspacePage.goToWorkspace();
+
+  await page.keyboard.press("Control+Alt+h");
+
+  await expect(
+    workspacePage.rightSidebar.getByText("There are no versions yet"),
+  ).toBeVisible();
 });

--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -464,11 +464,11 @@
                           :subsections [:panels]
                           :fn #(st/emit! (dcm/go-to-workspace :layout :assets))}
 
-   :toggle-history       {:tooltip (ds/alt "H")
-                          :command (ds/a-mod "h")
+   :toggle-history       {:tooltip (ds/meta-alt "H")
+                          :command (ds/ca-mod "h")
                           :subsections [:panels]
                           :fn #(emit-when-no-readonly
-                                (dcm/go-to-workspace :layout :document-history))}
+                                (dw/toggle-layout-flag :document-history))}
 
    :toggle-colorpalette  {:tooltip (ds/alt "P")
                           :command (ds/a-mod "p")

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -627,7 +627,10 @@
                                  :on-key-down on-show-version-history-key-down
                                  :id          "file-menu-show-version-history"}
          [:span {:class (stl/css :item-name)}
-          (tr "dashboard.show-version-history")]]
+          (tr "dashboard.show-version-history")]
+         [:span {:class (stl/css :shortcut)}
+          (for [sc (scd/split-sc (sc/get-tooltip :toggle-history))]
+            [:span {:class (stl/css :shortcut-key) :key sc} sc])]]
 
         [:div {:class (stl/css :separator)}]])
 

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -618,7 +618,7 @@
         [:> dropdown-menu-item* {:class (stl/css :submenu-item)
                                  :on-click    on-pin-version
                                  :on-key-down on-pin-version-key-down
-                                 :id          "file-menu-show-version-history"}
+                                 :id          "file-menu-create-version"}
          [:span {:class (stl/css :item-name)}
           (tr "dashboard.create-version-menu")]]
 


### PR DESCRIPTION
- :sparkles: Remove duplicate ID in file menu
- :bug: Fix shortcut for Show Version History
- :sparkles: Add regression test

### Related Ticket

https://tree.taiga.io/project/penpot/issue/11006

### Summary

This fixes the bug by introducing a new shortcut (`Ctrl + Alt + H`), since `Alt + H` was already taken for aligning shapes horizontally.

### Steps to reproduce 

1. Open any Penpot file _not_ in viewer role.
2. Press `Ctrl + Alt + H`

Expected behavior:

- The history panel is shown.
- Also, the shortcut is shown in the main menu `File / Version history`

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
