### PR TITLE
:sparkles: Add letter spacing token

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -107,11 +107,10 @@
 (def spacing-keys (schema-keys schema:spacing))
 
 (def ^:private schema:dimensions
-  [:merge
-   schema:sizing
-   schema:spacing
-   schema:stroke-width
-   schema:border-radius])
+  (reduce mu/union [schema:sizing
+                    schema:spacing
+                    schema:stroke-width
+                    schema:border-radius]))
 
 (def dimensions-keys (schema-keys schema:dimensions))
 
@@ -127,12 +126,18 @@
 
 (def font-size-keys (schema-keys schema:font-size))
 
+;; Not supported by penpot yet
+(def ^:private schema:line-height
+  [:map
+   [:line-height {:optional true} token-name-ref]])
+
+(def line-height-keys (schema-keys schema:line-height))
+
 (def typography-keys (set/union font-size-keys))
 
 (def ^:private schema:number
-  [:map
-   [:rotation {:optional true} token-name-ref]
-   [:line-height {:optional true} token-name-ref]])
+  (reduce mu/union [schema:line-height
+                    schema:rotation]))
 
 (def number-keys (schema-keys schema:number))
 
@@ -280,4 +285,3 @@
 
 (defn unapply-token-id [shape attributes]
   (update shape :applied-tokens d/without-keys attributes))
-

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -34,6 +34,7 @@
    :color         "color"
    :dimensions    "dimension"
    :font-size     "fontSizes"
+   :letter-spacing "letterSpacing"
    :number        "number"
    :opacity       "opacity"
    :other         "other"
@@ -133,7 +134,13 @@
 
 (def line-height-keys (schema-keys schema:line-height))
 
-(def typography-keys (set/union font-size-keys))
+(def ^:private schema:letter-spacing
+  [:map
+   [:letter-spacing {:optional true} token-name-ref]])
+
+(def letter-spacing-keys (schema-keys schema:letter-spacing))
+
+(def typography-keys (set/union font-size-keys letter-spacing-keys))
 
 (def ^:private schema:number
   (reduce mu/union [schema:line-height
@@ -164,6 +171,7 @@
    schema:rotation
    schema:number
    schema:font-size
+   schema:letter-spacing
    schema:dimensions])
 
 (defn shape-attr->token-attrs
@@ -192,6 +200,7 @@
        #{:m1 :m2 :m3 :m4})
 
      (font-size-keys shape-attr) #{shape-attr}
+     (letter-spacing-keys shape-attr) #{shape-attr}
      (border-radius-keys shape-attr) #{shape-attr}
      (sizing-keys shape-attr) #{shape-attr}
      (opacity-keys shape-attr) #{shape-attr}

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -127,13 +127,6 @@
 
 (def font-size-keys (schema-keys schema:font-size))
 
-;; Not supported by penpot yet
-(def ^:private schema:line-height
-  [:map
-   [:line-height {:optional true} token-name-ref]])
-
-(def line-height-keys (schema-keys schema:line-height))
-
 (def ^:private schema:letter-spacing
   [:map
    [:letter-spacing {:optional true} token-name-ref]])
@@ -143,7 +136,7 @@
 (def typography-keys (set/union font-size-keys letter-spacing-keys))
 
 (def ^:private schema:number
-  (reduce mu/union [schema:line-height
+  (reduce mu/union [[:map [:line-height {:optional true} token-name-ref]]
                     schema:rotation]))
 
 (def number-keys (schema-keys schema:number))

--- a/common/test/common_tests/logic/token_apply_test.cljc
+++ b/common/test/common_tests/logic/token_apply_test.cljc
@@ -58,7 +58,11 @@
                                   (ctob/add-token-in-set "test-token-set"
                                                          (ctob/make-token :name "token-font-size"
                                                                           :type :font-size
-                                                                          :value 24))))
+                                                                          :value 24))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-letter-spacing"
+                                                                          :type :letter-spacing
+                                                                          :value 2))))
       (tho/add-frame :frame1)
       (tho/add-text :text1 "Hello World!")))
 
