### PR TITLE
:sparkles: Manage empty property values in the combobox in design tab

### DIFF
--- a/common/src/app/common/files/variant.cljc
+++ b/common/src/app/common/files/variant.cljc
@@ -8,8 +8,7 @@
    [app.common.data.macros :as dm]
    [app.common.types.component :as ctc]
    [app.common.types.components-list :as ctcl]
-   [app.common.types.variant :as ctv]
-   [cuerdas.core :as str]))
+   [app.common.types.variant :as ctv]))
 
 
 (defn find-variant-components
@@ -20,11 +19,6 @@
        (map #(dm/get-in objects [% :component-id]))
        (map #(ctcl/get-component data % true))
        reverse))
-
-(defn- dashes-to-end
-  [property-values]
-  (let [dashes (if (some #(= % "--") property-values) ["--"] [])]
-    (concat (remove #(= % "--") property-values) dashes)))
 
 
 (defn extract-properties-names
@@ -42,10 +36,7 @@
        (group-by :name)
        (map (fn [[k v]]
               {:name k
-               :value (->> v
-                           (map #(if (str/empty? (:value %)) "--" (:value %)))
-                           distinct
-                           dashes-to-end)}))))
+               :value (distinct (map :value v))}))))
 
 (defn get-variant-mains
   [component data]

--- a/common/src/app/common/files/variant.cljc
+++ b/common/src/app/common/files/variant.cljc
@@ -36,7 +36,7 @@
        (group-by :name)
        (map (fn [[k v]]
               {:name k
-               :value (distinct (map :value v))}))))
+               :value (->> v (map :value) distinct)}))))
 
 (defn get-variant-mains
   [component data]

--- a/frontend/src/app/main/ui/ds/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/ds/controls/combobox.cljs
@@ -59,11 +59,12 @@
    [:disabled {:optional true} :boolean]
    [:default-selected {:optional true} :string]
    [:on-change {:optional true} fn?]
+   [:empty-to-end {:optional true} :boolean]
    [:has-error {:optional true} :boolean]])
 
 (mf/defc combobox*
   {::mf/schema schema:combobox}
-  [{:keys [id options class placeholder disabled has-error default-selected max-length on-change] :rest props}]
+  [{:keys [id options class placeholder disabled has-error default-selected max-length empty-to-end on-change] :rest props}]
   (let [is-open*        (mf/use-state false)
         is-open         (deref is-open*)
 
@@ -187,7 +188,6 @@
 
                    (kbd/enter? event)
                    (do
-                     #_(handle-selection focused-value* selected-value* is-open*)
                      (reset! selected-value* focused-value)
                      (reset! is-open* false)
                      (reset! focused-value* nil)
@@ -286,4 +286,5 @@
                               :focused focused-value
                               :set-ref set-option-ref
                               :id listbox-id
+                              :empty-to-end empty-to-end
                               :data-testid "combobox-options"}])]))

--- a/frontend/src/app/main/ui/ds/controls/select.cljs
+++ b/frontend/src/app/main/ui/ds/controls/select.cljs
@@ -15,6 +15,7 @@
    [app.util.dom :as dom]
    [app.util.keyboard :as kbd]
    [app.util.object :as obj]
+   [clojure.string :as str]
    [rumext.v2 :as mf]))
 
 (def listbox-id-index (atom 0))
@@ -66,13 +67,23 @@
    [:class {:optional true} :string]
    [:disabled {:optional true} :boolean]
    [:default-selected {:optional true} :string]
