### PR TITLE
:bug: Fix resize bar background

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 - Fix problem in viewer with the back button [Taiga #10907](https://tree.taiga.io/project/penpot/issue/10907)
 
 ### :bug: Bugs fixed
-
+- Fix resize bar background on tokens panel [Taiga #10811](https://tree.taiga.io/project/penpot/issue/10811)
 - Fix shortcut for history version panel [Taiga #11006](https://tree.taiga.io/project/penpot/issue/11006)
 - Fix positioning of comment drafts when near the right / bottom edges of viewport [Taiga #10534](https://tree.taiga.io/project/penpot/issue/10534)
 - Fix path having a wrong selrect [Taiga #10257](https://tree.taiga.io/project/penpot/issue/10257)

--- a/frontend/src/app/main/ui/workspace/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar.scss
@@ -85,6 +85,7 @@ $width-settings-bar-max: $s-500;
 }
 
 .resize-area-horiz {
+  background-color: var(--panel-background-color);
   position: absolute;
   left: 0;
   width: 100%;

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.scss
@@ -193,12 +193,14 @@
 }
 
 .resize-area-horiz {
+  background-color: var(--panel-background-color);
   position: absolute;
   left: 0;
   width: 100%;
   padding: $s-3 0 $s-1 0;
   height: $s-6;
   cursor: ns-resize;
+  z-index: 1;
 }
 
 .resize-handle-horiz {


### PR DESCRIPTION
### Related Ticket

This PR closes [this issue](https://tree.taiga.io/project/penpot/issue/10811)

### Summary

The horizontal resizing bar gives a glimpse of the pills tokens behind. 
![image](https://github.com/user-attachments/assets/3377e990-ca2c-4e61-907a-97abdd6664b8)

### Steps to reproduce 
1. Open a file
2. Go to token section
3. Create a token
4. Scroll down until pill is behind resize bar.


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