@@ -72,7 +76,8 @@
       (tht/apply-token-to-shape :frame1 "token-color" [:stroke-color] [:stroke-color] "#00ff00")
       (tht/apply-token-to-shape :frame1 "token-color" [:fill] [:fill] "#00ff00")
       (tht/apply-token-to-shape :frame1 "token-dimensions" [:width :height] [:width :height] 100)
-      (tht/apply-token-to-shape :text1 "token-font-size" [:font-size] [:font-size] 24)))
+      (tht/apply-token-to-shape :text1 "token-font-size" [:font-size] [:font-size] 24)
+      (tht/apply-token-to-shape :text1 "token-letter-spacing" [:letter-spacing] [:letter-spacing] 2)))
 
 (t/deftest apply-tokens-to-shape
   (let [;; ==== Setup
@@ -87,6 +92,7 @@
         token-color        (tht/get-token file "test-token-set" "token-color")
         token-dimensions   (tht/get-token file "test-token-set" "token-dimensions")
         token-font-size    (tht/get-token file "test-token-set" "token-font-size")
+        token-letter-spacing (tht/get-token file "test-token-set" "token-letter-spacing")
 
         ;; ==== Action
         changes (-> (-> (pcb/empty-changes nil)
@@ -123,7 +129,10 @@
                                                   (as-> shape $
                                                     (cto/apply-token-to-shape {:token token-font-size
                                                                                :shape $
-                                                                               :attributes [:font-size]})))
+                                                                               :attributes [:font-size]})
+                                                    (cto/apply-token-to-shape {:token token-letter-spacing
+                                                                               :shape $
+                                                                               :attributes [:letter-spacing]})))
                                                 (:objects page)
                                                 {}))
 
@@ -148,8 +157,9 @@
     (t/is (= (:fill applied-tokens') "token-color"))
     (t/is (= (:width applied-tokens') "token-dimensions"))
     (t/is (= (:height applied-tokens') "token-dimensions"))
-    (t/is (= (count text1-applied-tokens) 1))
-    (t/is (= (:font-size text1-applied-tokens) "token-font-size"))))
+    (t/is (= (count text1-applied-tokens) 2))
+    (t/is (= (:font-size text1-applied-tokens) "token-font-size"))
+    (t/is (= (:letter-spacing text1-applied-tokens) "token-letter-spacing"))))
 
 (t/deftest unapply-tokens-from-shape
   (let [;; ==== Setup
@@ -178,7 +188,8 @@
                     (cls/generate-update-shapes [(:id text1)]
                                                 (fn [shape]
                                                   (-> shape
-                                                      (cto/unapply-token-id [:font-size])))
+                                                      (cto/unapply-token-id [:font-size])
+                                                      (cto/unapply-token-id [:letter-spacing])))
                                                 (:objects page)
                                                 {}))
 
@@ -228,7 +239,8 @@
                                                    txt/is-content-node?
                                                    d/txt-merge
                                                    {:fills (ths/sample-fills-color :fill-color "#fabada")
-                                                    :font-size "1"}))
+                                                    :font-size "1"
+                                                    :letter-spacing "0"}))
                                                 (:objects page)
                                                 {}))
 

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -346,6 +346,18 @@
                            {:ignore-touched true
                             :page-id page-id})))))
 
