### PR TITLE
:bug: Remove unneeded check

### DIFF
--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -524,7 +524,6 @@
                            :or {ignore-geometry? false ignore-touched false with-objects? false}}]
    (assert-container-id! changes)
    (assert-objects! changes)
-   (assert-page-id! changes)
    (let [page-id      (::page-id (meta changes))
          component-id (::component-id (meta changes))
          objects      (lookup-objects changes)


### PR DESCRIPTION
### Summary

A check was done in `update-shapes` to require a `page-id`. But the page id does not exist when we are updating shapes inside a deleted component. In this case we have a `component-id` instead, and the `assert-container-id!` function already checks it.