### PR TITLE
:sparkles: Use system theme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,7 @@ A non exhaustive list of changes:
 - Copy to SVG from contextual menu [Github #838](https://github.com/penpot/penpot/issues/838)
 - Add styles for Inkeep Chat at workspace [Taiga #10708](https://tree.taiga.io/project/penpot/us/10708)
 - Add configuration for air gapped installations with Docker
+- Support system color scheme [Github #5030](https://github.com/penpot/penpot/issues/5030)
 
 ### :bug: Bugs fixed
 - Fix getCurrentUser for plugins api [Taiga #11057](https://tree.taiga.io/project/penpot/issue/11057)

--- a/frontend/src/app/main.cljs
+++ b/frontend/src/app/main.cljs
@@ -97,7 +97,8 @@
   (cur/init-styles)
   (thr/init!)
   (init-ui)
-  (st/emit! (plugins/initialize)
+  (st/emit! (theme/initialize)
+            (plugins/initialize)
             (initialize)))
 
 (defn ^:export reinit

--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -160,8 +160,10 @@
     (update [_ state]
       (update-in state [:profile :theme]
                  (fn [current]
-                   (if (= current "default")
-                     "light"
+                   (case current
+                     "dark"   "light"
+                     "light"  "system"
+                     "system" "dark"
                      "default"))))
 
     ptk/WatchEvent

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -30,6 +30,7 @@
    [app.main.ui.static :as static]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
+   [app.util.theme :as theme]
    [beicon.v2.core :as rx]
    [rumext.v2 :as mf]))
 
@@ -358,13 +359,12 @@
   (let [route   (mf/deref refs/route)
         edata   (mf/deref refs/exception)
         profile (mf/deref refs/profile)
-        theme   (case (:theme profile)
-                  "system" (dom/get-system-theme)
-                  "default" "dark"
-                  (:theme profile))]
+        profile-theme (:theme profile)
+        system-theme (mf/deref theme/preferred-color-scheme)]
 
-    (mf/with-effect [theme]
-      (dom/set-html-theme-color theme))
+    (mf/with-effect [profile-theme system-theme]
+      (dom/set-html-theme-color
+       (if (= profile-theme "system") system-theme profile-theme)))
 
     [:& (mf/provider ctx/current-route) {:value route}
      [:& (mf/provider ctx/current-profile) {:value profile}

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -358,7 +358,10 @@
   (let [route   (mf/deref refs/route)
         edata   (mf/deref refs/exception)
         profile (mf/deref refs/profile)
-        theme   (or (:theme profile) "default")]
+        theme   (case (:theme profile)
+                  "system" (dom/get-system-theme)
+                  "default" "dark"
+                  (:theme profile))]
 
     (mf/with-effect [theme]
       (dom/set-html-theme-color theme))

--- a/frontend/src/app/main/ui/settings/options.cljs
+++ b/frontend/src/app/main/ui/settings/options.cljs
@@ -59,8 +59,9 @@
       [:& fm/select {:label (tr "dashboard.select-ui-theme")
                      :name :theme
                      :default "default"
-                     :options [{:label "Penpot Dark (default)" :value "default"}
-                               {:label "Penpot Light" :value "light"}]
+                     :options [{:label (tr "dashboard.select-ui-theme.dark") :value "dark"}
+                               {:label (tr "dashboard.select-ui-theme.light") :value "light"}
+                               {:label (tr "dashboard.select-ui-theme.system") :value "system"}]
                      :data-testid "setting-theme"}]]
 
      [:> fm/submit-button*

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -280,9 +280,11 @@
                               :data-testid   "toggle-theme"
                               :id          "file-menu-toggle-theme"}
       [:span {:class (stl/css :item-name)}
-       (if (= (:theme profile) "default")
-         (tr "workspace.header.menu.toggle-light-theme")
-         (tr "workspace.header.menu.toggle-dark-theme"))]
+       (case (:theme profile)  ;; default = dark -> light -> system -> dark and so on
+         "default" (tr "workspace.header.menu.toggle-light-theme")
+         "light"   (tr "workspace.header.menu.toggle-system-theme")
+         "system" (tr "workspace.header.menu.toggle-dark-theme")
+         (tr "workspace.header.menu.toggle-light-theme"))]
       [:span {:class (stl/css :shortcut)}
        (for [sc (scd/split-sc (sc/get-tooltip :toggle-theme))]
          [:span {:class (stl/css :shortcut-key) :key sc} sc])]]]))

