### PR TITLE
:bug: Fix cursor overlap query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,7 @@ A non exhaustive list of changes:
 
 ### :bug: Bugs fixed
 
+- Fix selection of short paths [Github #4472](https://github.com/penpot/penpot/issues/4472)
 
 ## 2.7.0 (Unreleased)
 

--- a/frontend/src/app/worker/selection.cljs
+++ b/frontend/src/app/worker/selection.cljs
@@ -7,6 +7,7 @@
 (ns app.worker.selection
   (:require
    [app.common.data :as d]
+   [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.files.indices :as cfi]
    [app.common.geom.point :as gpt]
@@ -189,8 +190,16 @@
           (let [padding (->> (:strokes shape)
                              (map :stroke-width)
                              (reduce d/max 5))
+                ;; For paths that fit within a 5x5 box, there won't be any intersection
+                ;; when the cursor is around the center. We need to adjust the padding
+                ;; to make a narrower box in that case.
+                ;; FIXME: this should be a function of the zoom level as well, or use
+                ;;   pixel distances
+                width   (dm/get-in shape [:selrect :width] 1)
+                height  (dm/get-in shape [:selrect :height] 1)
+                padding (min padding (/ (max width height) 2))
                 center  (grc/rect->center rect)
-                rect    (grc/center->rect center  padding)]
+                rect    (grc/center->rect center padding)]
             (gsh/overlaps-path? shape rect false)))
 
         overlaps?


### PR DESCRIPTION
### Summary

A fix to

* Close #4472 

The issue is that the overlap query executed by the worker builds a 5x5 rectangle around the mouse position, irrespective of the size of the shape. This means that shapes which are smaller in size will not intersect the rectangle when the mouse hovers around the center, as illustrated in the issue.

---

This PR:

* Reduces the size of the intersecting box by accounting for shape size.

### Open issue

This works around the problem but is not entirely satisfactory because one should also account for the distance to nearby shapes. A perfect solution would cast a crosshair of rays around the mouse and take the first intersecting shape.

This is however a major change which I'd prefer not getting into. But it, or an alternative solution should probably be considered at some point.


### Behaviour with these changes

Alas, there is a [known bug in gnome](https://gitlab.gnome.org/GNOME/mutter/-/issues/3182) that breaks screen recording on my system and the mouse pointer doesn't show. In the video below I'm smoothly moving the mouse from one segment to the next one.

[select-segments.webm](https://github.com/user-attachments/assets/5d5f9668-ff85-49bf-94ee-d019e19ba083)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.