### PR TITLE
:bug: Fix text partial change doesn't show up on another page

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1808,6 +1808,13 @@
                              :else
                              (get origin-shape attr)))
 
+                ;; On a text-partial-change, we want to force a position-data reset
+                ;; so it's calculated again
+                [roperations uoperations]
+                (if text-partial-change?
+                  (add-update-attr-operations :position-data dest-shape roperations uoperations nil)
+                  [roperations uoperations])
+
                 [roperations' uoperations']
                 (if skip-operations?
                   [roperations uoperations]


### PR DESCRIPTION
### Related Tickets

https://tree.taiga.io/project/penpot/task/11382

https://tree.taiga.io/project/penpot/issue/11407

### Summary

When you do a partial text override, and the copy is in another page, the change is not shown (because the thumbnail isn't invalidated)

### Steps to reproduce 

1. Create a text component with the text "hello"
2. Make a copy of the component on another page
3. Change the text of the copy to "hello1"
4. Change the color of the main component to red

The copy should change color too

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.


