### PR TITLE
:lipstick: Add styles for Inkeep Chat at workspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,7 @@ A non exhaustive list of changes:
 - Create `input*` wrapper component, and `label*`, `input-field*` and `hint-message*` components [Taiga #10713](https://tree.taiga.io/project/penpot/us/10713)
 - Deselect layers (and path nodes) with Ctrl+Shift+Drag [Github #2509](https://github.com/penpot/penpot/issues/2509)
 - Copy to SVG from contextual menu [Github #838](https://github.com/penpot/penpot/issues/838)
+- Add styles for Inkeep Chat at workspace [Taiga #10708](https://tree.taiga.io/project/penpot/us/10708)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace/palette.cljs
+++ b/frontend/src/app/main/ui/workspace/palette.cljs
@@ -147,6 +147,7 @@
         (swap! state* assoc :width width)))
 
     [:div {:class (stl/css :palette-wrapper)
+           :id "palette-wrapper"
            :style  (calculate-palette-padding rulers?)
            :data-testid "palette"}
      (when-not workspace-read-only?

--- a/frontend/src/app/main/ui/workspace/palette.scss
+++ b/frontend/src/app/main/ui/workspace/palette.scss
@@ -4,6 +4,10 @@
 //
 // Copyright (c) KALEIDOS INC
 
+@use "../ds/spacing.scss" as *;
+@use "../ds/z-index.scss" as *;
+@use "../ds/_sizes.scss" as *;
+
 @import "refactor/common-refactor.scss";
 
 .palette-wrapper {
@@ -17,7 +21,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: $s-8;
+  gap: var(--sp-s);
 }
 
 .palettes {
@@ -173,25 +177,24 @@
 
 /** AI Chat button styles **/
 .help-btn {
-  z-index: $z-index-2;
+  z-index: var(--z-index-panels);
   flex-shrink: 0;
-  position: relative;
-  overflow: hidden;
   @extend .button-secondary;
-  height: $s-40;
-  width: $s-40;
+  inline-size: $sz-40;
+  block-size: $sz-40;
   border-radius: $br-circle;
-  border: none !important;
-  svg {
-    @extend .button-icon;
-    position: absolute;
-    top: $s-8;
-    left: $s-8;
-    stroke: var(--icon-foreground);
-    height: $s-24;
-    width: $s-24;
-  }
+  border: none;
   &.selected {
     @extend .button-icon-selected;
   }
+  &:hover {
+    border: none;
+  }
+}
+
+.icon-help {
+  @extend .button-icon;
+  stroke: var(--icon-foreground);
+  inline-size: var(--sp-xxl);
+  block-size: var(--sp-xxl);
 }

--- a/frontend/src/app/main/ui/workspace/palette.scss
+++ b/frontend/src/app/main/ui/workspace/palette.scss
@@ -12,6 +12,12 @@
   left: 0;
   bottom: 0;
   padding-bottom: $s-4;
+
+  /** Aligns AI Chat button **/
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $s-8;
 }
 
 .palettes {
@@ -162,5 +168,30 @@
   }
   .handler {
     padding-bottom: $s-8;
+  }
+}
+
+/** AI Chat button styles **/
+.help-btn {
+  z-index: $z-index-2;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+  @extend .button-secondary;
+  height: $s-40;
+  width: $s-40;
+  border-radius: $br-circle;
+  border: none !important;
+  svg {
+    @extend .button-icon;
+    position: absolute;
+    top: $s-8;
+    left: $s-8;
+    stroke: var(--icon-foreground);
+    height: $s-24;
+    width: $s-24;
+  }
+  &.selected {
+    @extend .button-icon-selected;
   }
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/10708

### Summary

Adds the styles for the AI Chat button at workspace. This button will be managed through GTM and added only when necessary.

The button can only be shown when the user has accepted the cookies.

### Steps to reproduce

- Open any file.
- Load the script to emulate GTM functionality. You may also need to manually add the consent cookie to your local penpot.
- Verify that the AI button is functioning correctly and matches Penpot's theme.

_Note that an adblocker can interfere with the button script._


https://github.com/user-attachments/assets/077c09e3-a1d1-4b1f-a6aa-fb8e81129e6c


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- ~~[ ] Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.