### PR TITLE
:wrench: Add option to skip tutorial/walkthrough when creating a profile from the script

### DIFF
--- a/backend/scripts/manage.py
+++ b/backend/scripts/manage.py
@@ -71,18 +71,26 @@ def run_cmd(params):
         print("EXC:", str(cause))
         sys.exit(-2)
 
-def create_profile(fullname, email, password):
+def create_profile(fullname, email, password, skip_tutorial=False, skip_walkthrough=False):
+    props = {}
+    if skip_tutorial:
+        props["viewed-tutorial?"] = True
+    if skip_walkthrough:
+        props["viewed-walkthrough?"] = True
+
     params = {
         "cmd": "create-profile",
         "params": {
             "fullname": fullname,
             "email": email,
-            "password": password
+            "password": password,
+            **props
         }
     }
 
     res = run_cmd(params)
     print(f"Created: {res['email']} / {res['id']}")
+
 
 def update_profile(email, fullname, password, is_active):
     params = {
@@ -170,6 +178,8 @@ parser.add_argument("-n", "--fullname", help="fullname", action="store")
 parser.add_argument("-e", "--email", help="email", action="store")
 parser.add_argument("-p", "--password", help="password", action="store")
 parser.add_argument("-c", "--connect", help="connect to PREPL", action="store", default="tcp://localhost:6063")
+parser.add_argument("--skip-tutorial", help="mark tutorial as viewed", action="store_true")
+parser.add_argument("--skip-walkthrough", help="mark walkthrough as viewed", action="store_true")
 
 args = parser.parse_args()
 

--- a/docs/technical-guide/developer/devenv.md
+++ b/docs/technical-guide/developer/devenv.md
@@ -170,6 +170,23 @@ similar to a webmail client. Simply navigate to:
 
 [http://localhost:1080](http://localhost:1080)
 
+## Create user
+
+You can register a new user manually, or create new users automatically with this script. From your tmux instance, run:
+
+
+```sh
+cd penpot/backend/scripts
+python3 manage.py create-profile
+```
+
+You can also skip tutorial and walkthrough steps:
+
+```sh
+python3 manage.py create-profile --skip-tutorial --skip-walkthrough
+python3 manage.py create-profile -n "Jane Doe" -e jane@example.com -p secretpassword --skip-tutorial --skip-walkthrough
+```
+
 ## Team Feature Flags
 
 To test a Feature Flag, you can enable or disable them by team through the `dbg` page:

--- a/docs/technical-guide/getting-started/docker.md
+++ b/docs/technical-guide/getting-started/docker.md
@@ -89,6 +89,13 @@ For instance, if  the registration is disabled, the only way to create a new use
 docker exec -ti penpot-penpot-backend-1 python3 manage.py create-profile
 ```
 
+or
+
+```bash
+docker exec -ti penpot-penpot-backend-1 python3 manage.py create-profile --skip-tutorial --skip-walkthrough
+```
+
+
 **NOTE:** the exact container name depends on your docker version and platform.
 For example it could be <code class="language-bash">penpot-penpot-backend-1</code> or <code class="language-bash">penpot_penpot-backend-1</code>.
 You can check the correct name executing <code class="language-bash">docker ps</code>.


### PR DESCRIPTION
Minor edit to be able to create new testing users locally without having to go through the tutorial & walkthrough