### PR TITLE
:bug: Fix misalignments at create account

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ on-premises instances** that want to keep up to date.
 - Fix element positioning on the right side to adjust to grid [#11073](https://tree.taiga.io/project/penpot/issue/11073)
 - Fix palette is over sidebar [#11160](https://tree.taiga.io/project/penpot/issue/11160)
 - Fix font size input not displaying "mixed" when multiple texts are selected [Taiga #11177](https://tree.taiga.io/project/penpot/issue/11177)
+- Misalignments at Create account [Taiga #11315](https://tree.taiga.io/project/penpot/issue/11315)
 
 
 ## 2.7.2

--- a/frontend/src/app/main/ui/auth/register.cljs
+++ b/frontend/src/app/main/ui/auth/register.cljs
@@ -35,6 +35,7 @@
            :content (tr "onboarding-v2.newsletter.updates")}])]
     [:div {:class (stl/css :fields-row :input-visible :newsletter-option-wrapper)}
      [:& fm/input {:name :accept-newsletter-updates
+                   :class (stl/css :checkbox-newsletter-updates)
                    :type "checkbox"
                    :default-checked false
                    :label updates-label}]]))
@@ -53,6 +54,7 @@
 
     [:div {:class (stl/css :fields-row :input-visible :accept-terms-and-privacy-wrapper)}
      [:& fm/input {:name :accept-terms-and-privacy
+                   :show-error false
                    :class (stl/css :checkbox-terms-and-privacy)
                    :type "checkbox"
                    :default-checked false

--- a/frontend/src/app/main/ui/auth/register.scss
+++ b/frontend/src/app/main/ui/auth/register.scss
@@ -14,9 +14,11 @@
   }
 }
 
-.checkbox-terms-and-privacy {
+.checkbox-terms-and-privacy,
+.checkbox-newsletter-updates {
   align-items: flex-start;
 }
+
 .register-form {
   gap: $s-24;
 }


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11315

### Summary

Checkboxes are misaligned in create account.

### Steps to reproduce 

1. Go to create an account.
2. The checkboxes should be aligned.
3. Check and uncheck terms of service checkbox, no error message is shown.

### Checklist

- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.