### PR TITLE
:sparkles: Adds new font-size icon to the DS

### DIFF
--- a/frontend/resources/images/icons/text-font-size.svg
+++ b/frontend/resources/images/icons/text-font-size.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" stroke-linecap="round" stroke-linejoin="round"  >
+  <path d="M2.5 5 4 3.5 5.5 5m-3 6L4 12.5 5.5 11M4 4v8m5-1 .899-2.158m0 0L11.5 5l1.601 3.842m-3.202 0h3.202m0 0L14 11"/>
+</svg>

--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.cljs
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.cljs
@@ -260,6 +260,7 @@
 (def ^:icon-id text-auto-width "text-auto-width")
 (def ^:icon-id text-bottom "text-bottom")
 (def ^:icon-id text-fixed "text-fixed")
+(def ^:icon-id text-font-size "text-font-size")
 (def ^:icon-id text-justify "text-justify")
 (def ^:icon-id text-letterspacing "text-letterspacing")
 (def ^:icon-id text-lineheight "text-lineheight")

--- a/frontend/src/app/main/ui/icons.cljs
+++ b/frontend/src/app/main/ui/icons.cljs
@@ -239,6 +239,7 @@
 (def ^:icon text-auto-width (icon-xref :text-auto-width))
 (def ^:icon text-bottom (icon-xref :text-bottom))
 (def ^:icon text-fixed (icon-xref :text-fixed))
+(def ^:icon text-font-size (icon-xref :text-font-size))
 (def ^:icon text-justify (icon-xref :text-justify))
 (def ^:icon text-letterspacing (icon-xref :text-letterspacing))
 (def ^:icon text-lineheight (icon-xref :text-lineheight))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11369

### Summary

Add new icon for font-size token

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
