### PR TITLE
:sparkles: Move guides and comments for wasm modifiers

### DIFF
--- a/frontend/src/app/main/data/workspace/guides.cljs
+++ b/frontend/src/app/main/data/workspace/guides.cljs
@@ -87,7 +87,7 @@
     (watch [_ state _]
       (let [ids (:ids args)
             object-modifiers (:modifiers args)
-
+            object-transforms (:transforms args)
             objects (dsh/lookup-page-objects state)
 
             is-frame? (fn [id] (= :frame (get-in objects [id :type])))
@@ -95,8 +95,18 @@
 
             build-move-event
             (fn [guide]
-              (let [frame (get objects (:frame-id guide))
-                    frame' (gsh/transform-shape frame (get-in object-modifiers [(:frame-id guide) :modifiers]))
+              (let [frame-id (:frame-id guide)
+                    frame (get objects frame-id)
+                    modifier (get-in object-modifiers [frame-id :modifiers])
+                    transform (get object-transforms frame-id)
+
+                    frame'
+                    (cond-> frame
+                      (some? modifier)
+                      (gsh/transform-shape modifier)
+
+                      (some? transform)
+                      (gsh/apply-transform transform))
 
                     moved (gpt/to-vec (gpt/point (:x frame) (:y frame))
                                       (gpt/point (:x frame') (:y frame')))

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -95,9 +95,9 @@
         read-only?        (mf/use-ctx ctx/workspace-read-only?)
 
         ;; DEREFS
-
         drawing           (mf/deref refs/workspace-drawing)
         focus             (mf/deref refs/workspace-focus-selected)
+        wasm-modifiers    (mf/deref workspace-wasm-modifiers)
 
         workspace-editor-state (mf/deref refs/workspace-editor-state)
 
@@ -105,10 +105,9 @@
         objects           (get page :objects)
         page-id           (get page :id)
         background        (get page :background clr/canvas)
+        guides            (get page :guides)
 
         base-objects      (ui-hooks/with-focus-objects objects focus)
-
-        wasm-modifiers    (mf/deref workspace-wasm-modifiers)
 
         objects-modified
         (mf/with-memo
@@ -575,9 +574,10 @@
          [:> guides/viewport-guides*
           {:zoom zoom
            :vbox vbox
-           :guides (:guides page)
+           :guides guides
            :hover-frame guide-frame
-           :disabled-guides disabled-guides?}])
+           :disabled-guides disabled-guides?
+           :modifiers wasm-modifiers}])
 
        ;; DEBUG LAYOUT DROP-ZONES
        (when (dbg/enabled? :layout-drop-zones)


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/task/11164

### Summary
Move guides and comments with frames

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
