### PR TITLE
:wrench: Fix subscriptions integration tests showing onboarding + refactor

### DIFF
--- a/frontend/playwright/ui/pages/SubscriptionProfilePage.js
+++ b/frontend/playwright/ui/pages/SubscriptionProfilePage.js
@@ -1,31 +1,29 @@
 import { expect } from "@playwright/test";
-import { BaseWebSocketPage } from "./BaseWebSocketPage";
+import { DashboardPage } from "./DashboardPage";
 
-export class SubscriptionProfilePage extends BaseWebSocketPage {
+export class SubscriptionProfilePage extends DashboardPage {
   static async init(page) {
-    await BaseWebSocketPage.initWebSockets(page);
-
-    await BaseWebSocketPage.mockRPC(
+    await DashboardPage.init(page);
+    await DashboardPage.mockRPC(
       page,
       "get-owned-teams",
       "subscription/get-owned-teams.json",
     );
-
   }
 
   constructor(page) {
     super(page);
 
-    this.mainHeading = page.getByRole('heading', { name: 'Subscription', level: 2 });
+    this.mainHeading = page.getByRole("heading", {
+      name: "Subscription",
+      level: 2,
+    });
   }
 
   async goToSubscriptions() {
-    await this.page.goto(
-      `#/settings/subscriptions`,
-    );
+    await this.page.goto(`#/settings/subscriptions`);
     await expect(this.mainHeading).toBeVisible();
   }
-
 }
 
 export default SubscriptionProfilePage;

--- a/frontend/playwright/ui/pages/WorkspacePage.js
+++ b/frontend/playwright/ui/pages/WorkspacePage.js
@@ -313,3 +313,5 @@ export class WorkspacePage extends BaseWebSocketPage {
       .click(clickOptions);
   }
 }
+
+export default WorkspacePage;

--- a/frontend/playwright/ui/specs/subscriptions-profile.spec.js
+++ b/frontend/playwright/ui/specs/subscriptions-profile.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import SubscriptionProfilePage from "../pages/SubscriptionProfilePage";
+
+test.beforeEach(async ({ page }) => {
+  await SubscriptionProfilePage.init(page);
+
+  await SubscriptionProfilePage.mockConfigFlags(page, [
+    "enable-subscriptions",
+    "disable-onboarding",
+  ]);
+});
+
+test.describe("Subscriptions: profile", () => {
+  test("When subscription is professional there is no manage subscription link", async ({
+    page,
+  }) => {
+    const subscriptionProfilePage = new SubscriptionProfilePage(page);
+    await subscriptionProfilePage.mockRPC(
+      "get-profile",
+      "logged-in-user/get-profile-logged-in.json",
+    );
+
+    await subscriptionProfilePage.goToSubscriptions();
+
+    await expect(
+      page.getByRole("button", { name: "Manage your subscription" }),
+    ).not.toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { name: "Other Penpot plans", level: 3 }),
+    ).toBeVisible();
+
+    await expect(page.getByText("$7")).toBeVisible();
+    await expect(page.getByText("$950")).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Try it free for 14 days" }).first(),
+    ).toBeVisible();
+  });
+
+  test("When subscription is unlimited there is manage subscription link", async ({
+    page,
+  }) => {
+    const subscriptionProfilePage = new SubscriptionProfilePage(page);
+
+    await subscriptionProfilePage.mockRPC(
+      "get-profile",
+      "subscription/get-profile-unlimited-subscription.json",
+    );
+
+    await subscriptionProfilePage.goToSubscriptions();
+
+    await expect(
+      page.getByRole("button", { name: "Manage your subscription" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { name: "Other Penpot plans", level: 3 }),
+    ).toBeVisible();
+
+    await expect(page.getByText("$0")).toBeVisible();
+    await expect(page.getByText("$950")).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Try it free for 14 days" }).first(),
+    ).not.toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Subscribe" }).first(),
+    ).toBeVisible();
+  });
+
+  test("When subscription is enteprise there is manage subscription link", async ({
+    page,
+  }) => {
+    const subscriptionProfilePage = new SubscriptionProfilePage(page);
+    await subscriptionProfilePage.mockRPC(
+      "get-profile",
+      "subscription/get-profile-enterprise-subscription.json",
+    );
+
+    await subscriptionProfilePage.goToSubscriptions();
+
+    await expect(
+      page.getByRole("button", { name: "Manage your subscription" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { name: "Other Penpot plans", level: 3 }),
+    ).toBeVisible();
+
+    await expect(page.getByText("$0")).toBeVisible();
+    await expect(page.getByText("$7")).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Try it free for 14 days" }).first(),
+    ).not.toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Subscribe" }).first(),
+    ).toBeVisible();
+  });
+});

