### PR TITLE
:bug: Properly propagate export errors from worker to main thread

### DIFF
--- a/frontend/src/app/worker/export.cljs
+++ b/frontend/src/app/worker/export.cljs
@@ -421,11 +421,9 @@
                             :uri uri}))
                  (rx/catch
                   (fn [cause]
-                    (rx/of (ex/raise :type :internal
-                                     :code :export-error
-                                     :hint "unexpected error on exporting file"
-                                     :file-id (:id file)
-                                     :cause cause))))))))
+                    (rx/of {:type :error
+                            :file-id (:id file)
+                            :hint (ex-message cause)})))))))
 
     (= format :legacy-zip)
     (->> (rx/from files)


### PR DESCRIPTION
### Summary

When an error ocurrs on backend on making a request, this error is incorrectly reported from worker to main browser thrad. We should send a plain map instead of raising an exception.

There are no easy way to test it, you will need to force in backend code an error in order to test it.