--- a/frontend/src/app/util/dom.cljs
+++ b/frontend/src/app/util/dom.cljs
@@ -76,9 +76,10 @@
 
 (defn set-html-theme-color
   [^string color]
-  (let [node (.querySelector js/document "body")]
+  (let [node (.querySelector js/document "body")
+        class (if (= color "dark") "default" "light")]
     (.removeAttribute node "class")
-    (.add ^js (.-classList ^js node) color)))
+    (.add ^js (.-classList ^js node) class)))
 
 (defn set-page-style!
   [styles]

--- a/frontend/src/app/util/globals.js
+++ b/frontend/src/app/util/globals.js
@@ -17,7 +17,7 @@
 
 goog.provide("app.util.globals");
 
-goog.scope(function() {
+goog.scope(function () {
   app.util.globals.global = goog.global;
 
   function createGlobalEventEmitter(k) {
@@ -25,22 +25,27 @@ goog.scope(function() {
      * may subscribe to them.
      */
     return {
-      addListener(...args) {
-      },
-      removeListener(...args) {
-      },
-      addEventListener(...args) {
-      },
-      removeEventListener(...args) {
-      }
-    }
+      addListener(...args) {},
+      removeListener(...args) {},
+      addEventListener(...args) {},
+      removeEventListener(...args) {},
+      dispatchEvent(...args) { return true; },
+    };
   }
 
-  app.util.globals.window = (function() {
+  app.util.globals.window = (function () {
     if (typeof goog.global.window !== "undefined") {
       return goog.global.window;
     } else {
-      return createGlobalEventEmitter();
+      const mockWindow = createGlobalEventEmitter();
+      mockWindow.matchMedia = function (query) {
+        const mediaObj = createGlobalEventEmitter();
+        mediaObj.matches = false;
+        mediaObj.media = query;
+        mediaObj.onchange = null;
+        return mediaObj;
+      };
+      return mockWindow;
     }
   })();
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -923,6 +923,15 @@ msgstr "Select UI language"
 msgid "dashboard.select-ui-theme"
 msgstr "Select theme"
 
+msgid "dashboard.select-ui-theme.dark"
+msgstr "Penpot Dark (default)"
+
+msgid "dashboard.select-ui-theme.light"
+msgstr "Penpot Light"
+
+msgid "dashboard.select-ui-theme.system"
+msgstr "System theme"
+
 #: src/app/main/ui/settings/notifications.cljs:57
 msgid "dashboard.settings.notifications.dashboard-comments.all"
 msgstr "All comments, mentions and replies"
@@ -5165,6 +5174,9 @@ msgstr "Switch to dark theme"
 #: src/app/main/ui/workspace/main_menu.cljs:283
 msgid "workspace.header.menu.toggle-light-theme"
 msgstr "Switch to light theme"
+
+msgid "workspace.header.menu.toggle-system-theme"
+msgstr "Switch to system theme"
 
 #: src/app/main/ui/workspace/main_menu.cljs:457
 msgid "workspace.header.menu.undo"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -935,6 +935,15 @@ msgstr "Cambiar el idioma de la interfaz"
 msgid "dashboard.select-ui-theme"
 msgstr "Selecciona un tema"
 
+msgid "dashboard.select-ui-theme.dark"
+msgstr "Penpot Dark (por defecto)"
+
+msgid "dashboard.select-ui-theme.light"
+msgstr "Penpot Light"
+
+msgid "dashboard.select-ui-theme.system"
+msgstr "Sistema"
+
 #: src/app/main/ui/settings/notifications.cljs:57
 msgid "dashboard.settings.notifications.dashboard-comments.all"
 msgstr "Todos los comentarios, menciones y respuestas"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5204,6 +5204,9 @@ msgstr "Cambiar a tema oscuro"
 msgid "workspace.header.menu.toggle-light-theme"
 msgstr "Cambiar a tema claro"
 
+msgid "workspace.header.menu.toggle-system-theme"
+msgstr "Cambiar a tema del sistema"
+
 #: src/app/main/ui/workspace/main_menu.cljs:457
 msgid "workspace.header.menu.undo"
 msgstr "Deshacer"


### PR DESCRIPTION
### Summary

This is a proposal to

* Close #5030 

which was a bit annoying in the evenings :)

---

This PR:

 - Introduces a new setting "System theme" accessible from the profile settings and the workspace menu
 - When it's in effect, the UI changes from light to dark theme as expected
 - Adds the `.matchMedia` method to the mock returned by `globals/window` when no actual window is available. No tests would fail right now without it, but it seemed prudent to add it

### Questions

I'm not 100% sure about the implementation. Any comments are welcome, and I'm happy to change whatever is required. The code:

 - Creates an observable that listens to the `change` event of a `window.matchMedia` query.
 - When it fires, an atom is updated with the system setting. It is referenced from `app.main.ui/app`. I chose this instead of using `st/state` because it's not really application state
 - Is mostly inside `app.util.theme`. It seems to me that the code already there is never used and might be the remnants of an old idea. Are actual themes ever going to be a thing, and if not, should I remove that dead code? I have to say it was a bit confusing at first to see it there, apparently doing nothing.


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
