### PR TITLE
:bug: Prevent unkown tokens hint always showing

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -844,7 +844,7 @@
              (if (and (not (some? token-type)) (some? token-type-str))
                (assoc unknown-tokens child-path token-type-str)
                unknown-tokens)))))
-     {}
+     nil
      tokens)))
 
 (defn flatten-nested-tokens-json


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/3

### Summary

The hint would always be shown even when trying to import data with no unknown tokens, because of the `(when unknown-tokens` check for an emty map `{}`.
We now return `nil` when no unkown tokens are found.

[tokens-test-import-message.json](https://github.com/user-attachments/files/20328026/tokens-test-import-message.json)


### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
