### PR TITLE
:bug: Allow importing file without any token but with themes or sets

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -1212,7 +1212,8 @@ Will return a value that matches this schema:
   "Searches through decoded token file and returns:
    - `:json-format/legacy` when first node satisfies `legacy-node?` predicate
    - `:json-format/dtcg` when first node satisfies `dtcg-node?` predicate
-   - `nil` if neither combination is found"
+   - If neither combination is found, return dtcg format by default (we assume that
+     the file does not contain any token, so the format is irrelevan)."
   ([decoded-json]
    (get-json-format decoded-json legacy-node? dtcg-node?))
   ([decoded-json legacy-node? dtcg-node?]
@@ -1230,9 +1231,10 @@ Will return a value that matches this schema:
                   (check-node node)
                   (when (branch? node)
                     (mapcat walk (children node))))))]
-     (->> (walk decoded-json)
-          (filter some?)
-          first)))) ;; TODO: throw error if format cannot be determined
+     (d/nilv (->> (walk decoded-json)
+                  (filter some?)
+                  first)
+             :json-format/dtcg))))
 
 (defn- legacy-json->dtcg-json
   "Converts a decoded json file in legacy format into DTCG format."
@@ -1291,9 +1293,17 @@ Will return a value that matches this schema:
   [set-name decoded-json-tokens]
   (assert (map? decoded-json-tokens) "expected a plain clojure map for `decoded-json-tokens`")
   (assert (= (get-json-format decoded-json-tokens) :json-format/dtcg) "expected a dtcg format for `decoded-json-tokens`")
-  (-> (make-tokens-lib)
-      (add-set (make-token-set :name (normalize-set-name set-name)
-                               :tokens (flatten-nested-tokens-json decoded-json-tokens "")))))
+
+  (let [set-name (normalize-set-name set-name)
+        tokens   (flatten-nested-tokens-json decoded-json-tokens "")]
+
+    (when (empty? tokens)
+      (throw (ex-info "the file doesn't contain any tokens"
+                      {:error/code :error.import/invalid-json-data})))
+
+    (-> (make-tokens-lib)
+        (add-set (make-token-set :name set-name
+                                 :tokens tokens)))))
 
 (defn- parse-single-set-legacy-json
   "Parse a decoded json file with a single set of tokens in legacy format into a TokensLib."
@@ -1384,6 +1394,10 @@ Will return a value that matches this schema:
                     (activate-theme library group name)))
                 library
                 active-theme-names)]
+
+    (when (and (empty? sets) (empty? themes))
+      (throw (ex-info "the file doesn't contain any tokens"
+                      {:error/code :error.import/invalid-json-data})))
 
     library))
 


### PR DESCRIPTION
### Summary

When importing a token json file, there is one step that tries to guess if tokens are formated in legacy or DTCG standard format. But in the case of not existing any token, the function fails to detect the format and generates an error.

In this case we should default to any format (e.g. DTCG) to be able to import the rest of the file contents.

### Steps to reproduce 

Download the [Labirynth UI Kit](https://penpot.app/penpothub/libraries-templates/labyrinth-ui-free-kit) library and try to import it.

It should import ok, but generates a message "expected a DTCG format for 'decoded json'".

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
