### PR TITLE
:sparkles: Support grid editor with wasm modifiers

### DIFF
--- a/frontend/src/app/main/data/workspace/modifiers.cljs
+++ b/frontend/src/app/main/data/workspace/modifiers.cljs
@@ -39,6 +39,43 @@
 (def ^:private xf:without-uuid-zero
   (remove #(= % uuid/zero)))
 
+(def ^:private transform-attrs
+  #{:selrect
+    :points
+    :x
+    :y
+    :r1
+    :r2
+    :r3
+    :r4
+    :shadow
+    :blur
+    :strokes
+    :width
+    :height
+    :content
+    :transform
+    :transform-inverse
+    :rotation
+    :flip-x
+    :flip-y
+    :grow-type
+    :position-data
+    :layout-gap
+    :layout-padding
+    :layout-item-h-sizing
+    :layout-item-max-h
+    :layout-item-max-w
+    :layout-item-min-h
+    :layout-item-min-w
+    :layout-item-v-sizing
+    :layout-padding-type
+    :layout-item-margin
+    :layout-item-margin-type
+    :layout-grid-cells
+    :layout-grid-columns
+    :layout-grid-rows})
+
 ;; -- temporary modifiers -------------------------------------------
 
 ;; During an interactive transformation of shapes (e.g. when resizing or rotating
@@ -598,6 +635,18 @@
     ptk/WatchEvent
     (watch [_ state _]
       (let [objects          (dsh/lookup-page-objects state)
+
+            ignore-tree
+            (calculate-ignore-tree modif-tree objects)
+
+            options
+            (-> params
+                (assoc :reg-objects? true)
+                (assoc :ignore-tree ignore-tree)
+                ;; Attributes that can change in the transform. This
+                ;; way we don't have to check all the attributes
+                (assoc :attrs transform-attrs))
+
             geometry-entries (parse-geometry-modifiers modif-tree)
 
             snap-pixel?
@@ -627,7 +676,7 @@
          (clear-local-transform)
          (ptk/event ::dwg/move-frame-guides {:ids ids :transforms transforms})
          (ptk/event ::dwcm/move-frame-comment-threads transforms)
-         (dwsh/update-shapes ids update-shape))))))
+         (dwsh/update-shapes ids update-shape options))))))
 
 (def ^:private
   xf-rotation-shape
@@ -713,43 +762,6 @@
                 (gm/set-objects-modifiers objects))]
 
         (assoc state :workspace-modifiers modif-tree)))))