+   [:empty-to-end {:optional true} :boolean]
    [:on-change {:optional true} fn?]])
 
 (mf/defc select*
   {::mf/schema schema:select}
-  [{:keys [options class disabled default-selected on-change] :rest props}]
-  (let [open* (mf/use-state false)
-        open  (deref open*)
+  [{:keys [options class disabled default-selected empty-to-end on-change] :rest props}]
+  (let [is-open*        (mf/use-state false)
+        is-open         (deref is-open*)
+
+        selected-value* (mf/use-state  #(get-selected-option-id options default-selected))
+        selected-value  (deref selected-value*)
+
+        focused-value*  (mf/use-state nil)
+        focused-value   (deref focused-value*)
+
+        has-focus*      (mf/use-state false)
+        has-focus       (deref has-focus*)
 
         listbox-id-ref     (mf/use-ref (dm/str "select-listbox-" (swap! listbox-id-index inc)))
         options-nodes-refs (mf/use-ref nil)
@@ -80,37 +91,9 @@
         select-ref         (mf/use-ref nil)
         listbox-id         (mf/ref-val listbox-id-ref)
 
-        selected* (mf/use-state  #(get-selected-option-id options default-selected))
-        selected  (deref selected*)
+        empty-selected-value? (str/blank? selected-value)
 
-        focused* (mf/use-state nil)
-        focused  (deref focused*)
-
-        has-focus* (mf/use-state false)
-        has-focus  (deref has-focus*)
-
-        on-click
-        (mf/use-fn
-         (mf/deps disabled)
-         (fn [event]
-           (dom/stop-propagation event)
-           (reset! has-focus* true)
-           (when-not disabled
-             (swap! open* not))))
-
-        on-option-click
-        (mf/use-fn
-         (mf/deps on-change)
-         (fn [event]
-           (let [node  (dom/get-current-target event)
-                 id    (dom/get-data node "id")]
-             (reset! selected* id)
-             (reset! focused* nil)
-             (reset! open* false)
-             (when (fn? on-change)
-               (on-change id)))))
-
-        set-ref
+        set-option-ref
         (mf/use-fn
          (fn [node id]
            (let [refs (or (mf/ref-val options-nodes-refs) #js {})
@@ -119,47 +102,69 @@
                         (obj/unset! refs id))]
              (mf/set-ref-val! options-nodes-refs refs))))
 
-        on-blur
+        on-option-click
+        (mf/use-fn
+         (mf/deps on-change)
+         (fn [event]
+           (let [node  (dom/get-current-target event)
+                 id    (dom/get-data node "id")]
+             (reset! selected-value* id)
+             (reset! focused-value* nil)
+             (reset! is-open* false)
+             (when (fn? on-change)
+               (on-change id)))))
+
+        on-component-click
+        (mf/use-fn
+         (mf/deps disabled)
+         (fn [event]
+           (dom/stop-propagation event)
+           (reset! has-focus* true)
+           (when-not disabled
+             (swap! is-open* not))))
+
+        on-component-blur
         (mf/use-fn
          (fn [event]
            (let [target (.-relatedTarget event)
                  outside? (not (.contains (mf/ref-val select-ref) target))]
              (when outside?
-               (reset! focused* nil)
-               (reset! open* false)
+               (reset! focused-value* nil)
+               (reset! is-open* false)
                (reset! has-focus* false)))))
 
-        on-key-down
+        on-component-focus
         (mf/use-fn
-         (mf/deps focused disabled)
+         (fn [_]
+           (reset! has-focus* true)))
+
+        on-button-key-down
+        (mf/use-fn
+         (mf/deps focused-value disabled)
          (fn [event]
+           (dom/stop-propagation event)
            (when-not disabled
              (let [options (mf/ref-val options-ref)
                    len     (alength options)
-                   index   (array/find-index #(= (deref focused*) (obj/get % "id")) options)]
-               (dom/stop-propagation event)
+                   index   (array/find-index #(= (deref focused-value*) (obj/get % "id")) options)]
                (cond
                  (kbd/home? event)
-                 (handle-focus-change options focused* 0 options-nodes-refs)
+                 (handle-focus-change options focused-value* 0 options-nodes-refs)
 
                  (kbd/up-arrow? event)
-                 (handle-focus-change options focused* (mod (- index 1) len) options-nodes-refs)
+                 (handle-focus-change options focused-value* (mod (- index 1) len) options-nodes-refs)
 
                  (kbd/down-arrow? event)
-                 (handle-focus-change options focused* (mod (+ index 1) len) options-nodes-refs)
+                 (handle-focus-change options focused-value* (mod (+ index 1) len) options-nodes-refs)
 
                  (or (kbd/space? event) (kbd/enter? event))
-                 (when (deref open*)
+                 (when (deref is-open*)
                    (dom/prevent-default event)
-                   (handle-selection focused* selected* open*))
+                   (handle-selection focused-value* selected-value* is-open*))
 
                  (kbd/esc? event)
-                 (do (reset! open* false)
-                     (reset! focused* nil)))))))
-
-        on-focus
-        (mf/use-fn
-         (fn [_] (reset! has-focus* true)))
+                 (do (reset! is-open* false)
+                     (reset! focused-value* nil)))))))
 
         class (dm/str class " " (stl/css-case :select true
                                               :focused has-focus))
@@ -168,13 +173,13 @@
                                       :role "combobox"
                                       :aria-controls listbox-id
                                       :aria-haspopup "listbox"
-                                      :aria-activedescendant focused
-                                      :aria-expanded open
-                                      :on-key-down on-key-down
+                                      :aria-activedescendant focused-value
+                                      :aria-expanded is-open
+                                      :on-key-down on-button-key-down
                                       :disabled disabled
-                                      :on-click on-click})
+                                      :on-click on-component-click})
 
-        selected-option (get-option options selected)
+        selected-option (get-option options selected-value)
         label (obj/get selected-option "label")
         icon (obj/get selected-option "icon")]
 
