### PR TITLE
:bug: Fix minor regression on paste shapes with fill-image

### DIFF
--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -679,14 +679,8 @@
                   mobj (get media-idx id)]
               (if mobj
                 (if (empty? attr-path)
-                  (-> mdata
-                      (assoc :id (:id mobj))
-                      (assoc :path (:path mobj)))
-                  (update-in mdata attr-path (fn [value]
-                                               (-> value
-                                                   (assoc :id (:id mobj))
-                                                   (assoc :path (:path mobj))))))
-
+                  (assoc mdata :id (:id mobj))
+                  (update-in mdata attr-path assoc :id (:id mobj)))
                 mdata)))
 
           (add-obj? [chg]


### PR DESCRIPTION
### Summary

Fixes a regression when you tries to paste a shape or shapes with fill-image. No related issue.

### How to reproduce

- Create a image (or rect with image background)
- Copy that shape
- Open a new file, try to paste.