-
-(def ^:private transform-attrs
-  #{:selrect
-    :points
-    :x
-    :y
-    :r1
-    :r2
-    :r3
-    :r4
-    :shadow
-    :blur
-    :strokes
-    :width
-    :height
-    :content
-    :transform
-    :transform-inverse
-    :rotation
-    :flip-x
-    :flip-y
-    :grow-type
-    :position-data
-    :layout-gap
-    :layout-padding
-    :layout-item-h-sizing
-    :layout-item-max-h
-    :layout-item-max-w
-    :layout-item-min-h
-    :layout-item-min-w
-    :layout-item-v-sizing
-    :layout-padding-type
-    :layout-item-margin
-    :layout-item-margin-type
-    :layout-grid-cells
-    :layout-grid-columns
-    :layout-grid-rows})
 
 (defn apply-modifiers*
   "A lower-level version of apply-modifiers, that expects receive ready

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -457,7 +457,7 @@ pub extern "C" fn set_structure_modifiers() {
                     let Some(shape) = state.shapes.get(&entry.id) else {
                         continue;
                     };
-                    for id in shape.all_children_with_self(&state.shapes) {
+                    for id in shape.all_children_with_self(&state.shapes, true) {
                         state.scale_content.insert(id, entry.value);
                     }
                 }

--- a/render-wasm/src/math.rs
+++ b/render-wasm/src/math.rs
@@ -412,7 +412,7 @@ pub fn resize_matrix(
     parent_transform.post_translate(center);
     parent_transform.pre_translate(-center);
 
-    let parent_transform_inv = &parent_transform.invert().unwrap();
+    let parent_transform_inv = &parent_transform.invert().unwrap_or_default();
     let origin = parent_transform_inv.map_point(child_bounds.nw);
 
     let mut scale = Matrix::scale((scale_width, scale_height));

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -930,7 +930,8 @@ impl RenderState {
                 let children_clip_bounds =
                     node_render_state.get_children_clip_bounds(element, modifiers.get(&element.id));
 
-                let mut children_ids = modified_children_ids(element, structure.get(&element.id));
+                let mut children_ids =
+                    modified_children_ids(element, structure.get(&element.id), false);
 
                 // Z-index ordering on Layouts
                 if element.has_layout() {
@@ -1020,7 +1021,7 @@ impl RenderState {
             let Some(root) = tree.get(&Uuid::nil()) else {
                 return Err(String::from("Root shape not found"));
             };
-            let root_ids = modified_children_ids(root, structure.get(&root.id));
+            let root_ids = modified_children_ids(root, structure.get(&root.id), false);
 
             // If we finish processing every node rendering is complete
             // let's check if there are more pending nodes
@@ -1119,7 +1120,7 @@ impl RenderState {
                     self.update_tile_for(&shape);
                 } else {
                     // We only need to rebuild tiles from the first level.
-                    let children = modified_children_ids(&shape, structure.get(&shape.id));
+                    let children = modified_children_ids(&shape, structure.get(&shape.id), false);
                     for child_id in children.iter() {
                         nodes.push(*child_id);
                     }
@@ -1149,7 +1150,7 @@ impl RenderState {
                     self.update_tile_for(&shape);
                 }
 
-                let children = modified_children_ids(&shape, structure.get(&shape.id));
+                let children = modified_children_ids(&shape, structure.get(&shape.id), false);
                 for child_id in children.iter() {
                     nodes.push(*child_id);
                 }

--- a/render-wasm/src/render/grid_layout.rs
+++ b/render-wasm/src/render/grid_layout.rs
@@ -30,7 +30,7 @@ pub fn render_overlay(
     }
 
     let layout_bounds = shape.bounds();
-    let children = modified_children_ids(shape, structure.get(&shape.id));
+    let children = modified_children_ids(shape, structure.get(&shape.id), false);
 
     let column_tracks = calculate_tracks(
         true,

--- a/render-wasm/src/render/grid_layout.rs
+++ b/render-wasm/src/render/grid_layout.rs
@@ -1,6 +1,8 @@
 use skia_safe::{self as skia};
 use std::collections::HashMap;
 
+use crate::shapes::modifiers::common::GetBounds;
+
 use crate::math::{Bounds, Matrix, Rect};
 use crate::shapes::modifiers::grid_layout::{calculate_tracks, create_cell_data};
 use crate::shapes::{modified_children_ids, Frame, Layout, Shape, StructureEntry, Type};
@@ -22,7 +24,7 @@ pub fn render_overlay(
         return;
     };
 
-    let bounds = &HashMap::<Uuid, Bounds>::new();
+    let bounds = &mut HashMap::<Uuid, Bounds>::new();
 
     let shape = &mut shape.clone();
     if let Some(modifiers) = modifiers.get(&shape.id) {
@@ -31,6 +33,18 @@ pub fn render_overlay(
 
     let layout_bounds = shape.bounds();
     let children = modified_children_ids(shape, structure.get(&shape.id), false);
+
+    for child_id in children.iter() {
+        let Some(child) = shapes.get(child_id) else {
+            continue;
+        };
+
+        if let Some(modifier) = modifiers.get(child_id) {
+            let mut b = bounds.find(child);
+            b.transform_mut(modifier);
+            bounds.insert(*child_id, b);
+        }
+    }
 
     let column_tracks = calculate_tracks(
         true,

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -25,7 +25,7 @@ fn propagate_children(
     structure: &HashMap<Uuid, Vec<StructureEntry>>,
     scale_content: &HashMap<Uuid, f32>,
 ) -> VecDeque<Modifier> {
-    let children_ids = modified_children_ids(shape, structure.get(&shape.id));
+    let children_ids = modified_children_ids(shape, structure.get(&shape.id), true);
 
     if children_ids.is_empty() || identitish(transform) {
         return VecDeque::new();
@@ -95,7 +95,7 @@ fn calculate_group_bounds(
     let shape_bounds = bounds.find(shape);
     let mut result = Vec::<Point>::new();
 
-    let children_ids = modified_children_ids(shape, structure.get(&shape.id));
+    let children_ids = modified_children_ids(shape, structure.get(&shape.id), true);
     for child_id in children_ids.iter() {
         let Some(child) = shapes.get(child_id) else {
             continue;
@@ -272,7 +272,7 @@ pub fn propagate_modifiers(
                         }
                         Type::Group(Group { masked: true }) => {
                             let children_ids =
-                                modified_children_ids(shape, state.structure.get(&shape.id));
+                                modified_children_ids(shape, state.structure.get(&shape.id), true);
                             if let Some(child) = shapes.get(&children_ids[0]) {
                                 let child_bounds = bounds.find(child);
                                 bounds.insert(shape.id, child_bounds);

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-mod common;
+pub mod common;
 mod constraints;
 mod flex_layout;
 pub mod grid_layout;

--- a/render-wasm/src/shapes/modifiers/constraints.rs
+++ b/render-wasm/src/shapes/modifiers/constraints.rs
@@ -11,26 +11,26 @@ pub fn calculate_resize(
 ) -> Option<(f32, f32)> {
     let scale_width = match constraint_h {
         ConstraintH::Left | ConstraintH::Right | ConstraintH::Center => {
-            parent_before.width() / parent_after.width()
+            parent_before.width() / f32::max(0.01, parent_after.width())
         }
         ConstraintH::LeftRight => {
             let left = parent_before.left(child_before.nw);
             let right = parent_before.right(child_before.ne);
             let target_width = parent_after.width() - left - right;
-            target_width / child_after.width()
+            target_width / f32::max(0.01, child_after.width())
         }
         _ => 1.0,
     };
 
     let scale_height = match constraint_v {
         ConstraintV::Top | ConstraintV::Bottom | ConstraintV::Center => {
-            parent_before.height() / parent_after.height()
+            parent_before.height() / f32::max(0.01, parent_after.height())
         }
         ConstraintV::TopBottom => {
             let top = parent_before.top(child_before.nw);
             let bottom = parent_before.bottom(child_before.sw);
             let target_height = parent_after.height() - top - bottom;
-            target_height / child_after.height()
+            target_height / f32::max(0.01, child_after.height())
         }
         _ => 1.0,
     };

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -184,7 +184,7 @@ fn initialize_tracks(
 ) -> Vec<TrackData> {
     let mut tracks = Vec::<TrackData>::new();
     let mut current_track = TrackData::default();
-    let mut children = modified_children_ids(shape, structure.get(&shape.id));
+    let mut children = modified_children_ids(shape, structure.get(&shape.id), true);
     let mut first = true;
 
     if flex_data.is_reverse() {

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -421,7 +421,7 @@ fn calculate_track_positions(
 
     for track in tracks.iter_mut() {
         track.anchor = next_anchor;
-        next_anchor += layout_axis.across_v * real_gap;
+        next_anchor += layout_axis.across_v * (track.across_size + real_gap);
     }
 }
 

--- a/render-wasm/src/shapes/modifiers/flex_layout.rs
+++ b/render-wasm/src/shapes/modifiers/flex_layout.rs
@@ -269,7 +269,11 @@ fn initialize_tracks(
 // Resize main axis fill
 fn distribute_fill_main_space(layout_axis: &LayoutAxis, tracks: &mut [TrackData]) {
     for track in tracks.iter_mut() {
-        let mut left_space = layout_axis.main_space() - track.main_size;
+        let mut left_space = if layout_axis.is_auto_main {
+            0.0
+        } else {
+            layout_axis.main_space() - track.main_size
+        };
         let mut to_resize_children: Vec<&mut ChildAxis> = Vec::new();
 
         for child in track.shapes.iter_mut() {
@@ -299,7 +303,13 @@ fn distribute_fill_main_space(layout_axis: &LayoutAxis, tracks: &mut [TrackData]
 fn distribute_fill_across_space(layout_axis: &LayoutAxis, tracks: &mut [TrackData]) {
     let total_across_size = tracks.iter().map(|t| t.across_size).sum::<f32>()
         + (tracks.len() - 1) as f32 * layout_axis.gap_across;
-    let mut left_space = layout_axis.across_space() - total_across_size;
+
+    let mut left_space = if layout_axis.is_auto_across {
+        0.0
+    } else {
+        layout_axis.across_space() - total_across_size
+    };
+
     let mut to_resize_tracks: Vec<&mut TrackData> = Vec::new();
 
     for track in tracks.iter_mut() {
@@ -435,13 +445,8 @@ fn calculate_track_data(
         structure,
     );
 
-    if !layout_axis.is_auto_main {
-        distribute_fill_main_space(&layout_axis, &mut tracks);
-    }
-
-    if !layout_axis.is_auto_across {
-        distribute_fill_across_space(&layout_axis, &mut tracks);
-    }
+    distribute_fill_main_space(&layout_axis, &mut tracks);
+    distribute_fill_across_space(&layout_axis, &mut tracks);
 
     let total_across_size = tracks.iter().map(|t| t.across_size).sum::<f32>();
 

--- a/render-wasm/src/shapes/modifiers/grid_layout.rs
+++ b/render-wasm/src/shapes/modifiers/grid_layout.rs
@@ -117,7 +117,7 @@ fn set_auto_base_size(
             (cell.row, cell.row_span)
         };
 
-        if prop_span != 1 || (prop as usize) >= tracks.len() {
+        if prop_span != 1 || (prop as usize) > tracks.len() {
             continue;
         }
 

--- a/render-wasm/src/shapes/modifiers/grid_layout.rs
+++ b/render-wasm/src/shapes/modifiers/grid_layout.rs
@@ -634,7 +634,7 @@ pub fn reflow_grid_layout(
 ) -> VecDeque<Modifier> {
     let mut result = VecDeque::new();
     let layout_bounds = bounds.find(shape);
-    let children = modified_children_ids(shape, structure.get(&shape.id));
+    let children = modified_children_ids(shape, structure.get(&shape.id), true);
 
     let column_tracks = calculate_tracks(
         true,


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/task/11319

### Summary
- Support grid editing with the new render
- Fix problem with flex layout fill elements going to zero
- Fix problem while moving masks, bools and groups

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
