### PR TITLE
:bug: Fix storing custom fonts

### DIFF
--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -66,7 +66,8 @@
     (let [font-uuid (custom-font-id->uuid font-id)
           matching-font (d/seek (fn [[_ font]]
                                   (and (= (:font-id font) font-uuid)
-                                       (= (:font-variant-id font) font-variant-id)))
+                                       (or (nil? (:font-variant-id font))
+                                           (= (:font-variant-id font) font-variant-id))))
                                 (seq @fonts))]
       (when matching-font
         (:ttf-file-id (second matching-font))))
@@ -116,7 +117,7 @@
     :google
     (google-font-ttf-url font-id font-variant-id)
     :custom
-    (dm/str (u/join cf/public-uri "assets/by-id/" font-id))
+    (dm/str (u/join cf/public-uri "assets/by-id/" asset-id))
     :builtin
     (dm/str (u/join cf/public-uri "fonts/" asset-id))))
 


### PR DESCRIPTION
### Related Ticket

### Summary

Custom fonts were not being loaded, we need to use asset-id instead of font-id to load them

### Steps to reproduce 

- Add a custom font
- Go to a file or create a new one
- Select the custom font
- Check it loads correctly
- Check it switches to custom fonts correctly

![image](https://github.com/user-attachments/assets/50ebacb9-74de-4a2e-82ed-8e3bea55f129)
 
### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.