### PR TITLE
:bug: Fix wasm render path issues

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -739,7 +739,7 @@
     (when (and (some? content)
                (or (= type :path)
                    (= type :bool)))
-      (when (some? svg-attrs)
+      (when (seq svg-attrs)
         (set-shape-path-attrs svg-attrs))
       (set-shape-path-content content))
     (when (and (some? content) (= type :svg-raw))

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -449,7 +449,15 @@ impl RenderState {
                     s.canvas().concat(&matrix);
                 });
 
-                if shape.fills.is_empty() && !matches!(shape.shape_type, Type::Group(_)) {
+                let has_fill_none = matches!(
+                    shape.svg_attrs.get("fill").map(String::as_str),
+                    Some("none")
+                );
+
+                if shape.fills.is_empty()
+                    && !matches!(shape.shape_type, Type::Group(_))
+                    && !has_fill_none
+                {
                     if let Some(fills_to_render) = self.nested_fills.last() {
                         let fills_to_render = fills_to_render.clone();
                         for fill in fills_to_render.iter() {


### PR DESCRIPTION
- Fix errors like this in avataars testing file:
![image](https://github.com/user-attachments/assets/c3adb2b1-ec1a-419e-a863-7aa0e75a9818)

- And group fills propagation when the svg-attr fill is none
![image](https://github.com/user-attachments/assets/475e6319-bbcd-484d-a0b9-1f6c1c2f1d85)
