### PR TITLE
:sparkles: Reflow flex on grow text height

### DIFF
--- a/frontend/src/app/main/data/workspace/transforms.cljs
+++ b/frontend/src/app/main/data/workspace/transforms.cljs
@@ -217,11 +217,14 @@
 
                   ;; When the horizontal/vertical scale a flex children with auto/fill
                   ;; we change it too fixed
-                  set-fix-width?
+                  change-width?
                   (not (mth/close? (dm/get-prop scalev :x) 1))
 
-                  set-fix-height?
-                  (not (mth/close? (dm/get-prop scalev :y) 1))]
+                  change-height?
+                  (not (mth/close? (dm/get-prop scalev :y) 1))
+
+                  auto-width-text?  (and (cfh/text-shape? shape) (= :auto-width (dm/get-prop shape :grow-type)))
+                  auto-height-text? (and (cfh/text-shape? shape) (= :auto-height (dm/get-prop shape :grow-type)))]
 
               (cond-> (ctm/empty)
                 (some? displacement)
@@ -230,11 +233,17 @@
                 :always
                 (ctm/resize scalev resize-origin shape-transform shape-transform-inverse)
 
-                ^boolean set-fix-width?
+                ^boolean change-width?
                 (ctm/change-property :layout-item-h-sizing :fix)
 
-                ^boolean set-fix-height?
+                ^boolean change-height?
                 (ctm/change-property :layout-item-v-sizing :fix)
+
+                (and auto-width-text? (or change-width? change-height?))
+                (ctm/change-property :grow-type :fixed)
+
+                (and auto-height-text? change-height?)
+                (ctm/change-property :grow-type :fixed)
 
                 ^boolean scale-text
                 (ctm/scale-content (dm/get-prop scalev :x)))))

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -40,7 +40,11 @@ pub struct TextContent {
 pub fn set_paragraphs_width(width: f32, paragraphs: &mut Vec<Vec<skia::textlayout::Paragraph>>) {
     for group in paragraphs {
         for paragraph in group {
-            paragraph.layout(width)
+            // We first set max so we can get the min_intrinsic_width (this is the min word size)
+            // then after we set either the real with or the min.
+            // This is done this way so the words are not break into lines.
+            paragraph.layout(f32::MAX);
+            paragraph.layout(f32::max(width, paragraph.min_intrinsic_width().ceil()));
         }
     }
 }


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/task/10908

### Summary
- Change auto-width/height sets the grow type to fixed
- Dynamic resize text will update constraints
- No word wrapping on resize

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
