### PR TITLE
:bug: Fix fonts initialization

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -640,9 +640,10 @@
               (swap! languages into (t/get-languages text))
               (t/write-shape-text leaves paragraph text))
             (recur (inc index))))))
+
     (let [updated-fonts
           (-> fonts
-              (cond-> emoji? (f/add-emoji-font))
+              (cond-> @emoji? (f/add-emoji-font))
               (f/add-noto-fonts @languages))]
       (f/store-fonts updated-fonts))))
 
@@ -742,8 +743,6 @@
       (set-shape-svg-raw-content (get-static-markup shape)))
     (when (some? corners) (set-shape-corners corners))
     (when (some? shadows) (set-shape-shadows shadows))
-    (when (and (= type :text) (some? content))
-      (set-shape-text content))
     (when (= type :text)
       (set-shape-grow-type grow-type))
     (when (or (ctl/any-layout? shape)

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -189,27 +189,28 @@
 
 (defn- get-string-length [string] (+ (count string) 1))
 
-(defn- store-image
+(defn- fetch-image
   [id]
   (let [buffer (uuid/get-u32 id)
         url    (cf/resolve-file-media {:id id})]
-    (->> (http/send! {:method :get
-                      :uri url
-                      :response-type :blob})
-         (rx/map :body)
-         (rx/mapcat wapi/read-file-as-array-buffer)
-         (rx/map (fn [image]
-                   (let [size    (.-byteLength image)
-                         offset  (mem/alloc-bytes size)
-                         heap    (mem/get-heap-u8)
-                         data    (js/Uint8Array. image)]
-                     (.set heap data offset)
-                     (h/call wasm/internal-module "_store_image"
-                             (aget buffer 0)
-                             (aget buffer 1)
-                             (aget buffer 2)
-                             (aget buffer 3))
-                     true))))))
+    {:key url
+     :callback #(->> (http/send! {:method :get
+                                  :uri url
+                                  :response-type :blob})
+                     (rx/map :body)
+                     (rx/mapcat wapi/read-file-as-array-buffer)
+                     (rx/map (fn [image]
+                               (let [size    (.-byteLength image)
+                                     offset  (mem/alloc-bytes size)
+                                     heap    (mem/get-heap-u8)
+                                     data    (js/Uint8Array. image)]
+                                 (.set heap data offset)
+                                 (h/call wasm/internal-module "_store_image"
+                                         (aget buffer 0)
+                                         (aget buffer 1)
+                                         (aget buffer 2)
+                                         (aget buffer 3))
+                                 true))))}))
 
 (defn- get-fill-images
   [leaf]
@@ -227,7 +228,7 @@
                                  (aget buffer 2)
                                  (aget buffer 3))]
        (when (zero? cached-image?)
-         (store-image id))))))
+         (fetch-image id))))))
 
 (defn set-shape-text-images
   [content]
@@ -269,7 +270,7 @@
                                           (aget buffer 2)
                                           (aget buffer 3))]
                 (when (zero? cached-image?)
-                  (store-image id))))
+                  (fetch-image id))))
             image-fills))))
 
 (defn set-shape-strokes
@@ -308,7 +309,7 @@
                                             (dm/get-prop image :height))
                 (h/call wasm/internal-module "_add_shape_stroke_fill")
                 (when (== cached-image? 0)
-                  (store-image id)))
+                  (fetch-image id)))
 
               (some? color)
               (do
@@ -763,16 +764,20 @@
       pending)))
 
 
+(defn process-pending
+  [pending]
+  (when-let [pending (-> (d/index-by :key :callback pending) vals)]
+    (->> (rx/from pending)
+         (rx/mapcat (fn [callback] (callback)))
+         (rx/reduce conj [])
+         (rx/subs! (fn [_]
+                     (clear-drawing-cache)
+                     (request-render "set-objects"))))))
+
 (defn process-object
   [shape]
   (let [pending (set-object [] shape)]
-    (when-let [pending (seq pending)]
-      (->> (rx/from pending)
-           (rx/mapcat identity)
-           (rx/reduce conj [])
-           (rx/subs! (fn [_]
-                       (clear-drawing-cache)
-                       (request-render "set-objects")))))))
+    (process-pending pending)))
 
 (defn set-objects
   [objects]
@@ -789,13 +794,7 @@
     (perf/end-measure "set-objects")
     (clear-drawing-cache)
     (request-render "set-objects")
-    (when-let [pending (seq pending)]
-      (->> (rx/from pending)
-           (rx/mapcat identity)
-           (rx/reduce conj [])
-           (rx/subs! (fn [_]
-                       (clear-drawing-cache)
-                       (request-render "set-objects")))))))
+    (process-pending pending)))
 
 (defn set-structure-modifiers
   [entries]

--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -131,7 +131,8 @@
                                        (aget id-buffer 2)
                                        (aget id-buffer 3)
                                        (:weight font-data)
-                                       (:style font-data)))]
+                                       (:style font-data)
+                                       emoji?))]
       (when-not font-stored?
         (store-font-url font-data uri emoji? fallback?)))))
 

