### PR TITLE
:sparkles: Improve formula validating and parsing

### DIFF
--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -107,8 +107,8 @@
      (add-new-props assigned remaining))))
 
 
-(defn properties-map->string
-  "Transforms a map of properties to a string of properties omitting the empty ones"
+(defn properties-map->formula
+  "Transforms a map of properties to a formula of properties omitting the empty ones"
   [properties]
   (->> properties
        (keep (fn [{:keys [name value]}]
@@ -117,22 +117,24 @@
        (str/join ", ")))
 
 
-(defn properties-string->map
-  "Transforms a string of properties to a map of properties"
+(defn properties-formula->map
+  "Transforms a formula of properties to a map of properties"
   [s]
   (->> (str/split s ",")
-       (mapv #(str/split % "="))
-       (filter (fn [[_ v]] (not (str/blank? (str/trim v)))))
+       (mapv #(str/split % "=" 2))
+       (filter (fn [[_ v]] (not (str/blank? v))))
        (mapv (fn [[k v]]
                {:name (str/trim k)
                 :value (str/trim v)}))))
 
 
-(defn valid-properties-string?
-  "Checks if a string of properties has a processable format or not"
+(defn valid-properties-formula?
+  "Checks if a formula is valid"
   [s]
-  (let [pattern #"^\s*([a-zA-Z0-9_ -]+=[^,]*)(,\s*[a-zA-Z0-9_ -]+=[^,]*)*\s*$"]
-    (not (nil? (re-matches pattern s)))))
+  (->> (str/split s ",")
+       (mapv #(str/split % "=" 2))
+       (every? #(and (= 2 (count %))
+                     (not (str/blank? (first %)))))))
 
 
 (defn find-properties-to-remove

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -9,11 +9,12 @@
    [app.common.types.variant :as ctv]
    [clojure.test :as t]))
 
-(t/deftest convert-between-variant-properties-maps-and-strings
+(t/deftest convert-between-variant-properties-maps-and-formulas
   (let [map-with-two-props           [{:name "border" :value "yes"} {:name "color" :value "gray"}]
         map-with-two-props-one-blank [{:name "border" :value "no"} {:name "color" :value ""}]
         map-with-two-props-dashes    [{:name "border" :value "no"} {:name "color" :value "--"}]
         map-with-one-prop            [{:name "border" :value "no"}]
+        map-with-equal               [{:name "border" :value "yes color=yes"}]
         map-with-spaces              [{:name "border 1" :value "of course"}
                                       {:name "color 2" :value "dark gray"}
                                       {:name "background 3" :value "anoth€r co-lor"}]
@@ -23,27 +24,37 @@
         string-valid-with-spaces     "border 1=of course, color 2=dark gray, background 3=anoth€r co-lor"
         string-valid-with-no-value   "border=no, color="
         string-valid-with-dashes     "border=no, color=--"
-        string-invalid               "border=yes, color"]
+        string-valid-with-equal      "border=yes color=yes"
+        string-invalid-1             ""
+        string-invalid-2             "=yes"
+        string-invalid-3             "border"
+        string-invalid-4             "border=yes, =gray"
+        string-invalid-5             "border=yes, color"]
 
-    (t/testing "convert map to string"
-      (t/is (= (ctv/properties-map->string map-with-two-props) string-valid-with-two-props))
-      (t/is (= (ctv/properties-map->string map-with-two-props-one-blank) string-valid-with-one-prop))
-      (t/is (= (ctv/properties-map->string map-with-spaces) string-valid-with-spaces)))
+    (t/testing "convert map to formula"
+      (t/is (= (ctv/properties-map->formula map-with-two-props) string-valid-with-two-props))
+      (t/is (= (ctv/properties-map->formula map-with-two-props-one-blank) string-valid-with-one-prop))
+      (t/is (= (ctv/properties-map->formula map-with-spaces) string-valid-with-spaces)))
 
-    (t/testing "convert string to map"
-      (t/is (= (ctv/properties-string->map string-valid-with-two-props) map-with-two-props))
-      (t/is (= (ctv/properties-string->map string-valid-with-one-prop) map-with-one-prop))
-      (t/is (= (ctv/properties-string->map string-valid-with-no-value) map-with-one-prop))
-      (t/is (= (ctv/properties-string->map string-valid-with-dashes) map-with-two-props-dashes))
-      (t/is (= (ctv/properties-string->map string-valid-with-spaces) map-with-spaces)))
+    (t/testing "convert formula to map"
+      (t/is (= (ctv/properties-formula->map string-valid-with-two-props) map-with-two-props))
+      (t/is (= (ctv/properties-formula->map string-valid-with-one-prop) map-with-one-prop))
+      (t/is (= (ctv/properties-formula->map string-valid-with-no-value) map-with-one-prop))
+      (t/is (= (ctv/properties-formula->map string-valid-with-dashes) map-with-two-props-dashes))
+      (t/is (= (ctv/properties-formula->map string-valid-with-equal) map-with-equal))
+      (t/is (= (ctv/properties-formula->map string-valid-with-spaces) map-with-spaces)))
 
-    (t/testing "check if a string is valid"
-      (t/is (= (ctv/valid-properties-string? string-valid-with-two-props) true))
-      (t/is (= (ctv/valid-properties-string? string-valid-with-one-prop) true))
-      (t/is (= (ctv/valid-properties-string? string-valid-with-spaces) true))
-      (t/is (= (ctv/valid-properties-string? string-valid-with-no-value) true))
-      (t/is (= (ctv/valid-properties-string? string-valid-with-dashes) true))
-      (t/is (= (ctv/valid-properties-string? string-invalid) false)))))
+    (t/testing "check if a formula is valid"
+      (t/is (= (ctv/valid-properties-formula? string-valid-with-two-props) true))
+      (t/is (= (ctv/valid-properties-formula? string-valid-with-one-prop) true))
+      (t/is (= (ctv/valid-properties-formula? string-valid-with-spaces) true))
+      (t/is (= (ctv/valid-properties-formula? string-valid-with-no-value) true))
+      (t/is (= (ctv/valid-properties-formula? string-valid-with-dashes) true))
+      (t/is (= (ctv/valid-properties-formula? string-invalid-1) false))
+      (t/is (= (ctv/valid-properties-formula? string-invalid-2) false))
+      (t/is (= (ctv/valid-properties-formula? string-invalid-3) false))
+      (t/is (= (ctv/valid-properties-formula? string-invalid-4) false))
+      (t/is (= (ctv/valid-properties-formula? string-invalid-5) false)))))
 
 
 (t/deftest find-properties

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -46,7 +46,7 @@
                            shape-name)
 
         default-value    (if variant-id
-                           (or variant-error (ctv/properties-map->string variant-properties))
+                           (or variant-error (ctv/properties-map->formula variant-properties))
                            shape-name)
 
         has-path?        (str/includes? shape-name "/")
@@ -70,8 +70,8 @@
              (on-stop-edit)
              (reset! edition* false)
              (if variant-name
-               (if (ctv/valid-properties-string? name)
-                 (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties (ctv/properties-string->map name))
+               (if (ctv/valid-properties-formula? name)
+                 (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties (ctv/properties-formula->map name))
                            (dwv/update-error component-id nil))
                  (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties {})
                            (dwv/update-error component-id name)))


### PR DESCRIPTION
### Related Ticket

Taiga [#11122](https://tree.taiga.io/project/penpot/task/11122)

### Summary

Instead of using a regex, which is quite difficult to read and prone to errors, we are using a formula validator more simple and that takes into account new cases:
- An equal symbol is parsed as a key=value separator only if it's the first one after a comma, so the value can contain it.
- An empty property name is forbidden.