### PR TITLE
:sparkles: Add export tokens modal with multi-file export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ on [its own changelog](library/CHANGES.md)
 - Support system color scheme [Github #5030](https://github.com/penpot/penpot/issues/5030)
 - Persist ruler visibility across files and reloads [GitHub #4586](https://github.com/penpot/penpot/issues/4586)
 - Update google fonts (at 2025/05/19) [Taiga 10792](https://tree.taiga.io/project/penpot/us/10792)
+- Adds tokens multi file export [Github #117](https://github.com/tokens-studio/penpot/issues/117)
 
 ### :bug: Bugs fixed
 - Fix getCurrentUser for plugins api [Taiga #11057](https://tree.taiga.io/project/penpot/issue/11057)

--- a/common/src/app/common/json.cljc
+++ b/common/src/app/common/json.cljc
@@ -98,7 +98,7 @@
 (defn encode
   [data & {:as opts}]
   #?(:clj (j/write-str data opts)
-     :cljs (.stringify js/JSON (->js data opts) nil (:indent-depth opts))))
+     :cljs (.stringify js/JSON (->js data opts) nil (:indent opts))))
 
 (defn decode
   [data & {:as opts}]

--- a/common/src/app/common/json.cljc
+++ b/common/src/app/common/json.cljc
@@ -98,7 +98,7 @@
 (defn encode
   [data & {:as opts}]
   #?(:clj (j/write-str data opts)
-     :cljs (.stringify js/JSON (->js data opts))))
+     :cljs (.stringify js/JSON (->js data opts) nil (:indent-depth opts))))
 
 (defn decode
   [data & {:as opts}]

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1448,11 +1448,11 @@ Will return a value that matches this schema:
              (into [] themes-xform))
 
         ;; Active themes without exposing hidden penpot theme
-        active-themes-clear
+        active-themes
         (-> (get-active-theme-paths tokens-lib)
             (disj hidden-theme-path))]
     {:themes themes
-     :active-themes active-themes-clear}))
+     :active-themes active-themes}))
 
 (defn export-dtcg-multi-file
   "Convert a TokensLib into a plain clojure map, suitable to be encoded as a multi json files each encoded in DTCG format."

--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1464,9 +1464,9 @@ Will return a value that matches this schema:
                   (into {}))]
     (-> sets
         (assoc "$themes.json" themes)
-        (assoc-in ["$metadata.json" "tokenSetOrder"] (get-ordered-set-names tokens-lib))
-        (assoc-in ["$metadata.json" "activeThemes"] active-themes)
-        (assoc-in ["$metadata.json" "activeSets"] (get-active-themes-set-names tokens-lib)))))
+        (assoc "$metadata.json" {"tokenSetOrder" (get-ordered-set-names tokens-lib)
+                                 "activeThemes" active-themes
+                                 "activeSets" (get-active-themes-set-names tokens-lib)}))))
 
 (defn export-dtcg-json
   "Convert a TokensLib into a plain clojure map, suitable to be encoded as a multi sets json string in DTCG format."
@@ -1491,9 +1491,9 @@ Will return a value that matches this schema:
 
     (-> sets
         (assoc "$themes" themes)
-        (assoc-in ["$metadata" "tokenSetOrder"] ordered-set-names)
-        (assoc-in ["$metadata" "activeThemes"] active-themes)
-        (assoc-in ["$metadata" "activeSets"] active-set-names))))
+        (assoc "$metadata" {"tokenSetOrder" ordered-set-names
+                            "activeThemes" active-themes
+                            "activeSets" active-set-names}))))
 
 (defn get-tokens-of-unknown-type
   "Search for all tokens in the decoded json file that have a type that is not currently

--- a/common/test/common_tests/types/tokens_lib_test.cljc
+++ b/common/test/common_tests/types/tokens_lib_test.cljc
@@ -1507,3 +1507,56 @@
                                                 "$type" "color"
                                                 "$description" ""}}}}}]
        (t/is (= expected result)))))
