### PR TITLE
:sparkles: Select all variants with errors when locating them from design tab

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -886,7 +886,7 @@
         select-shape-with-error
         (mf/use-fn
          (mf/deps object-error-ids)
-         #(st/emit! (dw/select-shape (first object-error-ids))))]
+         #(st/emit! (dw/select-shapes (into (d/ordered-set) object-error-ids))))]
 
     (when (seq shapes)
       [:div {:class (stl/css :element-set)}


### PR DESCRIPTION
### Related Ticket

Taiga [#11134](https://tree.taiga.io/project/penpot/task/11134)

### Summary

When there are multiple variants with error in a group and the user clicks on the link on the display tab to locate them, all of them are selected instead of just one.