### PR TITLE
:bug: Fix comment icon fill

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,7 +52,7 @@ on-premises instances** that want to keep up to date.
 - Fix issue with importing files where flex/grid is used [Taiga #11334](https://tree.taiga.io/project/penpot/issue/11334)
 - Fix wrong color in the export progress bar [Taiga #11299](https://tree.taiga.io/project/penpot/issue/11299)
 - Fix right sidebar width overflow on long layer names [Taiga #11212](https://tree.taiga.io/project/penpot/issue/11212)
-
+- Fix comment icon fill [Taiga #11388](https://tree.taiga.io/project/penpot/issue/11388)
 ## 2.7.2
 
 ### :bug: Bugs fixed

--- a/frontend/src/app/main/ui/comments.scss
+++ b/frontend/src/app/main/ui/comments.scss
@@ -301,11 +301,10 @@
 }
 
 .open-mentions-button {
-  stroke: none;
-  fill: var(--color-foreground-secondary);
+  color: var(--color-foreground-secondary);
 
   &.is-toggled {
-    fill: var(--color-accent-primary);
+    color: var(--color-accent-primary);
   }
 }
 


### PR DESCRIPTION
### Related Ticket

This PR fixes [this issue](https://tree.taiga.io/project/penpot/issue/11388)

### Summary

Comment icon has setted a fill instead of a stroke

### Steps to reproduce 
Go to a file
Create a comment on canvas
@ icon shoul look good.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
