### PR TITLE
:bug: Remove empty properties starting with the last one

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -195,10 +195,12 @@
             properties-empty-pos (->> variant-components
                                       (mapcat :variant-properties)
                                       (group-by :name)
-                                      (mapv (fn [[_ v]]
-                                              (->> v (mapv :value) (remove empty?))))
-                                      (mapv empty?)
-                                      (map-indexed vector)
+                                      (map-indexed
+                                       (fn [i [_ v]]
+                                         [i (->> v
+                                                 (map :value)
+                                                 (remove empty?)
+                                                 empty?)]))
                                       (reverse))
 
             changes (-> (pcb/empty-changes it page-id)


### PR DESCRIPTION
### Related Ticket

Taiga [#11406](https://tree.taiga.io/project/penpot/task/11406)

### Summary

When trying to calculate which properties are empty to remove them, we need to create an indexed map which indicates what to do for all positions, and reverse it, so we remove the last first. Otherwise we may get an "index out of bounds" error if we try to remove more than one property, because in the second and subsequent removals, the index no longer contains any data.