### PR TITLE
:sparkles: Delete variant property when it has no value anywhere

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -176,6 +176,46 @@
          (dwu/commit-undo-transaction undo-id))))))
 
 
+(defn remove-empty-properties
+  "Remove a property for all components when its value is empty for all of them"
+  [variant-id]
+  (ptk/reify ::remove-empty-properties
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [page-id (:current-page-id state)
+            data    (dsh/lookup-file-data state)
+            objects (-> (dsh/get-page data page-id)
+                        (get :objects))
+
+            variant-components (cfv/find-variant-components data objects variant-id)
+
+            properties-empty   (->> variant-components
+                                    (mapcat :variant-properties)
+                                    (group-by :name)
+                                    (mapv (fn [[_ v]]
+                                            (->> v (mapv :value) (remove empty?))))
+                                    (mapv empty?))
+
+            changes (-> (pcb/empty-changes it page-id)
+                        (pcb/with-library-data data)
+                        (pcb/with-objects objects))
+
+            changes (reduce
+                     (fn [changes [idx property-empty?]]
+                       (if property-empty?
+                         (-> changes
+                             (clvp/generate-remove-property variant-id idx))
+                         changes))
+                     changes
+                     (map-indexed vector properties-empty))
+
+            undo-id (js/Symbol)]
+
+        (rx/of
+         (dwu/start-undo-transaction undo-id)
+         (dch/commit-changes changes)
+         (dwu/commit-undo-transaction undo-id))))))
+
 
 (defn add-new-property
   "Add a new variant property to all the components with this variant-id"

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -72,8 +72,10 @@
              (if variant-name
                (if (ctv/valid-properties-formula? name)
                  (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties (ctv/properties-formula->map name))
+                           (dwv/remove-empty-properties variant-id)
                            (dwv/update-error component-id nil))
                  (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties {})
+                           (dwv/remove-empty-properties variant-id)
                            (dwv/update-error component-id name)))
                (st/emit! (dw/end-rename-shape shape-id name))))))
 


### PR DESCRIPTION
### Related Ticket

Taiga [#10765](https://tree.taiga.io/project/penpot/task/10765)

### Summary

After editing a formula, we check all the values for every property. If a property has only empty values, we remove it.