### PR TITLE
:wrench: Add methods to render text as path

### DIFF
--- a/render-wasm/docs/texts.md
+++ b/render-wasm/docs/texts.md
@@ -28,6 +28,18 @@ Penpot offers font handling for both Google Fonts and custom fonts, using Skia�
 - **Fallback Mechanism:** Skia requires explicit font data for proper Unicode rendering, so we cannot rely on browser fallback as with SVG. We detect the language used and automatically add the appropriate Noto Sans font as a fallback. If the user’s selected fonts cannot render the text, Skia’s fallback mechanism will try the next available font in the list.
 - **Emoji Support:** For emoji characters, we use Noto Color Emoji by default. Ideally in the future, users will be able to select custom emoji fonts instead of Noto Sans as default, as the code is ready for this scenario.
 
+## Texts as Paths
+
+In Skia, it's possible to render text as paths in different ways. However, to preserve paragraph properties, we need to convert text nodes to `TextBlob`, then convert them to `Path`, and finally render them. This is necessary to ensure each piece of text is rendered in its correct position within the paragraph layout. We achieve this by using **Line Metrics** and **Style Metrics**, which allow us to iterate through each text element and read its dimensions, position, and style properties.
+
+This feature is not currently activated, but it is explained step by step in [render-wasm/src/shapes/text_paths.rs](/render-wasm/src/shapes/text_paths.rs).
+
+1. Get the paragraph and set the layout width. This is important because the rest of the metrics depend on setting the layout correctly.
+2. Iterate through each line in the paragraph. Paragraph text style is retrieved through `LineMetrics`, which is why we go line by line.
+3. Get the styles present in the line for each text leaf. `StyleMetrics` contain the style for individual text leaves, which we convert to `TextBlob` and then to `Path`.
+4. Finally, `text::render` should paint all the paths on the canvas.
+
+
 ## References
 
 - [Noto: A typeface for the world](https://fonts.google.com/noto)

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -2,7 +2,7 @@ use super::{RenderState, SurfaceId};
 use crate::render::strokes;
 use crate::render::text::{self};
 use crate::shapes::{Shadow, Shape, Stroke, Type};
-use skia_safe::{textlayout::Paragraph, Paint};
+use skia_safe::{canvas::SaveLayerRec, textlayout::Paragraph, Paint, Path};
 
 // Fill Shadows
 pub fn render_fill_drop_shadows(render_state: &mut RenderState, shape: &Shape, antialias: bool) {
@@ -54,8 +54,9 @@ pub fn render_stroke_drop_shadows(
                 render_state,
                 shape,
                 stroke,
-                Some(SurfaceId::Strokes), // FIXME
+                None,
                 filter.as_ref(),
+                None,
                 antialias,
             )
         }
@@ -75,8 +76,9 @@ pub fn render_stroke_inner_shadows(
                 render_state,
                 shape,
                 stroke,
-                Some(SurfaceId::Strokes), // FIXME
+                None,
                 filter.as_ref(),
+                None,
                 antialias,
             )
         }
@@ -94,6 +96,29 @@ pub fn render_text_drop_shadows(
     }
 }
 
