### PR TITLE
:wrench: Enable render-wasm-dpr by default

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -149,7 +149,8 @@
    :enable-onboarding
    :enable-dashboard-templates-section
    :enable-google-fonts-provider
-   :enable-component-thumbnails])
+   :enable-component-thumbnails
+   :enable-render-wasm-dpr])
 
 (defn parse
   [& flags]

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -73,7 +73,7 @@
   (mem/get-list-size cells GRID-LAYOUT-CELL-ENTRY-SIZE))
 
 (def dpr
-  (if use-dpr? js/window.devicePixelRatio 1.0))
+  (if use-dpr? (if (exists? js/window) js/window.devicePixelRatio 1.0) 1.0))
 
 ;; Based on app.main.render/object-svg
 (mf/defc object-svg


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11247

### Summary

This sets the config flag `render-wasm-dpr` as true by default. Since it only takes effect when the wasm renderer is active, it should be OK to enable it to all users, even if the new renderer is disabled.

Eventually we'll want to make this a setting each user can toggle on/off (or group it under a "Favor performance" toggle).

### Steps to reproduce 

- Make sure you're working with DPR > 1 (you can force this by using the browser zoom and check `window.devicePixelRatio` in the browser console)
- Make sure there's no reference to `render-wasm-dpr` in your local `config.js`.
- Open a penpot file with the new renderer
- Images should be crisps & clear (this is more noticeable in a 2k or 4k screen).
- Check the browser console for the flag. It should appear as `"enabled"`.

<img width="568" alt="Screenshot 2025-06-19 at 4 45 51 PM" src="https://github.com/user-attachments/assets/11984f5a-52af-4172-a90d-a698af517f5b" />



### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~
