### PR TITLE
:sparkles: Shift+ctrl+drag to deselect

### DIFF
--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -54,13 +54,17 @@
       (assoc-in state [:workspace-local :selrect] selrect))))
 
 (defn handle-area-selection
-  [preserve? remove?]
+  [append? remove? ignore-groups?]
   (ptk/reify ::handle-area-selection
     ptk/WatchEvent
     (watch [_ state stream]
       (let [zoom          (dm/get-in state [:workspace-local :zoom] 1)
             stopper       (mse/drag-stopper stream)
             init-position @ms/mouse-position
+
+            initial-set   (if (or append? remove?)
+                            (dsh/lookup-selected state)
+                            lks/empty-linked-set)
 
             init-selrect  (grc/make-rect
                            (dm/get-prop init-position :x)
@@ -91,7 +95,7 @@
                  (rx/take-until stopper))]
 
         (rx/concat
-         (if preserve?
+         (if (or append? remove?)
            (rx/empty)
            (rx/of (deselect-all)))
 
@@ -103,22 +107,14 @@
                (rx/buffer-time 100)
                (rx/map last)
                (rx/pipe (rxo/distinct-contiguous))
-               ; Why are we reading from the keyboard stream again instead of
-               ; using args from the caller, where preserve? is set from ms/keyboard-shift?
-               (rx/with-latest-from ms/keyboard-shift ms/keyboard-mod)
-               (rx/map
-                (fn [[_ shift? mod?]]
-                  (select-shapes-by-current-selrect shift? mod? remove?))))
+               (rx/map #(select-shapes-by-current-selrect initial-set remove? ignore-groups?)))
 
           ;; The last "tick" from the mouse cannot be buffered so we are sure
           ;; a selection is returned. Without this we can have empty selections on
           ;; very fast movement
           (->> selrect-stream
                (rx/last)
-               (rx/with-latest-from ms/keyboard-shift ms/keyboard-mod)
-               (rx/map
-                (fn [[_ shift? mod?]]
-                  (select-shapes-by-current-selrect shift? mod? remove? false)))))
+               (rx/map #(select-shapes-by-current-selrect initial-set remove? ignore-groups? false))))
 
          (->> (rx/of (update-selrect nil))
               ;; We need the async so the current event finishes before updating the selrect
@@ -327,21 +323,19 @@
 ;; --- Select Shapes (By selrect)
 
 (defn select-shapes-by-current-selrect
-  ([preserve? ignore-groups? remove?]
-   (select-shapes-by-current-selrect preserve? ignore-groups? remove? true))
+  "Sends the current selection rectangle to the worker to compute the selection,
+  and sends its result to select-shapes for storage in the state."
+  ([initial-set remove? ignore-groups?]
+   (select-shapes-by-current-selrect initial-set remove? ignore-groups? true))
 
-  ([preserve? ignore-groups? remove? buffered?]
+  ([initial-set remove? ignore-groups? buffered?]
    (ptk/reify ::select-shapes-by-current-selrect
      ptk/WatchEvent
      (watch [_ state _]
-       (let [page-id     (:current-page-id state)
-             objects     (dsh/lookup-page-objects state)
-             selected    (dsh/lookup-selected state)
-             initial-set (if preserve?
-                           selected
-                           lks/empty-linked-set)
-             selrect     (dm/get-in state [:workspace-local :selrect])
-             blocked?    (fn [id] (dm/get-in objects [id :blocked] false))
+       (let [page-id (:current-page-id state)
+             objects (dsh/lookup-page-objects state)
+             selrect (dm/get-in state [:workspace-local :selrect])
+             blocked? (fn [id] (dm/get-in objects [id :blocked] false))
              ask-worker (if buffered? mw/ask-buffered! mw/ask!)
              filter-objs (comp
                           (filter (complement blocked?))

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -102,14 +102,14 @@
                    node-editing?
                    ;; Handle path node area selection
                    (when-not read-only?
-                     (st/emit! (dwdp/handle-area-selection shift?)))
+                     (st/emit! (dwdp/handle-area-selection shift? (and shift? mod?))))
 
                    drawing-tool
                    (when-not read-only?
                      (st/emit! (dd/start-drawing drawing-tool)))
 
                    (or (not id) mod?)
-                   (st/emit! (dw/handle-area-selection shift?))
+                   (st/emit! (dw/handle-area-selection shift? (and shift? mod?)))
 
                    (not drawing-tool)
                    (when-not read-only?

--- a/frontend/src/app/main/ui/workspace/viewport/actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/actions.cljs
@@ -109,7 +109,7 @@
                      (st/emit! (dd/start-drawing drawing-tool)))
 
                    (or (not id) mod?)
-                   (st/emit! (dw/handle-area-selection shift? (and shift? mod?)))
+                   (st/emit! (dw/handle-area-selection shift? (and shift? mod?) mod?))
 
                    (not drawing-tool)
                    (when-not read-only?


### PR DESCRIPTION
### Summary

**Note** If this PR is too big, I'm happy to split it into two. For instance one for layers another one for path nodes. But I thought the changes made sense together.

---

A proposal to

- Close #2509 

This PR:

- Allows removing shapes (nodes when in path mode) from the selection by holding Ctrl+Shift while dragging the mouse (using Alt conflicted with measurements. Is there a better choice?).
- Allows "backtracking" when adding or removing shapes: currently, Shift+drag behaves differently from just dragging because newly selected objects are immediately appended to the selection. This PR remembers the initial state, providing what I believe to be nicer visual feedback.
- Implements incremental highlighting of path nodes during selection. Currently there is no visual feedback on what nodes will make it into the selection.
- Pre-fetches previous selected shapes / points at the beginning of each selection event, instead of on every rect update
- Uses `dm/get-in` instead of stock `get-in` at a couple places
 
This is what the backtracking looks like in action (for some reason the screen recorder didn't capture the mouse pointer):

#### Appending shapes (Shift + drag)

[selection-append.webm](https://github.com/user-attachments/assets/685c1bce-50f4-4989-9830-227de0ed6e1c)


#### Removing shapes (Ctrl+Shift + drag)

[selection-removal.webm](https://github.com/user-attachments/assets/46b84b53-2e40-4bf0-a394-06f6d4ba6084)

#### Adding nodes (Shift + drag)

[node-selection-append.webm](https://github.com/user-attachments/assets/2443cc02-c95c-4ed2-a09e-85b089be8a86)

#### Removing nodes (Ctrl+Shift + drag)

[node-selection-removal.webm](https://github.com/user-attachments/assets/0b77534a-8bfc-41d6-932c-78f1447df15b)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
