### PR TITLE
:wrench: WIP text to path

### DIFF
--- a/frontend/resources/wasm-playground/js/texts.js
+++ b/frontend/resources/wasm-playground/js/texts.js
@@ -1,0 +1,1 @@
+// Placeholder for text-specific logic if needed in the future.

--- a/frontend/resources/wasm-playground/texts.html
+++ b/frontend/resources/wasm-playground/texts.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>WASM + WebGL2 Texts</title>
+  <style>
+    body {
+      margin: 0;
+      background: #111;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      overflow: hidden;
+    }
+    canvas {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="canvas"></canvas>
+  <script type="module">
+    import initWasmModule from '/js/render_wasm.js';
+    import {
+      init, assignCanvas, setupInteraction, useShape, setShapeChildren, addTextShape, hexToU32ARGB,getRandomInt, getRandomColor, getRandomFloat, addShapeSolidFill, addShapeSolidStroleFill
+    } from './js/lib.js';
+
+    const canvas = document.getElementById("canvas");
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    const MIN_LINES = 1;
+    const MAX_LINES = 5;
+    const MIN_WORDS = 1;
+    const MAX_WORDS = 10;
+
+    const params = new URLSearchParams(document.location.search);
+    const texts = params.get("texts") || 100;
+
+    function getRandomText() {
+      const words = ["Hello", "World", "Penpot", "Canvas", "Text", "Shape", "Random", "Line"];
+      const lines = Math.floor(Math.random() * MAX_LINES) + MIN_LINES;
+      let text = "";
+      for (let i = 0; i < lines; i++) {
+        const lineLength = Math.floor(Math.random() * MAX_WORDS) + MIN_WORDS;
+        const line = Array.from({ length: lineLength }, () => words[Math.floor(Math.random() * words.length)]).join(" ");
+        text += line;
+        if (i < lines - 1) text += "\n";
+      }
+      return text;
+    }
+
+    initWasmModule().then(Module => {
+      init(Module);
+      assignCanvas(canvas);
+      Module._set_canvas_background(hexToU32ARGB("#FABADA", 1));
+      Module._set_view(1, 0, 0);
+      Module._init_shapes_pool(texts + 1);
+      setupInteraction(canvas);
+
+      const children = [];
+      for (let i = 0; i < texts; i++) {
+        const uuid = crypto.randomUUID();
+        children.push(uuid);
+
+        useShape(uuid);
+        Module._set_parent(0, 0, 0, 0);
+        Module._set_shape_type(5);
+
+        const x1 = getRandomInt(0, canvas.width);
+        const y1 = getRandomInt(0, canvas.height);
+        const width = getRandomInt(20, 500);
+        const height = getRandomInt(20, 100);
+        Module._set_shape_selrect(x1, y1, x1 + width, y1 + height);
+
+        const fontSize = Math.random() * 50 + 10;
+        const text = getRandomText();
+        addTextShape(x1, y1, fontSize, text);
+      }
+
+      useShape("00000000-0000-0000-0000-000000000000");
+      setShapeChildren(children);
+
+      performance.mark('render:begin');
+      Module._render(Date.now());
+      performance.mark('render:end');
+      const { duration } = performance.measure('render', 'render:begin', 'render:end');
+      console.log(`Render time: ${duration.toFixed(2)}ms`);
+    });
+  </script>
+</body>
+</html>

--- a/render-wasm/Cargo.lock
+++ b/render-wasm/Cargo.lock
@@ -373,6 +373,8 @@ dependencies = [
  "gl",
  "indexmap",
  "skia-safe",
+ "unic-emoji-char",
+ "unicode-segmentation",
  "uuid",
 ]
 
@@ -546,10 +548,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-emoji-char"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "uuid"

--- a/render-wasm/Cargo.toml
+++ b/render-wasm/Cargo.toml
@@ -26,6 +26,8 @@ skia-safe = { version = "0.81.0", default-features = false, features = [
   "textlayout",
   "binary-cache",
 ] }
+unic-emoji-char = "0.9.0"
+unicode-segmentation = "1.12.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 
 [profile.release]

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -417,27 +417,27 @@ impl RenderState {
 
             Type::Text(text_content) => {
                 self.surfaces
-                    .apply_mut(&[SurfaceId::Fills, SurfaceId::Strokes], |s| {
+                    .apply_mut(&[SurfaceId::Fills, SurfaceId::Strokes, SurfaceId::InnerShadows, SurfaceId::DropShadows], |s| {
                         s.canvas().concat(&matrix);
                     });
 
                 let text_content = text_content.new_bounds(shape.selrect());
-                let paths = text_content.get_paths(antialias);
+                let blobs = text_content.get_text_blobs(antialias);
 
-                shadows::render_text_drop_shadows(self, &shape, &paths, antialias);
-                text::render(self, &paths, None, None);
+                shadows::render_text_drop_shadows(self, &shape, &blobs, antialias);
+                text::render(self, &blobs, None, None);
 
                 for stroke in shape.strokes().rev() {
                     shadows::render_text_stroke_drop_shadows(
-                        self, &shape, &paths, stroke, antialias,
+                        self, &shape, &blobs, stroke, antialias,
                     );
-                    strokes::render_text_paths(self, &shape, stroke, &paths, None, None, antialias);
+                    strokes::render_text_blobs(self, &shape, stroke, &blobs, None, None, antialias);
                     shadows::render_text_stroke_inner_shadows(
-                        self, &shape, &paths, stroke, antialias,
+                        self, &shape, &blobs, stroke, antialias,
                     );
                 }
 
-                shadows::render_text_inner_shadows(self, &shape, &paths, antialias);
+                shadows::render_text_inner_shadows(self, &shape, &blobs, antialias);
             }
             _ => {
                 self.surfaces.apply_mut(

--- a/render-wasm/src/render/fonts.rs
+++ b/render-wasm/src/render/fonts.rs
@@ -87,16 +87,6 @@ impl FontStore {
         let serialized = format!("{}", family);
         self.font_provider.family_names().any(|x| x == serialized)
     }
-
-    pub fn get_emoji_font(&self, size: f32) -> Option<Font> {
-        if let Some(typeface) = self
-            .font_provider
-            .match_family_style(DEFAULT_EMOJI_FONT, skia::FontStyle::default())
-        {
-            return Some(Font::from_typeface(typeface, size));
-        }
-        None
-    }
 }
 
 fn load_default_provider(font_mgr: &FontMgr) -> skia::textlayout::TypefaceFontProvider {

--- a/render-wasm/src/render/fonts.rs
+++ b/render-wasm/src/render/fonts.rs
@@ -87,6 +87,16 @@ impl FontStore {
         let serialized = format!("{}", family);
         self.font_provider.family_names().any(|x| x == serialized)
     }
+
+    pub fn get_emoji_font(&self, size: f32) -> Option<Font> {
+        if let Some(typeface) = self
+            .font_provider
+            .match_family_style(DEFAULT_EMOJI_FONT, skia::FontStyle::default())
+        {
+            return Some(Font::from_typeface(typeface, size));
+        }
+        None
+    }
 }
 
 fn load_default_provider(font_mgr: &FontMgr) -> skia::textlayout::TypefaceFontProvider {

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -2,7 +2,7 @@ use super::{RenderState, SurfaceId};
 use crate::render::strokes;
 use crate::render::text::{self};
 use crate::shapes::{Shadow, Shape, Stroke, Type};
-use skia_safe::{Paint, Path};
+use skia_safe::{self as skia, Paint};
 
 // Fill Shadows
 pub fn render_fill_drop_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
@@ -86,24 +86,24 @@ pub fn render_stroke_inner_shadows(
 pub fn render_text_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paths: &Vec<(Path, Paint)>,
+    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     antialias: bool,
 ) {
     for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_drop_shadow(render_state, shadow, paths, antialias);
+        render_text_drop_shadow(render_state, shadow, blobs, antialias);
     }
 }
 
 pub fn render_text_drop_shadow(
     render_state: &mut RenderState,
     shadow: &Shadow,
-    paths: &Vec<(Path, Paint)>,
+    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     antialias: bool,
 ) {
     let paint = shadow.get_drop_shadow_paint(antialias);
     text::render(
         render_state,
-        paths,
+        blobs,
         Some(SurfaceId::DropShadows),
         Some(paint),
     );
@@ -112,17 +112,17 @@ pub fn render_text_drop_shadow(
 pub fn render_text_stroke_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paths: &Vec<(Path, Paint)>,
+    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     stroke: &Stroke,
     antialias: bool,
 ) {
     for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
         let stroke_shadow = shadow.get_drop_shadow_filter();
-        strokes::render_text_paths(
+        strokes::render_text_blobs(
             render_state,
             shape,
             stroke,
-            paths,
+            blobs,
             Some(SurfaceId::DropShadows),
             stroke_shadow.as_ref(),
             antialias,
@@ -133,28 +133,28 @@ pub fn render_text_stroke_drop_shadows(
 pub fn render_text_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paths: &Vec<(Path, Paint)>,
+    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     antialias: bool,
 ) {
     for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_inner_shadow(render_state, shadow, paths, antialias);
+        render_text_inner_shadow(render_state, shadow, blobs, antialias);
     }
 }
 
 pub fn render_text_stroke_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paths: &Vec<(Path, Paint)>,
+    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     stroke: &Stroke,
     antialias: bool,
 ) {
     for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
         let stroke_shadow = shadow.get_inner_shadow_filter();
-        strokes::render_text_paths(
+        strokes::render_text_blobs(
             render_state,
             shape,
             stroke,
-            paths,
+            blobs,
             Some(SurfaceId::InnerShadows),
             stroke_shadow.as_ref(),
             antialias,
@@ -165,13 +165,13 @@ pub fn render_text_stroke_inner_shadows(
 pub fn render_text_inner_shadow(
     render_state: &mut RenderState,
     shadow: &Shadow,
-    paths: &Vec<(Path, Paint)>,
+    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     antialias: bool,
 ) {
     let paint = shadow.get_inner_shadow_paint(antialias);
     text::render(
         render_state,
-        paths,
+        blobs,
         Some(SurfaceId::InnerShadows),
         Some(paint),
     );

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -2,7 +2,7 @@ use super::{RenderState, SurfaceId};
 use crate::render::strokes;
 use crate::render::text::{self};
 use crate::shapes::{Shadow, Shape, Stroke, Type};
-use skia_safe::{textlayout::Paragraph, Paint};
+use skia_safe::{Paint, Path};
 
 // Fill Shadows
 pub fn render_fill_drop_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
@@ -86,56 +86,92 @@ pub fn render_stroke_inner_shadows(
 pub fn render_text_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paragraphs: &[Vec<Paragraph>],
+    paths: &Vec<(Path, Paint)>,
     antialias: bool,
 ) {
     for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_drop_shadow(render_state, shape, shadow, paragraphs, antialias);
+        render_text_drop_shadow(render_state, shadow, paths, antialias);
     }
 }
 
 pub fn render_text_drop_shadow(
     render_state: &mut RenderState,
-    shape: &Shape,
     shadow: &Shadow,
-    paragraphs: &[Vec<Paragraph>],
+    paths: &Vec<(Path, Paint)>,
     antialias: bool,
 ) {
     let paint = shadow.get_drop_shadow_paint(antialias);
-
     text::render(
         render_state,
-        shape,
-        paragraphs,
+        paths,
         Some(SurfaceId::DropShadows),
         Some(paint),
     );
 }
 
+pub fn render_text_stroke_drop_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paths: &Vec<(Path, Paint)>,
+    stroke: &Stroke,
+    antialias: bool,
+) {
+    for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+        let stroke_shadow = shadow.get_drop_shadow_filter();
+        strokes::render_text_paths(
+            render_state,
+            shape,
+            stroke,
+            paths,
+            Some(SurfaceId::DropShadows),
+            stroke_shadow.as_ref(),
+            antialias,
+        );
+    }
+}
+
 pub fn render_text_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    paragraphs: &[Vec<Paragraph>],
+    paths: &Vec<(Path, Paint)>,
     antialias: bool,
 ) {
     for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_inner_shadow(render_state, shape, shadow, paragraphs, antialias);
+        render_text_inner_shadow(render_state, shadow, paths, antialias);
+    }
+}
+
+pub fn render_text_stroke_inner_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paths: &Vec<(Path, Paint)>,
+    stroke: &Stroke,
+    antialias: bool,
+) {
+    for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+        let stroke_shadow = shadow.get_inner_shadow_filter();
+        strokes::render_text_paths(
+            render_state,
+            shape,
+            stroke,
+            paths,
+            Some(SurfaceId::InnerShadows),
+            stroke_shadow.as_ref(),
+            antialias,
+        );
     }
 }
 
 pub fn render_text_inner_shadow(
     render_state: &mut RenderState,
-    shape: &Shape,
     shadow: &Shadow,
-    paragraphs: &[Vec<Paragraph>],
+    paths: &Vec<(Path, Paint)>,
     antialias: bool,
 ) {
     let paint = shadow.get_inner_shadow_paint(antialias);
-
     text::render(
         render_state,
-        shape,
-        paragraphs,
+        paths,
         Some(SurfaceId::InnerShadows),
         Some(paint),
     );

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -86,46 +86,51 @@ pub fn render_stroke_inner_shadows(
 pub fn render_text_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
+    paragraphs: &mut Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)>, // Updated type
     antialias: bool,
+    fonts: &skia::textlayout::FontCollection,
 ) {
     for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_drop_shadow(render_state, shadow, blobs, antialias);
+        render_text_drop_shadow(render_state, shadow, paragraphs, antialias, fonts);
     }
 }
 
 pub fn render_text_drop_shadow(
     render_state: &mut RenderState,
     shadow: &Shadow,
-    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
+    paragraphs: &mut Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)>, // Updated type
     antialias: bool,
+    fonts: &skia::textlayout::FontCollection,
 ) {
     let paint = shadow.get_drop_shadow_paint(antialias);
     text::render(
         render_state,
-        blobs,
+        paragraphs,
         Some(SurfaceId::DropShadows),
         Some(paint),
+        fonts,
     );
 }
 
 pub fn render_text_stroke_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
+    paragraphs: &mut Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)>, // Updated type
     stroke: &Stroke,
     antialias: bool,
+    fonts: &skia::textlayout::FontCollection,
 ) {
     for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
         let stroke_shadow = shadow.get_drop_shadow_filter();
-        strokes::render_text_blobs(
+        strokes::render_text_paragraphs(
             render_state,
             shape,
             stroke,
-            blobs,
+            paragraphs,
             Some(SurfaceId::DropShadows),
             stroke_shadow.as_ref(),
             antialias,
+            fonts,
         );
     }
 }
@@ -133,31 +138,34 @@ pub fn render_text_stroke_drop_shadows(
 pub fn render_text_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
+    paragraphs: &mut Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)>, // Updated type
     antialias: bool,
+    fonts: &skia::textlayout::FontCollection,
 ) {
     for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_inner_shadow(render_state, shadow, blobs, antialias);
+        render_text_inner_shadow(render_state, shadow, paragraphs, antialias, fonts);
     }
 }
 
 pub fn render_text_stroke_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
