### PR TITLE
:sparkles: Avoid duplicated property names adding a number

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -23,7 +23,7 @@
         props              (-> related-components last :variant-properties)
         prop-names         (mapv :name props)
         prop-names         (concat (subvec prop-names 0 pos) (subvec prop-names (inc pos)))
-        new-name           (ctv/add-number-to-repeated-item prop-names new-name)]
+        new-name           (ctv/update-number-in-repeated-item prop-names new-name)]
     (reduce (fn [changes component]
               (pcb/update-component
                changes (:id component)
@@ -87,7 +87,7 @@
         property-name      (or property-name (str ctv/property-prefix next-prop-num))
 
         prop-names         (mapv :name props)
-        property-name      (ctv/add-number-to-repeated-item prop-names property-name)
+        property-name      (ctv/update-number-in-repeated-item prop-names property-name)
 
         [_ changes]
         (reduce (fn [[num changes] component]

--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -18,7 +18,12 @@
   [changes variant-id pos new-name]
   (let [data               (pcb/get-library-data changes)
         objects            (pcb/get-objects changes)
-        related-components (cfv/find-variant-components data objects variant-id)]
+        related-components (cfv/find-variant-components data objects variant-id)
+
+        props              (-> related-components last :variant-properties)
+        prop-names         (mapv :name props)
+        prop-names         (concat (subvec prop-names 0 pos) (subvec prop-names (inc pos)))
+        new-name           (ctv/add-number-to-repeated-item prop-names new-name)]
     (reduce (fn [changes component]
               (pcb/update-component
                changes (:id component)
@@ -80,6 +85,9 @@
         props              (-> related-components last :variant-properties)
         next-prop-num      (ctv/next-property-number props)
         property-name      (or property-name (str ctv/property-prefix next-prop-num))
+
+        prop-names         (mapv :name props)
+        property-name      (ctv/add-number-to-repeated-item prop-names property-name)
 
         [_ changes]
         (reduce (fn [[num changes] component]

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -139,7 +139,6 @@
                      (< (count (first %)) property-max-length)
                      (< (count (second %)) property-max-length)))))
 
-
 (defn find-properties-to-remove
   "Compares two property maps to find which properties should be removed"
   [prev-props upd-props]
@@ -159,6 +158,35 @@
   [prev-props upd-props]
   (let [prev-names (set (map :name prev-props))]
     (filterv #(not (contains? prev-names (:name %))) upd-props)))
+
+
+(defn add-number-to-repeated-prop-names
+  "Adds an incremental number to each repeated property name"
+  [props]
+  (->> (map-indexed vector props)
+       (mapv (fn [[idx prop]]
+               (->> (mapv :name props)
+                    (take idx)
+                    (filter #(= % (:name prop)))
+                    (count)
+                    (assoc prop :num))))
+       (mapv (fn [prop]
+               (let [num       (:num prop)
+                     name-base (:name prop)
+                     name      (if (= num 0) name-base (str name-base " (" num ")"))]
+                 (assoc (dissoc prop :num) :name name))))))
+
+
+(defn add-number-to-repeated-item
+  "Adds a number to an item if it already exists in a list"
+  ([prop-names name-base]
+   (add-number-to-repeated-item prop-names name-base 0))
+
+  ([prop-names name-base num]
+   (let [name (if (= num 0) name-base (str name-base " (" num ")"))]
+     (if (some #(= name %) prop-names)
+       (add-number-to-repeated-item prop-names name-base (inc num))
+       name))))
 
 
 (defn find-index-for-property-name

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -174,7 +174,9 @@
                (let [num       (:num prop)
                      name-base (:name prop)
                      name      (if (= num 0) name-base (str name-base " (" num ")"))]
-                 (assoc (dissoc prop :num) :name name))))))
+                 (-> prop
+                     (dissoc :num)
+                     (assoc :name name)))))))
 
 
 (defn add-number-to-repeated-item

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -131,3 +131,26 @@
       (t/is (= (ctv/same-variant? components-2) false))
       (t/is (= (ctv/same-variant? components-3) false))
       (t/is (= (ctv/same-variant? components-4) false)))))
+
+
+(t/deftest add-number-to-repeated-item
+  (let [names ["border" "color" "color (1)" "size"]]
+
+    (t/testing "add-number-to-repeated-item"
+      (t/is (= (ctv/add-number-to-repeated-item names "background") "background"))
+      (t/is (= (ctv/add-number-to-repeated-item names "border")     "border (1)"))
+      (t/is (= (ctv/add-number-to-repeated-item names "color")      "color (2)")))))
+
+
+(t/deftest add-number-to-repeated-prop-names
+  (let [props          [{:name "color"     :value "yellow"}
+                        {:name "color"     :value "blue"}
+                        {:name "color"     :value "red"}
+                        {:name "border"    :value "yes"}]
+        numbered-props [{:name "color"     :value "yellow"}
+                        {:name "color (1)" :value "blue"}
+                        {:name "color (2)" :value "red"}
+                        {:name "border"    :value "yes"}]]
+
+    (t/testing "add-number-to-repeated-prop-names"
+      (t/is (= (ctv/add-number-to-repeated-prop-names props) numbered-props)))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -15,13 +15,13 @@
         map-with-two-props-dashes    [{:name "border" :value "no"} {:name "color" :value "--"}]
         map-with-one-prop            [{:name "border" :value "no"}]
         map-with-equal               [{:name "border" :value "yes color=yes"}]
-        map-with-spaces              [{:name "border 1" :value "of course"}
-                                      {:name "color 2" :value "dark gray"}
-                                      {:name "background 3" :value "anoth€r co-lor"}]
+        map-with-spaces              [{:name "border (1)" :value "of course"}
+                                      {:name "color (2)" :value "dark gray"}
+                                      {:name "background (3)" :value "anoth€r co-lor"}]
 
         string-valid-with-two-props  "border=yes, color=gray"
         string-valid-with-one-prop   "border=no"
-        string-valid-with-spaces     "border 1=of course, color 2=dark gray, background 3=anoth€r co-lor"
+        string-valid-with-spaces     "border (1)=of course, color (2)=dark gray, background (3)=anoth€r co-lor"
         string-valid-with-no-value   "border=no, color="
         string-valid-with-dashes     "border=no, color=--"
         string-valid-with-equal      "border=yes color=yes"
@@ -133,24 +133,29 @@
       (t/is (= (ctv/same-variant? components-4) false)))))
 
 