--- a/frontend/playwright/ui/specs/subscriptions-workspace.spec.js
+++ b/frontend/playwright/ui/specs/subscriptions-workspace.spec.js
@@ -1,0 +1,122 @@
+import { test, expect } from "@playwright/test";
+import WorkspacePage from "../pages/WorkspacePage";
+
+test.beforeEach(async ({ page }) => {
+  await WorkspacePage.init(page);
+  await WorkspacePage.mockConfigFlags(page, ["enable-subscriptions"]);
+});
+
+test.describe("Subscriptions: workspace", () => {
+  test("Unlimited team should have 'Power up your plan' link in main menu", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile();
+    await workspace.mockRPC(
+      "get-profile",
+      "subscription/get-profile-unlimited-subscription.json",
+    );
+    await workspace.mockRPC(
+      "push-audit-events",
+      "workspace/audit-event-empty.json",
+    );
+    await workspace.goToWorkspace();
+    await page.getByRole("button", { name: "Main menu" }).click();
+    await expect(page.getByText("Power up your plan")).toBeVisible();
+  });
+
+  test("Enterprise team should not have 'Power up your plan' link in main menu", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile();
+    await workspace.mockRPC(
+      "get-profile",
+      "subscription/get-profile-enterprise-subscription.json",
+    );
+    await workspace.mockRPC(
+      "push-audit-events",
+      "workspace/audit-event-empty.json",
+    );
+    await workspace.goToWorkspace();
+    await page.getByRole("button", { name: "Main menu" }).click();
+    await expect(page.getByText("Power up your plan")).not.toBeVisible();
+  });
+
+  test("Professional team should have 7 days autosaved versions", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile();
+    await workspace.mockRPC(
+      "push-audit-events",
+      "workspace/audit-event-empty.json",
+    );
+    await workspace.mockRPC(
+      "get-file-snapshots?file-id=*",
+      "workspace/versions-snapshot-1.json",
+    );
+    await workspace.goToWorkspace();
+    await page.getByLabel("History").click();
+    await expect(
+      page.getByText("Autosaved versions will be kept for 7 days."),
+    ).toBeVisible();
+  });
+
+  test("Unlimited team should have 30 days autosaved versions", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile();
+    await workspace.mockRPC(
+      "get-profile",
+      "subscription/get-profile-unlimited-subscription.json",
+    );
+    await workspace.mockRPC(
+      "get-teams",
+      "subscription/get-teams-unlimited-one-team.json",
+    );
+    await workspace.mockRPC(
+      "push-audit-events",
+      "workspace/audit-event-empty.json",
+    );
+    await workspace.mockRPC(
+      "get-file-snapshots?file-id=*",
+      "workspace/versions-snapshot-1.json",
+    );
+    await workspace.goToWorkspace();
+    await page.getByLabel("History").click();
+    await expect(
+      page.getByText("Autosaved versions will be kept for 30 days."),
+    ).toBeVisible();
+  });
+
+  test("Unlimited team should have 90 days autosaved versions", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page);
+    await workspace.setupEmptyFile();
+    await workspace.mockRPC(
+      "get-profile",
+      "subscription/get-profile-enterprise-subscription.json",
+    );
+    await workspace.mockRPC(
+      "get-teams",
+      "subscription/get-teams-enterprise-one-team.json",
+    );
+    await workspace.mockRPC(
+      "push-audit-events",
+      "workspace/audit-event-empty.json",
+    );
+    await workspace.mockRPC(
+      "get-file-snapshots?file-id=*",
+      "workspace/versions-snapshot-1.json",
+    );
+    await workspace.goToWorkspace();
+    await page.getByLabel("History").click();
+
+    await expect(
+      page.getByText("Autosaved versions will be kept for 90 days."),
+    ).toBeVisible();
+  });
+});

