### PR TITLE
:zap: Avoid double id lookup when calling lookup-page-objects

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -395,7 +395,7 @@
      (watch [it state _]
        (let [file-id  (:current-file-id state)
              page-id  (:current-page-id state)
-             objects  (dsh/lookup-page-objects state page-id)
+             objects  (dsh/lookup-page-objects state file-id page-id)
              shapes   (dwg/shapes-for-grouping objects selected)
              parents  (into #{} (map :parent-id) shapes)]
          (when-not (empty? shapes)

--- a/frontend/src/app/main/data/workspace/path/changes.cljs
+++ b/frontend/src/app/main/data/workspace/path/changes.cljs
@@ -6,6 +6,7 @@
 
 (ns app.main.data.workspace.path.changes
   (:require
+   [app.common.data.macros :as dm]
    [app.common.files.changes-builder :as pcb]
    [app.common.types.path :as path]
    [app.main.data.changes :as dch]
@@ -74,10 +75,10 @@
 
      ptk/WatchEvent
      (watch [it state _]
-       (let [objects     (dsh/lookup-page-objects state)
-             page-id     (:current-page-id state)
-             id          (get-in state [:workspace-local :edition])
-             old-content (get-in state [:workspace-local :edit-path id :old-content])
+       (let [page-id     (:current-page-id state)
+             objects     (dsh/lookup-page-objects state page-id)
+             id          (dm/get-in state [:workspace-local :edition])
+             old-content (dm/get-in state [:workspace-local :edit-path id :old-content])
              shape       (st/get-path state)]
 
          (if (and (some? old-content) (some? (:id shape)))

--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -332,11 +332,11 @@
    (ptk/reify ::select-shapes-by-current-selrect
      ptk/WatchEvent
      (watch [_ state _]
-       (let [page-id (:current-page-id state)
-             objects (dsh/lookup-page-objects state)
-             selrect (dm/get-in state [:workspace-local :selrect])
-             blocked? (fn [id] (dm/get-in objects [id :blocked] false))
-             ask-worker (if buffered? mw/ask-buffered! mw/ask!)
+       (let [page-id     (:current-page-id state)
+             objects     (dsh/lookup-page-objects state page-id)
+             selrect     (dm/get-in state [:workspace-local :selrect])
+             blocked?    (fn [id] (dm/get-in objects [id :blocked] false))
+             ask-worker  (if buffered? mw/ask-buffered! mw/ask!)
              filter-objs (comp
                           (filter (complement blocked?))
                           (remove (partial cfh/hidden-parent? objects)))]


### PR DESCRIPTION
### Summary

As suggested by @niwinz in https://github.com/penpot/penpot/pull/6494#discussion_r2097957420, this PR:

* Passes already available page-id and file-id to `dsh/lookup-page-objects`
* Does this across the whole code base wherever the lookups were already there.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
