### PR TITLE
:wrench: Make TokenSet an abstract data type

### DIFF
--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -418,7 +418,7 @@
       [:type [:= :set-token-set]]
       [:set-name :string]
       [:group? :boolean]
-      [:token-set [:maybe ctob/schema:token-set-attrs]]]]
+      [:token-set [:maybe [:fn ctob/token-set?]]]]]
 
     [:set-token
      [:map {:title "SetTokenChange"}
@@ -1025,11 +1025,10 @@
                   (ctob/delete-set lib' set-name))
 
                 (not (ctob/get-set lib' set-name))
-                (ctob/add-set lib' (ctob/make-token-set token-set))
+                (ctob/add-set lib' token-set)
 
                 :else
-                (ctob/update-set lib' set-name (fn [prev-token-set]
-                                                 (ctob/make-token-set (merge prev-token-set token-set)))))))))
+                (ctob/update-set lib' set-name (fn [_] token-set)))))))
 
 (defmethod process-change :set-token-theme
   [data {:keys [group theme-name theme]}]

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -916,7 +916,7 @@
     (-> changes
         (update :redo-changes conj {:type :set-token-set
                                     :set-name name
-                                    :token-set (assoc prev-token-set :name new-name)
+                                    :token-set (ctob/rename prev-token-set new-name)
                                     :group? false})
         (update :undo-changes conj {:type :set-token-set
                                     :set-name new-name
@@ -937,11 +937,11 @@
                                     :group? group?})
         (update :undo-changes conj (if prev-token-set
                                      {:type :set-token-set
-                                      :set-name (or
-                                                 ;; Undo of edit
-                                                 (:name token-set)
-                                                 ;; Undo of delete
-                                                 set-name)
+                                      :set-name (if token-set
+                                                  ;; Undo of edit
+                                                  (ctob/get-name token-set)
+                                                  ;; Undo of delete
+                                                  set-name)
                                       :token-set prev-token-set
                                       :group? group?}
                                      ;; Undo of create

--- a/common/src/app/common/logic/tokens.cljc
+++ b/common/src/app/common/logic/tokens.cljc
@@ -41,7 +41,7 @@
   [group-path tokens-lib tokens-lib-theme]
   (let [deactivate? (contains? #{:all :partial} (ctob/sets-at-path-all-active? tokens-lib group-path))
         sets-names  (->> (ctob/get-sets-at-path tokens-lib group-path)
-                         (map :name)
+                         (map ctob/get-name)
                          (into #{}))]
     (if deactivate?
       (ctob/disable-sets tokens-lib-theme sets-names)

--- a/common/test/common_tests/logic/token_test.cljc
+++ b/common/test/common_tests/logic/token_test.cljc
@@ -269,8 +269,7 @@
           new-set-name "foo1"
           changes (-> (pcb/empty-changes)
                       (pcb/with-library-data (:data file))
-                      (pcb/set-token-set set-name false (assoc prev-token-set
-                                                               :name new-set-name)))
+                      (pcb/set-token-set set-name false (ctob/rename prev-token-set new-set-name)))
           redo (thf/apply-changes file changes)
           redo-lib (tht/get-tokens-lib redo)
           undo (thf/apply-undo-changes redo changes)

--- a/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
@@ -175,7 +175,7 @@
     ptk/WatchEvent
     (watch [it state _]
       (let [data       (dsh/lookup-file-data state)
-            name       (ctob/normalize-set-name name (:name token-set))
+            name       (ctob/normalize-set-name name (ctob/get-name token-set))
             tokens-lib (get data :tokens-lib)]
 
         (if (ctob/get-set tokens-lib name)
@@ -185,7 +185,7 @@
                             :timeout 9000}))
           (let [changes (-> (pcb/empty-changes it)
                             (pcb/with-library-data data)
-                            (pcb/rename-token-set (:name token-set) name))]
+                            (pcb/rename-token-set (ctob/get-name token-set) name))]
             (rx/of (set-selected-token-set-name name)
                    (dch/commit-changes changes))))))))
 
@@ -202,7 +202,7 @@
         (when-let [set (ctob/duplicate-set name tokens-lib {:suffix suffix})]
           (let [changes (-> (pcb/empty-changes it)
                             (pcb/with-library-data data)
-                            (pcb/set-token-set (:name set) is-group set))]
+                            (pcb/set-token-set (ctob/get-name set) is-group set))]
             (rx/of (set-selected-token-set-name name)
                    (dch/commit-changes changes))))))))
 
@@ -346,7 +346,7 @@
                 token-type (:type token)
                 changes (-> (pcb/empty-changes it)
                             (pcb/with-library-data data)
-                            (pcb/set-token (:name token-set)
+                            (pcb/set-token (ctob/get-name token-set)
                                            (:name token)
                                            token))]
 
@@ -371,7 +371,7 @@
             token-type (:type token)
             changes   (-> (pcb/empty-changes it)
                           (pcb/with-library-data data)
-                          (pcb/set-token (:name token-set)
+                          (pcb/set-token (ctob/get-name token-set)
                                          (:name token)
                                          token'))]
 

--- a/frontend/src/app/main/data/workspace/tokens/selected_set.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/selected_set.cljs
@@ -17,7 +17,7 @@
               (get :tokens-lib)
               (ctob/get-sets)
               (first)
-              :name)))
+              (ctob/get-name))))
 
 (defn get-selected-token-set [state]
   (when-let [set-name (get-selected-token-set-name state)]
@@ -31,4 +31,4 @@
 
 (defn get-all-tokens-in-selected-set [state]
   (some-> (get-selected-token-set state)
-          :tokens))
+          (ctob/get-tokens-map)))

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -80,7 +80,7 @@
         ;; select the first one from the list of sets
         selected-token-set-tokens
         (when selected-token-set
-          (get selected-token-set :tokens))
+          (ctob/get-tokens-map selected-token-set))
 
         tokens
         (mf/with-memo [active-theme-tokens selected-token-set-tokens]
@@ -120,7 +120,7 @@
                           (not (ctob/get-set tokens-lib selected-token-set-name)))))
         (let [match (->> (ctob/get-sets tokens-lib)
                          (first)
-                         (:name))]
+                         (ctob/get-name))]
           (st/emit! (dwtl/set-selected-token-set-name match)))))
 
     [:*

--- a/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sets/lists.cljs
@@ -212,7 +212,7 @@
   [{:keys [id set label tree-depth tree-path tree-index is-selected is-active is-draggable is-editing
            on-select on-drop on-toggle on-start-edition on-reset-edition on-edit-submit]}]
 
-  (let [set-name  (get set :name)
+  (let [set-name  (ctob/get-name set)
         can-edit? (mf/use-ctx ctx/can-edit?)
 
         on-click


### PR DESCRIPTION
### Related Ticket

[https://tree.taiga.io/project/penpot/task/11448](https://tree.taiga.io/project/penpot/task/11448)

### Summary

Make all access to TokenSet and Token objects to be through helper functions. This way we can change later the internal structure without impact on client code.

### Steps to reproduce 

No change in user-visible behavior. But should make a regression test of all tokens functionality.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
