### PR TITLE
:recycle: Put token settings under config flag

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -10,6 +10,7 @@
    [app.common.data :as d]
    [app.common.json :as json]
    [app.common.types.tokens-lib :as ctob]
+   [app.config :as cf]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.data.style-dictionary :as sd]
@@ -414,13 +415,15 @@
                                :on-click on-export}
        (tr "labels.export")]]
 
-     [:> tooltip* {:tooltip-content "Tokens settings"
-                   :id "button-setting"}
-      [:> icon-button* {:variant "secondary"
-                        :icon "settings"
-                        :tooltip-id "button-setting"
-                        :aria-label "Settings"
-                        :on-click open-settings-modal}]]]))
+
+     (when (contains? cf/flags :token-units)
+       [:> tooltip* {:tooltip-content "Tokens settings"
+                     :id "button-setting"}
+        [:> icon-button* {:variant "secondary"
+                          :icon "settings"
+                          :tooltip-id "button-setting"
+                          :aria-label "Settings"
+                          :on-click open-settings-modal}]])]))
 
 (mf/defc tokens-sidebar-tab*
   {::mf/wrap [mf/memo]}


### PR DESCRIPTION
### Related Ticket

This PR closes [this taks](https://tree.taiga.io/project/penpot/task/11147)

### Summary

I've added a config flag for `token-units` and I've placed the token settings modal under that flag.

### Steps to reproduce 

If you don't enable the flag you will not be able to see the token settings  modal. 
![Screenshot from 2025-05-26 10-46-06](https://github.com/user-attachments/assets/01b62546-7008-4e5e-b8ed-dd4f864a23cb)

Add `enable-token-units` to this file `frontend/resources/public/js/config.js` and refresh the page

![Screenshot from 2025-05-26 10-47-34](https://github.com/user-attachments/assets/25c65055-d39e-439c-8b02-23fb5c3e59bf)

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
