### PR TITLE
:tada: Add text stroke fills

### DIFF
--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -41,7 +41,7 @@ impl Gradient {
         self.offsets.extend(offsets);
     }
 
-    fn to_linear_shader(&self, rect: &Rect) -> Option<skia::Shader> {
+    pub fn to_linear_shader(&self, rect: &Rect) -> Option<skia::Shader> {
         let start = (
             rect.left + self.start.0 * rect.width(),
             rect.top + self.start.1 * rect.height(),
@@ -60,7 +60,7 @@ impl Gradient {
         )
     }
 
-    fn to_radial_shader(&self, rect: &Rect) -> Option<skia::Shader> {
+    pub fn to_radial_shader(&self, rect: &Rect) -> Option<skia::Shader> {
         let center = skia::Point::new(
             rect.left + self.start.0 * rect.width(),
             rect.top + self.start.1 * rect.height(),
@@ -118,6 +118,10 @@ impl ImageFill {
 
     pub fn id(&self) -> Uuid {
         self.id
+    }
+
+    pub fn opacity(&self) -> u8 {
+        self.opacity
     }
 }
 


### PR DESCRIPTION
### Related Ticket

Follow up for https://tree.taiga.io/project/penpot/task/10899

### Summary

This is PR adds support to all text stroke fills

### Steps to reproduce

Use different kinds of strokes on texts

![image](https://github.com/user-attachments/assets/5cf01802-0a23-4e11-805b-f891a650d710)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