--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -94,13 +94,14 @@
             fallback?)
     true))
 
-(defn- store-font-url
+(defn- fetch-font
   [font-data font-url emoji? fallback?]
-  (->> (http/send! {:method :get
-                    :uri font-url
-                    :response-type :buffer})
-       (rx/map (fn [{:keys [body]}]
-                 (store-font-buffer font-data body emoji? fallback?)))))
+  {:key font-url
+   :callback #(->> (http/send! {:method :get
+                                :uri font-url
+                                :response-type :buffer})
+                   (rx/map (fn [{:keys [body]}]
+                             (store-font-buffer font-data body emoji? fallback?))))})
 
 (defn- google-font-ttf-url
   [font-id font-variant-id]
@@ -134,7 +135,7 @@
                                        (:style font-data)
                                        emoji?))]
       (when-not font-stored?
-        (store-font-url font-data uri emoji? fallback?)))))
+        (fetch-font font-data uri emoji? fallback?)))))
 
 (defn serialize-font-style
   [font-style]

--- a/frontend/src/app/render_wasm/api/texts.cljs
+++ b/frontend/src/app/render_wasm/api/texts.cljs
@@ -148,7 +148,7 @@
 
   (h/call wasm/internal-module "_set_shape_text_content"))
 
-(def ^:private emoji-pattern #"[\uD83C-\uDBFF][\uDC00-\uDFFF]")
+(def ^:private emoji-pattern #"[\uD83C-\uDBFF][\uDC00-\uDFFF]|[\u2600-\u27BF]")
 
 (def ^:private unicode-ranges
   {:japanese    #"[\u3040-\u30FF\u31F0-\u31FF\uFF66-\uFF9F]"
@@ -198,7 +198,7 @@
 
 
 (defn contains-emoji? [text]
-  (boolean (re-find emoji-pattern text)))
+  (boolean (some #(re-find emoji-pattern %) (seq text))))
 
 (defn get-languages [text]
   (reduce-kv (fn [result lang pattern]

--- a/render-wasm/src/render/fonts.rs
+++ b/render-wasm/src/render/fonts.rs
@@ -66,7 +66,7 @@ impl FontStore {
         is_emoji: bool,
         is_fallback: bool,
     ) -> Result<(), String> {
-        if self.has_family(&family) {
+        if self.has_family(&family, is_emoji) {
             return Ok(());
         }
 
@@ -92,9 +92,14 @@ impl FontStore {
         Ok(())
     }
 
-    pub fn has_family(&self, family: &FontFamily) -> bool {
-        let serialized = format!("{}", family);
-        self.font_provider.family_names().any(|x| x == serialized)
+    pub fn has_family(&self, family: &FontFamily, is_emoji: bool) -> bool {
+        let alias = format!("{}", family);
+        let font_name = if is_emoji {
+            DEFAULT_EMOJI_FONT
+        } else {
+            alias.as_str()
+        };
+        self.font_provider.family_names().any(|x| x == font_name)
     }
 
     pub fn get_fallback(&self) -> &HashSet<String> {

--- a/render-wasm/src/wasm/fonts.rs
+++ b/render-wasm/src/wasm/fonts.rs
@@ -31,11 +31,19 @@ pub extern "C" fn store_font(
 }
 
 #[no_mangle]
-pub extern "C" fn is_font_uploaded(a: u32, b: u32, c: u32, d: u32, weight: u32, style: u8) -> bool {
+pub extern "C" fn is_font_uploaded(
+    a: u32,
+    b: u32,
+    c: u32,
+    d: u32,
+    weight: u32,
+    style: u8,
+    is_emoji: bool,
+) -> bool {
     with_state!(state, {
         let id = uuid_from_u32_quartet(a, b, c, d);
         let family = FontFamily::new(id, weight, style.into());
-        let res = state.render_state().fonts().has_family(&family);
+        let res = state.render_state().fonts().has_family(&family, is_emoji);
 
         res
     })


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11289 & https://tree.taiga.io/project/penpot/task/11295

### Summary

This PR fixes several issues related with font loading and caching:

1. Emoji detection was returning some false positives, fixed it
2. Emoji was not being correctly cached, now we detect it properly
3. When initializing, all requests to fetch fonts were being sent, now we filter the requests to fetch each detected font only once at the beginning, catching it properly
4. Some fonts were not being imported correctly

### Steps to reproduce 

Create a file with multiple texts, with and without emoji, using same fonts, and check they're not being called more than once

![image](https://github.com/user-attachments/assets/4dabf024-5418-41b2-bf17-47ddaa1b60d2)
![image](https://github.com/user-attachments/assets/259631c1-8406-428a-b2c2-e94067b19249)

![image](https://github.com/user-attachments/assets/89e0e594-fa67-46e5-8d90-4cf8c6520c48)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.