-    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
+    paragraphs: &mut Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)>, // Updated type
     stroke: &Stroke,
     antialias: bool,
+    fonts: &skia::textlayout::FontCollection,
 ) {
     for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
         let stroke_shadow = shadow.get_inner_shadow_filter();
-        strokes::render_text_blobs(
+        strokes::render_text_paragraphs(
             render_state,
             shape,
             stroke,
-            blobs,
+            paragraphs,
             Some(SurfaceId::InnerShadows),
             stroke_shadow.as_ref(),
             antialias,
+            fonts,
         );
     }
 }
@@ -165,15 +173,18 @@ pub fn render_text_stroke_inner_shadows(
 pub fn render_text_inner_shadow(
     render_state: &mut RenderState,
     shadow: &Shadow,
-    blobs: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
+    paragraphs: &mut Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)>, // Updated type
     antialias: bool,
+    fonts: &skia::textlayout::FontCollection,
 ) {
     let paint = shadow.get_inner_shadow_paint(antialias);
+
     text::render(
         render_state,
-        blobs,
+        paragraphs,
         Some(SurfaceId::InnerShadows),
         Some(paint),
+        fonts,
     );
 }
 

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -3,7 +3,7 @@ use skia_safe::{self as skia, canvas::SaveLayerRec};
 
 pub fn render(
     render_state: &mut RenderState,
-    paths: &Vec<(skia::Path, skia::Paint)>,
+    paths: &Vec<(skia::TextBlob, skia::Point, skia::Paint)>,
     surface_id: Option<SurfaceId>,
     paint: Option<skia::Paint>,
 ) {
@@ -15,11 +15,8 @@ pub fn render(
 
     canvas.save_layer(&mask);
 
-    for (path, paint) in paths {
-        if path.is_empty() {
-            eprintln!("Warning: Empty path detected");
-        }
-        canvas.draw_path(path, paint);
+    for (text_blob, origin, paint) in paths {
+        canvas.draw_text_blob(text_blob, *origin, paint);
     }
     canvas.restore();
 }

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -1,10 +1,9 @@
-use super::{RenderState, Shape, SurfaceId};
-use skia_safe::{self as skia, canvas::SaveLayerRec, textlayout::Paragraph};
+use super::{RenderState, SurfaceId};
+use skia_safe::{self as skia, canvas::SaveLayerRec};
 
 pub fn render(
     render_state: &mut RenderState,
-    shape: &Shape,
-    paragraphs: &[Vec<Paragraph>],
+    paths: &Vec<(skia::Path, skia::Paint)>,
     surface_id: Option<SurfaceId>,
     paint: Option<skia::Paint>,
 ) {
@@ -15,13 +14,12 @@ pub fn render(
         .canvas(surface_id.unwrap_or(SurfaceId::Fills));
 
     canvas.save_layer(&mask);
-    for group in paragraphs {
-        let mut offset_y = 0.0;
-        for skia_paragraph in group {
-            let xy = (shape.selrect().x(), shape.selrect.y() + offset_y);
-            skia_paragraph.paint(canvas, xy);
-            offset_y += skia_paragraph.height();
+
+    for (path, paint) in paths {
+        if path.is_empty() {
+            eprintln!("Warning: Empty path detected");
         }
+        canvas.draw_path(path, paint);
     }
     canvas.restore();
 }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -602,11 +602,24 @@ impl Shape {
 
             rect.join(shadow_rect);
         }
+
         if self.blur.blur_type != blurs::BlurType::None {
             rect.left -= self.blur.value;
             rect.top -= self.blur.value;
             rect.right += self.blur.value;
             rect.bottom += self.blur.value;
+        }
+
+        if let Some(max_stroke_width) = self
+            .strokes
+            .iter()
+            .map(|s| s.width)
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            rect.left -= max_stroke_width / 2.0;
+            rect.top -= max_stroke_width / 2.0;
+            rect.right += max_stroke_width / 2.0;
+            rect.bottom += max_stroke_width / 2.0;
         }
 
         rect
@@ -704,6 +717,7 @@ impl Shape {
         match self.shape_type {
             Type::Text(ref mut text) => {
                 text.add_paragraph(paragraph);
+                text.new_bounds(self.selrect);
                 Ok(())
             }
             _ => Err("Shape is not a text".to_string()),

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -1,4 +1,4 @@
-use skia_safe::{self as skia, Paint, Rect};
+use skia_safe::{self as skia, Rect};
 
 pub use super::Color;
 use crate::utils::get_image;
@@ -139,87 +139,62 @@ pub enum Fill {
 
 impl Fill {
     pub fn to_paint(&self, rect: &Rect, anti_alias: bool) -> skia::Paint {
-        match self {
-            Self::Solid(SolidColor(color)) => {
-                let mut p = skia::Paint::default();
-                p.set_color(*color);
-                p.set_style(skia::PaintStyle::Fill);
-                p.set_anti_alias(anti_alias);
-                p.set_blend_mode(skia::BlendMode::SrcOver);
-                p
-            }
-            Self::LinearGradient(gradient) => {
-                let mut p = skia::Paint::default();
-                p.set_shader(gradient.to_linear_shader(rect));
-                p.set_alpha(gradient.opacity);
-                p.set_style(skia::PaintStyle::Fill);
-                p.set_anti_alias(anti_alias);
-                p.set_blend_mode(skia::BlendMode::SrcOver);
-                p
-            }
-            Self::RadialGradient(gradient) => {
-                let mut p = skia::Paint::default();
-                p.set_shader(gradient.to_radial_shader(rect));
-                p.set_alpha(gradient.opacity);
-                p.set_style(skia::PaintStyle::Fill);
-                p.set_anti_alias(anti_alias);
-                p.set_blend_mode(skia::BlendMode::SrcOver);
-                p
-            }
-            Self::Image(image_fill) => {
-                let mut p = skia::Paint::default();
-                p.set_style(skia::PaintStyle::Fill);
-                p.set_anti_alias(anti_alias);
-                p.set_blend_mode(skia::BlendMode::SrcOver);
-                p.set_alpha(image_fill.opacity);
-                p
-            }
+        let mut paint = skia::Paint::default();
+        paint.set_style(skia::PaintStyle::Fill);
+        paint.set_anti_alias(anti_alias);
+        paint.set_blend_mode(skia::BlendMode::SrcOver);
+        let shader = self.get_fill_shader(rect);
+        if let Some(shader) = shader {
+            paint.set_shader(shader);
         }
+        paint
     }
-}
 
-pub fn get_fill_shader(fill: &Fill, bounding_box: &Rect) -> Option<skia::Shader> {
-    match fill {
-        Fill::Solid(SolidColor(color)) => Some(skia::shaders::color(*color)),
-        Fill::LinearGradient(gradient) => gradient.to_linear_shader(bounding_box),
-        Fill::RadialGradient(gradient) => gradient.to_radial_shader(bounding_box),
-        Fill::Image(image_fill) => {
-            let mut image_shader = None;
-            let image = get_image(&image_fill.id);
-            if let Some(image) = image {
-                let sampling_options =
-                    skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Nearest);
+    pub fn get_fill_shader(&self, bounding_box: &Rect) -> Option<skia::Shader> {
+        match self {
+            Fill::Solid(SolidColor(color)) => Some(skia::shaders::color(*color)),
+            Fill::LinearGradient(gradient) => gradient.to_linear_shader(bounding_box),
+            Fill::RadialGradient(gradient) => gradient.to_radial_shader(bounding_box),
+            Fill::Image(image_fill) => {
+                let mut image_shader = None;
+                let image = get_image(&image_fill.id);
+                if let Some(image) = image {
+                    let sampling_options = skia::SamplingOptions::new(
+                        skia::FilterMode::Linear,
+                        skia::MipmapMode::Nearest,
+                    );
 
-                // FIXME no image ratio applied, centered to the current rect
-                let tile_modes = (skia::TileMode::Clamp, skia::TileMode::Clamp);
-                let image_width = image_fill.width as f32;
-                let image_height = image_fill.height as f32;
-                let scale_x = bounding_box.width() / image_width;
-                let scale_y = bounding_box.height() / image_height;
-                let scale = scale_x.max(scale_y);
-                let scaled_width = image_width * scale;
-                let scaled_height = image_height * scale;
-                let pos_x = bounding_box.left() - (scaled_width - bounding_box.width()) / 2.0;
-                let pos_y = bounding_box.top() - (scaled_height - bounding_box.height()) / 2.0;
+                    // FIXME no image ratio applied, centered to the current rect
+                    let tile_modes = (skia::TileMode::Clamp, skia::TileMode::Clamp);
+                    let image_width = image_fill.width as f32;
+                    let image_height = image_fill.height as f32;
+                    let scale_x = bounding_box.width() / image_width;
+                    let scale_y = bounding_box.height() / image_height;
+                    let scale = scale_x.max(scale_y);
+                    let scaled_width = image_width * scale;
+                    let scaled_height = image_height * scale;
+                    let pos_x = bounding_box.left() - (scaled_width - bounding_box.width()) / 2.0;
+                    let pos_y = bounding_box.top() - (scaled_height - bounding_box.height()) / 2.0;
 
-                let mut matrix = skia::Matrix::new_identity();
-                matrix.pre_translate((pos_x, pos_y));
-                matrix.pre_scale((scale, scale), None);
+                    let mut matrix = skia::Matrix::new_identity();
+                    matrix.pre_translate((pos_x, pos_y));
+                    matrix.pre_scale((scale, scale), None);
 
-                let opacity = image_fill.opacity();
-                let alpha_color = skia::Color4f::new(1.0, 1.0, 1.0, opacity as f32 / 255.0);
-                let alpha_shader = skia::shaders::color(alpha_color.to_color());
+                    let opacity = image_fill.opacity();
+                    let alpha_color = skia::Color4f::new(1.0, 1.0, 1.0, opacity as f32 / 255.0);
+                    let alpha_shader = skia::shaders::color(alpha_color.to_color());
 
-                image_shader = image.to_shader(tile_modes, sampling_options, &matrix);
-                if let Some(shader) = image_shader {
-                    image_shader = Some(skia::shaders::blend(
-                        skia::Blender::mode(skia::BlendMode::DstIn),
-                        shader,
-                        alpha_shader,
-                    ));
+                    image_shader = image.to_shader(tile_modes, sampling_options, &matrix);
+                    if let Some(shader) = image_shader {
+                        image_shader = Some(skia::shaders::blend(
+                            skia::Blender::mode(skia::BlendMode::DstIn),
+                            shader,
+                            alpha_shader,
+                        ));
+                    }
                 }
+                image_shader
             }
-            image_shader
         }
     }
 }
@@ -229,7 +204,7 @@ pub fn merge_fills(fills: &[Fill], bounding_box: Rect) -> skia::Paint {
     let mut fills_paint = skia::Paint::default();
 
     for fill in fills {
-        let shader = get_fill_shader(fill, &bounding_box);
+        let shader = fill.get_fill_shader(&bounding_box);
 
         if let Some(shader) = shader {
             combined_shader = match combined_shader {
@@ -245,11 +220,4 @@ pub fn merge_fills(fills: &[Fill], bounding_box: Rect) -> skia::Paint {
 
     fills_paint.set_shader(combined_shader.clone());
     fills_paint
-}
-
-pub fn set_paint_fill(paint: &mut Paint, fill: &Fill, bounding_box: &Rect) {
-    let shader = get_fill_shader(fill, bounding_box);
-    if let Some(shader) = shader {
-        paint.set_shader(shader);
-    }
 }

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -108,8 +108,6 @@ pub fn propagate_modifiers(
     modifiers: &[TransformEntry],
 ) -> (Vec<TransformEntry>, HashMap<Uuid, Bounds>) {
     let shapes = &state.shapes;
-
-    let font_col = state.render_state.fonts.font_collection();
     let mut entries: VecDeque<_> = modifiers
         .iter()
         .map(|entry| Modifier::Transform(entry.clone()))
@@ -147,9 +145,9 @@ pub fn propagate_modifiers(
 
                     if let Type::Text(content) = &shape.shape_type {
                         if content.grow_type() == GrowType::AutoHeight {
-                            let mut paragraphs = content.get_skia_paragraphs(font_col);
+                            let mut paragraphs = content.get_skia_paragraphs();
                             set_paragraphs_width(shape_bounds_after.width(), &mut paragraphs);
-                            let height = auto_height(&paragraphs);
+                            let height = auto_height(&mut paragraphs);
                             let resize_transform = math::resize_matrix(
                                 &shape_bounds_after,
                                 &shape_bounds_after,

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -224,6 +224,29 @@ impl Stroke {
         antialias: bool,
     ) -> skia::Paint {
         let mut paint = self.to_paint(rect, svg_attrs, scale, antialias);
+
+        match self.render_kind(is_open) {
+            StrokeKind::Inner => {
+                paint.set_stroke_width(2. * paint.stroke_width());
+            }
+            StrokeKind::Center => {}
+            StrokeKind::Outer => {
+                paint.set_stroke_width(2. * paint.stroke_width());
+            }
+        }
+
+        paint
+    }
+
+    pub fn to_text_stroked_paint(
+        &self,
+        is_open: bool,
+        rect: &Rect,
+        svg_attrs: &HashMap<String, String>,
+        scale: f32,
+        antialias: bool,
+    ) -> skia::Paint {
+        let mut paint = self.to_paint(rect, svg_attrs, scale, antialias);
         match self.render_kind(is_open) {
             StrokeKind::Inner => {
                 paint.set_stroke_width(2. * paint.stroke_width());

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -8,7 +8,7 @@ use crate::{
 use skia_safe::{
     self as skia,
     textlayout::{ParagraphBuilder, ParagraphStyle},
-    Point, TextBlob,
+    Point,
 };
 
 use crate::skia::FontMetrics;
@@ -18,7 +18,6 @@ use crate::shapes::{self, merge_fills};
 use crate::utils::uuid_from_u32;
 use crate::wasm::fills::parse_fills_from_bytes;
 use crate::Uuid;
-use unic_emoji_char::is_emoji;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum GrowType {
@@ -129,99 +128,25 @@ impl TextContent {
         self.grow_type = grow_type;
     }
 
-    pub fn get_text_blobs(&self, antialias: bool) -> Vec<(skia::TextBlob, skia::Point, skia::Paint)> {
-        let mut text_blobs = Vec::new();
-    
+    pub fn get_text_paragraphs(
+        &self,
+    ) -> Vec<(skia::textlayout::ParagraphBuilder, skia::Point, f32)> {
+        let mut text_paragraphs = Vec::new();
+
         let mut offset_y = self.bounds.y();
-        let mut paragraphs = self.get_skia_paragraphs();
-        for paragraph_builder in paragraphs.iter_mut() {
+        let paragraphs = self.get_skia_paragraphs();
+        for mut paragraph_builder in paragraphs.into_iter() {
             let mut skia_paragraph = paragraph_builder.build();
-            let text = paragraph_builder.get_text();
+
             let paragraph_width = self.bounds.width();
             skia_paragraph.layout(paragraph_width);
-            let mut segment_start_index = 0;
-    
-            let mut line_offset_y = offset_y;
-    
-            for line_metrics in skia_paragraph.get_line_metrics() {
-                let line_baseline = line_metrics.baseline as f32;
-                let line_height = line_metrics.height as f32;
-                let start = line_metrics.start_index;
-                let end = line_metrics.end_index;
-    
-                let style_metrics = line_metrics.get_style_metrics(start..end);
-                let mut offset_x = 0.0;
-    
-                for (i, (start_index, style_metric)) in style_metrics.iter().enumerate() {
-                    let end_index = style_metrics.get(i + 1).map_or(end, |next| next.0);
-
-                    let start_byte = text
-                        .char_indices()
-                        .nth(*start_index)
-                        .map(|(i, _)| i)
-                        .unwrap_or(0);
-                    let end_byte = text
-                        .char_indices()
-                        .nth(end_index)
-                        .map(|(i, _)| i)
-                        .unwrap_or(text.len());
-
-                    let affected_text = &text[start_byte..end_byte];
-                    let segments = split_text_into_segments(affected_text);
-
-                    for segment in segments {
-                        let font = skia_paragraph.get_font_at(segment_start_index);
-                        segment_start_index += segment.len();
-    
-                        let blob_offset_x = self.bounds.x() + line_metrics.left as f32 + offset_x;
-                        let blob_offset_y = line_offset_y;
-    
-                        if let Some((text_blob, origin, paint)) = self.generate_text_blob(
-                            &segment,
-                            &font,
-                            blob_offset_x,
-                            blob_offset_y,
-                            style_metric,
-                            antialias,
-                        ) {
-                            let text_width = font.measure_str(&segment, None).0;
-                            offset_x += text_width;
-                            text_blobs.push((text_blob, origin, paint));
-                        }
-                    }
-                }
-                line_offset_y += line_height; // Increment line_offset_y by the line height
-            }
-
-            offset_y = line_offset_y; // Update offset_y to the last line's position
-        }
-        text_blobs
-    }
-    
-    fn generate_text_blob(
-        &self,
-        affected_text: &str,
-        font: &skia::Font,
-        blob_offset_x: f32,
-        blob_offset_y: f32,
-        style_metric: &skia::textlayout::StyleMetrics,
-        antialias: bool,
-    ) -> Option<(TextBlob, skia::Point, skia::Paint)> {
-        if let Some(text_blob) = TextBlob::from_str(affected_text, font) {
-            let bounds = text_blob.bounds();
-            let origin = Point::new(
-                blob_offset_x + bounds.left,
-                blob_offset_y - bounds.top,
-            );
-
-            let mut paint = style_metric.text_style.foreground();
-            paint.set_anti_alias(antialias);
-
-            return Some((text_blob, origin, paint));
+            let paragraph_height = skia_paragraph.height();
+            let origin = Point::new(self.bounds.x(), offset_y);
+            offset_y += paragraph_height;
+            text_paragraphs.push((paragraph_builder, origin, paragraph_width));
         }
 
-        eprintln!("Failed to create TextBlob for text: {}", affected_text);
-        None
+        text_paragraphs
     }
 
     fn collect_paragraphs<'a>(
@@ -684,29 +609,4 @@ pub fn auto_height(paragraphs: &mut [ParagraphBuilder]) -> f32 {
         paragraph.layout(f32::MAX);
         auto_height + paragraph.height()
     })
-}
-
-fn split_text_into_segments(text: &str) -> Vec<String> {
-    let mut segments = Vec::new();
-    let mut current_segment = String::new();
-
-    let mut chars = text.chars().peekable();
-    while let Some(c) = chars.next() {
-        let is_current_emoji = is_emoji(c);
-
-        current_segment.push(c);
-
-        while let Some(&next_char) = chars.peek() {
-            if is_emoji(next_char) == is_current_emoji {
-                current_segment.push(chars.next().unwrap());
-            } else {
-                break;
-            }
-        }
-
-        segments.push(current_segment.clone());
-        current_segment.clear();
-    }
-
-    segments
 }

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -1,8 +1,8 @@
 use crate::mem;
 use crate::shapes::{auto_height, auto_width, GrowType, RawTextData, Type};
 
+use crate::with_current_shape;
 use crate::STATE;
-use crate::{with_current_shape, with_state};
 
 #[no_mangle]
 pub extern "C" fn clear_shape_text() {
@@ -35,11 +35,6 @@ pub extern "C" fn set_shape_grow_type(grow_type: u8) {
 
 #[no_mangle]
 pub extern "C" fn get_text_dimensions() -> *mut u8 {
-    let font_col;
-    with_state!(state, {
-        font_col = state.render_state.fonts.font_collection();
-    });
-
     let mut width = 0.01;
     let mut height = 0.01;
     with_current_shape!(state, |shape: &mut Shape| {
@@ -47,10 +42,10 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
         height = shape.selrect.height();
 
         if let Type::Text(content) = &shape.shape_type {
-            let paragraphs = content.get_skia_paragraphs(font_col);
-            height = auto_height(&paragraphs).ceil();
+            let mut paragraphs = content.to_paragraphs();
+            height = auto_height(&mut paragraphs).ceil();
             if content.grow_type() == GrowType::AutoWidth {
-                width = auto_width(&paragraphs).ceil();
+                width = auto_width(&mut paragraphs).ceil();
             }
         }
     });


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11088
https://tree.taiga.io/project/penpot/task/11021

### Summary

This PR is related to several tickets, as it uses a new approach to render text shapes by converting them to paths. Apart from these fixes, it also introduce shape rotation and fixes text decoration and alignment.

Instead of using the paragraph API to paint the text in the canvas, it first converts each text leaf into a text blob and uses the API to get the path from it. Then, we paint it in the canvas through the canvas API as the rest of shapes.

We have to build the path manually since it gives us some advantages:
- Text decoration doesn't support all the fills we have, only solid colors.
- Text decoration doesn't support fills on "decoration strokes"
- Using paths allows us to reuse the same functions to calculate different strokes, so we don't need to rely on text stroke paints directly

The downsides are:

- We have to parse each text blob and its decoration manually
- Converting it to paths each time might add some cost
- We need to find a way to render emoji 

I've added a simple playground as starting point to test and compare performance when drawing texts

### Steps to reproduce 

![image](https://github.com/user-attachments/assets/ddb14225-18f4-4560-8db6-210d63aab8f9)


Test this file and compare it to production [test_texts.zip](https://github.com/user-attachments/files/20409938/test_texts.zip)



### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

