### PR TITLE
:books: Add copyright to docs files

### DIFF
--- a/frontend/src/app/main/ui/ds/buttons/buttons.mdx
+++ b/frontend/src/app/main/ui/ds/buttons/buttons.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+
 import { Canvas, Meta } from '@storybook/blocks';
 import * as ButtonStories from "./button.stories";
 import * as IconButtonStories from "./icon_button.stories";

--- a/frontend/src/app/main/ui/ds/controls/combobox.mdx
+++ b/frontend/src/app/main/ui/ds/controls/combobox.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+
 import { Canvas, Meta } from "@storybook/blocks";
 import * as ComboboxStories from "./combobox.stories";
 

--- a/frontend/src/app/main/ui/ds/controls/input.mdx
+++ b/frontend/src/app/main/ui/ds/controls/input.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+
 import { Canvas, Meta } from '@storybook/blocks';
 import * as InputStories from "./input.stories";
 

--- a/frontend/src/app/main/ui/ds/controls/select.mdx
+++ b/frontend/src/app/main/ui/ds/controls/select.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+
 import { Canvas, Meta } from '@storybook/blocks';
 import * as SelectStories from "./select.stories";
 

--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from '@storybook/blocks';
 import * as IconStories from "./icon.stories"
 

--- a/frontend/src/app/main/ui/ds/foundations/assets/raw_svg.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/assets/raw_svg.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from "@storybook/blocks";
 import * as RawSvgStories from "./raw_svg.stories";
 

--- a/frontend/src/app/main/ui/ds/foundations/typography/heading.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/typography/heading.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from "@storybook/blocks";
 import * as HeadingStories from "./heading.stories";
 

--- a/frontend/src/app/main/ui/ds/foundations/typography/text.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/typography/text.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from "@storybook/blocks";
 import * as TextStories from "./text.stories";
 

--- a/frontend/src/app/main/ui/ds/foundations/typography/typography.mdx
+++ b/frontend/src/app/main/ui/ds/foundations/typography/typography.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from "@storybook/blocks";
 import Components from "@target/components";
 import * as TextStories from "../typography/text.stories";

--- a/frontend/src/app/main/ui/ds/layout/tab_switcher.mdx
+++ b/frontend/src/app/main/ui/ds/layout/tab_switcher.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from '@storybook/blocks';
 import * as TabSwitcher from "./tab_switcher.stories";
 

--- a/frontend/src/app/main/ui/ds/notifications/notifications.mdx
+++ b/frontend/src/app/main/ui/ds/notifications/notifications.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from '@storybook/blocks';
 import * as ToastStories from "./toast.stories";
 

--- a/frontend/src/app/main/ui/ds/product/input_with_meta.mdx
+++ b/frontend/src/app/main/ui/ds/product/input_with_meta.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+  
 import { Canvas, Meta } from '@storybook/blocks';
 import * as InputWithMetaStories from "./input_with_meta.stories";
 

--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.mdx
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.mdx
@@ -1,6 +1,11 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+
 import { Canvas, Meta } from '@storybook/blocks';
 import * as Tooltip from "./tooltip.stories";
-
 
 <Meta title= "Tooltip" />
 

--- a/frontend/src/app/main/ui/ds/utilities/swatch.mdx
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.mdx
@@ -1,3 +1,9 @@
+{ /* This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) KALEIDOS INC */ }
+
 import { Canvas, Meta } from "@storybook/blocks";
 import * as SwatchStories from "./swatch.stories";
 


### PR DESCRIPTION
### Related Ticket

No ticket

### Summary

We didn't have copyright on our doc files for DS components.

### Steps to reproduce 

Enter storybook and check copyright is not visible from there. 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
