### PR TITLE
:sparkles: Text grow width/height

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/text_edition_outline.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/text_edition_outline.cljs
@@ -8,35 +8,52 @@
   (:require
    [app.common.geom.shapes :as gsh]
    [app.main.data.workspace.texts :as dwt]
+   [app.main.features :as features]
    [app.main.refs :as refs]
+   [app.main.store :as st]
+   [app.render-wasm.api :as wasm.api]
    [rumext.v2 :as mf]))
 
 (mf/defc text-edition-outline
   [{:keys [shape zoom modifiers]}]
-  (let [modifiers (get-in modifiers [(:id shape) :modifiers])
+  (if (features/active-feature? @st/state "render-wasm/v1")
+    (let [transform (gsh/transform-str shape)
+          {:keys [id x y]} shape
+          {:keys [width height]} (wasm.api/text-dimensions id)]
+      [:rect.main.viewport-selrect
+       {:x x
+        :y y
+        :width width
+        :height height
+        :transform transform
+        :style {:stroke "var(--color-accent-tertiary)"
+                :stroke-width (/ 1 zoom)
+                :fill "none"}}])
 
-        text-modifier-ref
-        (mf/use-memo (mf/deps (:id shape)) #(refs/workspace-text-modifier-by-id (:id shape)))
+    (let [modifiers (get-in modifiers [(:id shape) :modifiers])
 
-        text-modifier
-        (mf/deref text-modifier-ref)
+          text-modifier-ref
+          (mf/use-memo (mf/deps (:id shape)) #(refs/workspace-text-modifier-by-id (:id shape)))
 
-        shape (cond-> shape
-                (some? modifiers)
-                (gsh/transform-shape modifiers)
+          text-modifier
+          (mf/deref text-modifier-ref)
 
-                (some? text-modifier)
-                (dwt/apply-text-modifier text-modifier))
+          shape (cond-> shape
+                  (some? modifiers)
+                  (gsh/transform-shape modifiers)
 
-        transform (gsh/transform-str shape)
-        {:keys [x y width height]} shape]
+                  (some? text-modifier)
+                  (dwt/apply-text-modifier text-modifier))
 
-    [:rect.main.viewport-selrect
-     {:x x
-      :y y
-      :width width
-      :height height
-      :transform transform
-      :style {:stroke "var(--color-accent-tertiary)"
-              :stroke-width (/ 1 zoom)
-              :fill "none"}}]))
+          transform (gsh/transform-str shape)
+          {:keys [x y width height]} shape]
+
+      [:rect.main.viewport-selrect
+       {:x x
+        :y y
+        :width width
+        :height height
+        :transform transform
+        :style {:stroke "var(--color-accent-tertiary)"
+                :stroke-width (/ 1 zoom)
+                :fill "none"}}])))

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -69,7 +69,10 @@
         on-blur
         (fn []
           (when-let [content (content/dom->cljs (dwt/get-editor-root instance))]
-            (st/emit! (dwt/v2-update-text-shape-content shape-id content update-name? (gen-name instance))))
+            (st/emit! (dwt/v2-update-text-shape-content shape-id content
+                                                        :update-name? update-name?
+                                                        :name (gen-name instance)
+                                                        :finalize? true)))
 
           (let [container-node (mf/ref-val container-ref)]
             (dom/set-style! container-node "opacity" 0)))
@@ -87,7 +90,7 @@
         on-needs-layout
         (fn []
           (when-let [content (content/dom->cljs (dwt/get-editor-root instance))]
-            (st/emit! (dwt/v2-update-text-shape-content shape-id content true)))
+            (st/emit! (dwt/v2-update-text-shape-content shape-id content :update-name? true)))
           ;; FIXME: We need to find a better way to trigger layout changes.
           #_(st/emit!
              (dwt/v2-update-text-shape-position-data shape-id [])))
@@ -95,7 +98,7 @@
         on-change
         (fn []
           (when-let [content (content/dom->cljs (dwt/get-editor-root instance))]
-            (st/emit! (dwt/v2-update-text-shape-content shape-id content true))))]
+            (st/emit! (dwt/v2-update-text-shape-content shape-id content :update-name? true))))]
 
     (.addEventListener ^js global/document "keyup" on-key-up)
     (.addEventListener ^js instance "blur" on-blur)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.cljs
@@ -15,6 +15,7 @@
    [app.main.data.workspace.shortcuts :as sc]
    [app.main.data.workspace.texts :as dwt]
    [app.main.data.workspace.undo :as dwu]
