### PR TITLE
:sparkles: Add editors count to get-owned-teams rpc method response

### DIFF
--- a/backend/src/app/rpc/commands/teams.clj
+++ b/backend/src/app/rpc/commands/teams.clj
@@ -192,7 +192,8 @@
 
 (def ^:private sql:get-owned-teams
   "SELECT t.id, t.name,
-          (SELECT count(*) FROM team_profile_rel WHERE team_id=t.id) AS total_members
+          (SELECT count(*) FROM team_profile_rel WHERE team_id=t.id) AS total_members,
+          (SELECT count(*) FROM team_profile_rel WHERE team_id=t.id AND can_edit=true) AS total_editors
      FROM team AS t
      JOIN team_profile_rel AS tpr ON (tpr.team_id = t.id)
     WHERE t.is_default IS false

--- a/backend/test/backend_tests/rpc_team_test.clj
+++ b/backend/test/backend_tests/rpc_team_test.clj
@@ -460,11 +460,14 @@
                   ::rpc/profile-id (:id profile1)}
         out      (th/command! params)]
 
+    ;; (th/print-result! out)
     (t/is (th/success? out))
-    (let [result (:result out)]
+    (let [[item1 :as result] (:result out)]
       (t/is (= 1 (count result)))
-      (t/is (= (:id team1) (-> result first :id)))
-      (t/is (not= (:default-team-id profile1) (-> result first :id))))))
+      (t/is (= (:id team1) (:id item1)))
+      (t/is (= 1 (:total-members item1)))
+      (t/is (= 1 (:total-editors item1)))
+      (t/is (not= (:default-team-id profile1) (:id item1))))))
 
 
 (t/deftest team-deletion-1


### PR DESCRIPTION
### Summary

Add `total-editors` property to `get-owned-teams` RPC method response.

No test required, unit test included.
