### PR TITLE
:whale: Migrate from Redis to Valkey

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,13 @@ The initial prototype is completly reworked for provide a more consistent API
 and to have proper validation and params decoding. All the details can be found
 on [its own changelog](library/CHANGES.md)
 
+**Penpot migrate from Redis to Valkey**
+
+As [Valkey](https://valkey.io/) is an opne-souce fork of [Redis](https://redis.io/)
+version 7.2.4, this version of Penpot will be compatible with Redis but may diverge 
+in future versions. Therefore, **migration from Redis to ValKey is recommended for all 
+on-premises instances** that want to keep up to date.
+
 ### :heart: Community contributions (Thank you!)
 
 ### :sparkles: New features & Enhancements

--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
     depends_on:
       penpot-postgres:
         condition: service_healthy
-      penpot-redis:
+      penpot-valkey:
         condition: service_healthy
 
     networks:
@@ -148,10 +148,10 @@ services:
       PENPOT_DATABASE_USERNAME: penpot
       PENPOT_DATABASE_PASSWORD: penpot
 
-      ## Redis is used for the websockets notifications. Don't touch unless the redis
-      ## container has different parameters or different name.
+      ## Valkey (or previously redis) is used for the websockets notifications. Don't touch
+      ## unless the valkey container has different parameters or different name.
 
-      PENPOT_REDIS_URI: redis://penpot-redis/0
+      PENPOT_REDIS_URI: redis://penpot-valkey/0
 
       ## Default configuration for assets storage: using filesystem based with all files
       ## stored in a docker volume.
@@ -195,7 +195,7 @@ services:
     restart: always
 
     depends_on:
-      penpot-redis:
+      penpot-valkey:
         condition: service_healthy
 
     networks:
@@ -206,8 +206,8 @@ services:
       # communicate with the frontend.
       PENPOT_PUBLIC_URI: http://penpot-frontend:8080
 
-      ## Redis is used for the websockets notifications.
-      PENPOT_REDIS_URI: redis://penpot-redis/0
+      ## Valkey (or previowsly Redis) is used for the websockets notifications.
+      PENPOT_REDIS_URI: redis://penpot-valkey/0
 
   penpot-postgres:
     image: "postgres:15"
@@ -233,12 +233,12 @@ services:
       - POSTGRES_USER=penpot
       - POSTGRES_PASSWORD=penpot
 
-  penpot-redis:
-    image: redis:7.2
+  penpot-valkey:
+    image: valkey/valkey:8.1
     restart: always
 
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      test: ["CMD-SHELL", "valkey-cli ping | grep PONG"]
       interval: 1s
       timeout: 3s
       retries: 5

--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -353,9 +353,9 @@ If you are not using SMTP configuration and want to log the emails in the consol
 PENPOT_FLAGS: [...] enable-log-emails
 ```
 
-## Redis
+## Valkey
 
-The Redis configuration is very simple, just provide a valid redis URI. Redis is used
+The Valkey configuration is very simple, just provide a valid redis URI. Valkey is used
 mainly for websocket notifications coordination.
 
 ```bash

--- a/docs/technical-guide/getting-started/kubernetes.md
+++ b/docs/technical-guide/getting-started/kubernetes.md
@@ -72,7 +72,7 @@ argument to helm install. For example,
 ```bash
 helm install my-release \
   --set global.postgresqlEnabled=true \
-  --set global.redisEnabled=true \
+  --set global.valkeyEnabled=true \
   --set persistence.assets.enabled=true \
   penpot/penpot
 ```


### PR DESCRIPTION
<div align="center">

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3EybjJlM3Byb3RqazZ3ZjBxYTF2bXh3bGc5ZHh5eDczbjh4Nmt4YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Tb7kidAdyEIve/giphy.gif)

</div>

### Summary

Penpot migrates from Redis to Valkey. Valkey is just an open source fork of Redis version 7.2.4. So Redis and Valkey are fundamentally similar at the moment, but as time goes on, both the functionality they offer and the code base will diverge.  

### How to test
- [ ]  Start an on-premise instance from the docker-compose file available in `docker/images/`.
- [ ] Check that everything is working normally. 
  *TIP: Websockets, exports to png or sending invitation emails are actions that require the use of Valkey*.