+// Render text paths (unused)
+#[allow(dead_code)]
+pub fn render_text_path_stroke_drop_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paths: &Vec<(Path, Paint)>,
+    stroke: &Stroke,
+    antialias: bool,
+) {
+    for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+        let stroke_shadow = shadow.get_drop_shadow_filter();
+        strokes::render_text_paths(
+            render_state,
+            shape,
+            stroke,
+            paths,
+            Some(SurfaceId::DropShadows),
+            stroke_shadow.as_ref(),
+            antialias,
+        );
+    }
+}
+
 pub fn render_text_drop_shadow(
     render_state: &mut RenderState,
     shape: &Shape,
@@ -102,14 +127,19 @@ pub fn render_text_drop_shadow(
     antialias: bool,
 ) {
     let paint = shadow.get_drop_shadow_paint(antialias);
+    let mask_paint = paint.clone();
+    let mask = SaveLayerRec::default().paint(&mask_paint);
+    let canvas = render_state.get_canvas_at(SurfaceId::DropShadows);
+    canvas.save_layer(&mask);
 
     text::render(
         render_state,
         shape,
         paragraphs,
         Some(SurfaceId::DropShadows),
-        Some(paint),
     );
+
+    render_state.restore_canvas(SurfaceId::DropShadows);
 }
 
 pub fn render_text_inner_shadows(
@@ -131,14 +161,43 @@ pub fn render_text_inner_shadow(
     antialias: bool,
 ) {
     let paint = shadow.get_inner_shadow_paint(antialias);
+    let mask_paint = paint.clone();
+    let mask = SaveLayerRec::default().paint(&mask_paint);
+    let canvas = render_state.get_canvas_at(SurfaceId::InnerShadows);
+
+    canvas.save_layer(&mask);
 
     text::render(
         render_state,
         shape,
         paragraphs,
         Some(SurfaceId::InnerShadows),
-        Some(paint),
     );
+
+    render_state.restore_canvas(SurfaceId::InnerShadows);
+}
+
+// Render text paths (unused)
+#[allow(dead_code)]
+pub fn render_text_path_stroke_inner_shadows(
+    render_state: &mut RenderState,
+    shape: &Shape,
+    paths: &Vec<(Path, Paint)>,
+    stroke: &Stroke,
+    antialias: bool,
+) {
+    for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+        let stroke_shadow = shadow.get_inner_shadow_filter();
+        strokes::render_text_paths(
+            render_state,
+            shape,
+            stroke,
+            paths,
+            Some(SurfaceId::InnerShadows),
+            stroke_shadow.as_ref(),
+            antialias,
+        );
+    }
 }
 
 fn render_shadow_paint(

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -1,25 +1,15 @@
 use super::{RenderState, Shape, SurfaceId};
-use skia_safe::{self as skia, canvas::SaveLayerRec, textlayout::Paragraph};
+use skia_safe::{textlayout::Paragraph, Paint, Path};
 
 pub fn render(
     render_state: &mut RenderState,
     shape: &Shape,
     paragraphs: &[Vec<Paragraph>],
     surface_id: Option<SurfaceId>,
-    paint: Option<skia::Paint>,
 ) {
-    let use_save_layer = paint.is_some();
-    let mask_paint = paint.unwrap_or_default();
-    let mask = SaveLayerRec::default().paint(&mask_paint);
     let canvas = render_state
         .surfaces
         .canvas(surface_id.unwrap_or(SurfaceId::Fills));
-
-    // Skip save_layer when no custom paint is provided to avoid isolating content unnecessarily.
-    // This ensures inner strokes and fills can blend correctly on the same surface.
-    if use_save_layer {
-        canvas.save_layer(&mask);
-    }
 
     for group in paragraphs {
         let mut offset_y = 0.0;
@@ -29,7 +19,47 @@ pub fn render(
             offset_y += skia_paragraph.height();
         }
     }
-    if use_save_layer {
-        canvas.restore();
+}
+
+// Render text paths (unused)
+#[allow(dead_code)]
+pub fn render_as_path(
+    render_state: &mut RenderState,
+    paths: &Vec<(Path, Paint)>,
+    surface_id: Option<SurfaceId>,
+) {
+    let canvas = render_state
+        .surfaces
+        .canvas(surface_id.unwrap_or(SurfaceId::Fills));
+
+    for (path, paint) in paths {
+        // Note: path can be empty
+        canvas.draw_path(path, paint);
     }
 }
+
+// How to use it?
+// Type::Text(text_content) => {
+//     self.surfaces
+//         .apply_mut(&[SurfaceId::Fills, SurfaceId::Strokes], |s| {
+//             s.canvas().concat(&matrix);
+//         });
+
+//     let text_content = text_content.new_bounds(shape.selrect());
+//     let paths = text_content.get_paths(antialias);
+
+//     shadows::render_text_drop_shadows(self, &shape, &paths, antialias);
+//     text::render(self, &paths, None, None);
+
+//     for stroke in shape.strokes().rev() {
+//         shadows::render_text_path_stroke_drop_shadows(
+//             self, &shape, &paths, stroke, antialias,
+//         );
+//         strokes::render_text_paths(self, &shape, stroke, &paths, None, None, antialias);
+//         shadows::render_text_path_stroke_inner_shadows(
+//             self, &shape, &paths, stroke, antialias,
+//         );
+//     }
+
+//     shadows::render_text_inner_shadows(self, &shape, &paths, antialias);
+// }

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -910,6 +910,10 @@ impl Shape {
     pub fn has_fills(&self) -> bool {
         !self.fills.is_empty()
     }
+
+    pub fn has_inner_strokes(&self) -> bool {
+        self.strokes.iter().any(|s| s.kind == StrokeKind::Inner)
+    }
 }
 
 /*

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -240,4 +240,28 @@ impl Stroke {
 
         paint
     }
+
+    // Render text paths (unused)
+    #[allow(dead_code)]
+    pub fn to_text_stroked_paint(
+        &self,
+        is_open: bool,
+        rect: &Rect,
+        svg_attrs: &HashMap<String, String>,
+        scale: f32,
+        antialias: bool,
+    ) -> skia::Paint {
+        let mut paint = self.to_paint(rect, svg_attrs, scale, antialias);
+        match self.render_kind(is_open) {
+            StrokeKind::Inner => {
+                paint.set_stroke_width(2. * paint.stroke_width());
+            }
+            StrokeKind::Center => {}
+            StrokeKind::Outer => {
+                paint.set_stroke_width(2. * paint.stroke_width());
+            }
+        }
+
+        paint
+    }
 }

--- a/render-wasm/src/shapes/text_paths.rs
+++ b/render-wasm/src/shapes/text_paths.rs
@@ -1,0 +1,198 @@
+use crate::shapes::text::TextContent;
+use skia_safe::{self as skia, textlayout::ParagraphBuilder, Path, Paint};
+use std::ops::Deref;
+
+pub struct TextPaths(TextContent);
+
+// Note: This class is not being currently used.
+// It's an example of how to convert texts to paths
+#[allow(dead_code)]
+impl TextPaths {
+    pub fn new(content: TextContent) -> Self {
+        Self(content)
+    }
+        
+    pub fn get_skia_paragraphs(&self) -> Vec<ParagraphBuilder> {
+        let mut paragraphs = self.to_paragraphs();
+        self.collect_paragraphs(&mut paragraphs);
+        paragraphs
+    }
+
+    pub fn get_paths(&self, antialias: bool) -> Vec<(skia::Path, skia::Paint)> {
+        let mut paths = Vec::new();
+
+        let mut offset_y = self.bounds.y();
+        let mut paragraphs = self.get_skia_paragraphs();
+        for paragraph_builder in paragraphs.iter_mut() {
+            // 1. Get paragraph and set the width layout
+            let mut skia_paragraph = paragraph_builder.build();
+            let text = paragraph_builder.get_text();
+            let paragraph_width = self.bounds.width();
+            skia_paragraph.layout(paragraph_width);
+
+            let mut line_offset_y = offset_y;
+
+            // 2. Iterate through each line in the paragraph
+            for line_metrics in skia_paragraph.get_line_metrics() {
+                let line_baseline = line_metrics.baseline as f32;
+                let start = line_metrics.start_index;
+                let end = line_metrics.end_index;
+
+                // 3. Get styles present in line for each text leaf
+                let style_metrics = line_metrics.get_style_metrics(start..end);
+
+                let mut offset_x = 0.0;
+
+                for (i, (start_index, style_metric)) in style_metrics.iter().enumerate() {
+                    let end_index = style_metrics.get(i + 1).map_or(end, |next| next.0);
+
+                    let start_byte = text
+                        .char_indices()
+                        .nth(*start_index)
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    let end_byte = text
+                        .char_indices()
+                        .nth(end_index)
+                        .map(|(i, _)| i)
+                        .unwrap_or(text.len());
+
+                    let leaf_text = &text[start_byte..end_byte];
+
+                    let font = skia_paragraph.get_font_at(*start_index);
+
+                    let blob_offset_x = self.bounds.x() + line_metrics.left as f32 + offset_x;
+                    let blob_offset_y = line_offset_y;
+
+                    // 4. Get the path for each text leaf
+                    if let Some((text_path, paint)) = self.generate_text_path(
+                        leaf_text,
+                        &font,
+                        blob_offset_x,
+                        blob_offset_y,
+                        style_metric,
+                        antialias,
+                    ) {
+                        let text_width = font.measure_text(leaf_text, None).0;
+                        offset_x += text_width;
+                        paths.push((text_path, paint));
+                    }
+                }
+                line_offset_y = offset_y + line_baseline;
+            }
+            offset_y += skia_paragraph.height();
+        }
+        paths
+    }
+
+    fn generate_text_path(
+        &self,
+        leaf_text: &str,
+        font: &skia::Font,
+        blob_offset_x: f32,
+        blob_offset_y: f32,
+        style_metric: &skia::textlayout::StyleMetrics,
+        antialias: bool,
+    ) -> Option<(skia::Path, skia::Paint)> {
+        // Convert text to path, including text decoration
+        // TextBlob might be empty and, in this case, we return None
+        // This is used to avoid rendering empty paths, but we can
+        // revisit this logic later
+        if let Some((text_blob_path, text_blob_bounds)) =
+            Self::get_text_blob_path(leaf_text, font, blob_offset_x, blob_offset_y)
+        {
+            let mut text_path = text_blob_path.clone();
+            let text_width = font.measure_text(leaf_text, None).0;
+
+            let decoration = style_metric.text_style.decoration();
+            let font_metrics = style_metric.font_metrics;
+
+            let blob_left = blob_offset_x;
+            let blob_top = blob_offset_y;
+            let blob_height = text_blob_bounds.height();
+
+            if let Some(decoration_rect) = self.calculate_text_decoration_rect(
+                decoration.ty,
+                font_metrics,
+                blob_left,
+                blob_top,
+                text_width,
+                blob_height,
+            ) {
+                text_path.add_rect(decoration_rect, None);
+            }
+
+            let mut paint = style_metric.text_style.foreground();
+            paint.set_anti_alias(antialias);
+
+            return Some((text_path, paint));
+        }
+        None
+    }
+
+    fn calculate_text_decoration_rect(
+        &self,
+        decoration: skia::textlayout::TextDecoration,
+        font_metrics: FontMetrics,
+        blob_left: f32,
+        blob_offset_y: f32,
+        text_width: f32,
+        blob_height: f32,
+    ) -> Option<Rect> {
+        match decoration {
+            skia::textlayout::TextDecoration::LINE_THROUGH => {
+                let underline_thickness = font_metrics.underline_thickness().unwrap_or(0.0);
+                let underline_position = blob_height / 2.0;
+                Some(Rect::new(
+                    blob_left,
+                    blob_offset_y + underline_position - underline_thickness / 2.0,
+                    blob_left + text_width,
+                    blob_offset_y + underline_position + underline_thickness / 2.0,
+                ))
+            }
+            skia::textlayout::TextDecoration::UNDERLINE => {
+                let underline_thickness = font_metrics.underline_thickness().unwrap_or(0.0);
+                let underline_position = blob_height - underline_thickness;
+                Some(Rect::new(
+                    blob_left,
+                    blob_offset_y + underline_position - underline_thickness / 2.0,
+                    blob_left + text_width,
+                    blob_offset_y + underline_position + underline_thickness / 2.0,
+                ))
+            }
+            _ => None,
+        }
+    }
+
+
+    fn get_text_blob_path(
+        leaf_text: &str,
+        font: &skia::Font,
+        blob_offset_x: f32,
+        blob_offset_y: f32,
+    ) -> Option<(skia::Path, skia::Rect)> {
+        with_state!(state, {
+            let utf16_text = leaf_text.encode_utf16().collect::<Vec<u16>>();
+            let text = unsafe { skia_safe::as_utf16_unchecked(&utf16_text) };
+            let emoji_font = state.render_state.fonts().get_emoji_font(font.size());
+            let use_font = emoji_font.as_ref().unwrap_or(font);
+
+            if let Some(mut text_blob) = TextBlob::from_text(text, use_font) {
+                let path = SkiaParagraph::get_path(&mut text_blob);
+                let d = Point::new(blob_offset_x, blob_offset_y);
+                let offset_path = path.with_offset(d);
+                let bounds = text_blob.bounds();
+                return Some((offset_path, *bounds));
+            }
+        });
+        None
+    }
+}
+
+impl Deref for TextPaths {
+    type Target = TextContent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11297

### Summary

This PR adds the functionality (currently unused) to convert text to path, and updates the internal documentation

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully
