### PR TITLE
:wrench: Fix race condition in colorpicker gradient tests

### DIFF
--- a/frontend/playwright/ui/specs/colorpicker.spec.js
+++ b/frontend/playwright/ui/specs/colorpicker.spec.js
@@ -61,24 +61,28 @@ test("Create a LINEAR gradient", async ({ page }) => {
 
   const removeBtn = workspacePage.colorpicker
     .getByRole("button", { name: "Remove color" })
-    .nth(2);
+    .last();
   await removeBtn.click();
   await removeBtn.click();
 
   const inputColor1 = workspacePage.colorpicker
-    .getByPlaceholder("Mixed")
-    .nth(1);
-  await inputColor1.fill("fabada");
+    .getByRole("textbox", { name: "Color" })
+    .first();
+  await inputColor1.fill("#fabada");
 
-  const inputOpacity1 = workspacePage.colorpicker.getByPlaceholder("--").nth(1);
+  const inputOpacity1 = workspacePage.colorpicker
+    .getByTestId("opacity-input")
+    .first();
   await inputOpacity1.fill("100");
 
   const inputColor2 = workspacePage.colorpicker
-    .getByPlaceholder("Mixed")
-    .nth(2);
-  await inputColor2.fill("red");
+    .getByRole("textbox", { name: "Color" })
+    .last();
+  await inputColor2.fill("#ff0000");
 
-  const inputOpacity2 = workspacePage.colorpicker.getByPlaceholder("--").nth(2);
+  const inputOpacity2 = workspacePage.colorpicker
+    .getByTestId("opacity-input")
+    .last();
   await inputOpacity2.fill("40");
 
   const inputOpacityGlobal = workspacePage.colorpicker.getByTestId(
@@ -139,20 +143,28 @@ test("Create a RADIAL gradient", async ({ page }) => {
 
   const removeBtn = workspacePage.colorpicker
     .getByRole("button", { name: "Remove color" })
-    .nth(2);
+    .last();
   await removeBtn.click();
   await removeBtn.click();
 
-  const inputColor1 = workspacePage.page.getByPlaceholder("Mixed").nth(1);
-  await inputColor1.fill("fabada");
+  const inputColor1 = workspacePage.page
+    .getByRole("textbox", { name: "Color" })
+    .first();
+  await inputColor1.fill("#fabada");
 
-  const inputOpacity1 = workspacePage.colorpicker.getByPlaceholder("--").nth(1);
+  const inputOpacity1 = workspacePage.colorpicker
+    .getByTestId("opacity-input")
+    .first();
   await inputOpacity1.fill("100");
 
-  const inputColor2 = workspacePage.page.getByPlaceholder("Mixed").nth(2);
-  await inputColor2.fill("red");
+  const inputColor2 = workspacePage.page
+    .getByRole("textbox", { name: "Color" })
+    .last();
+  await inputColor2.fill("#ff0000");
 
-  const inputOpacity2 = workspacePage.colorpicker.getByPlaceholder("--").nth(2);
+  const inputOpacity2 = workspacePage.colorpicker
+    .getByTestId("opacity-input")
+    .last();
   await inputOpacity2.fill("100");
 
   const inputOpacityGlobal = workspacePage.colorpicker.getByTestId(

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -267,6 +267,7 @@
                              :on-focus on-focus
                              :on-blur on-blur
                              :on-change handle-opacity-change
+                             :data-testid "opacity-input"
                              :default 100
                              :min 0
                              :max 100}]])]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11386

### Summary

This PR fixes a race condition in the colorpicker's gradient integration tests. TL;DR: we were trying to access the `nth(2)` element of a locator but that element might have been already removed.

### Steps to reproduce 

Run the tests on Playwright as usual.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~
