### PR TITLE
:sparkles: Keep the swapped childs if the copies when doing a variant switch

### DIFF
--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -473,12 +473,14 @@
          (fn [undo-changes shape]
            (let [prev-sibling (cfh/get-prev-sibling objects (:id shape))]
              (conj undo-changes
-                   {:type :mov-objects
-                    :page-id (::page-id (meta changes))
-                    :parent-id (:parent-id shape)
-                    :shapes [(:id shape)]
-                    :after-shape prev-sibling
-                    :index 0}))) ; index is used in case there is no after-shape (moving bottom shapes)
+                   (cond-> {:type :mov-objects
+                            :page-id (::page-id (meta changes))
+                            :parent-id (:parent-id shape)
+                            :shapes [(:id shape)]
+                            :after-shape prev-sibling
+                            :index 0} ; index is used in case there is no after-shape (moving bottom shapes)
+                     (:component-swap options)
+                     (assoc :component-swap true)))))
 
          restore-touched-change
          {:type :mod-obj

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2257,10 +2257,21 @@
                                    {}))]))
 
 (defn generate-component-swap
-  [changes objects shape file page libraries id-new-component index target-cell keep-props-values]
-  (let [[all-parents changes]
+  [changes objects shape file page libraries id-new-component
+   index target-cell keep-props-values keep-touched]
+  (let [;; When we keep the touched properties, we can't delete the
+        ;; swapped children (we will keep them too)
+        ignore-swapped-fn
+        (if keep-touched
+          #(-> (get objects %)
+               (ctk/get-swap-slot))
+          (constantly false))
+
+        [all-parents changes]
         (-> changes
-            (cls/generate-delete-shapes file page objects (d/ordered-set (:id shape)) {:component-swap true}))
+            (cls/generate-delete-shapes
+             file page objects (d/ordered-set (:id shape))
+             {:component-swap true :ignore-children-fn ignore-swapped-fn}))
         [new-shape changes]
         (-> changes
             (generate-new-shape-for-swap shape file page libraries id-new-component index target-cell keep-props-values))]

--- a/common/src/app/common/logic/variants.cljc
+++ b/common/src/app/common/logic/variants.cljc
@@ -1,13 +1,17 @@
 (ns app.common.logic.variants
   (:require
+   [app.common.data :as d]
    [app.common.files.changes-builder :as pcb]
    [app.common.files.helpers :as cfh]
    [app.common.files.variant :as cfv]
    [app.common.logic.libraries :as cll]
+   [app.common.logic.shapes :as cls]
    [app.common.logic.variant-properties :as clvp]
+   [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
    [app.common.types.file :as ctf]
-   [app.common.types.variant :as ctv]))
+   [app.common.types.variant :as ctv]
+   [app.common.uuid :as uuid]))
 
 (defn generate-add-new-variant
   [changes shape variant-id new-component-id new-shape-id prop-num]
@@ -62,6 +66,59 @@
       shapes))))
 
 
