### PR TITLE
:lipstick: Rename some namespace aliases for consistency

### DIFF
--- a/frontend/src/app/main.cljs
+++ b/frontend/src/app/main.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.css-cursors :as cur]
    [app.main.ui.delete-shared]
    [app.main.ui.routes :as rt]
-   [app.main.worker :as worker]
+   [app.main.worker :as mw]
    [app.plugins :as plugins]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n]
@@ -91,7 +91,7 @@
 
 (defn ^:export init
   []
-  (worker/init!)
+  (mw/init!)
   (i18n/init! cf/translations)
   (theme/init! cf/themes)
   (cur/init-styles)

--- a/frontend/src/app/main/data/workspace/drawing/common.cljs
+++ b/frontend/src/app/main/data/workspace/drawing/common.cljs
@@ -16,7 +16,7 @@
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace.shapes :as dwsh]
    [app.main.data.workspace.undo :as dwu]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -82,7 +82,7 @@
               (rx/of (dwsh/add-shape shape {:no-select? (= tool :curve)}))
               (if (cfh/frame-shape? shape)
                 (rx/concat
-                 (->> (uw/ask! {:cmd :selection/query
+                 (->> (mw/ask! {:cmd :selection/query
                                 :page-id page-id
                                 :rect (:selrect shape)
                                 :include-frames? true

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -29,7 +29,7 @@
    [app.main.refs :as refs]
    [app.main.router :as rt]
    [app.main.streams :as ms]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.util.mouse :as mse]
    [beicon.v2.core :as rx]
    [beicon.v2.operators :as rxo]
@@ -340,7 +340,7 @@
              selrect     (dm/get-in state [:workspace-local :selrect])
              blocked?    (fn [id] (dm/get-in objects [id :blocked] false))
 
-             ask-worker (if buffered? uw/ask-buffered! uw/ask!)]
+             ask-worker (if buffered? mw/ask-buffered! mw/ask!)]
 
          (if (some? selrect)
            (->> (ask-worker

--- a/frontend/src/app/main/snap.cljs
+++ b/frontend/src/app/main/snap.cljs
@@ -17,7 +17,7 @@
    [app.common.math :as mth]
    [app.common.uuid :refer [zero]]
    [app.main.refs :as refs]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.util.range-tree :as rt]
    [beicon.v2.core :as rx]
    [clojure.set :as set]))
@@ -84,7 +84,7 @@
   (let [value (get point coord)
         vbox @refs/vbox
         ranges [[(- value (/ 0.5 zoom)) (+ value (/ 0.5 zoom))]]]
-    (->> (uw/ask! {:cmd :snaps/range-query
+    (->> (mw/ask! {:cmd :snaps/range-query
                    :page-id page-id
                    :frame-id frame-id
                    :axis coord
@@ -101,7 +101,7 @@
                     (mapv #(vector (- % snap-accuracy)
                                    (+ % snap-accuracy))))
         vbox @refs/vbox]
-    (->> (uw/ask! {:cmd :snaps/range-query
+    (->> (mw/ask! {:cmd :snaps/range-query
                    :page-id page-id
                    :frame-id frame-id
                    :axis coord
@@ -217,7 +217,7 @@
 
 (defn select-shapes-area
   [page-id frame-id selected objects area]
-  (->> (uw/ask! {:cmd :selection/query
+  (->> (mw/ask! {:cmd :selection/query
                  :page-id page-id
                  :frame-id frame-id
                  :include-frames? true

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -32,7 +32,7 @@
    [app.main.ui.ds.product.loader :refer [loader*]]
    [app.main.ui.hooks :as h]
    [app.main.ui.icons :as i]
-   [app.main.worker :as wrk]
+   [app.main.worker :as mw]
    [app.util.color :as uc]
    [app.util.dom :as dom]
    [app.util.dom.dnd :as dnd]
@@ -56,9 +56,9 @@
 
 (defn render-thumbnail
   [file-id revn]
-  (->> (wrk/ask! {:cmd :thumbnails/generate-for-file
-                  :revn revn
-                  :file-id file-id})
+  (->> (mw/ask! {:cmd :thumbnails/generate-for-file
+                 :revn revn
+                 :file-id file-id})
        (rx/mapcat (fn [{:keys [fonts] :as result}]
                     (->> (fonts/render-font-styles fonts)
                          (rx/map (fn [styles]

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -20,7 +20,7 @@
    [app.main.ui.ds.product.loader :refer [loader*]]
    [app.main.ui.icons :as i]
    [app.main.ui.notifications.context-notification :refer [context-notification]]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [app.util.keyboard :as kbd]
@@ -162,7 +162,7 @@
 (defn- analyze-entries
   [state entries]
   (let [features (get @st/state :features)]
-    (->> (uw/ask-many!
+    (->> (mw/ask-many!
           {:cmd :analyze-import
            :files entries
            :features features})
@@ -178,7 +178,7 @@
                                         :num-files (count entries)}))
 
   (let [features (get @st/state :features)]
-    (->> (uw/ask-many!
+    (->> (mw/ask-many!
           {:cmd :import-files
            :project-id project-id
            :files entries

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -16,7 +16,7 @@
    [app.main.store :as st]
    [app.main.ui.ds.product.loader :refer [loader*]]
    [app.main.ui.icons :as i]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer  [tr]]
    [beicon.v2.core :as rx]
@@ -91,7 +91,7 @@
          (mf/deps team-id selected files features)
          (fn []
            (swap! state* assoc :status :exporting)
-           (->> (uw/ask-many!
+           (->> (mw/ask-many!
                  {:cmd :export-files
                   :format format
                   :team-id team-id

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -28,7 +28,7 @@
    [app.main.ui.workspace.shapes.frame.dynamic-modifiers :as sfd]
    [app.main.ui.workspace.viewport.actions :as actions]
    [app.main.ui.workspace.viewport.utils :as utils]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.util.debug :as dbg]
    [app.util.dom :as dom]
    [app.util.globals :as globals]
@@ -206,7 +206,7 @@
 
              (if (mf/ref-val hover-disabled-ref)
                (rx/of nil)
-               (->> (uw/ask-buffered!
+               (->> (mw/ask-buffered!
                      {:cmd :selection/query
                       :page-id page-id
                       :rect rect

--- a/frontend/src/app/main/worker.cljs
+++ b/frontend/src/app/main/worker.cljs
@@ -5,9 +5,10 @@
 ;; Copyright (c) KALEIDOS INC
 
 (ns app.main.worker
+  "Interface to communicate with the web worker"
   (:require
    [app.config :as cf]
-   [app.main.errors :as err]
+   [app.main.errors :as errors]
    [app.util.worker :as uw]
    [beicon.v2.core :as rx]))
 
@@ -15,7 +16,7 @@
 
 (defn init!
   []
-  (let [worker (uw/init cf/worker-uri err/on-error)]
+  (let [worker (uw/init cf/worker-uri errors/on-error)]
     (uw/ask! worker {:cmd :configure
                      :config {:public-uri cf/public-uri
                               :build-data cf/build-date

--- a/frontend/src/app/plugins/file.cljs
+++ b/frontend/src/app/plugins/file.cljs
@@ -15,7 +15,7 @@
    [app.main.data.workspace.versions :as dwv]
    [app.main.repo :as rp]
    [app.main.store :as st]
-   [app.main.worker :as uw]
+   [app.main.worker :as mw]
    [app.plugins.format :as format]
    [app.plugins.page :as page]
    [app.plugins.parser :as parser]
@@ -244,7 +244,7 @@
                                 (if (contains? cf/flags :export-file-v3)
                                   :binfile-v3
                                   :binfile-v1))]
-               (->> (uw/ask-many!
+               (->> (mw/ask-many!
                      {:cmd :export-files
                       :format format
                       :type type


### PR DESCRIPTION
### Summary

As mentioned in [this comment](https://github.com/penpot/penpot/pull/6477#issuecomment-2882882554) of #6477, this PR:

* fixes namespace aliasing inconsistencies for `app.main.worker` and `app.main.errors`.
* does not attempt to be exhaustive: other required ns might still use inconsistent aliases.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] ~Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.~
- [ ] ~Include screenshots or videos, if applicable.~
- [ ] ~Add or modify existing integration tests in case of bugs or new features, if applicable.~
- [x] Check CI passes successfully.
- [ ] ~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~
