### PR TITLE
:wrench: Add :invalid-container validator for components and repair file

### DIFF
--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -61,6 +61,7 @@
     :missing-slot
     :shape-ref-cycle
     :not-a-variant
+    :invalid-container
     :invalid-variant-id
     :invalid-variant-properties
     :variant-not-main
@@ -598,10 +599,18 @@
 (defn- check-component
   "Validate semantic coherence of a component. Report all errors found."
   [component file]
+
   (when (and (contains? component :objects) (nil? (:objects component)))
     (report-error :component-nil-objects-not-allowed
                   "Objects list cannot be nil"
                   component file nil))
+
+  (let [component-page (ctf/get-component-page (:data file) component)]
+    (when (nil? component-page)
+      (report-error :invalid-container
+                    (str/ffmt "Component container is nil")
+                    component file nil)))
+
   (when (:deleted component)
     (check-component-duplicate-swap-slot component file)
     (check-ref-cycles component file))


### PR DESCRIPTION
### Related Ticket

_WIP_

https://tree.taiga.io/project/penpot/issue/9623

After taking a look, it seems that the components might be in an inconsistent status after the partial deletion. I have not been able to reproduce that yet, but I've been checking about adding a validation to detect this situation and be able to fix the corrupted file.

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
