### PR TITLE
:sparkles: Add reporting for token type errors

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7433,3 +7433,9 @@ msgstr "The following files have errors:"
 
 msgid "dashboard.import.import-error.message2"
 msgstr "Files with errors will not be uploaded."
+
+msgid "workspace.token.unknown-token-type"
+msgstr "Skipped tokens"
+
+msgid "workspace.token.unknown-token-type-section"
+msgstr "Type '%s' is not supported (%s)\n"


### PR DESCRIPTION
### Related Ticket

[<!-- Reference the related GitHub/Taiga ticket. -->](https://github.com/tokens-studio/penpot/issues/3)

### Summary

Adds information messages for unknown token types on import

### Steps to reproduce 

import the following file
[tokens_type_error.json](https://github.com/user-attachments/files/20205458/tokens_type_error.json)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
