### PR TITLE
:bug: Fix right-sidebar width overflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,7 @@ on-premises instances** that want to keep up to date.
 - Misalignments at Create account [Taiga #11315](https://tree.taiga.io/project/penpot/issue/11315)
 - Fix issue with importing files where flex/grid is used [Taiga #11334](https://tree.taiga.io/project/penpot/issue/11334)
 - Fix wrong color in the export progress bar [Taiga #11299](https://tree.taiga.io/project/penpot/issue/11299)
+- Fix right sidebar width overflow on long layer names [Taiga #11212](https://tree.taiga.io/project/penpot/issue/11212)
 
 ## 2.7.2
 

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -35,7 +35,7 @@
 
 .shape-row {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: $s-8;
   align-items: center;
   height: $s-32;

--- a/frontend/src/app/main/ui/workspace/sidebar.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar.scss
@@ -63,7 +63,7 @@ $width-settings-bar-max: $sz-500;
 .right-settings-bar {
   grid-area: right-sidebar;
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto minmax(0, 1fr);
   height: 100vh;
   width: $width-settings-bar;
   background-color: var(--panel-background-color);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11212

### Summary

Right sidebar was overflowing on inspect mode when having an item with a long width.

### Steps to reproduce 

- Create a layer in a document with a long name
- Go to the "Inspect" tab in the right sidebar
- Check the sidebar does not expand and the content fits  

![image](https://github.com/user-attachments/assets/e1140b52-47bc-4d9d-810b-0daac482fa67)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
