### PR TITLE
:sparkles: Fix choppy behaviour of new node on path

### DIFF
--- a/common/src/app/common/types/path/segment.cljc
+++ b/common/src/app/common/types/path/segment.cljc
@@ -235,44 +235,6 @@
         from-p
         to-p))))
 
-;; FIXME: incorrect API, complete shape is not necessary here
-(defn path-closest-point
-  "Given a path and a position"
-  [shape position]
-
-  (let [point+distance
-        (fn [[cur-segment prev-segment]]
-          (let [from-p (helpers/segment->point prev-segment)
-                to-p   (helpers/segment->point cur-segment)
-                h1 (gpt/point (get-in cur-segment [:params :c1x])
-                              (get-in cur-segment [:params :c1y]))
-                h2 (gpt/point (get-in cur-segment [:params :c2x])
-                              (get-in cur-segment [:params :c2y]))
-                point
-                (case (:command cur-segment)
-                  :line-to
-                  (line-closest-point position from-p to-p)
-
-                  :curve-to
-                  (curve-closest-point position from-p to-p h1 h2)
-
-                  nil)]
-            (when point
-              [point (gpt/distance point position)])))
-
-        find-min-point
-        (fn [[min-p min-dist :as acc] [cur-p cur-dist :as cur]]
-          (if (and (some? acc) (or (not cur) (<= min-dist cur-dist)))
-            [min-p min-dist]
-            [cur-p cur-dist]))]
-
-    (->> (:content shape)
-         (d/with-prev)
-         (map point+distance)
-         (reduce find-min-point)
-         (first))))
-
-
 (defn closest-point
   "Returns the closest point in the path to the position, at a given precision"
   [content position precision]

--- a/common/src/app/common/types/path/segment.cljc
+++ b/common/src/app/common/types/path/segment.cljc
@@ -182,11 +182,11 @@
 ;; FIXME: move to helpers?, this function need performance review, it
 ;; is executed so many times on path edition
 (defn- curve-closest-point
-  [position start end h1 h2]
+  [position start end h1 h2 precision]
   (let [d (memoize (fn [t] (gpt/distance position (helpers/curve-values start end h1 h2 t))))]
     (loop [t1 0.0
            t2 1.0]
-      (if (<= (mth/abs (- t1 t2)) path-closest-point-accuracy)
+      (if (<= (mth/abs (- t1 t2)) precision)
         (-> (helpers/curve-values start end h1 h2 t1)
             ;; store the segment info
             (with-meta {:t t1 :from-p start :to-p end}))
@@ -214,7 +214,7 @@
                  (double t2)))))))
 
 (defn- line-closest-point
-  "Point on line"
+  "Finds the closest point in the line segment defined by from-p and to-p"
   [position from-p to-p]
 
   (let [e1 (gpt/to-vec from-p to-p)
@@ -274,13 +274,12 @@
 
 
 (defn closest-point
-  "Given a path and a position"
-  [content position]
-
+  "Returns the closest point in the path to the position, at a given precision"
+  [content position precision]
   (let [point+distance
         (fn [[cur-segment prev-segment]]
           (let [from-p (helpers/segment->point prev-segment)
-                to-p   (helpers/segment->point cur-segment)
+                to-p (helpers/segment->point cur-segment)
                 h1 (gpt/point (get-in cur-segment [:params :c1x])
                               (get-in cur-segment [:params :c1y]))
                 h2 (gpt/point (get-in cur-segment [:params :c2x])
@@ -291,7 +290,7 @@
                   (line-closest-point position from-p to-p)
 
                   :curve-to
-                  (curve-closest-point position from-p to-p h1 h2)
+                  (curve-closest-point position from-p to-p h1 h2 precision)
 
                   nil)]
             (when point

--- a/frontend/src/app/main/ui/workspace/shapes/path/editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/path/editor.cljs
@@ -348,7 +348,7 @@
      ms/mouse-position
      (mf/deps base-content zoom)
      (fn [position]
-       (when-let [point (path.segment/closest-point base-content position)]
+       (when-let [point (path.segment/closest-point base-content position (/ 0.01 zoom))]
          (reset! hover-point (when (< (gpt/distance position point) (/ 10 zoom)) point)))))
 
     [:g.path-editor {:ref editor-ref}


### PR DESCRIPTION
### Summary

While working on #6530 I realized that the computation of where a new node would fall on a path was a bit choppy. 

This PR:

* Makes the precision for `closest-point` computation a function of the zoom

### Current behaviour

As mentioned in #6530 my mouse pointer doesn't show in recordings, sorry.

In the video I'm moving the mouse exactly over the path. The node disappears even though the mouse moves exactly over the line.

[choppy-node.webm](https://github.com/user-attachments/assets/4d0bcdc1-05e5-4ff6-adb4-e46bd3c92217)

### New behaviour

[smooth-node.webm](https://github.com/user-attachments/assets/54a9c7c2-be02-4ccc-83c8-781bf433b705)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