@@ -182,10 +187,11 @@
       (mf/set-ref-val! options-ref options))
 
     [:div {:class (stl/css :select-wrapper)
-           :on-click on-click
-           :on-focus on-focus
+           :on-click on-component-click
+           :on-focus on-component-focus
            :ref select-ref
-           :on-blur on-blur}
+           :on-blur on-component-blur}
+
      [:> :button props
       [:span {:class (stl/css-case :select-header true
                                    :header-icon (some? icon))}
@@ -193,16 +199,19 @@
          [:> icon* {:icon-id icon
                     :size "s"
                     :aria-hidden true}])
-       [:span {:class (stl/css :header-label)}
-        label]]
+       [:span {:class (stl/css-case :header-label true
+                                    :header-label-dimmed empty-selected-value?)}
+        (if empty-selected-value? "--" label)]]
       [:> icon* {:icon-id i/arrow
                  :class (stl/css :arrow)
                  :size "m"
                  :aria-hidden true}]]
-     (when open
+
+     (when is-open
        [:> options-dropdown* {:on-click on-option-click
                               :id listbox-id
                               :options options
-                              :selected selected
-                              :focused focused
-                              :set-ref set-ref}])]))
+                              :selected selected-value
+                              :focused focused-value
+                              :empty-to-end empty-to-end
+                              :set-ref set-option-ref}])]))

