### PR TITLE
:books: Add missing command to open a repl on frontend process

### DIFF
--- a/docs/technical-guide/developer/devenv.md
+++ b/docs/technical-guide/developer/devenv.md
@@ -78,24 +78,25 @@ connect to penpot by browsing to http://localhost:3449 .
 ### Frontend
 
 The frontend build process is located on the tmux **window 0** and
-**window 1**. On the **window 0** we have the gulp process responsible
-of watching and building styles, fonts, icon-spreads and templates.
+**window 1**. On **window 0** we have the gulp process responsible
+for watching and building styles, fonts, icon-spreads and templates.
 
-On the **window 1** we can found the **shadow-cljs** process that is
-responsible on watch and build frontend clojurescript code.
+On **window 1** we can find the **shadow-cljs** process that is
+responsible for watching and building frontend clojurescript code.
 
-Additionally to the watch process you probably want to be able open a REPL
-process on the frontend application, for this case you can split the window
-and execute this:
+Additionally to the watch process you probably want to be able to open a REPL
+process on the frontend application. In order to do this you can split the
+window and execute:
 
 ```bash
+cd penpot/frontend
 npx shadow-cljs cljs-repl main
 ```
 
 ### Storybook
 
 The storybook local server is started on tmux **window 2** and will listen
-for changes in the styles, components or stories defined in the folders 
+for changes in the styles, components or stories defined in the folders
 under the design system namespace: `app.main.ui.ds`.
 
 You can open the broser on http://localhost:6006/ to see it.

--- a/docs/technical-guide/developer/devenv.md
+++ b/docs/technical-guide/developer/devenv.md
@@ -84,14 +84,25 @@ for watching and building styles, fonts, icon-spreads and templates.
 On **window 1** we can find the **shadow-cljs** process that is
 responsible for watching and building frontend clojurescript code.
 
-Additionally to the watch process you probably want to be able to open a REPL
+In addition to the watch process you probably want to be able to open a REPL
 process on the frontend application. In order to do this you can split the
-window and execute:
+window (`Ctrl+b "`) and execute:
 
 ```bash
 cd penpot/frontend
 npx shadow-cljs cljs-repl main
 ```
+
+In order to have the REPL working you need to have an active browser session
+with the penpot application opened (otherwise, you will get the error
+`No application has connected to the REPL server.`).
+
+Finally, in case you want to connect to the REPL from your IDE, you can set it
+up to use nREPL with the port `3447` and the host `localhost` (you can see the
+port in the startup message of the shadow-cljs process in **window 1**). You
+will also need to call `(shadow/repl :main)` in the REPL to start the connection,
+as explained [here](https://shadow-cljs.github.io/docs/UsersGuide.html#_server_options).
+
 
 ### Storybook
 


### PR DESCRIPTION
### Summary

This PR:
* adds a single `cd` command to the steps required to open a REPL on the frontend process when using the containerized development environment ([this line](https://github.com/penpot/penpot/pull/6458/files#diff-bd4c80b352cc8d7666401f0bb1990f5141b74389dc7f6905fe0167b9fcebd2d5R92))
* adds some information on starting the repl, and configuring a client
* fixes a few grammar mistakes in the same section of the documentation.

### Steps to reproduce 

As it is currently, splitting the tmux window starts a new shell in the home folder for the docker container. Then, running `npx shadow-cljs cljs-repl main` fails because the file `/home/penpot/shadow-cljs.edn` has no build configurations.

```shell
penpot@6a3e63459540:~$ npx shadow-cljs cljs-repl main
------------------------------------------------------------------------------

   WARNING: shadow-cljs not installed in project.
   See https://shadow-cljs.github.io/docs/UsersGuide.html#project-install

------------------------------------------------------------------------------
shadow-cljs - config: /home/penpot/shadow-cljs.edn
No config for build "main" found.
Build id required.
penpot@6a3e63459540:~$ 
```

Instead we want to cd to the frontend folder first:

```shell
penpot@6a3e63459540:~$ cd penpot/frontend/
penpot@6a3e63459540:~/penpot/frontend$ npx shadow-cljs cljs-repl main
shadow-cljs - config: /home/penpot/penpot/frontend/shadow-cljs.edn
shadow-cljs - connected to server
cljs.user=> 
```

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] ~Include screenshots or videos, if applicable.~
- [ ] ~Add or modify existing integration tests in case of bugs or new features, if applicable.~
- [ ] ~Check CI passes successfully.~
- [ ] ~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~

