### PR TITLE
:sparkles: Add scale content to render wasm

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -793,17 +793,19 @@
 (defn set-structure-modifiers
   [entries]
   (when-not (empty? entries)
-    (let [offset (mem/alloc-bytes-32 (mem/get-list-size entries 40))
-          heapu32 (mem/get-heap-u32)]
+    (let [offset (mem/alloc-bytes-32 (mem/get-list-size entries 44))
+          heapu32 (mem/get-heap-u32)
+          heapf32 (mem/get-heap-f32)]
       (loop [entries (seq entries)
              current-offset  offset]
         (when-not (empty? entries)
-          (let [{:keys [type parent id index] :as entry} (first entries)]
+          (let [{:keys [type parent id index value] :as entry} (first entries)]
             (sr/heapu32-set-u32 (sr/translate-structure-modifier-type type) heapu32 (+ current-offset 0))
             (sr/heapu32-set-u32 (or index 0) heapu32 (+ current-offset 1))
             (sr/heapu32-set-uuid parent heapu32 (+ current-offset 2))
             (sr/heapu32-set-uuid id heapu32 (+ current-offset 6))
-            (recur (rest entries) (+ current-offset 10)))))
+            (aset heapf32 (+ current-offset 10) value)
+            (recur (rest entries) (+ current-offset 11)))))
       (h/call wasm/internal-module "_set_structure_modifiers"))))
 
 (defn propagate-modifiers

--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -281,7 +281,8 @@
   [type]
   (case type
     :remove-children 1
-    :add-children    2))
+    :add-children    2
+    :scale-content 3))
 
 (defn translate-grow-type
   [grow-type]

--- a/frontend/src/app/render_wasm/shape.cljs
+++ b/frontend/src/app/render_wasm/shape.cljs
@@ -6,6 +6,7 @@
 
 (ns app.render-wasm.shape
   (:require
+   [app.common.data.macros :as dm]
    [app.common.transit :as t]
    [app.common.types.shape :as shape]
    [app.common.types.shape.layout :as ctl]
@@ -131,6 +132,12 @@
       :shadow       (api/set-shape-shadows v)
       :constraints-h (api/set-constraints-h v)
       :constraints-v (api/set-constraints-v v)
+
+      (:r1 :r2 :r3 :r4)
+      (api/set-shape-corners [(dm/get-prop shape :r1)
+                              (dm/get-prop shape :r2)
+                              (dm/get-prop shape :r3)
+                              (dm/get-prop shape :r4)])
 
       :svg-attrs
       (when (= (:type shape) :path)

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5115,9 +5115,14 @@ msgstr "File"
 msgid "workspace.header.menu.option.help-info"
 msgstr "Help & info"
 
+#: src/app/main/ui/workspace/main_menu.cljs:881
+msgid "workspace.header.menu.option.preferences"
+msgstr "Preferences"
+
 #: src/app/main/ui/workspace/main_menu.cljs:916
 msgid "workspace.header.menu.option.power-up"
 msgstr "Power up your plan"
+
 msgid "workspace.header.menu.option.view"
 msgstr "View"
 

--- a/render-wasm/src/shapes/blurs.rs
+++ b/render-wasm/src/shapes/blurs.rs
@@ -35,4 +35,8 @@ impl Blur {
             value,
         }
     }
+
+    pub fn scale_content(&mut self, value: f32) {
+        self.value *= value;
+    }
 }

--- a/render-wasm/src/shapes/corners.rs
+++ b/render-wasm/src/shapes/corners.rs
@@ -21,3 +21,14 @@ pub fn make_corners(raw_corners: (f32, f32, f32, f32)) -> Option<Corners> {
         ])
     }
 }
+
+pub fn scale_corners(corners: &mut Corners, value: f32) {
+    corners[0].x *= value;
+    corners[0].y *= value;
+    corners[1].x *= value;
+    corners[1].y *= value;
+    corners[2].x *= value;
+    corners[2].y *= value;
+    corners[3].x *= value;
+    corners[3].y *= value;
+}

