### PR TITLE
:recycle: Factor index management out of app.worker.impl

### DIFF
--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -13,7 +13,7 @@
    [app.common.types.shape-tree :as ctst]
    [app.common.uuid :as uuid]
    [app.main.data.helpers :as dsh]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.util.time :as dt]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
@@ -53,7 +53,7 @@
         (->> (rx/from changes)
              (rx/merge-map (fn [[page-id changes]]
                              (log/debug :hint "update-indexes" :page-id page-id :changes (count changes))
-                             (uw/ask! {:cmd :update-page-index
+                             (mw/ask! {:cmd     :index/update-page-index
                                        :page-id page-id
                                        :changes changes})))
              (rx/catch (fn [cause]

--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -53,7 +53,7 @@
         (->> (rx/from changes)
              (rx/merge-map (fn [[page-id changes]]
                              (log/debug :hint "update-indexes" :page-id page-id :changes (count changes))
-                             (mw/ask! {:cmd     :index/update-page-index
+                             (mw/ask! {:cmd :index/update-page-index
                                        :page-id page-id
                                        :changes changes})))
              (rx/catch (fn [cause]

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -85,7 +85,7 @@
    [app.main.repo :as rp]
    [app.main.router :as rt]
    [app.main.streams :as ms]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.render-wasm :as wasm]
    [app.render-wasm.api :as api]
    [app.util.code-gen.style-css :as css]
@@ -165,7 +165,7 @@
                (rx/mapcat
                 (fn [[id page]]
                   (let [page (update page :objects ctst/start-page-index)]
-                    (->> (uw/ask! {:cmd :initialize-page-index :page page})
+                    (->> (mw/ask! {:cmd :index/initialize-page-index :page page})
                          (rx/map (fn [_] [id page]))))))
                (rx/reduce conj {})
                (rx/map (fn [pages-index]

--- a/frontend/src/app/worker.cljs
+++ b/frontend/src/app/worker.cljs
@@ -13,6 +13,7 @@
    [app.worker.export]
    [app.worker.impl :as impl]
    [app.worker.import]
+   [app.worker.index]
    [app.worker.messages :as wm]
    [app.worker.selection]
    [app.worker.snaps]

--- a/frontend/src/app/worker/impl.cljs
+++ b/frontend/src/app/worker/impl.cljs
@@ -5,18 +5,14 @@
 ;; Copyright (c) KALEIDOS INC
 
 (ns app.worker.impl
+  "Dispatcher for messages received from the main thread."
   (:require
-   [app.common.data.macros :as dm]
-   [app.common.files.changes :as ch]
    [app.common.logging :as log]
-   [app.config :as cf]
-   [okulary.core :as l]))
+   [app.config :as cf]))
 
 (log/set-level! :info)
 
 (enable-console-print!)
-
-(defonce state (l/atom {:pages-index {}}))
 
 ;; --- Handler
 
@@ -29,25 +25,6 @@
 (defmethod handler :echo
   [message]
   message)
-
-(defmethod handler :initialize-page-index
-  [{:keys [page] :as message}]
-  (swap! state update :pages-index assoc (:id page) page)
-  (handler (assoc message :cmd :selection/initialize-page-index))
-  (handler (assoc message :cmd :snaps/initialize-page-index)))
-
-(defmethod handler :update-page-index
-  [{:keys [page-id changes] :as message}]
-
-  (let [old-page (dm/get-in @state [:pages-index page-id])
-        new-page (-> state
-                     (swap! ch/process-changes changes false)
-                     (dm/get-in [:pages-index page-id]))
-        message (assoc message
-                       :old-page old-page
-                       :new-page new-page)]
-    (handler (assoc message :cmd :selection/update-page-index))
-    (handler (assoc message :cmd :snaps/update-page-index))))
 
 (defmethod handler :configure
   [{:keys [config]}]

--- a/frontend/src/app/worker/index.cljs
+++ b/frontend/src/app/worker/index.cljs
@@ -1,0 +1,35 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.worker.index
+  "Page index management within the worker."
+  (:require
+    [app.common.data.macros :as dm]
+    [app.common.files.changes :as ch]
+    [app.worker.impl :as impl]
+    [okulary.core :as l]))
+
+(defonce state (l/atom {:pages-index {}}))
+
+
+(defmethod impl/handler :index/initialize-page-index
+  [{:keys [page] :as message}]
+  (swap! state update :pages-index assoc (:id page) page)
+  (impl/handler (assoc message :cmd :selection/initialize-page-index))
+  (impl/handler (assoc message :cmd :snaps/initialize-page-index)))
+
+(defmethod impl/handler :index/update-page-index
+  [{:keys [page-id changes] :as message}]
+
+  (let [old-page (dm/get-in @state [:pages-index page-id])
+        new-page (-> state
+                     (swap! ch/process-changes changes false)
+                     (dm/get-in [:pages-index page-id]))
+        message (assoc message
+                  :old-page old-page
+                  :new-page new-page)]
+    (impl/handler (assoc message :cmd :selection/update-page-index))
+    (impl/handler (assoc message :cmd :snaps/update-page-index))))

--- a/frontend/src/app/worker/index.cljs
+++ b/frontend/src/app/worker/index.cljs
@@ -14,7 +14,6 @@
 
 (defonce state (l/atom {:pages-index {}}))
 
-
 (defmethod impl/handler :index/initialize-page-index
   [{:keys [page] :as message}]
   (swap! state update :pages-index assoc (:id page) page)

--- a/frontend/src/app/worker/index.cljs
+++ b/frontend/src/app/worker/index.cljs
@@ -7,10 +7,10 @@
 (ns app.worker.index
   "Page index management within the worker."
   (:require
-    [app.common.data.macros :as dm]
-    [app.common.files.changes :as ch]
-    [app.worker.impl :as impl]
-    [okulary.core :as l]))
+   [app.common.data.macros :as dm]
+   [app.common.files.changes :as ch]
+   [app.worker.impl :as impl]
+   [okulary.core :as l]))
 
 (defonce state (l/atom {:pages-index {}}))
 
@@ -28,7 +28,7 @@
                      (swap! ch/process-changes changes false)
                      (dm/get-in [:pages-index page-id]))
         message (assoc message
-                  :old-page old-page
-                  :new-page new-page)]
+                       :old-page old-page
+                       :new-page new-page)]
     (impl/handler (assoc message :cmd :selection/update-page-index))
     (impl/handler (assoc message :cmd :snaps/update-page-index))))


### PR DESCRIPTION
### Summary

This PR is a kind request for clarification, in the form of a somewhat pedantic refactor...

I'm trying to add functionality to the web worker and I'm trying to understand whether `defmethod impl/handler` is the way to go. If that is the case, then it seems to me that `app.worker.impl` contained code that should be in a separate file, as is the case with other message handlers like `app.worker.snaps`.

Hence, this PR:

* Creates `app.worker.index` and renames the messages it handles to `:index/initialize-page-index` and `:index/update-page-index`
* Does the proper find-and-replace in the codebase
* In passing: changes namespace alias `[app.main.worker :as uw]` to `[app.main.worker :as mw]` for consistency in the two files I had to touch. There are other places where the convention is violated. If this is not much of a PITA to review, I can do those too.

If this is not how one would go about adding new handlers, I'm fine with dropping the PR entirely. I'm just trying to find my bearings in the code.

(Sorry about the two cosmetic commits, my workflow isn't exactly polished yet)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] ~Include screenshots or videos, if applicable.~
- [ ] ~Add or modify existing integration tests in case of bugs or new features, if applicable.~
- [ ] Check CI passes successfully.
- [ ] ~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~
