### PR TITLE
:bug: Sanitize inputs for variant property names and values in design tab

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -269,7 +269,8 @@
         (mf/use-fn
          (mf/deps component-ids)
          (fn [pos value]
-           (let [value (if (= value empty-indicator) "" value)]
+           (let [value (str/trim value)
+                 value (if (= value empty-indicator) "" value)]
              (doseq [id component-ids]
                (st/emit! (dwv/update-property-value id pos value))
                (st/emit! (dwv/update-error id nil))))))
@@ -278,11 +279,12 @@
         (mf/use-fn
          (mf/deps variant-id)
          (fn [event]
-           (let [value (dom/get-target-val event)
+           (let [value (str/trim (dom/get-target-val event))
                  pos   (-> (dom/get-current-target event)
                            (dom/get-data "position")
                            int)]
-             (st/emit! (dwv/update-property-name variant-id pos value)))))]
+             (when (seq value)
+               (st/emit! (dwv/update-property-name variant-id pos value))))))]
 
     [:*
      [:div {:class (stl/css :variant-property-list)}


### PR DESCRIPTION
### Related Ticket

Taiga [#11124](https://tree.taiga.io/project/penpot/task/11124)

### Summary

This fix sanitizes the inputs for the variant properties names and values in the design tab.
- Property names
  - Trim the spaces before and after
  - Do not update the value if empty
- Property values
  - Trim the spaces before and after

