### PR TITLE
:sparkles: Change "Copy as SVG" menu order

### DIFF
--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -204,12 +204,12 @@
 
      [:> menu-entry* {:title (tr "workspace.shape.menu.copy-paste-as")
                       :on-pointer-enter (when (cf/check-browser? :chrome) handle-hover-copy-paste)}
-      [:> menu-entry* {:title (tr "workspace.shape.menu.copy-svg")
-                       :on-click handle-copy-svg}]
       [:> menu-entry* {:title (tr "workspace.shape.menu.copy-css")
                        :on-click handle-copy-css}]
       [:> menu-entry* {:title (tr "workspace.shape.menu.copy-css-nested")
                        :on-click handle-copy-css-nested}]
+      [:> menu-entry* {:title (tr "workspace.shape.menu.copy-svg")
+                       :on-click handle-copy-svg}]
 
       [:> menu-separator* {}]
 


### PR DESCRIPTION
This is an adjustment to [this PR](https://github.com/penpot/penpot/pull/6510).

"Copy as SVG" is a great addition to the copy menu. However, the CSS options will probably be used more frequently, and the order of the elements should reflect this preference to facilitate the most common usage. The Penpot design team has confirmed their agreement with this change.