+(defn- keep-swapped-item
+  "As part of the keep-touched process on a switch, given a child on the original
+   copy that was swapped (orig-swapped-child), and its related shape on the new copy
+   (related-shape-in-new), move the orig-swapped-child into the parent of
+   related-shape-in-new, fix its swap-slot if needed, and then delete
+   related-shape-in-new"
+  [changes related-shape-in-new orig-swapped-child ldata page swap-ref-id]
+  (let [;; Before to the swap, temporary move the previous
+        ;; shape to the root panel to avoid problems when
+        ;; the previous parent is deleted.
+        before-changes (-> (pcb/empty-changes)
+                           (pcb/with-page page)
+                           (pcb/with-objects (:objects page))
+                           (pcb/change-parent uuid/zero [orig-swapped-child] 0 {:component-swap true}))
+
+        objects         (pcb/get-objects changes)
+        prev-swap-slot  (ctk/get-swap-slot orig-swapped-child)
+        current-parent  (get objects (:parent-id related-shape-in-new))
+        pos             (d/index-of (:shapes current-parent) (:id related-shape-in-new))]
+
+
+    (-> (pcb/concat-changes before-changes changes)
+
+        ;; Move the previous shape to the new parent
+        (pcb/change-parent (:parent-id related-shape-in-new) [orig-swapped-child] pos {:component-swap true})
+
+        ;; We need to update the swap slot only when it pointed
+        ;; to the swap-ref-id. Oterwise this is a swapped item
+        ;; inside a nested copy, so we need to keep it.
+        (cond->
+         (= prev-swap-slot swap-ref-id)
+          (pcb/update-shapes
+           [(:id orig-swapped-child)]
+           #(ctk/set-swap-slot % (:shape-ref related-shape-in-new))))
+
+        ;; Delete new non-swapped item
+        (cls/generate-delete-shapes ldata page objects (d/ordered-set (:id related-shape-in-new)) {:component-swap true})
+        second)))
+
+(defn- child-of-swapped?
+  "Check if any ancestor of a shape (between base-parent-id and shape) was swapped"
+  [shape objects base-parent-id]
+  (let [ancestors (->> (ctn/get-parent-heads objects shape)
+                        ;; Ignore ancestors ahead of base-parent
+                       (drop-while #(not= base-parent-id (:id %)))
+                       seq)
+        num-ancestors (count ancestors)
+        ;; Ignore first and last (base-parent and shape)
+        ancestors (when (and ancestors (<= 3 num-ancestors))
+                    (subvec (vec ancestors) 1 (dec num-ancestors)))]
+    (some ctk/get-swap-slot ancestors)))
+
+
 (defn generate-keep-touched
   "This is used as part of the switch process, when you switch from
    an original-shape to a new-shape. It generate changes to
@@ -71,12 +128,20 @@
    * On the main components, both have the same name (the name on the copies are ignored)
    * Both has the same type of ancestors, on the same order (see generate-path for the
      translation of the types)"
-  [changes new-shape original-shape original-shapes page libraries]
+  [changes new-shape original-shape original-shapes page libraries ldata]
   (let [objects            (pcb/get-objects changes)
         container          (ctn/make-container page :page)
+        page-objects       (:objects page)
 
         ;; Get the touched children of the original-shape
-        orig-touched       (filter (comp seq :touched) original-shapes)
+        ;; Ignore children of swapped items, because
+        ;; they will be moved without change when
+        ;; managing their swapped ancestor
+        orig-touched       (->> (filter (comp seq :touched) original-shapes)
+                                (remove
+                                 #(child-of-swapped? %
+                                                     page-objects
+                                                     (:id original-shape))))
 
         ;; Adds a :shape-path attribute to the children of the new-shape,
         ;; that contains the type of its ancestors and its name
@@ -106,17 +171,37 @@
     ;; Process each touched children of the original-shape
     (reduce
      (fn [changes orig-child-touched]
-       (let [;; orig-child-touched is in a copy. Get the referenced shape on the main component
-             orig-ref-shape (ctf/find-ref-shape nil container libraries orig-child-touched)
+       (let [;; If the orig-child-touched was swapped, get its swap-slot
+             swap-slot      (ctk/get-swap-slot orig-child-touched)
+
+             ;; orig-child-touched is in a copy. Get the referenced shape on the main component
+             ;; If there is a swap slot, we will get the referenced shape in another way
+             orig-ref-shape (when-not swap-slot
+                              ;; TODO Maybe just get it from o-ref-shapes-wp
+                              (ctf/find-ref-shape nil container libraries orig-child-touched))
+
+             orig-ref-id    (if swap-slot
+                              ;; If there is a swap slot, find the referenced shape id
+                              (ctf/find-ref-id-for-swapped orig-child-touched container libraries)
+                              ;; If there is not a swap slot, get the id from the orig-ref-shape
+                              (:id orig-ref-shape))
+
              ;; Get the shape path of the referenced main
-             shape-path     (get o-ref-shapes-p-map (:id orig-ref-shape))
+             shape-path     (get o-ref-shapes-p-map orig-ref-id)
              ;; Get its related shape in the children of new-shape: the one that
              ;; has the same shape-path
              related-shape-in-new  (get new-shapes-map shape-path)]
+         ;; If there is a related shape, keep its data
          (if related-shape-in-new
-           ;; If there is a related shape, copy the touched attributes into it
-           (cll/update-attrs-on-switch
-            changes related-shape-in-new orig-child-touched new-shape original-shape orig-ref-shape container)
+           (if swap-slot
+             ;; If the orig-child-touched was swapped, keep it
+             (keep-swapped-item changes related-shape-in-new orig-child-touched
+                                ldata page orig-ref-id)
+             ;; If the orig-child-touched wasn't swapped, copy
+             ;; the touched attributes into it
+             (cll/update-attrs-on-switch
+              changes related-shape-in-new orig-child-touched
+              new-shape original-shape orig-ref-shape container))
            changes)))
      changes
      orig-touched)))

--- a/common/src/app/common/test_helpers/components.cljc
+++ b/common/src/app/common/test_helpers/components.cljc
@@ -156,7 +156,7 @@
 
         [new_shape _ changes]
         (-> (pcb/empty-changes nil (:id page))
-            (cll/generate-component-swap objects shape (:data file) page libraries id-new-component 0 nil keep-props-values))
+            (cll/generate-component-swap objects shape (:data file) page libraries id-new-component 0 nil keep-props-values false))
 
         file' (thf/apply-changes file changes)]
 

--- a/common/src/app/common/test_helpers/compositions.cljc
+++ b/common/src/app/common/test_helpers/compositions.cljc
@@ -291,7 +291,8 @@
                                           :id)
                                      0
                                      nil
-                                     {})
+                                     {}
+                                     false)
 
         file' (thf/apply-changes file changes)]
     (if propagate-fn

--- a/common/src/app/common/types/file.cljc
+++ b/common/src/app/common/types/file.cljc
@@ -397,6 +397,47 @@
       (or (= slot-main slot-inst)
           (= (:id shape-main) slot-inst)))))
 