-(t/deftest add-number-to-repeated-item
-  (let [names ["border" "color" "color (1)" "size"]]
+(t/deftest update-number-in-repeated-item
+  (let [names ["border" "color" "color 1" "color 2" "color (1)" "color (7)" "area 51"]]
 
-    (t/testing "add-number-to-repeated-item"
-      (t/is (= (ctv/add-number-to-repeated-item names "background") "background"))
-      (t/is (= (ctv/add-number-to-repeated-item names "border")     "border (1)"))
-      (t/is (= (ctv/add-number-to-repeated-item names "color")      "color (2)")))))
+    (t/testing "update-number-in-repeated-item"
+      (t/is (= (ctv/update-number-in-repeated-item names "background") "background"))
+      (t/is (= (ctv/update-number-in-repeated-item names "border")     "border (1)"))
+      (t/is (= (ctv/update-number-in-repeated-item names "color")      "color (2)"))
+      (t/is (= (ctv/update-number-in-repeated-item names "color 1")    "color 1 (1)"))
+      (t/is (= (ctv/update-number-in-repeated-item names "color (1)")  "color (2)"))
+      (t/is (= (ctv/update-number-in-repeated-item names "area 51")    "area 51 (1)")))))
 
 
-(t/deftest add-number-to-repeated-prop-names
-  (let [props          [{:name "color"     :value "yellow"}
-                        {:name "color"     :value "blue"}
-                        {:name "color"     :value "red"}
-                        {:name "border"    :value "yes"}]
-        numbered-props [{:name "color"     :value "yellow"}
-                        {:name "color (1)" :value "blue"}
-                        {:name "color (2)" :value "red"}
-                        {:name "border"    :value "yes"}]]
+(t/deftest update-number-in-repeated-prop-names
+  (let [props          [{:name "color"      :value "yellow"}
+                        {:name "color"      :value "blue"}
+                        {:name "color"      :value "red"}
+                        {:name "border (1)" :value "no"}
+                        {:name "border (1)" :value "yes"}]
+        numbered-props [{:name "color"      :value "yellow"}
+                        {:name "color (1)"  :value "blue"}
+                        {:name "color (2)"  :value "red"}
+                        {:name "border (1)" :value "no"}
+                        {:name "border (2)" :value "yes"}]]
 
-    (t/testing "add-number-to-repeated-prop-names"
-      (t/is (= (ctv/add-number-to-repeated-prop-names props) numbered-props)))))
+    (t/testing "update-number-in-repeated-prop-names"
+      (t/is (= (ctv/update-number-in-repeated-prop-names props) numbered-props)))))

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -49,7 +49,7 @@
             objects (-> (dsh/get-page data page-id)
                         (get :objects))
 
-            updated-properties   (ctv/add-number-to-repeated-prop-names updated-properties)
+            updated-properties   (ctv/update-number-in-repeated-prop-names updated-properties)
 
             properties-to-remove (ctv/find-properties-to-remove previous-properties updated-properties)
             properties-to-add    (ctv/find-properties-to-add previous-properties updated-properties)

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -49,6 +49,8 @@
             objects (-> (dsh/get-page data page-id)
                         (get :objects))
 
+            updated-properties   (ctv/add-number-to-repeated-prop-names updated-properties)
+
             properties-to-remove (ctv/find-properties-to-remove previous-properties updated-properties)
             properties-to-add    (ctv/find-properties-to-add previous-properties updated-properties)
             properties-to-update (ctv/find-properties-to-update previous-properties updated-properties)


### PR DESCRIPTION
### Related Ticket

Taiga [#10789](https://tree.taiga.io/project/penpot/task/10789)

### Summary

Add a number at the end of a property name if it already exists, to avoid duplicates.