### PR TITLE
:bug: Fix restore component when its original parent with layout is deleted

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2055,7 +2055,8 @@
                     (pcb/with-objects objects)
                     (pcb/resize-parents new-objects-ids)
                     ;; Fix the order of the children inside the parent
-                    (cond-> parent-id (pcb/reorder-children parent-id (get-in objects [parent-id :shapes]))))]
+                    (cond-> (ctl/any-layout? objects parent-id)
+                      (pcb/reorder-children parent-id (get-in objects [parent-id :shapes]))))]
     (assoc changes :file-id library-id)))
 
 (defn generate-detach-component


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10934 (last issue)

### Summary
When restoring a component should check if the original parent  had layout and still exists before reordering its children.

### Steps to reproduce 
- Create a component inside a board with flex
- Create a copy of the component
- Delete the board
- Restore the component

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