+
+#?(:clj
+   (t/deftest export-dtcg-multi-file
+     (let [now (dt/now)
+           tokens-lib (-> (ctob/make-tokens-lib)
+                          (ctob/add-set (ctob/make-token-set :name "some/set"
+                                                             :tokens {"colors.red.600"
+                                                                      (ctob/make-token
+                                                                       {:name "colors.red.600"
+                                                                        :type :color
+                                                                        :value "#e53e3e"})
+                                                                      "spacing.multi-value"
+                                                                      (ctob/make-token
+                                                                       {:name "spacing.multi-value"
+                                                                        :type :spacing
+                                                                        :value "{dimension.sm} {dimension.xl}"
+                                                                        :description "You can have multiple values in a single spacing token"})
+                                                                      "button.primary.background"
+                                                                      (ctob/make-token
+                                                                       {:name "button.primary.background"
+                                                                        :type :color
+                                                                        :value "{accent.default}"})}))
+                          (ctob/add-theme (ctob/make-token-theme :name "theme-1"
+                                                                 :group "group-1"
+                                                                 :external-id "test-id-01"
+                                                                 :modified-at now
+                                                                 :sets #{"some/set"}))
+                          (ctob/toggle-theme-active? "group-1" "theme-1"))
+           result   (ctob/export-dtcg-multi-file tokens-lib)
+           expected {"$themes.json" [{"description" ""
+                                      "group" "group-1"
+                                      "is-source" false
+                                      "modified-at" now
+                                      "id" "test-id-01"
+                                      "name" "theme-1"
+                                      "selectedTokenSets" {"some/set" "enabled"}}]
+                     "$metadata.json" {"tokenSetOrder" ["some/set"]
+                                       "activeThemes" #{"group-1/theme-1"}
+                                       "activeSets" #{"some/set"}}
+                     "some/set.json"
+                     {"colors" {"red" {"600" {"$value" "#e53e3e"
+                                              "$type" "color"
+                                              "$description" ""}}}
+                      "spacing"
+                      {"multi-value"
+                       {"$value" "{dimension.sm} {dimension.xl}"
+                        "$type" "spacing"
+                        "$description" "You can have multiple values in a single spacing token"}}
+                      "button"
+                      {"primary" {"background" {"$value" "{accent.default}"
+                                                "$type" "color"
+                                                "$description" ""}}}}}]
+       (t/is (= expected result)))))

--- a/frontend/src/app/main/ui/workspace.cljs
+++ b/frontend/src/app/main/ui/workspace.cljs
@@ -33,6 +33,7 @@
    [app.main.ui.workspace.sidebar.collapsable-button :refer [collapsed-button]]
    [app.main.ui.workspace.sidebar.history :refer [history-toolbox*]]
    [app.main.ui.workspace.tokens.modals]
+   [app.main.ui.workspace.tokens.modals.export]
    [app.main.ui.workspace.tokens.modals.import]
    [app.main.ui.workspace.tokens.modals.settings]
    [app.main.ui.workspace.tokens.modals.themes]

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
@@ -25,8 +25,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc export-tab*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-export is-disabled children]}]
   [:div {:class (stl/css :export-preview)}
    (when-not is-disabled
@@ -48,8 +47,7 @@
      (tr "workspace.tokens.export")]]])
 
 (mf/defc single-file-tab*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   (let [tokens-data (some-> (deref refs/tokens-lib)
                             (ctob/export-dtcg-json))
@@ -77,8 +75,7 @@
         (.then #(dom/trigger-download "tokens.zip" %)))))
 
 (mf/defc multi-file-tab*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   (let [files (some->> (deref refs/tokens-lib)
                        (ctob/export-dtcg-multi-file))

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
@@ -1,0 +1,147 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns app.main.ui.workspace.tokens.modals.export
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [app.common.json :as json]
+   [app.common.types.tokens-lib :as ctob]
+   [app.main.data.modal :as modal]
+   [app.main.refs :as refs]
+   [app.main.ui.components.code-block :refer [code-block]]
+   [app.main.ui.ds.buttons.button :refer [button*]]
+   [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.foundations.assets.icon :refer [icon*]]
+   [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
+   [app.main.ui.ds.foundations.typography.text :refer [text*]]
+   [app.main.ui.ds.layout.tab-switcher :refer [tab-switcher*]]
+   [app.util.dom :as dom]
+   [app.util.i18n :refer [tr]]
+   [app.util.webapi :as wapi]
+   [app.util.zip :as zip]
+   [rumext.v2 :as mf]))
+
+(mf/defc export-tab*
+  {::mf/props :obj
+   ::mf/private true}
+  [{:keys [on-export is-disabled children]}]
+  [:div {:class (stl/css :export-preview)}
+   (when-not is-disabled
+     [:> text* {:as "span" :typography "body-medium" :class (stl/css :preview-label)}
+      (tr "workspace.tokens.export.preview")])
+   (if is-disabled
+     [:div {:class (stl/css :disabled-message)}
+      (tr "workspace.tokens.export.no-tokens-themes-sets")]
+     children)
+   [:div {:class (stl/css :export-actions)}
+    [:> button* {:variant "secondary"
+                 :type "button"
+                 :on-click modal/hide!}
+     (tr "labels.cancel")]
+    [:> button* {:variant "primary"
+                 :type "button"
+                 :disabled is-disabled
+                 :on-click on-export}
+     (tr "workspace.tokens.export")]]])
+
+(mf/defc single-file-tab*
+  {::mf/props :obj
+   ::mf/private true}
+  []
+  (let [tokens-data (some-> (deref refs/tokens-lib)
+                            (ctob/export-dtcg-json))
+        tokens-json (some-> tokens-data
+                            (json/encode :key-fn identity :indent-depth 2))
+        is-disabled (empty? tokens-data)
+        on-export
+        (mf/use-fn
+         (mf/deps tokens-json)
+         (fn []
+           (when tokens-json
+             (->> (wapi/create-blob (or tokens-json "{}") "application/json")
+                  (dom/trigger-download "tokens.json")))))]
+    [:> export-tab* {:is-disabled is-disabled
+                     :on-export on-export}
+     [:div {:class (stl/css :json-preview)}
+      [:> code-block {:code tokens-json :type "json"}]]]))
+
+(defn download-tokens-zip! [multi-file-entries]
+  (let [writer (-> (zip/blob-writer {:mtype "application/zip"})
+                   (zip/writer))]
+    (doseq [[path content] multi-file-entries]
+      (zip/add writer path (json/encode content :key-fn identity)))
+    (-> (zip/close writer)
+        (.then #(dom/trigger-download "tokens.zip" %)))))
+
+(mf/defc multi-file-tab*
+  {::mf/props :obj
+   ::mf/private true}
+  []
+  (let [files (some->> (deref refs/tokens-lib)
+                       (ctob/export-dtcg-multi-file))
+        is-disabled (or (empty? files)
+                        (every? (fn [[_ v]] (empty? v)) files))
+        on-export
+        (mf/use-fn
+         (mf/deps files)
+         (fn []
+           (download-tokens-zip! files)))]
+    [:> export-tab* {:on-export on-export
+                     :is-disabled is-disabled}
+     [:div {:class (stl/css :preview-container)}
+      [:ul {:class (stl/css :file-list)}
+       (for [[path] files]
+         [:li {:key path
+               :class (stl/css :file-item)}
+          [:div {:class (stl/css :file-icon)}
+           [:> icon* {:icon-id "document"}]]
+          [:div {:class (stl/css :file-name) :title path}
+           path]])]]]))
+
+(mf/defc export-modal-body*
+  {::mf/private true}
+  []
+  (let [selected-tab (mf/use-state "single-file")
+
+        on-change-tab
+        (mf/use-fn
+         (fn [tab-id]
+           (reset! selected-tab tab-id)))
+
+        single-file-content
+        (mf/html [:> single-file-tab*])
+
+        multiple-files-content
+        (mf/html [:> multi-file-tab*])
+
+        tabs #js [#js {:label (tr "workspace.tokens.export.single-file")
+                       :id "single-file"
+                       :content single-file-content}
+                  #js {:label (tr "workspace.tokens.export.multiple-files")
+                       :id "multiple-files"
+                       :content multiple-files-content}]]
+
+    [:div {:class (stl/css :export-modal-wrapper)}
+     [:> heading* {:level 2 :typography "headline-medium" :class (stl/css :export-modal-title)}
+      (tr "workspace.tokens.export-tokens")]
+
+     [:> tab-switcher*
+      {:tabs tabs
+       :selected @selected-tab
+       :on-change-tab on-change-tab}]]))
+
+(mf/defc export-modal*
+  {::mf/register modal/components
+   ::mf/register-as :tokens/export}
+  []
+  [:div {:class (stl/css :modal-overlay)}
+   [:div {:class (stl/css :modal-dialog)}
+    [:> icon-button* {:class (stl/css :close-btn)
+                      :on-click modal/hide!
+                      :aria-label (tr "labels.close")
+                      :variant "ghost"
+                      :icon "close"}]
+    [:> export-modal-body*]]])

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
@@ -72,7 +72,7 @@
   (let [writer (-> (zip/blob-writer {:mtype "application/zip"})
                    (zip/writer))]
     (doseq [[path content] multi-file-entries]
-      (zip/add writer path (json/encode content :key-fn identity)))
+      (zip/add writer path (json/encode content :key-fn identity :indent 2)))
     (-> (zip/close writer)
         (.then #(dom/trigger-download "tokens.zip" %)))))
 

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
@@ -54,7 +54,7 @@
   (let [tokens-data (some-> (deref refs/tokens-lib)
                             (ctob/export-dtcg-json))
         tokens-json (some-> tokens-data
-                            (json/encode :key-fn identity :indent-depth 2))
+                            (json/encode :key-fn identity :indent 2))
         is-disabled (empty? tokens-data)
         on-export
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
@@ -45,7 +45,7 @@
 }
 
 .preview-container {
-  border: $b-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border: $b-1 solid var(--color-background-quaternary);
   border-radius: $br-8;
   overflow-y: auto;
   padding: var(--sp-xs) var(--sp-m);
@@ -100,7 +100,7 @@
 }
 
 .json-preview pre {
-  border: $b-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border: $b-1 solid var(--color-background-quaternary);
   border-radius: $br-8;
   margin: 0;
   max-height: var(--container-max-height);
@@ -117,7 +117,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: $b-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border: $b-1 solid var(--color-background-quaternary);
   border-radius: $br-8;
   overflow-y: auto;
   padding: var(--sp-s) var(--sp-m);

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+@use "../../../ds/typography.scss" as t;
+@use "../../../ds/_sizes.scss" as *;
+@import "refactor/common-refactor.scss";
+
+.modal-overlay {
+  @extend .modal-overlay-base;
+}
+
+.modal-dialog {
+  --modal-width: 485px;
+  --modal-padding: 2rem;
+  @extend .modal-container-base;
+  user-select: none;
+  width: 485px;
+  max-width: 100%;
+}
+
+.export-modal-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xxl);
+}
+
+.export-modal-title {
+  color: var(--color-foreground-primary);
+}
+
+.export-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-m);
+  padding-top: var(--sp-m);
+}
+
+.preview-label {
+  color: var(--color-foreground-secondary);
+}
+
+.preview-container {
+  border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border-radius: $s-8;
+  overflow-y: auto;
+  padding: var(--sp-xs) var(--sp-m);
+  max-height: 16rem;
+}
+
+.file-list {
+  width: 100%;
+  margin-bottom: 0;
+  overflow-y: auto;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  cursor: default;
+  color: var(--color-foreground-secondary);
+  border: 2px solid transparent;
+}
+
+.file-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.file-name {
+  @include textEllipsis;
+  @include bodyMediumTypography;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: var(--sp-s);
+}
+
+.export-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-s);
+}
+
+.close-btn {
+  position: absolute;
+  inset-block-start: var(--sp-s);
+  inset-inline-end: var(--sp-s);
+}
+
+.json-preview {
+  width: 100%;
+}
+
+.json-preview pre {
+  border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border-radius: $s-8;
+  margin: 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  overflow-x: auto;
+  word-wrap: normal;
+  white-space: pre;
+  max-width: calc(var(--modal-width) - var(--modal-padding) * 2);
+}
+
+.disabled-message {
+  @include bodySmallTypography;
+  color: var(--color-foreground-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border-radius: $s-8;
+  overflow-y: auto;
+  padding: var(--sp-s) var(--sp-m);
+  max-height: 16rem;
+}

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
@@ -14,7 +14,7 @@
 }
 
 .modal-dialog {
-  --modal-width: 30.3125rem;
+  --modal-width: 32rem;
   --modal-padding: var(--sp-xxxl);
   --container-max-height: 16rem;
   @extend .modal-container-base;

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.scss
@@ -6,6 +6,7 @@
 
 @use "../../../ds/typography.scss" as t;
 @use "../../../ds/_sizes.scss" as *;
+@use "../../../ds/_borders.scss" as *;
 @import "refactor/common-refactor.scss";
 
 .modal-overlay {
@@ -13,11 +14,12 @@
 }
 
 .modal-dialog {
-  --modal-width: 485px;
-  --modal-padding: 2rem;
+  --modal-width: 30.3125rem;
+  --modal-padding: var(--sp-xxxl);
+  --container-max-height: 16rem;
   @extend .modal-container-base;
   user-select: none;
-  width: 485px;
+  width: var(--modal-width);
   max-width: 100%;
 }
 
@@ -43,11 +45,11 @@
 }
 
 .preview-container {
-  border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
-  border-radius: $s-8;
+  border: $b-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border-radius: $br-8;
   overflow-y: auto;
   padding: var(--sp-xs) var(--sp-m);
-  max-height: 16rem;
+  max-height: var(--container-max-height);
 }
 
 .file-list {
@@ -62,7 +64,7 @@
   width: 100%;
   cursor: default;
   color: var(--color-foreground-secondary);
-  border: 2px solid transparent;
+  border: $br-2 solid transparent;
 }
 
 .file-icon {
@@ -73,7 +75,7 @@
 
 .file-name {
   @include textEllipsis;
-  @include bodyMediumTypography;
+  @include t.use-typography("body-medium");
   flex-grow: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -98,10 +100,10 @@
 }
 
 .json-preview pre {
-  border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
-  border-radius: $s-8;
+  border: $b-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border-radius: $br-8;
   margin: 0;
-  max-height: 16rem;
+  max-height: var(--container-max-height);
   overflow-y: auto;
   overflow-x: auto;
   word-wrap: normal;
@@ -110,14 +112,14 @@
 }
 
 .disabled-message {
-  @include bodySmallTypography;
+  @include t.use-typography("body-small");
   color: var(--color-foreground-secondary);
   display: flex;
   align-items: center;
   justify-content: center;
-  border: $s-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
-  border-radius: $s-8;
+  border: $b-1 solid color-mix(in hsl, var(--color-foreground-secondary) 30%, transparent);
+  border-radius: $br-8;
   overflow-y: auto;
   padding: var(--sp-s) var(--sp-m);
-  max-height: 16rem;
+  max-height: var(--container-max-height);
 }

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -8,7 +8,6 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data :as d]
-   [app.common.json :as json]
    [app.common.types.tokens-lib :as ctob]
    [app.config :as cf]
    [app.main.data.event :as ev]
@@ -37,7 +36,6 @@
    [app.util.array :as array]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
-   [app.util.webapi :as wapi]
    [okulary.core :as l]
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]
@@ -387,11 +385,7 @@
         (mf/use-fn
          (fn []
            (st/emit! (ptk/data-event ::ev/event {::ev/name "export-tokens"}))
-           (let [tokens-json (some-> (deref refs/tokens-lib)
-                                     (ctob/export-dtcg-json)
-                                     (json/encode :key-fn identity))]
-             (->> (wapi/create-blob (or tokens-json "{}") "application/json")
-                  (dom/trigger-download "tokens.json")))))
+           (modal/show! :tokens/export {})))
 
         on-modal-show
         (mf/use-fn

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7249,6 +7249,30 @@ msgstr "Importing a JSON file will override all your current tokens, sets and th
 msgid "workspace.tokens.import-warning"
 msgstr "Importing tokens will override all your current tokens, sets and themes."
 
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:74
+msgid "workspace.tokens.export"
+msgstr "Export"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:47
+msgid "workspace.tokens.export-tokens"
+msgstr "Export tokens"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:51
+msgid "workspace.tokens.export.single-file"
+msgstr "Single file"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:54
+msgid "workspace.tokens.export.multiple-files"
+msgstr "Multiple files"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:60
+msgid "workspace.tokens.export.preview"
+msgstr "Preview:"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:37
+msgid "workspace.tokens.export.no-tokens-themes-sets"
+msgstr "There are no tokens, themes or sets to export."
+
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:341
 msgid "workspace.tokens.inactive-set"
 msgstr "Inactive"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7265,6 +7265,26 @@ msgstr "Al importar un fichero JSON sobreescribirás todos tus tokens, sets y th
 msgid "workspace.tokens.import-warning"
 msgstr "Al importar tokens sobreescribirás todos tus tokens, sets y themes."
 
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:74
+msgid "workspace.tokens.export"
+msgstr "Exportar"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:51
+msgid "workspace.tokens.export.single-file"
+msgstr "fichero único"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:54
+msgid "workspace.tokens.export.multiple-files"
+msgstr "Múltiples ficheros"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:60
+msgid "workspace.tokens.export.preview"
+msgstr "Previsualizar:"
+
+#: src/app/main/ui/workspace/tokens/modals/export.cljs:37
+msgid "workspace.tokens.export.no-tokens-themes-sets"
+msgstr "No existen tokens, temas o sets para exportar."
+
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:341
 msgid "workspace.tokens.inactive-set"
 msgstr "Inactivo"


### PR DESCRIPTION
### Related Ticket

https://github.com/orgs/tokens-studio/projects/69/views/11?pane=issue&itemId=109791182&issue=tokens-studio%7Cpenpot%7C117

### Summary


https://github.com/user-attachments/assets/87a4e068-0620-443c-8e23-7180f73b092c



Implements multi file export for tokens and adds modal for the 2 export variants.
UI File: https://design.penpot.app/challenge.html?redirect=%2Fworkspace%3Fteam-id%3D52961d58-0a92-80c2-8003-38569623b41c%26file-id%3D941f4c15-09d2-8062-8006-1c8b363c6525%26page-id%3D055b07af-5aa2-808e-8006-369a930dc9cf%26layout%3Dtokens

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
