### PR TITLE
:tada: Add token export event tag

### DIFF
--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -36,6 +36,7 @@
 
 (defn- hide-popover
   [node]
+  (dom/unset-css-property! node "block-size")
   (dom/unset-css-property! node "display")
   (.hidePopover ^js node))
 

--- a/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/export.cljs
@@ -9,8 +9,10 @@
   (:require
    [app.common.json :as json]
    [app.common.types.tokens-lib :as ctob]
+   [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.refs :as refs]
+   [app.main.store :as st]
    [app.main.ui.components.code-block :refer [code-block]]
    [app.main.ui.ds.buttons.button :refer [button*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
@@ -22,6 +24,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.webapi :as wapi]
    [app.util.zip :as zip]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc export-tab*
@@ -59,6 +62,7 @@
          (mf/deps tokens-json)
          (fn []
            (when tokens-json
+             (st/emit! (ptk/data-event ::ev/event {::ev/name "export-tokens" :type "single"}))
              (->> (wapi/create-blob (or tokens-json "{}") "application/json")
                   (dom/trigger-download "tokens.json")))))]
     [:> export-tab* {:is-disabled is-disabled
@@ -85,6 +89,7 @@
         (mf/use-fn
          (mf/deps files)
          (fn []
+           (st/emit! (ptk/data-event ::ev/event {::ev/name "export-tokens" :type "multiple"}))
            (download-tokens-zip! files)))]
     [:> export-tab* {:on-export on-export
                      :is-disabled is-disabled}

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -10,7 +10,6 @@
    [app.common.data :as d]
    [app.common.types.tokens-lib :as ctob]
    [app.config :as cf]
-   [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.data.style-dictionary :as sd]
    [app.main.data.workspace.tokens.application :as dwta]
@@ -37,7 +36,6 @@
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [okulary.core :as l]
-   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]
    [shadow.resource]))
 
@@ -384,7 +382,6 @@
         on-export
         (mf/use-fn
          (fn []
-           (st/emit! (ptk/data-event ::ev/event {::ev/name "export-tokens"}))
            (modal/show! :tokens/export {})))
 
         on-modal-show

--- a/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/theme_select.cljs
@@ -47,29 +47,32 @@
                    :class (stl/css-case :check-icon true
                                         :check-icon-visible selected?)}]])]))
 
+(defn- open-tokens-theme-modal
+  []
+  (modal/show! :tokens/themes {}))
+
 (mf/defc theme-options
   [{:keys [active-theme-paths themes on-close]}]
-  (let [on-edit-click #(modal/show! :tokens/themes {})]
-    [:ul {:class (stl/css :theme-options :custom-select-dropdown)
-          :role "listbox"}
-     (for [[group themes] themes]
-       [:li {:key group
-             :aria-labelledby (dm/str group "-label")
-             :role "group"}
-        (when (seq group)
-          [:> text* {:as "span" :typography "headline-small" :class (stl/css :group) :id (dm/str (str/kebab group) "-label") :title group} group])
-        [:& themes-list {:themes themes
-                         :active-theme-paths active-theme-paths
-                         :on-close on-close
-                         :grouped? true}]])
-     [:li {:class (stl/css :separator)
-           :aria-hidden true}]
-     [:li {:class (stl/css-case :checked-element true
-                                :checked-element-button true)
-           :role "option"
-           :on-click on-edit-click}
-      [:> text* {:as "span" :typography "body-small"} (tr "workspace.tokens.edit-themes")]
-      [:> icon* {:icon-id i/arrow-right :aria-hidden true}]]]))
+  [:ul {:class (stl/css :theme-options :custom-select-dropdown)
+        :role "listbox"}
+   (for [[group themes] themes]
+     [:li {:key group
+           :aria-labelledby (dm/str group "-label")
+           :role "group"}
+      (when (seq group)
+        [:> text* {:as "span" :typography "headline-small" :class (stl/css :group) :id (dm/str (str/kebab group) "-label") :title group} group])
+      [:& themes-list {:themes themes
+                       :active-theme-paths active-theme-paths
+                       :on-close on-close
+                       :grouped? true}]])
+   [:li {:class (stl/css :separator)
+         :aria-hidden true}]
+   [:li {:class (stl/css-case :checked-element true
+                              :checked-element-button true)
+         :role "option"
+         :on-click open-tokens-theme-modal}
+    [:> text* {:as "span" :typography "body-small"} (tr "workspace.tokens.edit-themes")]
+    [:> icon* {:icon-id i/arrow-right :aria-hidden true}]]])
 
 (mf/defc theme-select
   [{:keys []}]


### PR DESCRIPTION
### Related Ticket

This PR closes[ this task](https://tree.taiga.io/project/penpot/task/11323)

### Summary

We now have two different token export events. We need to differenciate them to measure.

### Steps to reproduce 
1. Import tokens file from [this US ](https://tree.taiga.io/project/penpot/us/10977)
2. Open tokens export modal.
3. Choose single file option. 
**The event should have the "single" type prop**

4. Then choose the multiple file option
**The event should have the "multiple" type prop**
### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