+   [app.main.features :as features]
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.radio-buttons :refer [radio-button radio-buttons]]
@@ -130,6 +131,9 @@
              (st/emit!
               (dwu/start-undo-transaction uid)
               (dwsh/update-shapes ids #(assoc % :grow-type grow-type)))
+
+             (when (features/active-feature? @st/state "render-wasm/v1")
+               (st/emit! (dwt/resize-wasm-text-all ids)))
              ;; We asynchronously commit so every sychronous event is resolved first and inside the transaction
              (ts/schedule #(st/emit! (dwu/commit-undo-transaction uid))))
            (when (some? on-blur) (on-blur))))]

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -16,6 +16,7 @@
    [app.common.types.shape-tree :as ctt]
    [app.common.types.shape.layout :as ctl]
    [app.main.data.workspace.modifiers :as dwm]
+   [app.main.data.workspace.transforms :as dwt]
    [app.main.features :as features]
    [app.main.refs :as refs]
    [app.main.store :as st]
@@ -305,9 +306,12 @@
           (let [content (-> active-editor-state
                             (ted/get-editor-current-content)
                             (ted/export-content))]
+            (wasm.api/use-shape edition)
             (wasm.api/set-shape-text-content content)
-            (wasm.api/clear-drawing-cache)
-            (wasm.api/request-render "content")))))
+            (let [dimension (wasm.api/text-dimensions)]
+              (st/emit! (dwt/resize-text-editor edition dimension))
+              (wasm.api/clear-drawing-cache)
+              (wasm.api/request-render "content"))))))
 
     (mf/with-effect [vport]
       (when @canvas-init?

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -283,6 +283,13 @@
     :remove-children 1
     :add-children    2))
 
+(defn translate-grow-type
+  [grow-type]
+  (case grow-type
+    :auto-width 1
+    :auto-height 2
+    0))
+
 (defn- serialize-enum
   [value enum-map]
   (get enum-map value 0))

--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -152,6 +152,9 @@
         (= (:type shape) :text)
         (into [] (api/set-shape-text-content v)))
 
+      :grow-type
+      (api/set-shape-grow-type v)
+
       (:layout-item-margin
        :layout-item-margin-type
        :layout-item-h-sizing

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -356,6 +356,7 @@ impl RenderState {
                     s.canvas().concat(&matrix);
                 });
 
+                let text_content = text_content.new_bounds(shape.selrect());
                 let paragraphs = text_content.get_skia_paragraphs(&self.fonts.font_collection());
 
                 shadows::render_text_drop_shadows(self, &shape, &paragraphs, antialias);

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -711,9 +711,9 @@ impl Shape {
     }
 
     pub fn clear_text(&mut self) {
-        match self.shape_type {
-            Type::Text(_) => {
-                let new_text_content = TextContent::new(self.selrect);
+        match &self.shape_type {
+            Type::Text(old_text_content) => {
+                let new_text_content = TextContent::new(self.selrect, old_text_content.grow_type());
                 self.shape_type = Type::Text(new_text_content);
             }
             _ => {}

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -1,7 +1,8 @@
 use crate::mem;
-use crate::shapes::RawTextData;
-use crate::with_current_shape;
+use crate::shapes::{auto_height, auto_width, GrowType, RawTextData, Type};
+
 use crate::STATE;
+use crate::{with_current_shape, with_state};
 
 #[no_mangle]
 pub extern "C" fn clear_shape_text() {
@@ -21,4 +22,49 @@ pub extern "C" fn set_shape_text_content() {
     });
 
     mem::free_bytes();
+}
+
+#[no_mangle]
+pub extern "C" fn set_shape_grow_type(grow_type: u8) {
+    with_current_shape!(state, |shape: &mut Shape| {
+        if let Type::Text(text_content) = &mut shape.shape_type {
+            text_content.set_grow_type(GrowType::from(grow_type));
+        }
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn get_text_dimensions() -> *mut u8 {
+    let font_col;
+    with_state!(state, {
+        font_col = state.render_state.fonts.font_collection();
+    });
+
+    let mut width = 0.01;
+    let mut height = 0.01;
+    with_current_shape!(state, |shape: &mut Shape| {
+        width = shape.selrect.width();
+        height = shape.selrect.height();
+
+        if let Type::Text(content) = &shape.shape_type {
+            match content.grow_type() {
+                GrowType::AutoWidth => {
+                    let paragraphs = content.get_skia_paragraphs(font_col);
+                    width = auto_width(&paragraphs);
+                    height = auto_height(&paragraphs);
+                }
+                GrowType::AutoHeight => {
+                    let paragraphs = content.get_skia_paragraphs(font_col);
+                    height = auto_height(&paragraphs);
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let mut bytes = Vec::<u8>::with_capacity(8);
+    bytes.resize(8, 0);
+    bytes[0..4].clone_from_slice(&width.to_le_bytes());
+    bytes[4..8].clone_from_slice(&height.to_le_bytes());
+    mem::write_bytes(bytes)
 }


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/task/10908

### Summary
Auto-width / auto-height text growing dynamically in new renderer.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
