### PR TITLE
:bug: Fix incorrect path tool handling on shapes not coerced to path

### DIFF
--- a/frontend/src/app/main/data/workspace/path/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/path/drawing.cljs
@@ -304,11 +304,8 @@
   (ptk/reify ::handle-drawing-end
     ptk/UpdateEvent
     (update [_ state]
-      (let [content (dm/get-in state [:workspace-drawing :object :content])]
-
-        (assert (path/check-path-content content)
-                "expected valid path content instance")
-
+      (let [content (some-> (dm/get-in state [:workspace-drawing :object :content])
+                            (path/check-path-content))]
         (if (> (count content) 1)
           (assoc-in state [:workspace-drawing :object :initialized?] true)
           state)))

--- a/frontend/src/app/main/data/workspace/path/tools.cljs
+++ b/frontend/src/app/main/data/workspace/path/tools.cljs
@@ -7,7 +7,6 @@
 (ns app.main.data.workspace.path.tools
   (:require
    [app.common.data.macros :as dm]
-   [app.common.files.helpers :as cfh]
    [app.common.types.path :as path]
    [app.common.types.path.segment :as path.segment]
    [app.main.data.changes :as dch]
@@ -48,12 +47,10 @@
                  (changes/generate-path-changes it objects page-id shape (:content shape) new-content)]
 
              (rx/concat
-              (if (cfh/path-shape? shape)
-                (rx/empty)
-                (rx/of (dwsh/update-shapes [id] path/convert-to-path)))
-              (rx/of (dch/commit-changes changes)
-                     (when (empty? new-content)
-                       (dwe/clear-edition-mode)))))))))))
+              (rx/of (dwsh/update-shapes [id] path/convert-to-path)
+                     (dch/commit-changes changes))
+              (when (empty? new-content)
+                (rx/of (dwe/clear-edition-mode)))))))))))
 
 (defn make-corner
   ([]


### PR DESCRIPTION
Related issue: https://tree.taiga.io/project/penpot/issue/11351

This PR fixes the issue when you try to use path edition on not-yet coerced to path shape.