### PR TITLE
:bug: Fix team name dropdown menu from dashboard

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -680,7 +680,7 @@
 
 
          (and (not (:is-default team))
-              (not (contains? cf/flags :subscriptions)))
+              (or (not= "unlimited" subscription-name) (not= "enterprise" subscription-name)))
          [:div {:class (stl/css :team-name)}
           [:img {:src (cf/resolve-team-photo-url team)
                  :class (stl/css :team-picture)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11167

### Summary

When a team is selected in the dashboard menu that is not the default team and the user does not have a subscription, the team name is missing.

![image](https://github.com/user-attachments/assets/f936d0b1-5b6b-4049-a592-6ed11092a0ff)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
