### PR TITLE
:sparkles: Allow variants with no properties

### DIFF
--- a/common/src/app/common/files/repair.cljc
+++ b/common/src/app/common/files/repair.cljc
@@ -602,11 +602,6 @@
   (log/error :hint "Variant error code, we don't want to auto repair it for now" :code (:code error))
   file)
 
-(defmethod repair-error :variant-no-properties
-  [_ error file _]
-  (log/error :hint "Variant error code, we don't want to auto repair it for now" :code (:code error))
-  file)
-
 (defmethod repair-error :variant-bad-variant-name
   [_ error file _]
   (log/error :hint "Variant error code, we don't want to auto repair it for now" :code (:code error))

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -68,7 +68,6 @@
     :variant-bad-name
     :variant-bad-variant-name
     :variant-component-bad-name
-    :variant-no-properties
     :variant-component-bad-id})
 
 (def ^:private schema:error
@@ -589,11 +588,7 @@
     (when-not (ctk/is-variant? main-component)
       (report-error :not-a-variant
                     (str/ffmt "Shape % should be a variant" (:id main-component))
-                    main-component file component-page))
-    (when (< (count (:variant-properties component)) 1)
-      (report-error :variant-no-properties
-                    (str/ffmt "Component variant % should have properties" (:id main-component))
-                    main-component file nil))))
+                    main-component file component-page))))
 
 (defn- check-component
   "Validate semantic coherence of a component. Report all errors found."


### PR DESCRIPTION
### Related Ticket

Taiga [#11390](https://tree.taiga.io/project/penpot/task/11390)

### Summary

Even though it is forbidden to remove the last property from the design tab, we need to allow to make this possible internally, because this is what actually happens when the user removes all the formulas, all the formulas are malformed, or a mix of both.