### PR TITLE
:bug: Fix select color tooltip error

### DIFF
--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -128,7 +128,8 @@
         position-tooltip
         (fn [^js tooltip trigger-rect]
           (let [all-placements (get-fallback-order placement)]
-            (.showPopover ^js tooltip)
+            (when (.-isConnected tooltip)
+              (.showPopover ^js tooltip))
             (loop [[current-placement & remaining-placements] all-placements]
               (when current-placement
                 (reset! placement* current-placement)


### PR DESCRIPTION
### Related Ticket

This PR closes [this issue](https://tree.taiga.io/project/penpot/issue/11290)

### Summary

The button dissapear from DOM after click, so popup api crashed. 

### Steps to reproduce 

1. Create two rects
2. Add a different fill to one of them
3. Select to rectangles
4. Press "select this color" on sidebar.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
