### PR TITLE
:bug: Fix token unapply for text shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@ on-premises instances** that want to keep up to date.
 - Fix button width [Taiga #11394](https://tree.taiga.io/project/penpot/issue/11394)
 - Fix mixed letter spacing and line height [Taiga #11178](https://tree.taiga.io/project/penpot/issue/11178)
 - Fix snap nodes shortcut [Taiga #11054](https://tree.taiga.io/project/penpot/issue/11054)
+- Fix changing a text property in a text layer does not unapply the previously applied token in the same property [Taiga #11337}(https://tree.taiga.io/project/penpot/issue/11337)
 
 ## 2.7.2
 

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -161,7 +161,6 @@
    (contains? (meta changes) ::file-data)
    "Call (with-file-data) before using this function"))
 
-
 (defn- lookup-objects
   [changes]
   (let [data (::file-data (meta changes))]

--- a/common/src/app/common/test_helpers/compositions.cljc
+++ b/common/src/app/common/test_helpers/compositions.cljc
@@ -37,8 +37,6 @@
                           (merge shape
                                  text-params))))
 
-
-
 (defn add-frame
   [file frame-label & {:keys [] :as params}]
   ;; Generated shape tree:

--- a/common/src/app/common/test_helpers/shapes.cljc
+++ b/common/src/app/common/test_helpers/shapes.cljc
@@ -11,6 +11,7 @@
    [app.common.files.helpers :as cfh]
    [app.common.test-helpers.files :as thf]
    [app.common.test-helpers.ids-map :as thi]
+   [app.common.text :as txt]
    [app.common.types.color :as ctc]
    [app.common.types.container :as ctn]
    [app.common.types.pages-list :as ctpl]
@@ -80,6 +81,21 @@
               (ctpl/update-page file-data
                                 (:id page)
                                 #(ctst/set-shape % (ctn/set-shape-attr shape attr val)))))))
+
+(defn update-shape-text
+  [file shape-label attr val & {:keys [page-label]}]
+  (let [page (if page-label
+               (thf/get-page file page-label)
+               (thf/current-page file))
+        shape (ctst/get-shape page (thi/id shape-label))]
+    (update file :data
+            (fn [file-data]
+              (ctpl/update-page file-data
+                                (:id page)
+                                #(ctst/set-shape % (txt/update-text-content shape
+                                                                            txt/is-content-node?
+                                                                            d/txt-merge
+                                                                            {attr val})))))))
 
 (defn sample-library-color
   [label & {:keys [name path color opacity gradient image]}]

--- a/common/test/common_tests/types/text_test.cljc
+++ b/common/test/common_tests/types/text_test.cljc
@@ -29,16 +29,31 @@
                                                      #(conj % line)))
 
 (t/deftest test-get-diff-type
-  (let [diff-text (cttx/get-diff-type content-base content-changed-text)
-        diff-attr (cttx/get-diff-type content-base content-changed-attr)
-        diff-both (cttx/get-diff-type content-base content-changed-both)
-        diff-structure (cttx/get-diff-type content-base content-changed-structure)
+  (let [diff-text                 (cttx/get-diff-type content-base content-changed-text)
+        diff-attr                 (cttx/get-diff-type content-base content-changed-attr)
+        diff-both                 (cttx/get-diff-type content-base content-changed-both)
+        diff-structure            (cttx/get-diff-type content-base content-changed-structure)
         diff-structure-same-attrs (cttx/get-diff-type content-base content-changed-structure-same-attrs)]
+
     (t/is (= #{:text-content-text} diff-text))
     (t/is (= #{:text-content-attribute} diff-attr))
     (t/is (= #{:text-content-text :text-content-attribute} diff-both))
     (t/is (= #{:text-content-structure} diff-structure))
     (t/is (= #{:text-content-structure :text-content-structure-same-attrs} diff-structure-same-attrs))))
+
+
+(t/deftest test-get-diff-attrs
+  (let [attrs-text                 (cttx/get-diff-attrs content-base content-changed-text)
+        attrs-attr                 (cttx/get-diff-attrs content-base content-changed-attr)
+        attrs-both                 (cttx/get-diff-attrs content-base content-changed-both)
+        attrs-structure            (cttx/get-diff-attrs content-base content-changed-structure)
+        attrs-structure-same-attrs (cttx/get-diff-attrs content-base content-changed-structure-same-attrs)]
+
+    (t/is (= #{} attrs-text))
+    (t/is (= #{:font-size} attrs-attr))
+    (t/is (= #{:font-size} attrs-both))
+    (t/is (= #{} attrs-structure))
+    (t/is (= #{} attrs-structure-same-attrs))))
 
 
 (t/deftest test-equal-structure


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11337

### Summary

The automatic token unapply was not working for text shapes, because the change is applied to the `:content` attribute. We must dig into text blocks to see what attributes have actually changed.

### Steps to reproduce 

See Taiga Issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
