### PR TITLE
:bug: Fix incorrect relink operation for stroke image

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -626,6 +626,9 @@
               (map? (:fill-image form))
               (update-in [:fill-image :id] lookup-index)
 
+              (map? (:stroke-image form))
+              (update-in [:stroke-image :id] lookup-index)
+
               ;; This covers old shapes and the new :fills.
               (uuid? (:fill-color-ref-file form))
               (update :fill-color-ref-file lookup-index)


### PR DESCRIPTION
### Summary

When you import file with stroke image, that image is not properly imported.


#### How to reproduce

Try to import this file, the stroke image gets 404.
[sample-sync.zip](https://github.com/user-attachments/files/20421713/sample-sync.zip)

