### PR TITLE
:arrow_up: Update cuerdas library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### :bug: Bugs fixed
 
 - Fix incorrect handling of strokes with images on importing files
+- Fix tokens disappearing after manual additions [Taiga #11063](https://tree.taiga.io/project/penpot/issue/11063)
 
 
 ## 2.7.0 

--- a/common/deps.edn
+++ b/common/deps.edn
@@ -28,7 +28,7 @@
   integrant/integrant {:mvn/version "0.13.1"}
 
   funcool/tubax {:mvn/version "2021.05.20-0"}
-  funcool/cuerdas {:mvn/version "2023.11.09-407"}
+  funcool/cuerdas {:mvn/version "2025.05.26-411"}
   funcool/promesa
   {:git/sha "0c5ed6ad033515a2df4b55addea044f60e9653d0"
    :git/url "https://github.com/funcool/promesa"}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11063

### Summary

Token sets with a name that starts with uppercase "E" or "Q" are not updated when saved to backend.

### Steps to reproduce 

- Import a tokens json file, that contains a set named "Elements / Button" (see file attached to the Taiga Issue).
- Add a new token to this set.
- Check that the token exists and can be edited or applied.
- Reload the page, or navigate out to dashboard and edit the same file again.
- The token has disappeared.

### Tecnical explanation

The code uses `funcool.cuerdas.core/trim` function to convert a path like `" Elements / Button "` into `["Elements", "Button"]` removing spaces around `" / "`. In Clojurescript this works well, and that's why initially you can create and use the token. But in Clojure, the `cuerdas` library had [a bug that caused it to recognice uppercase E and Q as white space](https://github.com/funcool/cuerdas/pull/94). That way, when frontend sends a command to the backend to create the token, it interprets that it needs to create it in `["lements" "Button"]`. Since this path doesn't lead to an existent set, the command is ignored.

This has been fixed in the latest release of `cuerdas`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
