### PR TITLE
:bug: Fix panning and scroll when dpr > 1 (render wasm)

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -605,10 +605,7 @@ impl RenderState {
             // Scale and translate the target according to the cached data
             let navigate_zoom = self.viewbox.zoom / self.cached_viewbox.zoom;
 
-            canvas.scale((
-                navigate_zoom * self.options.dpr(),
-                navigate_zoom * self.options.dpr(),
-            ));
+            canvas.scale((navigate_zoom, navigate_zoom));
 
             let TileRect(start_tile_x, start_tile_y, _, _) =
                 tiles::get_tiles_for_viewbox_with_interest(
@@ -616,8 +613,8 @@ impl RenderState {
                     VIEWPORT_INTEREST_AREA_THRESHOLD,
                     scale,
                 );
-            let offset_x = self.viewbox.area.left * self.cached_viewbox.zoom;
-            let offset_y = self.viewbox.area.top * self.cached_viewbox.zoom;
+            let offset_x = self.viewbox.area.left * self.cached_viewbox.zoom * self.options.dpr();
+            let offset_y = self.viewbox.area.top * self.cached_viewbox.zoom * self.options.dpr();
 
             canvas.translate((
                 (start_tile_x as f32 * tiles::TILE_SIZE) - offset_x,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11276

### Summary

This PR fixes a visual glitch when the DPR > 1 and we do pan or scroll in the viewport.

### Steps to reproduce 

- Make sure you have `enable-render-wasm-dpr` in your `config.js`
- Make sure your device has a pixel ratio > 1 (you can force this via browser zoom) by running in the browser console `window.devicePixelRatio`.
- Open a penpot file.
- Do scroll and/or pan.

Shapes must not change size while the scrolling or panning is taking place. See the attached video in the Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~
