### PR TITLE
:sparkles: Use different copies for different variant selection cases

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -238,7 +238,7 @@
 
 (defn- get-variant-error-message [errors]
   (cond
-    (and (= (count errors) 1) (not (nil? (first errors))))
+    (and (= (count errors) 1) (some? (first errors)))
     (tr "workspace.options.component.variant.malformed.single.one")
 
     (and (seq errors) (every? some? errors))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -235,12 +235,26 @@
         (when (or editing? creating?)
           [:div {:class (stl/css  :counter)} (str size "/300")])]])))
 
+
+(defn- get-variant-error-message [errors]
+  (cond
+    (and (= (count errors) 1) (not (nil? (first errors))))
+    (tr "workspace.options.component.variant.malformed.single.one")
+
+    (and (seq errors) (every? some? errors))
+    (tr "workspace.options.component.variant.malformed.single.all")
+
+    (and (seq errors) (some some? errors))
+    (tr "workspace.options.component.variant.malformed.single.some")
+
+    :else nil))
+
+
 (mf/defc component-variant-main-instance*
-  [{:keys [components shape data]}]
+  [{:keys [components shapes data]}]
   (let [component      (first components)
 
         variant-id     (:variant-id component)
-        variant-error? (:variant-error shape)
 
         objects        (-> (dsh/get-page data (:main-instance-page component))
                            (get :objects))
@@ -253,6 +267,9 @@
 
         prop-vals       (mf/with-memo [data objects variant-id]
                           (cfv/extract-properties-values data objects variant-id))
+
+        variant-errors     (mapv :variant-error shapes)
+        variant-error-msg  (get-variant-error-message variant-errors)
 
         empty-indicator "--"
 
@@ -301,14 +318,14 @@
                            :options (clj->js (get-options (:name prop)))
                            :on-change (partial update-property-value pos)}])]])]
 
-     (when variant-error?
+     (when variant-error-msg
        [:div {:class (stl/css :variant-error-wrapper)}
         [:> icon* {:icon-id "msg-neutral"
                    :class (stl/css :variant-error-darken)}]
         [:div {:class (stl/css :variant-error-highlight)}
-         (tr "workspace.options.component.variant.malformed.single")]
+         (str variant-error-msg " " (tr "workspace.options.component.variant.malformed.structure.title"))]
         [:div {:class (stl/css :variant-error-darken)}
-         (tr "workspace.options.component.variant.malformed.structure")]])]))
+         (tr "workspace.options.component.variant.malformed.structure.example")]])]))
 
 (mf/defc component-variant*
   [{:keys [component shape data]}]
@@ -807,7 +824,7 @@
 
           (when (and is-variant? main-instance? same-variant? (not swap-opened?))
             [:> component-variant-main-instance* {:components components
-                                                  :shape shape
+                                                  :shapes shapes
                                                   :data data}])
 
           (when (dbg/enabled? :display-touched)
@@ -951,7 +968,7 @@
            [:> icon* {:icon-id "msg-neutral"
                       :class (stl/css :variant-error-darken)}]
            [:div {:class (stl/css :variant-error-highlight)}
-            (tr "workspace.options.component.variant.malformed.multi")]
+            (tr "workspace.options.component.variant.malformed.group.title")]
            [:button {:class (stl/css :variant-error-button)
                      :on-click select-shape-with-error}
-            (tr "workspace.options.component.variant.malformed.locate")]])]])))
+            (tr "workspace.options.component.variant.malformed.group.locate")]])]])))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5312,20 +5312,32 @@ msgid "workspace.options.component.variant"
 msgstr "Variant"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:957
-msgid "workspace.options.component.variant.malformed.locate"
+msgid "workspace.options.component.variant.malformed.group.locate"
 msgstr "Locate invalid variants"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:954
-msgid "workspace.options.component.variant.malformed.multi"
+msgid "workspace.options.component.variant.malformed.group.title"
 msgstr "Some variants have invalid names"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
-msgid "workspace.options.component.variant.malformed.single"
-msgstr "This variant has an invalid name. Try using the following structure:"
+msgid "workspace.options.component.variant.malformed.single.all"
+msgstr "These variants have invalid names."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
+msgid "workspace.options.component.variant.malformed.single.one"
+msgstr "This variant has an invalid name."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
+msgid "workspace.options.component.variant.malformed.single.some"
+msgstr "Some of these variants have invalid names."
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:311
-msgid "workspace.options.component.variant.malformed.structure"
+msgid "workspace.options.component.variant.malformed.structure.example"
 msgstr "[property]=[value], [property]=[value]"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
+msgid "workspace.options.component.variant.malformed.structure.title"
+msgstr "Try using the following structure:"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs:163
 msgid "workspace.options.constraints"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5337,22 +5337,32 @@ msgid "workspace.options.component.variant"
 msgstr "Variante"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:957
-msgid "workspace.options.component.variant.malformed.locate"
+msgid "workspace.options.component.variant.malformed.group.locate"
 msgstr "Localizar variantes no válidas"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:954
-msgid "workspace.options.component.variant.malformed.multi"
+msgid "workspace.options.component.variant.malformed.group.title"
 msgstr "Algunas variantes tienen nombres no válidos"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
-msgid "workspace.options.component.variant.malformed.single"
-msgstr ""
-"Esta variante tiene un nombre no válido. Prueba a utilizar la siguiente "
-"estructura:"
+msgid "workspace.options.component.variant.malformed.single.all"
+msgstr "Estas variantes tienen nombres no válidos."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
+msgid "workspace.options.component.variant.malformed.single.one"
+msgstr "Esta variante tiene un nombre no válido."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
+msgid "workspace.options.component.variant.malformed.single.some"
+msgstr "Algunas de estas variantes tienen nombres no válidos."
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:311
-msgid "workspace.options.component.variant.malformed.structure"
+msgid "workspace.options.component.variant.malformed.structure.example"
 msgstr "[propiedad]=[valor], [propiedad]=[valor]"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
+msgid "workspace.options.component.variant.malformed.structure.title"
+msgstr "Prueba a utilizar la siguiente estructura:"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs:163
 msgid "workspace.options.constraints"


### PR DESCRIPTION
### Related Ticket

Taiga [#11127](https://tree.taiga.io/project/penpot/task/11127)

### Summary

When multiple variants are selected, the user can have three different cases:

- No selected variant has any errors.
- All variants have an error each.
- Some variants have an error, some not.

We use different copies for each of these cases, and should be different of having just one variant selected with an error, which is the current and only case.
