### PR TITLE
:tada: Separate the content of the text of the rest of properties on variants

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1776,12 +1776,13 @@
                 ;; and attrs (bold, font, etc) are in the same attr :content.
                 ;; If only one of them is touched, we want to adress this case and
                 ;; only update the untouched one
-                text-partial-change? (when (and
-                                            omit-touched?
-                                            (cfh/text-shape? origin-shape)
-                                            (= :content attr)
-                                            (touched attr-group))
-                                       (is-text-partial-change? origin-shape dest-shape))
+                text-partial-change?
+                (when (and
+                       omit-touched?
+                       (cfh/text-shape? origin-shape)
+                       (= :content attr)
+                       (touched attr-group))
+                  (is-text-partial-change? origin-shape dest-shape))
 
                 skip-operations?
                 (or (= (get origin-shape attr) (get dest-shape attr))
@@ -1819,7 +1820,12 @@
   "Copy attributes that have changed in the shape previous to the switch
    to the current shape (post switch). Used only on variants switch"
   ;; NOTE: This function have similitudes but is very different to
-  ;; update-attrs
+  ;; update-attrs:
+  ;; In components (update-attrs), the source shape is "clean", and the destination
+  ;; shape may have touched elements that shouldn't be overwritten.
+  ;; In variants (update-attrs-on-switch), the destination shape is "clean",
+  ;; and it's the source shape that may have touched elements, and we only want
+  ;; to copy those touched elements.
   [changes current-shape previous-shape current-root prev-root origin-ref-shape container]
   (let [;; We need to sync only the position relative to the origin of the component.
         ;; (see update-attrs for a full explanation)
@@ -1856,13 +1862,14 @@
               ;; and attrs (bold, font, etc) are in the same attr :content.
               ;; If only one of them is touched, we want to adress this case and
               ;; only update the untouched one
-              text-partial-change? (when (and
-                                          (not skip-operations?)
-                                          (cfh/text-shape? current-shape)
-                                          (cfh/text-shape? previous-shape)
-                                          (= :content attr)
-                                          (touched attr-group))
-                                     (is-text-partial-change? current-shape previous-shape))
+              text-partial-change?
+              (when (and
+                     (not skip-operations?)
+                     (cfh/text-shape? current-shape)
+                     (cfh/text-shape? previous-shape)
+                     (= :content attr)
+                     (touched attr-group))
+                (is-text-partial-change? current-shape previous-shape))
 
               ;; position-data is a special case because can be affected by :geometry-group and :content-group
               ;; so, if the position-data changes but the geometry is touched we need to reset the position-data

--- a/common/src/app/common/logic/variants.cljc
+++ b/common/src/app/common/logic/variants.cljc
@@ -75,16 +75,16 @@
                             objects
                             (:id new-shape))
         new-shapes-map     (into {} (map (juxt :shape-path identity) new-shapes-w-path))
-        orig-touched      (filter (comp seq :touched) orig-shapes-w-path)
+        orig-touched       (filter (comp seq :touched) orig-shapes-w-path)
 
         container          (ctn/make-container page :page)]
     (reduce
-     (fn [changes touched-shape]
-       (let [related-shape  (get new-shapes-map (:shape-path touched-shape))
-             orig-ref-shape (ctf/find-ref-shape nil container libraries touched-shape)]
-         (if related-shape
+     (fn [changes previous-shape]
+       (let [current-shape  (get new-shapes-map (:shape-path previous-shape))
+             orig-ref-shape (ctf/find-ref-shape nil container libraries previous-shape)]
+         (if current-shape
            (cll/update-attrs-on-switch
-            changes related-shape touched-shape new-shape original-shape orig-ref-shape container)
+            changes current-shape previous-shape new-shape original-shape orig-ref-shape container)
            changes)))
      changes
      orig-touched)))


### PR DESCRIPTION

### Related Ticket

https://tree.taiga.io/project/penpot/task/11222

### Summary

When you change from one variant to another, and there has been changes on the texts, manage the changes in attributes and in the actual letters separately


### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Check CI passes successfully.
