### PR TITLE
:bug: Add workaround for webkit issue on fileReader

### DIFF
--- a/frontend/src/app/util/webapi.cljs
+++ b/frontend/src/app/util/webapi.cljs
@@ -18,17 +18,32 @@
 
 (log/set-level! :warn)
 
+;; NOTE: this operation is necessary because some versions of safari/webkit,
+;; returns something like "data:image/png, image/png;base64,iVBOR" (repeated
+;; mimetype). The regex replacement strips the repeated mimetype.
+(def webkit-datauri-fix-re
+  #"^(data:image/\w+)(,\s*image/\w+)?(;base64.*)$")
+
+(defn- fix-webkit-data-uri
+  [duri]
+  (str/replace duri webkit-datauri-fix-re "$1$3"))
+
 (defn- file-reader
   [f]
   (rx/create
    (fn [subs]
      (let [reader (js/FileReader.)]
-       (obj/set! reader "onload" #(do (rx/push! subs (.-result ^js reader))
-                                      (rx/end! subs)))
-       (obj/set! reader "onerror" #(rx/error! subs %))
-       (obj/set! reader "onabort" #(rx/error! subs (ex/error :type :internal
-                                                             :code :abort
-                                                             :hint "operation aborted")))
+       (obj/set! reader "onload"
+                 #(let [result (.-result ^js reader)
+                        result (fix-webkit-data-uri result)]
+                    (rx/push! subs result)
+                    (rx/end! subs)))
+       (obj/set! reader "onerror"
+                 #(rx/error! subs %))
+       (obj/set! reader "onabort"
+                 #(rx/error! subs (ex/error :type :internal
+                                            :code :abort
+                                            :hint "operation aborted")))
        (f reader)
        (fn []
          (.abort ^js reader))))))


### PR DESCRIPTION
Relevant issue: https://tree.taiga.io/project/penpot/issue/11343

More context:

- It happens on any webkit broser, is reproducible on localhost with epiphany/gnome-web
- You should refresh after each test, because we have internal resolution cache
- The issue happens once the thumbnail is generated