+(defn update-letter-spacing
+  ([value shape-ids attributes] (update-letter-spacing value shape-ids attributes nil))
+  ([value shape-ids _attributes page-id] ; The attributes param is needed to have the same arity that other update functions
+   (let [update-node? (fn [node]
+                        (or (txt/is-text-node? node)
+                            (txt/is-paragraph-node? node)))]
+     (when (number? value)
+       (dwsh/update-shapes shape-ids
+                           #(txt/update-text-content % update-node? d/txt-merge {:letter-spacing (str value)})
+                           {:ignore-touched true
+                            :page-id page-id})))))
+
 (defn update-font-size
   ([value shape-ids attributes] (update-font-size value shape-ids attributes nil))
   ([value shape-ids _attributes page-id]
@@ -390,6 +402,14 @@
     :modal {:key :tokens/font-size
             :fields [{:label "Font Size"
                       :key :font-size}]}}
+
+   :letter-spacing
+   {:title "Letter Spacing"
+    :attributes ctt/letter-spacing-keys
+    :on-update-shape update-letter-spacing
+    :modal {:key :tokens/letter-spacing
+            :fields [{:label "Letter Spacing"
+                      :key :letter-spacing}]}}
 
    :stroke-width
    {:title "Stroke Width"

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -333,10 +333,7 @@
 
 (defn update-line-height
   ([value shape-ids attributes] (update-line-height value shape-ids attributes nil))
-  ([value shape-ids _attributes page-id] ; The attributes param is
-                                         ; needed to have the same
-                                         ; arity that other update
-                                         ; functions
+  ([value shape-ids _attributes page-id]
    (let [update-node? (fn [node]
                         (or (txt/is-text-node? node)
                             (txt/is-paragraph-node? node)))]
@@ -348,7 +345,7 @@
 
 (defn update-letter-spacing
   ([value shape-ids attributes] (update-letter-spacing value shape-ids attributes nil))
-  ([value shape-ids _attributes page-id] ; The attributes param is needed to have the same arity that other update functions
+  ([value shape-ids _attributes page-id]
    (let [update-node? (fn [node]
                         (or (txt/is-text-node? node)
                             (txt/is-paragraph-node? node)))]

--- a/frontend/src/app/main/data/workspace/tokens/propagation.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/propagation.cljs
@@ -34,6 +34,7 @@
    ctt/opacity-keys dwta/update-opacity
    #{:line-height} dwta/update-line-height
    #{:font-size} dwta/update-font-size
+   #{:letter-spacing} dwta/update-letter-spacing
    #{:x :y} dwta/update-shape-position
    #{:p1 :p2 :p3 :p4} dwta/update-layout-padding
    #{:m1 :m2 :m3 :m4} dwta/update-layout-item-margin

--- a/frontend/src/app/main/ui/workspace/tokens/management.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management.cljs
@@ -2,6 +2,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data :as d]
+   [app.common.types.token :as ctt]
    [app.common.types.tokens-lib :as ctob]
    [app.config :as cf]
    [app.main.data.style-dictionary :as sd]
@@ -21,6 +22,9 @@
 (def ref:token-type-open-status
   (l/derived (l/key :open-status-by-type) refs/workspace-tokens))
 
+(defn- remove-keys [m ks]
+  (d/removem (comp ks key) m))
+
 (defn- get-sorted-token-groups
   "Separate token-types into groups of `empty` or `filled` depending if
   tokens exist for that type. Sort each group alphabetically (by their type).
@@ -30,7 +34,7 @@
         token-typography-types? (contains? cf/flags :token-typography-types)
         all-types (cond-> dwta/token-properties
                     (not token-units?) (dissoc :number)
-                    (not token-typography-types?) (dissoc :font-size))
+                    (not token-typography-types?) (remove-keys ctt/typography-keys))
         all-types (-> all-types keys seq)]
     (loop [empty  #js []
            filled #js []

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/modals.cljs
@@ -185,3 +185,9 @@
    ::mf/register-as :tokens/font-size}
   [properties]
   [:& token-update-create-modal properties])
+
+(mf/defc letter-spacing-modal
+  {::mf/register modal/components
+   ::mf/register-as :tokens/letter-spacing}
+  [properties]
+  [:& token-update-create-modal properties])

--- a/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/group.cljs
@@ -28,6 +28,7 @@
     :color "drop"
     :boolean "boolean-difference"
     :font-size "text-font-size"
+    :letter-spacing "text-letterspacing"
     :opacity "percentage"
     :number "number"
     :rotation "rotation"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/111
https://tree.taiga.io/project/penpot/us/10940

### Summary


https://github.com/user-attachments/assets/7f7f4d18-4b88-4cd2-a282-c3cc1459f1d1


- Adds letter spacing token
- Fixes `:merge` schema not working correctly and using it as intended in `number` token

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
