### PR TITLE
:bug: Fix fills & strokes when dpr > 1

### DIFF
--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -100,14 +100,14 @@ pub fn render_debug_tiles_for_viewbox(
 
 // Renders the tiles in the viewbox
 pub fn render_debug_viewbox_tiles(render_state: &mut RenderState) {
+    let scale = render_state.get_scale();
     let canvas = render_state.surfaces.canvas(SurfaceId::Debug);
     let mut paint = skia::Paint::default();
     paint.set_style(skia::PaintStyle::Stroke);
     paint.set_color(skia::Color::from_rgb(255, 0, 127));
     paint.set_stroke_width(1.);
 
-    let tile_size = tiles::get_tile_size(render_state.viewbox);
-    let (sx, sy, ex, ey) = tiles::get_tiles_for_rect(render_state.viewbox.area, tile_size);
+    let (sx, sy, ex, ey) = tiles::get_tiles_for_viewbox(render_state.viewbox, scale);
     let str_rect = format!("{} {} {} {}", sx, sy, ex, ey);
 
     let debug_font = render_state.fonts.debug_font();
@@ -118,6 +118,7 @@ pub fn render_debug_viewbox_tiles(render_state: &mut RenderState) {
         &paint,
     );
 
+    let tile_size = tiles::get_tile_size(scale);
     for y in sy..=ey {
         for x in sx..=ex {
             let rect = Rect::from_xywh(
@@ -137,14 +138,15 @@ pub fn render_debug_viewbox_tiles(render_state: &mut RenderState) {
 }
 
 pub fn render_debug_tiles(render_state: &mut RenderState) {
+    let scale = render_state.get_scale();
     let canvas = render_state.surfaces.canvas(SurfaceId::Debug);
     let mut paint = skia::Paint::default();
     paint.set_style(skia::PaintStyle::Stroke);
     paint.set_color(skia::Color::from_rgb(127, 0, 255));
     paint.set_stroke_width(1.);
 
-    let tile_size = tiles::get_tile_size(render_state.viewbox);
-    let (sx, sy, ex, ey) = tiles::get_tiles_for_rect(render_state.viewbox.area, tile_size);
+    let (sx, sy, ex, ey) = tiles::get_tiles_for_viewbox(render_state.viewbox, scale);
+    let tile_size = tiles::get_tile_size(scale);
     for y in sy..=ey {
         for x in sx..=ex {
             let tile = (x, y);

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -1,5 +1,4 @@
 use crate::shapes::Shape;
-use crate::view::Viewbox;
 use skia_safe::{self as skia, IRect, Paint, RRect};
 
 use super::{gpu_state::GpuState, tiles::Tile, tiles::TILE_SIZE};
@@ -145,10 +144,10 @@ impl Surfaces {
         }
     }
 
-    pub fn update_render_context(&mut self, render_area: skia::Rect, viewbox: Viewbox) {
+    pub fn update_render_context(&mut self, render_area: skia::Rect, scale: f32) {
         let translation = (
-            -render_area.left() + self.margins.width as f32 / viewbox.zoom,
-            -render_area.top() + self.margins.height as f32 / viewbox.zoom,
+            -render_area.left() + self.margins.width as f32 / scale,
+            -render_area.top() + self.margins.height as f32 / scale,
         );
         self.apply_mut(
             &[

--- a/render-wasm/src/render/tiles.rs
+++ b/render-wasm/src/render/tiles.rs
@@ -28,34 +28,34 @@ pub fn get_tiles_for_rect(rect: skia::Rect, tile_size: f32) -> (i32, i32, i32, i
     (sx, sy, ex, ey)
 }
 
-pub fn get_tiles_for_viewbox(viewbox: Viewbox) -> (i32, i32, i32, i32) {
-    let tile_size = get_tile_size(viewbox);
+pub fn get_tiles_for_viewbox(viewbox: Viewbox, scale: f32) -> (i32, i32, i32, i32) {
+    let tile_size = get_tile_size(scale);
     get_tiles_for_rect(viewbox.area, tile_size)
 }
 
 pub fn get_tiles_for_viewbox_with_interest(
     viewbox: Viewbox,
     interest: i32,
+    dpr: f32,
 ) -> (i32, i32, i32, i32) {
-    let (sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox);
+    let (sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox, dpr);
     (sx - interest, sy - interest, ex + interest, ey + interest)
 }
 
-pub fn get_tile_pos(viewbox: Viewbox, (x, y): Tile) -> (f32, f32) {
+pub fn get_tile_pos((x, y): Tile, scale: f32) -> (f32, f32) {
     (
-        x as f32 * get_tile_size(viewbox),
-        y as f32 * get_tile_size(viewbox),
+        x as f32 * get_tile_size(scale),
+        y as f32 * get_tile_size(scale),
     )
 }
 
-pub fn get_tile_size(viewbox: Viewbox) -> f32 {
-    // TODO:  * self.options.dpr() too?
-    1. / viewbox.zoom * TILE_SIZE
+pub fn get_tile_size(scale: f32) -> f32 {
+    1. / scale * TILE_SIZE
 }
 
-pub fn get_tile_rect(viewbox: Viewbox, tile: Tile) -> skia::Rect {
-    let (tx, ty) = get_tile_pos(viewbox, tile);
-    let ts = get_tile_size(viewbox);
+pub fn get_tile_rect(tile: Tile, scale: f32) -> skia::Rect {
+    let (tx, ty) = get_tile_pos(tile, scale);
+    let ts = get_tile_size(scale);
     skia::Rect::from_xywh(tx, ty, ts, ts)
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11030

### Summary

This fixes our tile-based rendering not taking into account the device pixel ratio.

<img width="1282" alt="Screenshot 2025-05-15 at 11 03 35 AM" src="https://github.com/user-attachments/assets/2f14580f-1e72-4b01-a0a5-540304180212" />

### Steps to reproduce 

- Add the config flag `enable-render-wasm-dpr` to your `config.js`.
- Open a Penpot file in a device with a DPR > 1 (note: you can simulate this via the browser's zoom —_not_ Penpot's zoom).

Expected behavior:

- Shapes fills & strokes should be rendered properly.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

