### PR TITLE
:sparkles: Implement font-size token type

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -117,6 +117,7 @@
     ;; Only for developtment.
     :tiered-file-data-storage
     :token-units
+    :token-typography-types
     :transit-readable-response
     :user-feedback
     ;; TODO: remove this flag.

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -186,6 +186,7 @@
        changed-sub-attr
        #{:m1 :m2 :m3 :m4})
 
+     (font-size-keys shape-attr) #{shape-attr}
      (border-radius-keys shape-attr) #{shape-attr}
      (sizing-keys shape-attr) #{shape-attr}
      (opacity-keys shape-attr) #{shape-attr}

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -33,6 +33,7 @@
    :border-radius "borderRadius"
    :color         "color"
    :dimensions    "dimension"
+   :font-size     "fontSize"
    :number        "number"
    :opacity       "opacity"
    :other         "other"
@@ -122,6 +123,12 @@
 
 (def rotation-keys (schema-keys schema:rotation))
 
+(def ^:private schema:font-size
+  [:map
+   [:font-size {:optional true} token-name-ref]])
+
+(def font-size-keys (schema-keys schema:font-size))
+
 (def ^:private schema:number
   [:map
    [:rotation {:optional true} token-name-ref]
@@ -137,6 +144,7 @@
                          spacing-keys
                          dimensions-keys
                          rotation-keys
+                         font-size-keys
                          number-keys))
 
 (def ^:private schema:tokens
@@ -150,6 +158,7 @@
    schema:spacing
    schema:rotation
    schema:number
+   schema:font-size
    schema:dimensions])
 
 (defn shape-attr->token-attrs

--- a/common/test/common_tests/logic/token_apply_test.cljc
+++ b/common/test/common_tests/logic/token_apply_test.cljc
@@ -230,7 +230,8 @@
                                                    shape
                                                    txt/is-content-node?
                                                    d/txt-merge
-                                                   {:fills (ths/sample-fills-color :fill-color "#fabada")}))
+                                                   {:fills (ths/sample-fills-color :fill-color "#fabada")
+                                                    :font-size "1"}))
                                                 (:objects page)
                                                 {}))
 

--- a/frontend/src/app/main/data/workspace/tokens/propagation.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/propagation.cljs
@@ -33,6 +33,7 @@
    ctt/sizing-keys dwta/update-shape-dimensions
    ctt/opacity-keys dwta/update-opacity
    #{:line-height} dwta/update-line-height
+   #{:font-size} dwta/update-font-size
    #{:x :y} dwta/update-shape-position
    #{:p1 :p2 :p3 :p4} dwta/update-layout-padding
    #{:m1 :m2 :m3 :m4} dwta/update-layout-item-margin