--- a/frontend/src/app/main/ui/ds/controls/select.cljs
+++ b/frontend/src/app/main/ui/ds/controls/select.cljs
@@ -95,6 +95,7 @@
 
         set-option-ref
         (mf/use-fn
+         (mf/deps options-nodes-refs)
          (fn [node id]
            (let [refs (or (mf/ref-val options-nodes-refs) #js {})
                  refs (if node

--- a/frontend/src/app/main/ui/ds/controls/select.scss
+++ b/frontend/src/app/main/ui/ds/controls/select.scss
@@ -11,6 +11,7 @@
 .select-wrapper {
   --select-icon-fg-color: var(--color-foreground-secondary);
   --select-fg-color: var(--color-foreground-primary);
+  --select-fg-color-dimmed: var(--color-foreground-secondary);
   --select-bg-color: var(--color-background-tertiary);
   --select-outline-color: none;
   --select-border-color: none;
@@ -78,6 +79,10 @@
   padding-inline-start: var(--sp-xxs);
   text-align: left;
   color: var(--select-fg-color);
+}
+
+.header-label-dimmed {
+  color: var(--select-fg-color-dimmed);
 }
 
 .header-icon {

--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
@@ -55,61 +55,48 @@
   (let [props (mf/spread-props props
                                {:class (stl/css :option-list)
                                 :tab-index "-1"
-                                :role "listbox"})]
+                                :role "listbox"})
 
-    (if empty-to-end
+        options-blank (when empty-to-end
+                        (array/filter #(str/blank? (obj/get % "id")) options))
+        options       (if empty-to-end
+                        (array/filter #((complement str/blank?) (obj/get % "id")) options)
+                        options)]
 
-      (let [with-id       (array/filter #((complement str/blank?) (obj/get % "id")) options)
-            with-blank-id (array/filter #(str/blank? (obj/get % "id")) options)]
-        [:> "ul" props
-         (for [option ^js with-id]
-           (let [id    (obj/get option "id")
-                 label (obj/get option "label")
-                 aria-label (obj/get option "aria-label")
-                 icon (obj/get option "icon")]
-             [:> option* {:selected (= id selected)
-                          :key id
-                          :id id
-                          :label label
-                          :icon icon
-                          :aria-label aria-label
-                          :set-ref set-ref
-                          :focused (= id focused)
-                          :dimmed false
-                          :on-click on-click}]))
+    [:> "ul" props
+     (for [option ^js options]
+       (let [id    (obj/get option "id")
+             label (obj/get option "label")
+             aria-label (obj/get option "aria-label")
+             icon (obj/get option "icon")]
+         [:> option* {:selected (= id selected)
+                      :key id
+                      :id id
+                      :label label
+                      :icon icon
+                      :aria-label aria-label
+                      :set-ref set-ref
+                      :focused (= id focused)
+                      :dimmed false
+                      :on-click on-click}]))
 
-         (when (seq with-blank-id)
-           [:hr {:class (stl/css :option-separator)}])
+     (when (seq options-blank)
+       [:*
+        (when (seq options)
+          [:hr {:class (stl/css :option-separator)}])
 
-         (for [option ^js with-blank-id]
-           (let [id    (obj/get option "id")
-                 label (obj/get option "label")
-                 aria-label (obj/get option "aria-label")
-                 icon (obj/get option "icon")]
-             [:> option* {:selected (= id selected)
-                          :key id
-                          :id id
-                          :label label
-                          :icon icon
-                          :aria-label aria-label
-                          :set-ref set-ref
-                          :focused (= id focused)
-                          :dimmed true
-                          :on-click on-click}]))])
-
-      [:> "ul" props
-       (for [option ^js options]
-         (let [id    (obj/get option "id")
-               label (obj/get option "label")
-               aria-label (obj/get option "aria-label")
-               icon (obj/get option "icon")]
-           [:> option* {:selected (= id selected)
-                        :key id
-                        :id id
-                        :label label
-                        :icon icon
-                        :aria-label aria-label
-                        :set-ref set-ref
-                        :focused (= id focused)
-                        :dimmed false
-                        :on-click on-click}]))])))
+        (for [option ^js options-blank]
+          (let [id    (obj/get option "id")
+                label (obj/get option "label")
+                aria-label (obj/get option "aria-label")
+                icon (obj/get option "icon")]
+            [:> option* {:selected (= id selected)
+                         :key id
+                         :id id
+                         :label label
+                         :icon icon
+                         :aria-label aria-label
+                         :set-ref set-ref
+                         :focused (= id focused)
+                         :dimmed true
+                         :on-click on-click}]))])]))

--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
@@ -9,12 +9,14 @@
    [app.main.style :as stl])
   (:require
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
+   [app.util.array :as array]
    [app.util.object :as obj]
+   [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
 (mf/defc option*
   {::mf/private true}
-  [{:keys [id label icon aria-label on-click selected set-ref focused] :rest props}]
+  [{:keys [id label icon aria-label on-click selected set-ref focused dimmed] :rest props}]
 
   [:> :li {:value id
            :class (stl/css-case :option true
@@ -38,7 +40,8 @@
        :aria-hidden (when label true)
        :aria-label  (when (not label) aria-label)}])
 
-   [:span {:class (stl/css :option-text)} label]
+   [:span {:class (stl/css-case :option-text true
+                                :option-text-dimmed dimmed)} label]
    (when selected
      [:> icon*
       {:icon-id i/tick
@@ -48,23 +51,65 @@
 
 (mf/defc options-dropdown*
   {::mf/props :obj}
-  [{:keys [set-ref on-click options selected focused] :rest props}]
+  [{:keys [set-ref on-click options selected focused empty-to-end] :rest props}]
   (let [props (mf/spread-props props
                                {:class (stl/css :option-list)
                                 :tab-index "-1"
                                 :role "listbox"})]
-    [:> "ul" props
-     (for [option ^js options]
-       (let [id    (obj/get option "id")
-             label (obj/get option "label")
-             aria-label (obj/get option "aria-label")
-             icon (obj/get option "icon")]
-         [:> option* {:selected (= id selected)
-                      :key id
-                      :id id
-                      :label label
-                      :icon icon
-                      :aria-label aria-label
-                      :set-ref set-ref
-                      :focused (= id focused)
-                      :on-click on-click}]))]))
+
+    (if empty-to-end
+
+      (let [with-id       (array/filter #((complement str/blank?) (obj/get % "id")) options)
+            with-blank-id (array/filter #(str/blank? (obj/get % "id")) options)]
+        [:> "ul" props
+         (for [option ^js with-id]
+           (let [id    (obj/get option "id")
+                 label (obj/get option "label")
+                 aria-label (obj/get option "aria-label")
+                 icon (obj/get option "icon")]
+             [:> option* {:selected (= id selected)
+                          :key id
+                          :id id
+                          :label label
+                          :icon icon
+                          :aria-label aria-label
+                          :set-ref set-ref
+                          :focused (= id focused)
+                          :dimmed false
+                          :on-click on-click}]))
+
+         (when (seq with-blank-id)
+           [:hr {:class (stl/css :option-separator)}])
+
+         (for [option ^js with-blank-id]
+           (let [id    (obj/get option "id")
+                 label (obj/get option "label")
+                 aria-label (obj/get option "aria-label")
+                 icon (obj/get option "icon")]
+             [:> option* {:selected (= id selected)
+                          :key id
+                          :id id
+                          :label label
+                          :icon icon
+                          :aria-label aria-label
+                          :set-ref set-ref
+                          :focused (= id focused)
+                          :dimmed true
+                          :on-click on-click}]))])
+
+      [:> "ul" props
+       (for [option ^js options]
+         (let [id    (obj/get option "id")
+               label (obj/get option "label")
+               aria-label (obj/get option "aria-label")
+               icon (obj/get option "icon")]
+           [:> option* {:selected (= id selected)
+                        :key id
+                        :id id
+                        :label label
+                        :icon icon
+                        :aria-label aria-label
+                        :set-ref set-ref
+                        :focused (= id focused)
+                        :dimmed false
+                        :on-click on-click}]))])))

--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.scss
@@ -13,6 +13,7 @@
   --options-dropdown-bg-color: var(--color-background-tertiary);
   --options-dropdown-outline-color: none;
   --options-dropdown-border-color: var(--color-background-quaternary);
+  --options-dropdown-empty: var(--color-canvas);
 
   position: absolute;
   right: 0;
@@ -66,6 +67,10 @@
   padding-inline-start: var(--sp-xxs);
 }
 
+.option-text-dimmed {
+  color: var(--options-dropdown-empty);
+}
+
 .option-icon {
   color: var(--options-dropdown-icon-fg-color);
 }
@@ -78,4 +83,10 @@
 .option-selected {
   --options-dropdown-fg-color: var(--color-accent-primary);
   --options-dropdown-icon-fg-color: var(--color-accent-primary);
+}
+
+.option-separator {
+  border: $b-1 solid var(--options-dropdown-border-color);
+  margin-top: var(--sp-xs);
+  margin-bottom: var(--sp-xs);
 }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2051,6 +2051,10 @@ msgstr "Edit file"
 msgid "labels.editor"
 msgstr "Editor"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:263
+msgid "labels.empty"
+msgstr "Empty"
+
 #: src/app/main/ui/dashboard/import.cljs:294
 msgid "labels.error"
 msgstr "Error"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -2088,6 +2088,10 @@ msgstr "Editar archivo"
 msgid "labels.editor"
 msgstr "Edición"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:263
+msgid "labels.empty"
+msgstr "Vacío"
+
 #: src/app/main/ui/dashboard/import.cljs:294
 msgid "labels.error"
 msgstr "Error"


### PR DESCRIPTION
### Related Ticket

Taiga [#11126](https://tree.taiga.io/project/penpot/task/11126)

### Summary

This improves the management of empty values for variant properties. We use the two dashes `(--)` only for indicating that an empty value is selected, but we have an `(Empty)` option in the dropdown list to choose this value.

This avoids the confusion between the two dashes as an indicator of emptiness vs a literal value.