--- a/frontend/playwright/ui/specs/subscriptions.spec.js
+++ b/frontend/playwright/ui/specs/subscriptions.spec.js
@@ -1,77 +1,70 @@
 import { test, expect } from "@playwright/test";
 import DashboardPage from "../pages/DashboardPage";
-import { WorkspacePage } from "../pages/WorkspacePage";
 import { SubscriptionProfilePage } from "../pages/SubscriptionProfilePage";
+
+test.beforeEach(async ({ page }) => {
+  await DashboardPage.init(page);
+  await DashboardPage.mockConfigFlags(page, [
+    "disable-onboarding",
+    "enable-subscriptions",
+  ]);
+});
 
 test.describe("Subscriptions: dashboard", () => {
   test("Team with unlimited subscription has specific icon in menu", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+    await dashboard.mockRPC(
       "get-profile",
       "subscription/get-profile-unlimited-subscription.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
-
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-owner.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
-    await dashboardPage.goToSecondTeamDashboard();
+
+    await dashboard.goToSecondTeamDashboard();
+
     await expect(page.getByTestId("subscription-icon")).toBeVisible();
   });
 
   test("The Unlimited subscription has its name in the sidebar dropdown", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+    await dashboard.mockRPC(
       "get-profile",
       "subscription/get-profile-unlimited-subscription.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
-
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-owner.json",
     );
-
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
-    await dashboardPage.goToDashboard();
+
+    await dashboard.goToDashboard();
 
     await expect(page.getByTestId("subscription-name")).toHaveText(
       "Unlimited plan (trial)",
@@ -83,46 +76,36 @@ test.describe("Subscriptions: Team members and invitations", () => {
   test("Team settings has susbscription name and no manage subscription link when is member", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+
+    await dashboard.mockRPC(
       "get-profile",
       "logged-in-user/get-profile-logged-in.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
-
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-member.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-subscription-member.json",
     );
-
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamSettingsSection();
+    await dashboard.goToSecondTeamSettingsSection();
+
     await expect(page.getByText("Unlimited (trial)")).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Manage your subscription" }),
@@ -132,52 +115,39 @@ test.describe("Subscriptions: Team members and invitations", () => {
   test("Team settings has susbscription name and manage subscription link when is owner", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+    await dashboard.mockRPC(
       "get-profile",
       "subscription/get-profile-unlimited-subscription.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
-
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-owner.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-subscription-owner.json",
     );
-
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-stats?team-id=*",
       "dashboard/get-team-stats.json",
     );
-
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamSettingsSection();
+    await dashboard.goToSecondTeamSettingsSection();
 
     await expect(page.getByText("Unlimited (trial)")).toBeVisible();
     await expect(
@@ -188,140 +158,123 @@ test.describe("Subscriptions: Team members and invitations", () => {
   test("Members tab has warning message when team has more members than subscriptions. Subscribe link is shown for owners.", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+    await dashboard.mockRPC(
       "get-profile",
       "subscription/get-profile-unlimited-subscription.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
 
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-owner.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-subscription-owner.json",
     );
 
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamMembersSection();
-    await expect(page.getByTestId("cta")).toBeVisible();
-    await expect(page.getByText("Subscribe now.")).toBeVisible();
+    await dashboard.goToSecondTeamMembersSection();
+    await expect(dashboard.page.getByTestId("cta")).toBeVisible();
+    await expect(dashboard.page.getByText("Subscribe now.")).toBeVisible();
   });
 
   test("Members tab has warning message when team has more members than subscriptions. Contact to owner is shown for members.", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+
+    await dashboard.mockRPC(
       "get-profile",
       "logged-in-user/get-profile-logged-in.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
 
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-member.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-subscription-member.json",
     );
 
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamMembersSection();
-    await expect(page.getByTestId("cta")).toBeVisible();
-    await expect(page.getByText("Contact with the team owner")).toBeVisible();
+    await dashboard.goToSecondTeamMembersSection();
+
+    await expect(dashboard.page.getByTestId("cta")).toBeVisible();
+    await expect(
+      dashboard.page.getByText("Contact with the team owner"),
+    ).toBeVisible();
   });
 
   test("Members tab has warning message when has professional subscription and more than 8 members.", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+    await dashboard.mockRPC(
       "get-profile",
       "logged-in-user/get-profile-logged-in.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
 
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-professional-subscription-owner.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-more-than-8.json",
     );
 
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamMembersSection();
+    await dashboard.goToSecondTeamMembersSection();
     await expect(page.getByTestId("cta")).toBeVisible();
     await expect(
       page.getByText(
@@ -333,52 +286,45 @@ test.describe("Subscriptions: Team members and invitations", () => {
   test("Invitations tab has warning message when subscription is expired", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+
+    await dashboard.mockRPC(
       "get-profile",
       "subscription/get-profile-unlimited-subscription.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
 
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-expired-owner.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-subscription-owner.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-invitations?team-id=*",
       "dashboard/get-team-invitations-empty.json",
     );
 
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamInvitationsSection();
+    await dashboard.goToSecondTeamInvitationsSection();
     await expect(page.getByTestId("cta")).toBeVisible();
     await expect(
       page.getByText(
@@ -390,323 +336,50 @@ test.describe("Subscriptions: Team members and invitations", () => {
   test("Invitations tab has warning message when has professional subscription and more than 8 members.", async ({
     page,
   }) => {
-    await DashboardPage.init(page);
-    await DashboardPage.mockConfigFlags(page, ["enable-subscriptions"]);
-    await DashboardPage.mockRPC(
-      page,
+    const dashboard = new DashboardPage(page);
+
+    await dashboard.mockRPC(
       "get-profile",
       "subscription/get-profile-unlimited-subscription.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-info",
       "subscription/get-team-info-subscriptions.json",
     );
 
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.setupDashboardFull();
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.setupDashboardFull();
+    await dashboard.mockRPC(
       "get-teams",
       "subscription/get-teams-unlimited-subscription-expired-owner.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-projects?team-id=*",
       "dashboard/get-projects-second-team.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-members?team-id=*",
       "subscription/get-team-members-more-than-8.json",
     );
 
-    await DashboardPage.mockRPC(
-      page,
+    await dashboard.mockRPC(
       "get-team-invitations?team-id=*",
       "dashboard/get-team-invitations-empty.json",
     );
 
-    await dashboardPage.mockRPC(
+    await dashboard.mockRPC(
       "push-audit-events",
       "workspace/audit-event-empty.json",
     );
 
-    await dashboardPage.goToSecondTeamInvitationsSection();
+    await dashboard.goToSecondTeamInvitationsSection();
     await expect(page.getByTestId("cta")).toBeVisible();
     await expect(
       page.getByText(
         "Looks like your team has grown! Your plan includes seats, but you're now using more than that.",
       ),
-    ).toBeVisible();
-  });
-});
-
-test.describe("Subscriptions: workspace", () => {
-  test("Unlimited team should have 'Power up your plan' link in main menu", async ({
-    page,
-  }) => {
-    await WorkspacePage.init(page);
-    await WorkspacePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    const workspacePage = new WorkspacePage(page);
-    await workspacePage.setupEmptyFile();
-
-    await WorkspacePage.mockRPC(
-      page,
-      "get-profile",
-      "subscription/get-profile-unlimited-subscription.json",
-    );
-
-    await workspacePage.mockRPC(
-      "push-audit-events",
-      "workspace/audit-event-empty.json",
-    );
-    await workspacePage.goToWorkspace();
-    await page.getByRole("button", { name: "Main menu" }).click();
-
-    await expect(page.getByText("Power up your plan")).toBeVisible();
-  });
-
-  test("Enterprise team should not have 'Power up your plan' link in main menu", async ({
-    page,
-  }) => {
-    await WorkspacePage.init(page);
-    await WorkspacePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    const workspacePage = new WorkspacePage(page);
-    await workspacePage.setupEmptyFile();
-
-    await WorkspacePage.mockRPC(
-      page,
-      "get-profile",
-      "subscription/get-profile-enterprise-subscription.json",
-    );
-
-    await workspacePage.mockRPC(
-      "push-audit-events",
-      "workspace/audit-event-empty.json",
-    );
-    await workspacePage.goToWorkspace();
-    await page.getByRole("button", { name: "Main menu" }).click();
-
-    await expect(page.getByText("Power up your plan")).not.toBeVisible();
-  });
-
-  test("Professional team should have 7 days autosaved versions", async ({
-    page,
-  }) => {
-    await WorkspacePage.init(page);
-    await WorkspacePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    const workspacePage = new WorkspacePage(page);
-    await workspacePage.setupEmptyFile();
-
-    await workspacePage.mockRPC(
-      "push-audit-events",
-      "workspace/audit-event-empty.json",
-    );
-    await workspacePage.goToWorkspace();
-
-    await workspacePage.mockRPC(
-      "get-file-snapshots?file-id=*",
-      "workspace/versions-snapshot-1.json",
-    );
-
-    await page.getByLabel("History").click();
-
-    await expect(
-      page.getByText("Autosaved versions will be kept for 7 days."),
-    ).toBeVisible();
-  });
-
-  test("Unlimited team should have 30 days autosaved versions", async ({
-    page,
-  }) => {
-    await WorkspacePage.init(page);
-    await WorkspacePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    const workspacePage = new WorkspacePage(page);
-    await workspacePage.setupEmptyFile();
-
-    await WorkspacePage.mockRPC(
-      page,
-      "get-profile",
-      "subscription/get-profile-unlimited-subscription.json",
-    );
-
-    await WorkspacePage.mockRPC(
-      page,
-      "get-teams",
-      "subscription/get-teams-unlimited-one-team.json",
-    );
-
-    await workspacePage.mockRPC(
-      "push-audit-events",
-      "workspace/audit-event-empty.json",
-    );
-    await workspacePage.goToWorkspace();
-
-    await workspacePage.mockRPC(
-      "get-file-snapshots?file-id=*",
-      "workspace/versions-snapshot-1.json",
-    );
-
-    await page.getByLabel("History").click();
-
-    await expect(
-      page.getByText("Autosaved versions will be kept for 30 days."),
-    ).toBeVisible();
-  });
-
-  test("Unlimited team should have 90 days autosaved versions", async ({
-    page,
-  }) => {
-    await WorkspacePage.init(page);
-    await WorkspacePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    const workspacePage = new WorkspacePage(page);
-    await workspacePage.setupEmptyFile();
-
-    await WorkspacePage.mockRPC(
-      page,
-      "get-profile",
-      "subscription/get-profile-enterprise-subscription.json",
-    );
-
-    await WorkspacePage.mockRPC(
-      page,
-      "get-teams",
-      "subscription/get-teams-enterprise-one-team.json",
-    );
-
-    await workspacePage.mockRPC(
-      "push-audit-events",
-      "workspace/audit-event-empty.json",
-    );
-    await workspacePage.goToWorkspace();
-
-    await workspacePage.mockRPC(
-      "get-file-snapshots?file-id=*",
-      "workspace/versions-snapshot-1.json",
-    );
-
-    await page.getByLabel("History").click();
-
-    await expect(
-      page.getByText("Autosaved versions will be kept for 90 days."),
-    ).toBeVisible();
-  });
-});
-
-test.describe("Subscriptions: profile", () => {
-  test("When subscription is professional there is no manage subscription link", async ({
-    page,
-  }) => {
-    await SubscriptionProfilePage.init(page);
-    await SubscriptionProfilePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    await SubscriptionProfilePage.mockRPC(
-      page,
-      "get-profile",
-      "logged-in-user/get-profile-logged-in.json",
-    );
-
-    const subscriptionProfilePage = new SubscriptionProfilePage(page);
-
-    await subscriptionProfilePage.goToSubscriptions();
-
-    await expect(
-      page.getByRole("button", { name: "Manage your subscription" }),
-    ).not.toBeVisible();
-
-    await expect(
-      page.getByRole("heading", { name: "Other Penpot plans", level: 3 }),
-    ).toBeVisible();
-
-    await expect(page.getByText("$7")).toBeVisible();
-
-    await expect(page.getByText("$950")).toBeVisible();
-
-    await expect(
-      page.getByRole("button", { name: "Try it free for 14 days" }).first(),
-    ).toBeVisible();
-  });
-
-  test("When subscription is unlimited there is manage subscription link", async ({
-    page,
-  }) => {
-    await SubscriptionProfilePage.init(page);
-    await SubscriptionProfilePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    await SubscriptionProfilePage.mockRPC(
-      page,
-      "get-profile",
-      "subscription/get-profile-unlimited-subscription.json",
-    );
-
-    const subscriptionProfilePage = new SubscriptionProfilePage(page);
-
-    await subscriptionProfilePage.goToSubscriptions();
-
-    await expect(
-      page.getByRole("button", { name: "Manage your subscription" }),
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole("heading", { name: "Other Penpot plans", level: 3 }),
-    ).toBeVisible();
-
-    await expect(page.getByText("$0")).toBeVisible();
-
-    await expect(page.getByText("$950")).toBeVisible();
-
-    await expect(
-      page.getByRole("button", { name: "Try it free for 14 days" }).first(),
-    ).not.toBeVisible();
-
-    await expect(
-      page.getByRole("button", { name: "Subscribe" }).first(),
-    ).toBeVisible();
-  });
-
-  test("When subscription is enteprise there is manage subscription link", async ({
-    page,
-  }) => {
-    await SubscriptionProfilePage.init(page);
-    await SubscriptionProfilePage.mockConfigFlags(page, ["enable-subscriptions"]);
-
-    await SubscriptionProfilePage.mockRPC(
-      page,
-      "get-profile",
-      "subscription/get-profile-enterprise-subscription.json",
-    );
-
-    const subscriptionProfilePage = new SubscriptionProfilePage(page);
-
-    await subscriptionProfilePage.goToSubscriptions();
-
-    await expect(
-      page.getByRole("button", { name: "Manage your subscription" }),
-    ).toBeVisible();
-
-    await expect(
-      page.getByRole("heading", { name: "Other Penpot plans", level: 3 }),
-    ).toBeVisible();
-
-    await expect(page.getByText("$0")).toBeVisible();
-
-    await expect(page.getByText("$7")).toBeVisible();
-
-    await expect(
-      page.getByRole("button", { name: "Try it free for 14 days" }).first(),
-    ).not.toBeVisible();
-
-    await expect(
-      page.getByRole("button", { name: "Subscribe" }).first(),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
### Related Ticket

None (this was prompted by a thread in Mattermost)

### Summary

This fixes and refactors the Subscriptions-related integration tests in this way:

- Disables the `onboarding` flag.
- Makes `SubscriptionsProfilePage` to inherit from `DashboardPage` (instead of `BaseSocketWebPage`, which is intended as the base class for the workspace and viewer).
- Makes the tests to use the page instance `mockRPG` methods rather than the base class ones.

### Steps to reproduce 

- Run Playwright tests in local. When looking at the screen caps Playwright takes, you should not see the onboarding modal.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~