+(defn- find-next-related-swap-shape-id
+  "Go up from the chain of references shapes that will eventually lead to the shape
+   with swap-slot-id as id. Returns the next shape on the chain"
+  [parent swap-slot-id libraries]
+  (let [container         (get-component-container-from-head parent libraries)
+        objects           (:objects container)
+
+        children          (cfh/get-children objects (:id parent))
+        original-shape-id (->> children
+                               (filter #(= swap-slot-id (:id %)))
+                               first
+                               :id)]
+    (if original-shape-id
+      ;; Return the children which id is the swap-slot-id
+      original-shape-id
+      ;; No children with swap-slot-id as id, go up
+      (let [referenced-shape (find-ref-shape nil container libraries parent)
+            ;; Recursive call that will get the id of the next shape on
+            ;; the chain that ends on a shape with swap-slot-id as id
+            next-shape-id    (when referenced-shape
+                               (find-next-related-swap-shape-id referenced-shape swap-slot-id libraries))]
+        ;; Return the children which shape-ref points to the next-shape-id
+        (->> children
+             (filter #(= next-shape-id (:shape-ref %)))
+             first
+             :id)))))
+
+(defn find-ref-id-for-swapped
+  "When a shape has been swapped, find the original ref-id that the shape had
+   before the swap"
+  [shape container libraries]
+  (let [swap-slot   (ctk/get-swap-slot shape)
+        objects     (:objects container)
+
+        parent      (get objects (:parent-id shape))
+        parent-head (ctn/get-head-shape objects parent)
+        parent-ref  (find-ref-shape nil container libraries parent-head)]
+
+    (when (and swap-slot parent-ref)
+      (find-next-related-swap-shape-id parent-ref swap-slot libraries))))
+
 (defn get-component-shapes
   "Retrieve all shapes of the component"
   [file-data component]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -975,10 +975,11 @@
             [new-shape all-parents changes]
             (-> (pcb/empty-changes it (:id page))
                 (pcb/set-undo-group undo-group)
-                (cll/generate-component-swap objects shape ldata page libraries id-new-component index target-cell keep-props-values))
+                (cll/generate-component-swap objects shape ldata page libraries id-new-component
+                                             index target-cell keep-props-values keep-touched?))
 
             changes (if keep-touched?
-                      (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries)
+                      (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries ldata)
                       changes)]
 
         (rx/of


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11375

### Summary

When doing a switch of a component of a variant, we can found that a child (or grandchild, etc) of that component has been swapped. In that case, we want to keep the swapped item.

### Steps to reproduce 


Simple swap (child)


https://github.com/user-attachments/assets/7dd43b21-f80d-4217-9323-5069a4837419


Complex swap (grandchild)



https://github.com/user-attachments/assets/e3bb6924-8a4d-41c9-94bd-5d909384de2a



### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [X] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.


