### PR TITLE
:sparkles: Show warning when selecting a copy of conflicted variant

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5487,6 +5487,14 @@ msgstr "Variant"
 msgid "workspace.options.component.variant.duplicated.group.locate"
 msgstr "Locate duplicated variants"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:440
+msgid "workspace.options.component.variant.duplicated.copy.title"
+msgstr "This component has conflicting variants. Make sure each variation has a unique set of property values."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:443
+msgid "workspace.options.component.variant.duplicated.copy.locate"
+msgstr "Go to main component"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:954
 msgid "workspace.options.component.variant.duplicated.group.title"
 msgstr "Some variants have identical properties and values"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5507,6 +5507,14 @@ msgstr "Desvinculado"
 msgid "workspace.options.component.variant"
 msgstr "Variante"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:440
+msgid "workspace.options.component.variant.duplicated.copy.title"
+msgstr "Este componente tiene variantes en conflicto. Comprueba que cada variante tenga un conjunto único de propiedades y valores."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:443
+msgid "workspace.options.component.variant.duplicated.copy.locate"
+msgstr "Ir al componente principal"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:957
 msgid "workspace.options.component.variant.duplicated.group.locate"
 msgstr "Localizar variantes duplicadas"


### PR DESCRIPTION
### Related Ticket

Taiga [#11393](https://tree.taiga.io/project/penpot/task/11393)

### Summary

When selecting a copy of a component of variants whose main instance has conflicting variants, show a warning and a link to the conflicting variants.