### PR TITLE
:sparkles: Notify user if imported file or directory doesn't contain token files

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/errors.cljs
@@ -14,6 +14,10 @@
    {:error/code :error.import/json-parse-error
     :error/fn #(tr "workspace.tokens.error-parse")}
 
+   :error.import/no-token-files-found
+   {:error/code :error.import/no-token-files-found
+    :error/fn #(tr "workspace.tokens.no-token-files-found")}
+
    :error.import/invalid-json-data
    {:error/code :error.import/invalid-json-data
     :error/fn #(tr "workspace.tokens.invalid-json")}

--- a/frontend/src/app/main/ui/workspace/tokens/modals/import.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/modals/import.scss
@@ -39,6 +39,7 @@
 }
 
 .import-actions {
+  @include t.use-typography("body-small");
   display: flex;
   justify-content: flex-end;
   gap: var(--sp-s);

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7279,6 +7279,10 @@ msgstr "Token Set grouping is not supported yet."
 msgid "workspace.tokens.import-error"
 msgstr "Import Error:"
 
+#: src/app/main/ui/workspace/tokens/modals/import.cljs
+msgid "workspace.tokens.no-token-files-found"
+msgstr "No tokens, sets, or themes were found in this file."
+
 #: src/app/main/ui/workspace/tokens/modals/import.cljs:99
 msgid "workspace.tokens.import-multiple-files"
 msgstr "In multiple files, the file name / path are the set names."

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7381,6 +7381,10 @@ msgstr "No hay temas."
 msgid "workspace.tokens.no-themes-currently"
 msgstr "Actualmente no existen temas."
 
+#: src/app/main/ui/workspace/tokens/modals/import.cljs
+msgid "workspace.tokens.no-tokens-found"
+msgstr "No se han encontrado tokens, sets o temas en este fichero."
+
 #: src/app/main/ui/workspace/tokens/modals/themes.cljs:148
 msgid "workspace.tokens.num-active-sets"
 msgstr "%s sets activos"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/120

### Summary

- Handle case where Zip / Directory import has no token files
- Make import dropdown menu text smaller  

### Steps to reproduce 

- Tokens Panel -> `Tools` -> `Import` -> `Import ZIP file` -> Select empty zip file
- Tokens Panel -> `Tools` -> `Import` -> Select `Import folder` -> Select empty folder


https://github.com/user-attachments/assets/c40af020-a39e-49c0-b565-f4aabd07993a

Please note that import of empty directory wouldn't emit a message in Chrome, while in Firefox it would.

https://github.com/user-attachments/assets/46235076-37af-4352-9b12-32f17ce534c6



### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