--- a/render-wasm/src/shapes/layouts.rs
+++ b/render-wasm/src/shapes/layouts.rs
@@ -8,6 +8,20 @@ pub enum Layout {
     GridLayout(LayoutData, GridData),
 }
 
+impl Layout {
+    pub fn scale_content(&mut self, value: f32) {
+        match self {
+            Layout::FlexLayout(layout_data, _) => {
+                layout_data.scale_content(value);
+            }
+            Layout::GridLayout(layout_data, grid_data) => {
+                layout_data.scale_content(value);
+                grid_data.scale_content(value);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum FlexDirection {
     Row,
@@ -184,6 +198,12 @@ impl GridTrack {
             value: f32::from_le_bytes(raw.value),
         }
     }
+
+    pub fn scale_content(&mut self, value: f32) {
+        if self.track_type == GridTrackType::Fixed {
+            self.value *= value;
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -260,6 +280,17 @@ pub struct LayoutData {
     pub column_gap: f32,
 }
 
+impl LayoutData {
+    pub fn scale_content(&mut self, value: f32) {
+        self.padding_top *= value;
+        self.padding_right *= value;
+        self.padding_bottom *= value;
+        self.padding_left *= value;
+        self.row_gap *= value;
+        self.column_gap *= value;
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum AlignSelf {
     Auto,
@@ -324,9 +355,7 @@ impl FlexData {
             FlexDirection::RowReverse | FlexDirection::Row
         )
     }
-}
 
-impl FlexData {
     pub fn is_wrap(&self) -> bool {
         matches!(self.wrap_type, WrapType::Wrap)
     }
@@ -348,6 +377,11 @@ impl GridData {
             columns: vec![],
             cells: vec![],
         }
+    }
+
+    pub fn scale_content(&mut self, value: f32) {
+        self.rows.iter_mut().for_each(|t| t.scale_content(value));
+        self.columns.iter_mut().for_each(|t| t.scale_content(value));
     }
 }
 
@@ -423,4 +457,17 @@ pub struct LayoutItem {
     pub is_absolute: bool,
     pub z_index: i32,
     pub align_self: Option<AlignSelf>,
+}
+
+impl LayoutItem {
+    pub fn scale_content(&mut self, value: f32) {
+        self.margin_top *= value;
+        self.margin_right *= value;
+        self.margin_bottom *= value;
+        self.margin_left *= value;
+        self.max_h = self.max_h.map(|max_h| max_h * value);
+        self.min_h = self.max_h.map(|max_h| max_h * value);
+        self.max_w = self.max_h.map(|max_h| max_h * value);
+        self.min_w = self.max_h.map(|max_h| max_h * value);
+    }
 }

--- a/render-wasm/src/shapes/modifiers/constraints.rs
+++ b/render-wasm/src/shapes/modifiers/constraints.rs
@@ -104,10 +104,12 @@ pub fn propagate_shape_constraints(
     constraint_h: ConstraintH,
     constraint_v: ConstraintV,
     transform: Matrix,
+    ignore_constrainst: bool,
 ) -> Matrix {
     // if the constrains are scale & scale or the transform has only moves we
     // can propagate as is
-    if (constraint_h == ConstraintH::Scale && constraint_v == ConstraintV::Scale)
+    if (ignore_constrainst
+        || constraint_h == ConstraintH::Scale && constraint_v == ConstraintV::Scale)
         || transform.is_translate()
     {
         return transform;

--- a/render-wasm/src/shapes/shadows.rs
+++ b/render-wasm/src/shapes/shadows.rs
@@ -125,4 +125,11 @@ impl Shadow {
 
         filter
     }
+
+    pub fn scale_content(&mut self, value: f32) {
+        self.blur *= value;
+        self.spread *= value;
+        self.offset.0 *= value;
+        self.offset.1 *= value;
+    }
 }

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -110,6 +110,10 @@ impl Stroke {
         }
     }
 
+    pub fn scale_content(&mut self, value: f32) {
+        self.width *= value;
+    }
+
     pub fn delta(&self) -> f32 {
         match self.kind {
             StrokeKind::Inner => 0.,

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -34,9 +34,9 @@ impl GrowType {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct TextContent {
-    paragraphs: Vec<Paragraph>,
-    bounds: Rect,
-    grow_type: GrowType,
+    pub paragraphs: Vec<Paragraph>,
+    pub bounds: Rect,
+    pub grow_type: GrowType,
 }
 
 pub fn set_paragraphs_width(width: f32, paragraphs: &mut Vec<Vec<skia::textlayout::Paragraph>>) {
@@ -284,6 +284,13 @@ impl Paragraph {
         });
         style
     }
+
+    pub fn scale_content(&mut self, value: f32) {
+        self.letter_spacing *= value;
+        self.children
+            .iter_mut()
+            .for_each(|l| l.scale_content(value));
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -387,6 +394,10 @@ impl TextLeaf {
                 .join(" "),
             _ => self.text.clone(),
         }
+    }
+
+    pub fn scale_content(&mut self, value: f32) {
+        self.font_size *= value;
     }
 }
 

--- a/render-wasm/src/shapes/transform.rs
+++ b/render-wasm/src/shapes/transform.rs
@@ -102,6 +102,7 @@ impl SerializableResult for TransformEntry {
 pub enum StructureEntryType {
     RemoveChild,
     AddChild,
+    ScaleContent,
 }
 
 impl StructureEntryType {
@@ -109,6 +110,7 @@ impl StructureEntryType {
         match value {
             1 => Self::RemoveChild,
             2 => Self::AddChild,
+            3 => Self::ScaleContent,
             _ => unreachable!(),
         }
     }
@@ -121,19 +123,27 @@ pub struct StructureEntry {
     pub index: u32,
     pub parent: Uuid,
     pub id: Uuid,
+    pub value: f32,
 }
 
 impl StructureEntry {
-    pub fn new(entry_type: StructureEntryType, index: u32, parent: Uuid, id: Uuid) -> Self {
+    pub fn new(
+        entry_type: StructureEntryType,
+        index: u32,
+        parent: Uuid,
+        id: Uuid,
+        value: f32,
+    ) -> Self {
         StructureEntry {
             entry_type,
             index,
             parent,
             id,
+            value,
         }
     }
 
-    pub fn from_bytes(bytes: [u8; 40]) -> Self {
+    pub fn from_bytes(bytes: [u8; 44]) -> Self {
         let entry_type = StructureEntryType::from_u32(u32::from_le_bytes([
             bytes[0], bytes[1], bytes[2], bytes[3],
         ]));
@@ -154,7 +164,9 @@ impl StructureEntry {
             u32::from_le_bytes([bytes[36], bytes[37], bytes[38], bytes[39]]),
         );
 
-        StructureEntry::new(entry_type, index, parent, id)
+        let value = f32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]);
+
+        StructureEntry::new(entry_type, index, parent, id, value)
     }
 }
 

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -69,6 +69,7 @@ pub(crate) struct State<'a> {
     pub current_shape: Option<&'a mut Shape>,
     pub shapes: HashMap<Uuid, &'a mut Shape>,
     pub modifiers: HashMap<Uuid, skia::Matrix>,
+    pub scale_content: HashMap<Uuid, f32>,
     pub structure: HashMap<Uuid, Vec<StructureEntry>>,
     pub shapes_pool: ShapesPool,
 }
@@ -81,6 +82,7 @@ impl<'a> State<'a> {
             current_shape: None,
             shapes: HashMap::with_capacity(capacity),
             modifiers: HashMap::new(),
+            scale_content: HashMap::new(),
             structure: HashMap::new(),
             shapes_pool: ShapesPool::new(),
         }
@@ -99,6 +101,7 @@ impl<'a> State<'a> {
             &mut self.shapes,
             &self.modifiers,
             &self.structure,
+            &self.scale_content,
             timestamp,
         )?;
         Ok(())
@@ -109,6 +112,7 @@ impl<'a> State<'a> {
             &mut self.shapes,
             &self.modifiers,
             &self.structure,
+            &self.scale_content,
             timestamp,
         )?;
         Ok(())


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/10731

### Summary
Support for proportional scale in new modifiers


https://github.com/user-attachments/assets/9fbb784f-f8a1-453d-a789-007153547ee2


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
