### PR TITLE
:recycle: Refactor tile iteration

### DIFF
--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -1,5 +1,3 @@
-use skia_safe as skia;
-
 #[cfg(target_arch = "wasm32")]
 mod emscripten;
 mod math;
@@ -9,19 +7,21 @@ mod performance;
 mod render;
 mod shapes;
 mod state;
+mod tiles;
 mod utils;
 mod uuid;
 mod view;
 mod wapi;
 mod wasm;
 
-use crate::mem::SerializableResult;
-use crate::shapes::{BoolType, ConstraintH, ConstraintV, StructureEntry, TransformEntry, Type};
-use crate::utils::uuid_from_u32_quartet;
-use crate::uuid::Uuid;
 use indexmap::IndexSet;
 use math::{Bounds, Matrix};
+use mem::SerializableResult;
+use shapes::{BoolType, ConstraintH, ConstraintV, StructureEntry, TransformEntry, Type};
+use skia_safe as skia;
 use state::State;
+use utils::uuid_from_u32_quartet;
+use uuid::Uuid;
 
 pub(crate) static mut STATE: Option<Box<State>> = None;
 

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -75,13 +75,8 @@ pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, inter
         .draw_rect(rect, &paint);
 }
 
-pub fn render_debug_tiles_for_viewbox(
-    render_state: &mut RenderState,
-    sx: i32,
-    sy: i32,
-    ex: i32,
-    ey: i32,
-) {
+pub fn render_debug_tiles_for_viewbox(render_state: &mut RenderState) {
+    let tiles::TileRect(sx, sy, ex, ey) = render_state.tile_viewbox.interest_rect;
     let canvas = render_state.surfaces.canvas(SurfaceId::Debug);
     let mut paint = skia::Paint::default();
     paint.set_style(skia::PaintStyle::Stroke);
@@ -102,7 +97,9 @@ pub fn render_debug_viewbox_tiles(render_state: &mut RenderState) {
     paint.set_color(skia::Color::from_rgb(255, 0, 127));
     paint.set_stroke_width(1.);
 
-    let (sx, sy, ex, ey) = tiles::get_tiles_for_viewbox(render_state.viewbox, scale);
+    let tile_size = tiles::get_tile_size(scale);
+    let tiles::TileRect(sx, sy, ex, ey) =
+        tiles::get_tiles_for_rect(render_state.viewbox.area, tile_size);
     let str_rect = format!("{} {} {} {}", sx, sy, ex, ey);
 
     let debug_font = render_state.fonts.debug_font();
@@ -135,11 +132,12 @@ pub fn render_debug_tiles(render_state: &mut RenderState) {
     paint.set_color(skia::Color::from_rgb(127, 0, 255));
     paint.set_stroke_width(1.);
 
-    let (sx, sy, ex, ey) = tiles::get_tiles_for_viewbox(render_state.viewbox, scale);
     let tile_size = tiles::get_tile_size(scale);
+    let tiles::TileRect(sx, sy, ex, ey) =
+        tiles::get_tiles_for_rect(render_state.viewbox.area, tile_size);
     for y in sy..=ey {
         for x in sx..=ex {
-            let tile = (x, y);
+            let tile = tiles::Tile(x, y);
             let shape_count = render_state.tiles.get_shapes_at(tile).iter().len();
             if shape_count == 0 {
                 continue;

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -5,6 +5,7 @@ use skia_safe as skia;
 use crate::render::RenderState;
 use crate::shapes::Shape;
 use crate::shapes::StructureEntry;
+use crate::tiles;
 use crate::uuid::Uuid;
 
 /// A pool allocator for `Shape` objects that attempts to minimize memory reallocations.
@@ -129,10 +130,10 @@ impl<'a> State<'a> {
     pub fn delete_shape(&mut self, id: Uuid) {
         // We don't really do a self.shapes.remove so that redo/undo keep working
         if let Some(shape) = self.shapes.get(&id) {
-            let (rsx, rsy, rex, rey) = self.render_state.get_tiles_for_shape(shape);
+            let tiles::TileRect(rsx, rsy, rex, rey) = self.render_state.get_tiles_for_shape(shape);
             for x in rsx..=rex {
                 for y in rsy..=rey {
-                    let tile = (x, y);
+                    let tile = tiles::Tile(x, y);
                     self.render_state.surfaces.remove_cached_tile_surface(tile);
                     self.render_state.tiles.remove_shape_at(tile, id);
                 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11059

### Summary

- Replace tuple alias types with tuple struct types.
- Pass arguments by reference instead of by value.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
