### PR TITLE
:tada: Add metrics to new multi file import

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/modals/import.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/import.cljs
@@ -29,11 +29,11 @@
    [rumext.v2 :as mf]))
 
 (defn- on-stream-imported
-  [tokens-lib-stream]
+  [type tokens-lib-stream]
   (rx/sub!
    tokens-lib-stream
    (fn [lib]
-     (st/emit! (ptk/data-event ::ev/event {::ev/name "import-tokens"})
+     (st/emit! (ptk/data-event ::ev/event {::ev/name "import-tokens" :type type})
                (dwtl/import-tokens-lib lib))
      (modal/hide!))
    (fn [err]
@@ -72,7 +72,7 @@
                                               [(.-webkitRelativePath file)
                                                file-text])))))
                   (dwti/import-directory-stream)
-                  (on-stream-imported))
+                  (on-stream-imported "multiple"))
 
              (-> (mf/ref-val dir-input-ref)
                  (dom/set-value! "")))))
@@ -85,7 +85,7 @@
                           (first))]
              (->> (wapi/read-file-as-text file)
                   (dwti/import-file-stream (.-name file))
-                  (on-stream-imported))
+                  (on-stream-imported "single"))
 
              (-> (mf/ref-val file-input-ref)
                  (dom/set-value! "")))))]


### PR DESCRIPTION
### Related Ticket

This PR closes [this task](https://tree.taiga.io/project/penpot/task/11221)

### Summary

Add info to import token event about import type (single file or multiple files)

### Steps to reproduce 

Test single import
1. Create a file
2. Go to tokens tab
3. Open dev tools on network tab
4. Import simple token.json file 
5. You should see this push audit event
![Screenshot from 2025-06-02 15-34-46](https://github.com/user-attachments/assets/e69210e1-d33a-4173-b6eb-cf168837cbc3)

Test multiple import
1. Go to this link and download zip https://tree.taiga.io/project/penpot/us/10977
2. extract zip on a folder
3. Create file
4. Go to tokens tab
5. Open dev tools on network tab
6. Import multiple file from folder
7. You should see this push audit event
![Screenshot from 2025-06-02 16-06-57](https://github.com/user-attachments/assets/969c5b6c-74e7-4c6b-af0a-b5dbacbe4f8e)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
