### PR TITLE
:bug: Fix unexpected exception on selectiong node on non path shape

### DIFF
--- a/common/src/app/common/types/path/segment.cljc
+++ b/common/src/app/common/types/path/segment.cljc
@@ -474,6 +474,8 @@
   "Given a content and a set of points return all the segments in the path
   that uses the points"
   [content points]
+  (assert (impl/path-data? content) "expected path data instance")
+
   (let [point-set (set points)]
     (loop [result      (transient [])
            prev-point  nil

--- a/frontend/src/app/main/ui/workspace/viewport/path_actions.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/path_actions.cljs
@@ -46,24 +46,25 @@
   (i/icon-xref :snap-nodes (stl/css :snap-nodes-icon :pathbar-icon)))
 
 (defn check-enabled [content selected-points]
-  (let [segments (path.segm/get-segments-with-points content selected-points)
-        num-segments (count segments)
-        num-points (count selected-points)
-        points-selected? (seq selected-points)
-        segments-selected? (seq segments)
-        ;; max segments for n points is (n × (n -1)) / 2
-        max-segments (-> num-points
-                         (* (- num-points 1))
-                         (/ 2))
-        is-curve? (some #(path.segm/is-curve? content %) selected-points)]
+  (when content
+    (let [segments (path.segm/get-segments-with-points content selected-points)
+          num-segments (count segments)
+          num-points (count selected-points)
+          points-selected? (seq selected-points)
+          segments-selected? (seq segments)
+          ;; max segments for n points is (n × (n -1)) / 2
+          max-segments (-> num-points
+                           (* (- num-points 1))
+                           (/ 2))
+          is-curve? (some #(path.segm/is-curve? content %) selected-points)]
 
-    {:make-corner (and points-selected? is-curve?)
-     :make-curve (and points-selected? (not is-curve?))
-     :add-node segments-selected?
-     :remove-node points-selected?
-     :merge-nodes segments-selected?
-     :join-nodes (and points-selected? (>= num-points 2) (< num-segments max-segments))
-     :separate-nodes segments-selected?}))
+      {:make-corner (and points-selected? is-curve?)
+       :make-curve (and points-selected? (not is-curve?))
+       :add-node segments-selected?
+       :remove-node points-selected?
+       :merge-nodes segments-selected?
+       :join-nodes (and points-selected? (>= num-points 2) (< num-segments max-segments))
+       :separate-nodes segments-selected?})))
 
 (mf/defc path-actions*
   [{:keys [shape edit-path]}]


### PR DESCRIPTION
Related issue: https://tree.taiga.io/project/penpot/issue/11358

It can be reproduced without attachment:

- Create an elipse
- Double click
- Try to select a handler