### PR TITLE
:sparkles: Control malformed variant formulas

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -60,6 +60,17 @@
         (pcb/update-shapes [main-id] #(assoc % :variant-name name)))))
 
 
+(defn generate-error
+  [changes component-id value]
+  (let [data      (pcb/get-library-data changes)
+        component (ctcl/get-component data component-id true)
+        main-id   (:main-instance-id component)]
+    (-> changes
+        (pcb/update-shapes [main-id] (if (str/blank? value)
+                                       #(dissoc % :variant-error)
+                                       #(assoc % :variant-error value))))))
+
+
 (defn generate-add-new-property
   [changes variant-id & {:keys [fill-values? property-name]}]
   (let [data               (pcb/get-library-data changes)

--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -60,7 +60,7 @@
         (pcb/update-shapes [main-id] #(assoc % :variant-name name)))))
 
 
-(defn generate-error
+(defn generate-set-variant-error
   [changes component-id value]
   (let [data      (pcb/get-library-data changes)
         component (ctcl/get-component data component-id true)

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -106,7 +106,7 @@
      (add-new-props assigned remaining))))
 
 
-(defn properties-map-to-string
+(defn properties-map->string
   "Transforms a map of properties to a string of properties omitting the empty ones"
   [properties]
   (->> properties
@@ -116,11 +116,12 @@
        (str/join ", ")))
 
 
-(defn properties-string-to-map
+(defn properties-string->map
   "Transforms a string of properties to a map of properties"
   [s]
   (->> (str/split s ",")
        (mapv #(str/split % "="))
+       (filter (fn [[_ v]] (not (str/blank? (str/trim v)))))
        (mapv (fn [[k v]]
                {:name (str/trim k)
                 :value (str/trim v)}))))
@@ -129,7 +130,7 @@
 (defn valid-properties-string?
   "Checks if a string of properties has a processable format or not"
   [s]
-  (let [pattern #"^([a-zA-Z0-9\s]+=[a-zA-Z0-9\s]+)(,\s*[a-zA-Z0-9\s]+=[a-zA-Z0-9\s]+)*$"]
+  (let [pattern #"^\s*([a-zA-Z0-9_ -]+=[^,]*)(,\s*[a-zA-Z0-9_ -]+=[^,]*)*\s*$"]
     (not (nil? (re-matches pattern s)))))
 
 

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -33,7 +33,8 @@
   ;; The root shape of the main instance of a variant component.
   [:map
    [:variant-id {:optional true} ::sm/uuid]
-   [:variant-name {:optional true} :string]])
+   [:variant-name {:optional true} :string]
+   [:variant-error {:optional true} :string]])
 
 (def schema:variant-container
   ;; is a board that contains all variant components of a variant set,

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -12,28 +12,37 @@
 (t/deftest convert-between-variant-properties-maps-and-strings
   (let [map-with-two-props           [{:name "border" :value "yes"} {:name "color" :value "gray"}]
         map-with-two-props-one-blank [{:name "border" :value "no"} {:name "color" :value ""}]
+        map-with-two-props-dashes    [{:name "border" :value "no"} {:name "color" :value "--"}]
         map-with-one-prop            [{:name "border" :value "no"}]
-        map-with-spaces              [{:name "border 1" :value "of course"} {:name "color 2" :value "dark gray"}]
+        map-with-spaces              [{:name "border 1" :value "of course"}
+                                      {:name "color 2" :value "dark gray"}
+                                      {:name "background 3" :value "anoth€r co-lor"}]
 
         string-valid-with-two-props  "border=yes, color=gray"
         string-valid-with-one-prop   "border=no"
-        string-valid-with-spaces     "border 1=of course, color 2=dark gray"
-        string-invalid               "border=yes, color="]
+        string-valid-with-spaces     "border 1=of course, color 2=dark gray, background 3=anoth€r co-lor"
+        string-valid-with-no-value   "border=no, color="
+        string-valid-with-dashes     "border=no, color=--"
+        string-invalid               "border=yes, color"]
 
     (t/testing "convert map to string"
-      (t/is (= (ctv/properties-map-to-string map-with-two-props) string-valid-with-two-props))
-      (t/is (= (ctv/properties-map-to-string map-with-two-props-one-blank) string-valid-with-one-prop))
-      (t/is (= (ctv/properties-map-to-string map-with-spaces) string-valid-with-spaces)))
+      (t/is (= (ctv/properties-map->string map-with-two-props) string-valid-with-two-props))
+      (t/is (= (ctv/properties-map->string map-with-two-props-one-blank) string-valid-with-one-prop))
+      (t/is (= (ctv/properties-map->string map-with-spaces) string-valid-with-spaces)))
 
     (t/testing "convert string to map"
-      (t/is (= (ctv/properties-string-to-map string-valid-with-two-props) map-with-two-props))
-      (t/is (= (ctv/properties-string-to-map string-valid-with-one-prop) map-with-one-prop))
-      (t/is (= (ctv/properties-string-to-map string-valid-with-spaces) map-with-spaces)))
+      (t/is (= (ctv/properties-string->map string-valid-with-two-props) map-with-two-props))
+      (t/is (= (ctv/properties-string->map string-valid-with-one-prop) map-with-one-prop))
+      (t/is (= (ctv/properties-string->map string-valid-with-no-value) map-with-one-prop))
+      (t/is (= (ctv/properties-string->map string-valid-with-dashes) map-with-two-props-dashes))
+      (t/is (= (ctv/properties-string->map string-valid-with-spaces) map-with-spaces)))
 
     (t/testing "check if a string is valid"
       (t/is (= (ctv/valid-properties-string? string-valid-with-two-props) true))
       (t/is (= (ctv/valid-properties-string? string-valid-with-one-prop) true))
       (t/is (= (ctv/valid-properties-string? string-valid-with-spaces) true))
+      (t/is (= (ctv/valid-properties-string? string-valid-with-no-value) true))
+      (t/is (= (ctv/valid-properties-string? string-valid-with-dashes) true))
       (t/is (= (ctv/valid-properties-string? string-invalid) false)))))
 
 

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -144,7 +144,7 @@
             changes    (-> (pcb/empty-changes it page-id)
                            (pcb/with-library-data data)
                            (pcb/with-objects objects)
-                           (clvp/generate-error component-id value))
+                           (clvp/generate-set-variant-error component-id value))
             undo-id    (js/Symbol)]
         (rx/of
          (dwu/start-undo-transaction undo-id)

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -130,6 +130,28 @@
          (dwu/commit-undo-transaction undo-id))))))
 
 
+(defn update-error
+  "Updates the error in a component"
+  [component-id value]
+  (ptk/reify ::update-error
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [page-id    (:current-page-id state)
+            data       (dsh/lookup-file-data state)
+            objects    (-> (dsh/get-page data page-id)
+                           (get :objects))
+
+            changes    (-> (pcb/empty-changes it page-id)
+                           (pcb/with-library-data data)
+                           (pcb/with-objects objects)
+                           (clvp/generate-error component-id value))
+            undo-id    (js/Symbol)]
+        (rx/of
+         (dwu/start-undo-transaction undo-id)
+         (dch/commit-changes changes)
+         (dwu/commit-undo-transaction undo-id))))))
+
+
 (defn remove-property
   "Remove the variant property on the position pos
    in all the components with this variant-id"

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -61,6 +61,7 @@
         is-variant-container? (when variants? (ctk/is-variant-container? item))
         variant-id            (when is-variant? (:variant-id item))
         variant-name          (when is-variant? (:variant-name item))
+        variant-error         (when is-variant? (:variant-error item))
 
         data                  (deref refs/workspace-data)
         component             (ctkl/get-component data (:component-id item))
@@ -144,6 +145,7 @@
                         :variant-id variant-id
                         :variant-name variant-name
                         :variant-properties variant-properties
+                        :variant-error variant-error
                         :component-id (:id component)
                         :is-hidden hidden?}]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -46,9 +46,7 @@
                            shape-name)
 
         default-value    (if variant-id
-                           (if variant-error
-                             variant-error
-                             (ctv/properties-map->string variant-properties))
+                           (or variant-error (ctv/properties-map->string variant-properties))
                            shape-name)
 
         has-path?        (str/includes? shape-name "/")

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -31,8 +31,8 @@
    ::mf/forward-ref true}
   [{:keys [shape-id shape-name is-shape-touched disabled-double-click
            on-start-edit on-stop-edit depth parent-size is-selected
-           type-comp type-frame variant-id variant-name variant-properties
-           component-id is-hidden is-blocked]} external-ref]
+           type-comp type-frame component-id is-hidden is-blocked
+           variant-id variant-name variant-properties variant-error]} external-ref]
   (let [edition*         (mf/use-state false)
         edition?         (deref edition*)
 
@@ -41,9 +41,14 @@
 
         shape-for-rename (mf/deref lens:shape-for-rename)
 
-        shape-name       (d/nilv variant-name shape-name)
+        shape-name       (if variant-id
+                           (d/nilv variant-error variant-name)
+                           shape-name)
+
         default-value    (if variant-id
-                           (ctv/properties-map-to-string variant-properties)
+                           (if variant-error
+                             variant-error
+                             (ctv/properties-map->string variant-properties))
                            shape-name)
 
         has-path?        (str/includes? shape-name "/")
@@ -67,9 +72,11 @@
              (on-stop-edit)
              (reset! edition* false)
              (if variant-name
-               (let [valid? (ctv/valid-properties-string? name)
-                     props  (if valid? (ctv/properties-string-to-map name) {})]
-                 (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties props)))
+               (if (ctv/valid-properties-string? name)
+                 (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties (ctv/properties-string->map name))
+                           (dwv/update-error component-id nil))
+                 (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties {})
+                           (dwv/update-error component-id name)))
                (st/emit! (dw/end-rename-shape shape-id name))))))
 
         cancel-edit

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.scss
@@ -10,6 +10,8 @@
   @include textEllipsis;
   @include bodySmallTypography;
   flex-grow: 1;