--- a/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/context_menu.cljs
@@ -233,7 +233,8 @@
    (dwta/update-shape-radius-for-corners value shape-ids attributes)))
 
 (def shape-attribute-actions-map
-  (let [stroke-width (partial generic-attribute-actions #{:stroke-width} "Stroke Width")]
+  (let [stroke-width (partial generic-attribute-actions #{:stroke-width} "Stroke Width")
+        font-size (partial generic-attribute-actions #{:font-size} "Font Size")]
     {:border-radius (partial all-or-separate-actions {:attribute-labels {:r1 "Top Left"
                                                                          :r2 "Top Right"
                                                                          :r4 "Bottom Left"
@@ -252,6 +253,7 @@
                [(generic-attribute-actions #{:rotation} "Rotation" (assoc context-data :on-update-shape dwta/update-rotation))
                 (generic-attribute-actions #{:line-height} "Line Height" (assoc context-data :on-update-shape dwta/update-line-height))])
      :stroke-width stroke-width
+     :font-size font-size
      :dimensions (fn [context-data]
                    (concat
                     [{:title "Sizing" :submenu :sizing}

--- a/frontend/src/app/main/ui/workspace/tokens/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/modals.cljs
@@ -179,3 +179,9 @@
    ::mf/register-as :tokens/typography}
   [properties]
   [:& token-update-create-modal properties])
+
+(mf/defc font-size-modal
+  {::mf/register modal/components
+   ::mf/register-as :tokens/font-size}
+  [properties]
+  [:& token-update-create-modal properties])

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -50,6 +50,7 @@
     :border-radius "corner-radius"
     :color "drop"
     :boolean "boolean-difference"
+    :font-size "percentage"
     :opacity "percentage"
     :number "number"
     :rotation "rotation"

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -50,7 +50,7 @@
     :border-radius "corner-radius"
     :color "drop"
     :boolean "boolean-difference"
-    :font-size "percentage"
+    :font-size "text-font-size"
     :opacity "percentage"
     :number "number"
     :rotation "rotation"

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -146,14 +146,15 @@
   tokens exist for that type. Sort each group alphabetically (by their type).
   If `:token-units` is not in cf/flags, number tokens are excluded."
   [tokens-by-type]
-  (let [all-types (-> dwta/token-properties keys seq)
-        token-units? (contains? cf/flags :token-units)
-        filtered-types (if token-units?
-                         all-types
-                         (remove #(= % :number) all-types))]
+  (let [token-units? (contains? cf/flags :token-units)
+        token-typography-types? (contains? cf/flags :token-typography-types)
+        all-types (cond-> dwta/token-properties
+                    (not token-units?) (dissoc :number)
+                    (not token-typography-types?) (dissoc :font-size))
+        all-types (-> all-types keys seq)]
     (loop [empty  #js []
            filled #js []
-           types  filtered-types]
+           types  all-types]
       (if-let [type (first types)]
         (if (not-empty (get tokens-by-type type))
           (recur empty

--- a/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/token_pill.cljs
@@ -162,6 +162,9 @@
         shape-ids         (into #{} xf:map-id selected-shapes)]
     (cft/shapes-applied-all? ids-by-attributes shape-ids attributes)))
 
+(def token-types-with-status-icon
+  #{:color :border-radius :rotation :sizing :dimensions :opacity :spacing :stroke-width})
+
 (mf/defc token-pill*
   {::mf/wrap [mf/memo]}
   [{:keys [on-click token on-context-menu selected-shapes active-theme-tokens]}]
@@ -208,7 +211,7 @@
             (or (dwtc/resolved-token-bullet-color theme-token)
                 (dwtc/resolved-token-bullet-color token))))
 
-        number-token (= type :number)
+        status-icon? (contains? token-types-with-status-icon type)
 
         on-click
         (mf/use-fn
@@ -255,7 +258,7 @@
 
     [:button {:class (stl/css-case
                       :token-pill true
-                      :token-pill-no-icon (and number-token (not errors?))
+                      :token-pill-no-icon (and (not status-icon?) (not errors?))
                       :token-pill-default can-edit?
                       :token-pill-applied (and can-edit? has-selected? (or half-applied? full-applied?))
                       :token-pill-invalid (and can-edit? errors?)
@@ -280,12 +283,13 @@
         {:icon-id "broken-link"
          :class (stl/css :token-pill-icon)}]
 
-       (not number-token)
-       (if color
-         [:& color-bullet {:color color :mini true}]
-         [:> token-status-icon*
-          {:icon-id token-status-id
-           :class (stl/css :token-pill-icon)}]))
+       color
+       [:& color-bullet {:color color :mini true}]
+
+       status-icon?
+       [:> token-status-icon*
+        {:icon-id token-status-id
+         :class (stl/css :token-pill-icon)}])
 
      (if contains-path?
        (let [[first-part last-part] (cfh/split-by-last-period name)]


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/108
https://tree.taiga.io/project/penpot/us/10938?no-milestone=1

### Summary


https://github.com/user-attachments/assets/918132f2-a212-497d-bfb5-6b1e3e00ed2d


- Introduces a `font-size` token that updates a the font size of text shapes
- Accepts `px` until the specs for `rem` have been resolved
- Hidden behind FF `token-typography-types`
- Will handle spec requirement ` if a text layer is selected,  left click on the token pill will apply the font-size token to the font-size property - If there is no text layer selected, the token will neihter be applied to the layer nor higlighted as applied.` in a different PR, this is related to https://github.com/tokens-studio/penpot/issues/8 and should be implemented in a overall solution
- Doesn't handle unapply on font-size update change yet, will be handled here: https://tree.taiga.io/project/penpot/issue/11337

### Steps to reproduce 

1. Enable the FF like this in `frontend/resources/public/js/config.js`

```
penpotFlags = "enable-token-units enable-token-typography-types";
```

2. Add `font-size` token from the sidebar
3. Apply it to a text shape

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.