### PR TITLE
:sparkles: Persist ruler layout flag to local storage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,7 @@ A non exhaustive list of changes:
 - Copy to SVG from contextual menu [Github #838](https://github.com/penpot/penpot/issues/838)
 - Add styles for Inkeep Chat at workspace [Taiga #10708](https://tree.taiga.io/project/penpot/us/10708)
 - Add configuration for air gapped installations with Docker
+- Persist ruler visibility across files and reloads [GitHub #4586](https://github.com/penpot/penpot/issues/4586)
 
 ### :bug: Bugs fixed
 - Fix getCurrentUser for plugins api [Taiga #11057](https://tree.taiga.io/project/penpot/issue/11057)

--- a/frontend/src/app/main/data/workspace/layout.cljs
+++ b/frontend/src/app/main/data/workspace/layout.cljs
@@ -142,7 +142,7 @@
   {:hide-palettes :app.main.data.workspace/hide-palettes?
    :colorpalette :app.main.data.workspace/show-colorpalette?
    :textpalette :app.main.data.workspace/show-textpalette?
-   :rulers :app.main.data.workspace/show-rulers? })
+   :rulers :app.main.data.workspace/show-rulers?})
 
 (defn load-layout-flags
   "Given the current layout flags, and updates them with the data

--- a/frontend/src/app/main/data/workspace/layout.cljs
+++ b/frontend/src/app/main/data/workspace/layout.cljs
@@ -141,7 +141,8 @@
   storage object. It should be namespace qualified."
   {:hide-palettes :app.main.data.workspace/hide-palettes?
    :colorpalette :app.main.data.workspace/show-colorpalette?
-   :textpalette :app.main.data.workspace/show-textpalette?})
+   :textpalette :app.main.data.workspace/show-textpalette?
+   :rulers :app.main.data.workspace/show-rulers? })
 
 (defn load-layout-flags
   "Given the current layout flags, and updates them with the data


### PR DESCRIPTION
### Summary

This PR: 
* Closes #4586 

With this PR, ruler visibility in the workspace (use `Ctrl-Shift-R` to toggle it) is persisted to the browser's local storage.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.