### PR TITLE
:fire: Remove incorrect assert on path segment helper

### DIFF
--- a/common/src/app/common/types/path/segment.cljc
+++ b/common/src/app/common/types/path/segment.cljc
@@ -470,8 +470,6 @@
   "Given a content and a set of points return all the segments in the path
   that uses the points"
   [content points]
-  (assert (impl/path-data? content) "expected path data instance")
-
   (let [point-set (set points)]
     (loop [result      (transient [])
            prev-point  nil


### PR DESCRIPTION
Related issue: https://tree.taiga.io/project/penpot/issue/11051
