### PR TITLE
:bug: Fix parsing text spaces

### DIFF
--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -1194,6 +1194,4 @@
                origin
                (:transform shape (gmt/matrix))
                (:transform-inverse shape (gmt/matrix)))}}]
-
-        (.log js/console (clj->js modifiers))
         (rx/of (dwm/set-wasm-modifiers modifiers))))))

--- a/frontend/src/app/render_wasm/api/texts.cljs
+++ b/frontend/src/app/render_wasm/api/texts.cljs
@@ -10,8 +10,7 @@
    [app.render-wasm.helpers :as h]
    [app.render-wasm.mem :as mem]
    [app.render-wasm.serializers :as sr]
-   [app.render-wasm.wasm :as wasm]
-   [clojure.string :as str]))
+   [app.render-wasm.wasm :as wasm]))
 
 (defn utf8->buffer [text]
   (let [encoder (js/TextEncoder.)]
@@ -21,8 +20,7 @@
   ;; buffer has the following format:
   ;; [<num-leaves> <paragraph_attributes> <leaves_attributes> <text>]
   [leaves paragraph text]
-  (let [leaves (filter #(not (str/blank? (:text %))) leaves)
-        num-leaves (count leaves)
+  (let [num-leaves (count leaves)
         paragraph-attr-size 48
         leaf-attr-size 52
         metadata-size (+ 1 paragraph-attr-size (* num-leaves leaf-attr-size))

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -125,10 +125,10 @@ impl TextContent {
                     let text: String = leaf.apply_text_transform(paragraph.text_transform);
                     builder.push_style(&stroke_style);
                     builder.add_text(&text);
-                    let p = builder.build();
-                    stroke_paragraphs.push(p);
+                    builder.pop();
                 }
-                builder.reset();
+                let p = builder.build();
+                stroke_paragraphs.push(p);
             }
             paragraph_group.push(stroke_paragraphs);
         }

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -451,8 +451,11 @@ impl RawTextData {
         }
 
         let text_utf8 = buffer[offset..text_end].to_vec();
-        let text = String::from_utf8(text_utf8).expect("Invalid UTF-8 text");
+        if text_utf8.is_empty() {
+            return (String::new(), text_end);
+        }
 
+        let text = String::from_utf8_lossy(&text_utf8).to_string();
         (text, text_end)
     }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11044 

### Summary

- Do not skip "empty" leaves, as this causes text to render improperly
- Handle stroke paragraphs properly when having multiple leaves

### Steps to reproduce 

1. Write text with different leaves separated by spaces, using various fonts and fills. Observe that some characters are being cut off.

Before:

![image](https://github.com/user-attachments/assets/16de0b52-c809-4324-81f5-e06a40e5dff4)


After:

![image](https://github.com/user-attachments/assets/47cc328a-4b8a-4460-9be3-dff432de1f8e)

2. Apply a stroke to the texts with different leaves

Before

![image](https://github.com/user-attachments/assets/2b367a96-6ea7-45ea-8b5a-d150f3320d36)

After

![image](https://github.com/user-attachments/assets/77bf8028-a028-48f7-a36d-aad03e1dae9d)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
