### PR TITLE
:bug: Fix font size import export

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -33,7 +33,7 @@
    :border-radius "borderRadius"
    :color         "color"
    :dimensions    "dimension"
-   :font-size     "fontSize"
+   :font-size     "fontSizes"
    :number        "number"
    :opacity       "opacity"
    :other         "other"

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -129,6 +129,8 @@
 
 (def font-size-keys (schema-keys schema:font-size))
 
+(def typography-keys (set/union font-size-keys))
+
 (def ^:private schema:number
   [:map
    [:rotation {:optional true} token-name-ref]
@@ -144,7 +146,7 @@
                          spacing-keys
                          dimensions-keys
                          rotation-keys
-                         font-size-keys
+                         typography-keys
                          number-keys))
 
 (def ^:private schema:tokens

--- a/frontend/src/app/main/data/workspace/tokens/import_export.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/import_export.cljs
@@ -8,7 +8,9 @@
   (:require
    [app.common.files.helpers :as cfh]
    [app.common.json :as json]
+   [app.common.types.token :as ctt]
    [app.common.types.tokens-lib :as ctob]
+   [app.config :as cf]
    [app.main.data.notifications :as ntf]
    [app.main.data.style-dictionary :as sd]
    [app.main.data.workspace.tokens.errors :as wte]
@@ -60,7 +62,17 @@
   [decoded-json file-name]
   (try
     {:tokens-lib (ctob/parse-decoded-json decoded-json file-name)
-     :unknown-tokens (ctob/get-tokens-of-unknown-type decoded-json)}
+     :unknown-tokens (ctob/get-tokens-of-unknown-type decoded-json
+                                                      ;; Filter out FF token-types
+                                                      {:process-token-type
+                                                       (fn [dtcg-token-type]
+                                                         (if (or
+                                                              (and (not (contains? cf/flags :token-units))
+                                                                   (= dtcg-token-type "number"))
+                                                              (and (not (contains? cf/flags :token-typography-types))
+                                                                   (contains? ctt/typography-keys dtcg-token-type)))
+                                                           nil
+                                                           dtcg-token-type))})}
     (catch js/Error e
       (let [err (or (extract-name-error e)
                     (wte/error-ex-info :error.import/invalid-json-data decoded-json e))]


### PR DESCRIPTION
### Summary

- Fixes import for `font-size` token type
- Restore warning for unsupported token-types when importing when the FF is disabled

### Steps to reproduce 

#### For enabled FF
 
1. Import [font.json](https://github.com/user-attachments/files/20882886/font.json) should create font-size token

#### For disabled FF

1. Import [font.json](https://github.com/user-attachments/files/20882886/font.json) should show warning for unsupported font type

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
