### PR TITLE
:sparkles: Add configuration for air gapped installations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,7 @@ A non exhaustive list of changes:
 - Deselect layers (and path nodes) with Ctrl+Shift+Drag [Github #2509](https://github.com/penpot/penpot/issues/2509)
 - Copy to SVG from contextual menu [Github #838](https://github.com/penpot/penpot/issues/838)
 - Add styles for Inkeep Chat at workspace [Taiga #10708](https://tree.taiga.io/project/penpot/us/10708)
+- Add configuration for air gapped installations with Docker
 
 ### :bug: Bugs fixed
 - Fix getCurrentUser for plugins api [Taiga #11057](https://tree.taiga.io/project/penpot/issue/11057)

--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -11,6 +11,7 @@ RUN set -ex; \
 ADD ./bundle-frontend/ /var/www/app/
 ADD ./files/config.js /var/www/app/js/config.js
 ADD ./files/nginx.conf /etc/nginx/nginx.conf.template
+ADD ./files/nginx-proxies.conf /etc/nginx/nginx-proxies.conf
 ADD ./files/resolvers.conf /etc/nginx/overrides.d/resolvers.conf.template
 ADD ./files/nginx-mime.types /etc/nginx/mime.types
 ADD ./files/nginx-entrypoint.sh /entrypoint.sh

--- a/docker/images/files/nginx-entrypoint.sh
+++ b/docker/images/files/nginx-entrypoint.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
 #########################################
+## Air Gapped config
+#########################################
+
+if [[ $PENPOT_FLAGS == *"enable-air-gapped-conf"* ]]; then
+    export INCLUDE_PROXIES=""
+    export PENPOT_FLAGS="$PENPOT_FLAGS disable-google-fonts-provider disable-dashboard-templates-section"
+else
+    export INCLUDE_PROXIES="include /etc/nginx/nginx-proxies.conf;"
+fi
+
+#########################################
 ## App Frontend config
 #########################################
 
@@ -15,20 +26,21 @@ update_flags() {
 update_flags /var/www/app/js/config.js
 
 
+
 #########################################
 ## Nginx Config
 #########################################
 
-export PENPOT_BACKEND_URI=${PENPOT_BACKEND_URI:-http://penpot-backend:6060};
-export PENPOT_EXPORTER_URI=${PENPOT_EXPORTER_URI:-http://penpot-exporter:6061};
-PENPOT_DEFAULT_INTERNAL_RESOLVER="$(awk 'BEGIN{ORS=" "} $1=="nameserver" { sub(/%.*$/,"",$2); print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf)";
-export PENPOT_INTERNAL_RESOLVER=${PENPOT_INTERNAL_RESOLVER:-$PENPOT_DEFAULT_INTERNAL_RESOLVER};
-export PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE=${PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE:-367001600}; # Default to 350MiB
+export PENPOT_BACKEND_URI=${PENPOT_BACKEND_URI:-http://penpot-backend:6060}
+export PENPOT_EXPORTER_URI=${PENPOT_EXPORTER_URI:-http://penpot-exporter:6061}
+PENPOT_DEFAULT_INTERNAL_RESOLVER="$(awk 'BEGIN{ORS=" "} $1=="nameserver" { sub(/%.*$/,"",$2); print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf)"
+export PENPOT_INTERNAL_RESOLVER=${PENPOT_INTERNAL_RESOLVER:-$PENPOT_DEFAULT_INTERNAL_RESOLVER}
+export PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE=${PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE:-367001600} # Default to 350MiB
 
-envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI,\$PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE" \
-         < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf;
+envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI,\$PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE,\$INCLUDE_PROXIES" \
+         < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 envsubst "\$PENPOT_INTERNAL_RESOLVER" \
-         < /etc/nginx/overrides.d/resolvers.conf.template > /etc/nginx/overrides.d/resolvers.conf;
+         < /etc/nginx/overrides.d/resolvers.conf.template > /etc/nginx/overrides.d/resolvers.conf
 
 exec "$@";

--- a/docker/images/files/nginx-proxies.conf
+++ b/docker/images/files/nginx-proxies.conf
@@ -1,0 +1,59 @@
+location ~ ^/github/penpot-files/(.+)$ {
+    rewrite ^/github/penpot-files/(.+) /penpot/penpot-files/refs/heads/main/$1 break;
+    proxy_pass https://raw.githubusercontent.com;
+
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Cookies;
+    proxy_set_header User-Agent "curl/8.5.0";
+    proxy_set_header Host "raw.githubusercontent.com";
+    proxy_set_header Accept "*/*";
+    add_header Access-Control-Allow-Origin $http_origin;
+    proxy_buffering off;
+}
+
+location ~ ^/internal/gfonts/font/(?<font_file>.+) {
+    proxy_pass https://fonts.gstatic.com/s/$font_file;
+
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Cross-Origin-Resource-Policy;
+    proxy_hide_header Link;
+    proxy_hide_header Alt-Svc;
+    proxy_hide_header Cache-Control;
+    proxy_hide_header Expires;
+    proxy_hide_header Cross-Origin-Opener-Policy;
+    proxy_hide_header Report-To;
+
+    proxy_ignore_headers Set-Cookie Vary Cache-Control Expires;
+
+    proxy_set_header User-Agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36";
+    proxy_set_header Host "fonts.gstatic.com";
+    proxy_set_header Accept "*/*";
+
+    proxy_cache penpot;
+
+    add_header Access-Control-Allow-Origin $http_origin;
+    add_header Cache-Control max-age=86400;
+    add_header X-Cache-Status $upstream_cache_status;
+}
+
+location ~ ^/internal/gfonts/css {
+    proxy_pass https://fonts.googleapis.com/css?$args;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Cross-Origin-Resource-Policy;
+    proxy_hide_header Link;
+    proxy_hide_header Alt-Svc;
+    proxy_hide_header Cache-Control;
+    proxy_hide_header Expires;
+
+    proxy_ignore_headers Set-Cookie Vary Cache-Control Expires;
+
+    proxy_set_header User-Agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36";
+    proxy_set_header Host "fonts.googleapis.com";
+    proxy_set_header Accept "*/*";
+
+    proxy_cache penpot;
+
+    add_header Access-Control-Allow-Origin $http_origin;
+    add_header Cache-Control max-age=86400;
+    add_header X-Cache-Status $upstream_cache_status;
+}

--- a/docker/images/files/nginx.conf
+++ b/docker/images/files/nginx.conf
@@ -135,65 +135,7 @@ http {
         }
 
         location / {
-            location ~ ^/github/penpot-files/(.+)$ {
-                rewrite ^/github/penpot-files/(.+) /penpot/penpot-files/refs/heads/main/$1 break;
-                proxy_pass https://raw.githubusercontent.com;
-
-                proxy_hide_header Access-Control-Allow-Origin;
-                proxy_hide_header Cookies;
-                proxy_set_header User-Agent "curl/8.5.0";
-                proxy_set_header Host "raw.githubusercontent.com";
-                proxy_set_header Accept "*/*";
-                add_header Access-Control-Allow-Origin $http_origin;
-                proxy_buffering off;
-            }
-
-            location ~ ^/internal/gfonts/font/(?<font_file>.+) {
-                proxy_pass https://fonts.gstatic.com/s/$font_file;
-
-                proxy_hide_header Access-Control-Allow-Origin;
-                proxy_hide_header Cross-Origin-Resource-Policy;
-                proxy_hide_header Link;
-                proxy_hide_header Alt-Svc;
-                proxy_hide_header Cache-Control;
-                proxy_hide_header Expires;
-                proxy_hide_header Cross-Origin-Opener-Policy;
-                proxy_hide_header Report-To;
-
-                proxy_ignore_headers Set-Cookie Vary Cache-Control Expires;
-
-                proxy_set_header User-Agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36";
-                proxy_set_header Host "fonts.gstatic.com";
-                proxy_set_header Accept "*/*";
-
-                proxy_cache penpot;
-
-                add_header Access-Control-Allow-Origin $http_origin;
-                add_header Cache-Control max-age=86400;
-                add_header X-Cache-Status $upstream_cache_status;
-            }
-
-            location ~ ^/internal/gfonts/css {
-                proxy_pass https://fonts.googleapis.com/css?$args;
-                proxy_hide_header Access-Control-Allow-Origin;
-                proxy_hide_header Cross-Origin-Resource-Policy;
-                proxy_hide_header Link;
-                proxy_hide_header Alt-Svc;
-                proxy_hide_header Cache-Control;
-                proxy_hide_header Expires;
-
-                proxy_ignore_headers Set-Cookie Vary Cache-Control Expires;
-
-                proxy_set_header User-Agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36";
-                proxy_set_header Host "fonts.googleapis.com";
-                proxy_set_header Accept "*/*";
-
-                proxy_cache penpot;
-
-                add_header Access-Control-Allow-Origin $http_origin;
-                add_header Cache-Control max-age=86400;
-                add_header X-Cache-Status $upstream_cache_status;
-            }
+            $INCLUDE_PROXIES
 
             location ~ ^/js/config.js$ {
                 add_header Cache-Control "no-store, no-cache, max-age=0" always;

--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -366,7 +366,7 @@ PENPOT_REDIS_URI: redis://localhost/0
 PENPOT_REDIS_URI: redis://localhost/0
 ```
 
-If you are using the official docker compose file, this is already configurRed.
+If you are using the official docker compose file, this is already configured.
 
 ## Demo environment
 
@@ -391,6 +391,22 @@ verification process:
 ```bash
 PENPOT_FLAGS: disable-email-verification enable-demo-warning
 ```
+
+## Air gapped environments
+
+The current Penpot installation defaults to several external proxies:
+- to Github, from where the libraries and templates are downloaded
+- to Google, from where the google-fonts are downloaded.
+
+This is implemented as specific locations in the penpot-front Nginx. If your organization needs to install Penpot
+in a 100% air-gapped environment, you can use the following configuration:
+
+```bash
+PENPOT_FLAGS: enable-air-gapped-conf
+```
+
+When Penpot starts, it will leave out the Nginx configuration related to external requests. This means that,
+with this flag enabled, the Penpot configuration will disable as well the libraries and templates dashboard and the use of Google fonts.
 
 ## Backend
 


### PR DESCRIPTION
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGtjb25qNnF4enV2bTdpYjZ4end0cGN5aDlhZmJwNDh3eWY5bm85MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/pbgvTDqj1sAaQ/giphy.gif)

This PR allows install Penpot in an air gapped environment. Default behaviour remains the same.

To test it:
- build a docker image in this branch
- run it as usual: you should have the google fonts available and the libraries and templates shown
- check the [temporary documentation](https://yms-airgapped-docker.penpot.pages.dev/technical-guide/configuration/#air-gapped-environments) and configure the instance as air gapped installation. Check there are no google fonts, nor libraries and templates.