### PR TITLE
:globe_with_meridians: I18n/error messages

### DIFF
--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -154,7 +154,7 @@
 (defmethod ptk/handle-error :assertion
   [error]
   (ts/schedule
-   #(st/emit! (ntf/show {:content "Internal Assertion Error"
+   #(st/emit! (ntf/show {:content (tr "errors.internal-assertion-error")
                          :type :toast
                          :level :error
                          :timeout 3000})))
@@ -170,7 +170,7 @@
   [error]
   (ts/schedule
    #(st/emit!
-     (ntf/show {:content "Something wrong has happened (on worker)."
+     (ntf/show {:content (tr "errors.internal-worker-error")
                 :type :toast
                 :level :error
                 :timeout 3000})))
@@ -180,11 +180,10 @@
                   (print-data! error))))
 
 ;; Error on parsing an SVG
-;; TODO: looks unused and deprecated
 (defmethod ptk/handle-error :svg-parser
   [_]
   (ts/schedule
-   #(st/emit! (ntf/show {:content "SVG is invalid or malformed"
+   #(st/emit! (ntf/show {:content (tr "errors.svg-parser.invalid-svg")
                          :type :toast
                          :level :error
                          :timeout 3000}))))
@@ -193,7 +192,7 @@
 (defmethod ptk/handle-error :comment-error
   [_]
   (ts/schedule
-   #(st/emit! (ntf/show {:content "There was an error with the comment"
+   #(st/emit! (ntf/show {:content (tr "errors.comment-error")
                          :type :toast
                          :level :error
                          :timeout 3000}))))

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -1180,6 +1180,18 @@ msgstr "Die E-Mail-Adresse «%s» hat viele permanente Unzustellbarkeitsberichte
 msgid "errors.email-spam-or-permanent-bounces"
 msgstr "Die E-Mail \"%s\" wurde als Spam oder dauerhaft abgelehnt gemeldet."
 
+msgid "errors.internal-assertion-error"
+msgstr "Interner Assertionsfehler"
+
+msgid "errors.internal-worker-error"
+msgstr "Mit dem Web Worker ist ein Fehler aufgetreten."
+
+msgid "errors.svg-parser.invalid-svg"
+msgstr "SVG ist ungültig oder fehlerhaft"
+
+msgid "errors.comment-error"
+msgstr "Beim Kommentar ist ein Fehler aufgetreten"
+
 #: src/app/main/errors.cljs:242
 msgid "errors.feature-mismatch"
 msgstr ""

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1240,6 +1240,18 @@ msgstr "The email «%s» has many permanent bounce reports."
 msgid "errors.email-spam-or-permanent-bounces"
 msgstr "The email «%s» has been reported as spam or permanently bounce."
 
+msgid "errors.internal-assertion-error"
+msgstr "Internal Assertion Error"
+
+msgid "errors.internal-worker-error"
+msgstr "Something wrong has happened with the web worker."
+
+msgid "errors.svg-parser.invalid-svg"
+msgstr "SVG is invalid or malformed"
+
+msgid "errors.comment-error"
+msgstr "There was an error with the comment"
+
 #: src/app/main/errors.cljs:242
 msgid "errors.feature-mismatch"
 msgstr ""

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1248,6 +1248,18 @@ msgstr "El correo electrónico «%s» tiene varios reportes de rebote permanente
 msgid "errors.email-spam-or-permanent-bounces"
 msgstr "El email «%s» tiene reportes de spam o de rebote permanente."
 
+msgid "errors.internal-assertion-error"
+msgstr "Error interno de aserción"
+
+msgid "errors.internal-worker-error"
+msgstr "Ha ocurrido un problema con el web worker."
+
+msgid "errors.svg-parser.invalid-svg"
+msgstr "El SVG no es válido o está mal formado"
+
+msgid "errors.comment-error"
+msgstr "Ha habido un error con el comentario"
+
 #: src/app/main/errors.cljs:242
 msgid "errors.feature-mismatch"
 msgstr ""

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -1004,6 +1004,18 @@ msgstr "L'adresse e-mail « %s » a un taux de rebond trop élevé."
 msgid "errors.email-spam-or-permanent-bounces"
 msgstr "L'e-mail \"%s\" a été signalé comme spam ou a été rejeté."
 
+msgid "errors.internal-assertion-error"
+msgstr "Erreur d'assertion interne"
+
+msgid "errors.internal-worker-error"
+msgstr "Un problème est survenu avec le web worker."
+
+msgid "errors.svg-parser.invalid-svg"
+msgstr "Le SVG est invalide ou mal formé"
+
+msgid "errors.comment-error"
+msgstr "Une erreur s'est produite avec le commentaire"
+
 #: src/app/main/errors.cljs:242
 msgid "errors.feature-mismatch"
 msgstr ""


### PR DESCRIPTION
### Summary

This PR:

* Adds some raw strings to the translation set in `en.po`
* Adds translations to Spanish, French and German

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.