+  height: 100%;
+  align-content: center;
   color: var(--context-hover-color, var(--layer-row-foreground-color));
 
   &.selected {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -236,9 +236,8 @@
           [:div {:class (stl/css  :counter)} (str size "/300")])]])))
 
 (mf/defc component-variant-main-instance*
-  [{:keys [components shapes data]}]
+  [{:keys [components shape data]}]
   (let [component      (first components)
-        shape          (first shapes)
 
         variant-id     (:variant-id component)
         variant-error? (:variant-error shape)
@@ -808,7 +807,7 @@
 
           (when (and is-variant? main-instance? same-variant? (not swap-opened?))
             [:> component-variant-main-instance* {:components components
-                                                  :shapes shapes
+                                                  :shape shape
                                                   :data data}])
 
           (when (dbg/enabled? :display-touched)
@@ -886,6 +885,7 @@
 
         select-shape-with-error
         (mf/use-fn
+         (mf/deps object-error-ids)
          #(st/emit! (dw/select-shape (first object-error-ids))))]
 
     (when (seq shapes)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -14,6 +14,7 @@
 
 .element-content {
   @include flexColumn;
+  gap: var(--sp-m);
 }
 
 .title-back {
@@ -706,7 +707,12 @@
   @include flexRow;
   justify-content: space-between;
   width: 100%;
-  margin-block-start: $s-12;
+}
+
+.variant-property-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
 }
 
 .variant-property-container {
@@ -735,4 +741,33 @@
   display: flex;
   flex: 0 0 auto;
   width: $s-104;
+}
+
+.variant-error-wrapper {
+  @include bodySmallTypography;
+  border: 1px solid var(--color-background-quaternary);
+  border-radius: $s-8;
+  padding: $s-12;
+  display: flex;
+  flex-direction: column;
+  gap: $s-8;
+}
+
+.variant-error-highlight {
+  color: var(--color-foreground-primary);
+}
+
+.variant-error-darken {
+  color: var(--color-foreground-secondary);
+}
+
+.variant-error-button {
+  @include bodySmallTypography;
+  background-color: transparent;
+  border: none;
+  appearance: none;
+  color: var(--color-accent-primary);
+  cursor: pointer;
+  padding: 0;
+  text-align: start;
 }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5224,6 +5224,26 @@ msgstr "Swap component"
 msgid "workspace.options.component.swap.empty"
 msgstr "There are no assets in this library yet"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:742
+msgid "workspace.options.component.variant"
+msgstr "Variant"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:942
+msgid "workspace.options.component.variant.malformed.locate"
+msgstr "Locate invalid variations"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:940
+msgid "workspace.options.component.variant.malformed.multi"
+msgstr "Some variations have invalid names"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:307
+msgid "workspace.options.component.variant.malformed.single"
+msgstr "This variant has an invalid name. Try using the following structure:"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:308
+msgid "workspace.options.component.variant.malformed.structure"
+msgstr "[property]=[value], [property]=[value]"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs:163
 msgid "workspace.options.constraints"
 msgstr "Constraints"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5230,11 +5230,11 @@ msgstr "Variant"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:942
 msgid "workspace.options.component.variant.malformed.locate"
-msgstr "Locate invalid variations"
+msgstr "Locate invalid variants"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:940
 msgid "workspace.options.component.variant.malformed.multi"
-msgstr "Some variations have invalid names"
+msgstr "Some variants have invalid names"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:307
 msgid "workspace.options.component.variant.malformed.single"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5250,6 +5250,26 @@ msgstr "Intercambiar componente"
 msgid "workspace.options.component.swap.empty"
 msgstr "Aún no hay recursos en esta biblioteca"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:742
+msgid "workspace.options.component.variant"
+msgstr "Variante"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:942
+msgid "workspace.options.component.variant.malformed.locate"
+msgstr "Localizar variantes no válidas"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:940
+msgid "workspace.options.component.variant.malformed.multi"
+msgstr "Algunas variantes tienen nombres no válidos"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:307
+msgid "workspace.options.component.variant.malformed.single"
+msgstr "Esta variante tiene un nombre no válido. Prueba a utilizar la siguiente estructura:"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:308
+msgid "workspace.options.component.variant.malformed.structure"
+msgstr "[propiedad]=[valor], [propiedad]=[valor]"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs:163
 msgid "workspace.options.constraints"
 msgstr "Restricciones"


### PR DESCRIPTION
### Related Ticket

Taiga [#10764](https://tree.taiga.io/project/penpot/task/10764)

### Summary

Manage the case where the variant formula introduced in the layers panel is malformed. When this happens, the malformed formula is visible instead of the values of the properties, and a box explaining the error appears in the design tab. The message will be different depending on which object is selected: the whole component, or just one of its malformed variants.