### PR TITLE
:sparkles: Send all fills of a shape in a single wasm call

### DIFF
--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -495,6 +495,10 @@ impl Shape {
         self.fills.iter()
     }
 
+    pub fn set_fills(&mut self, fills: Vec<Fill>) {
+        self.fills = fills;
+    }
+
     pub fn add_fill(&mut self, f: Fill) {
         self.fills.push(f);
     }

--- a/render-wasm/src/wasm/fills.rs
+++ b/render-wasm/src/wasm/fills.rs
@@ -64,6 +64,15 @@ pub fn parse_fills_from_bytes(buffer: &[u8], num_fills: usize) -> Vec<shapes::Fi
 }
 
 #[no_mangle]
+pub extern "C" fn set_shape_fills() {
+    with_current_shape!(state, |shape: &mut Shape| {
+        let bytes = mem::bytes();
+        let fills = parse_fills_from_bytes(&bytes, bytes.len() / RAW_FILL_DATA_SIZE);
+        shape.set_fills(fills);
+    });
+}
+
+#[no_mangle]
 pub extern "C" fn add_shape_fill() {
     with_current_shape!(state, |shape: &mut Shape| {
         let bytes = mem::bytes();


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11106

### Summary

This PR sends all the fill data of a shape **in a single call**, instead of making one call for clearing the fills, plus one extra call per fill.

<img width="720" alt="Screenshot 2025-06-03 at 3 39 55 PM" src="https://github.com/user-attachments/assets/51a6bc13-3f7e-40fe-99ef-e4b409bd6ba4" />


### Steps to reproduce 

Open a file with different fills, create new ones and remove some. Everything should work as expected.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~
