### PR TITLE
:sparkles: Implement object type specific tokens

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -203,6 +203,56 @@
     token-attr))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TOKEN SHAPE ATTRIBUTES
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def position-attributes #{:x :y})
+
+(def generic-attributes
+  (set/union color-keys
+             stroke-width-keys
+             rotation-keys
+             sizing-keys
+             opacity-keys
+             position-attributes))
+
+(def rect-attributes
+  (set/union generic-attributes
+             border-radius-keys))
+
+(def frame-attributes
+  (set/union rect-attributes
+             spacing-keys))
+
+(def text-attributes
+  (set/union generic-attributes
+             typography-keys
+             number-keys))
+
+(defn shape-type->attributes
+  [type]
+  (case type
+    :bool    generic-attributes
+    :circle  generic-attributes
+    :rect    rect-attributes
+    :frame   frame-attributes
+    :image   rect-attributes
+    :path    generic-attributes
+    :svg-raw generic-attributes
+    :text    text-attributes
+    nil))
+
+(defn appliable-attrs
+  "Returns intersection of shape `attributes` for `token-type`."
+  [attributes token-type]
+  (set/intersection attributes (shape-type->attributes token-type)))
+
+(defn any-appliable-attr?
+  "Checks if `token-type` supports given shape `attributes`."
+  [attributes token-type]
+  (seq (appliable-attrs attributes token-type)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TOKENS IN SHAPES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -66,13 +66,6 @@
    [:r3 {:optional true} token-name-ref]
    [:r4 {:optional true} token-name-ref]])
 
-(def ^:private schema:typography
-  [:map
-   [:line-height {:optional true} token-name-ref]
-   [:font-size {:optional true} token-name-ref]])
-
-(def typography-keys (schema-keys schema:typography))
-
 (def border-radius-keys (schema-keys schema:border-radius))
 
 (def ^:private schema:stroke-width

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -228,13 +228,6 @@
                                                    :attributes attributes})]
     (update shape :applied-tokens #(merge % applied-tokens))))
 
-(defn maybe-apply-token-to-shape
-  "When the passed `:token` is non-nil apply it to the `:applied-tokens` on a shape."
-  [{:keys [shape token _attributes] :as props}]
-  (if token
-    (apply-token-to-shape props)
-    shape))
-
 (defn unapply-token-id [shape attributes]
   (update shape :applied-tokens d/without-keys attributes))
 

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -109,9 +109,7 @@
    [:m1 {:optional true} token-name-ref]
    [:m2 {:optional true} token-name-ref]
    [:m3 {:optional true} token-name-ref]
-   [:m4 {:optional true} token-name-ref]
-   [:x {:optional true} token-name-ref]
-   [:y {:optional true} token-name-ref]])
+   [:m4 {:optional true} token-name-ref]])
 
 (def spacing-keys (schema-keys schema:spacing))
 

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -66,6 +66,13 @@
    [:r3 {:optional true} token-name-ref]
    [:r4 {:optional true} token-name-ref]])
 
+(def ^:private schema:typography
+  [:map
+   [:line-height {:optional true} token-name-ref]
+   [:font-size {:optional true} token-name-ref]])
+
+(def typography-keys (schema-keys schema:typography))
+
 (def border-radius-keys (schema-keys schema:border-radius))
 
 (def ^:private schema:stroke-width

--- a/common/test/common_tests/logic/token_apply_test.cljc
+++ b/common/test/common_tests/logic/token_apply_test.cljc
@@ -95,38 +95,35 @@
                     (cls/generate-update-shapes [(:id frame1)]
                                                 (fn [shape]
                                                   (as-> shape $
-                                                    (cto/maybe-apply-token-to-shape {:token nil ; test nil case
-                                                                                     :shape $
-                                                                                     :attributes []})
-                                                    (cto/maybe-apply-token-to-shape {:token token-radius
-                                                                                     :shape $
-                                                                                     :attributes [:r1 :r2 :r3 :r4]})
-                                                    (cto/maybe-apply-token-to-shape {:token token-rotation
-                                                                                     :shape $
-                                                                                     :attributes [:rotation]})
-                                                    (cto/maybe-apply-token-to-shape {:token token-opacity
-                                                                                     :shape $
-                                                                                     :attributes [:opacity]})
-                                                    (cto/maybe-apply-token-to-shape {:token token-stroke-width
-                                                                                     :shape $
-                                                                                     :attributes [:stroke-width]})
-                                                    (cto/maybe-apply-token-to-shape {:token token-color
-                                                                                     :shape $
-                                                                                     :attributes [:stroke-color]})
-                                                    (cto/maybe-apply-token-to-shape {:token token-color
-                                                                                     :shape $
-                                                                                     :attributes [:fill]})
-                                                    (cto/maybe-apply-token-to-shape {:token token-dimensions
-                                                                                     :shape $
-                                                                                     :attributes [:width :height]})))
+                                                    (cto/apply-token-to-shape {:token token-radius
+                                                                               :shape $
+                                                                               :attributes [:r1 :r2 :r3 :r4]})
+                                                    (cto/apply-token-to-shape {:token token-rotation
+                                                                               :shape $
+                                                                               :attributes [:rotation]})
+                                                    (cto/apply-token-to-shape {:token token-opacity
+                                                                               :shape $
+                                                                               :attributes [:opacity]})
+                                                    (cto/apply-token-to-shape {:token token-stroke-width
+                                                                               :shape $
+                                                                               :attributes [:stroke-width]})
+                                                    (cto/apply-token-to-shape {:token token-color
+                                                                               :shape $
+                                                                               :attributes [:stroke-color]})
+                                                    (cto/apply-token-to-shape {:token token-color
+                                                                               :shape $
+                                                                               :attributes [:fill]})
+                                                    (cto/apply-token-to-shape {:token token-dimensions
+                                                                               :shape $
+                                                                               :attributes [:width :height]})))
                                                 (:objects page)
                                                 {})
                     (cls/generate-update-shapes [(:id text1)]
                                                 (fn [shape]
                                                   (as-> shape $
-                                                    (cto/maybe-apply-token-to-shape {:token token-font-size
-                                                                                     :shape $
-                                                                                     :attributes [:font-size]})))
+                                                    (cto/apply-token-to-shape {:token token-font-size
+                                                                               :shape $
+                                                                               :attributes [:font-size]})))
                                                 (:objects page)
                                                 {}))
 

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -71,6 +71,16 @@
     :text    text-attributes
     nil))
 
+(defn appliable-attrs
+  "Returns intersection of shape `attributes` for `token-type`."
+  [attributes token-type]
+  (set/intersection attributes (shape-type->attributes token-type)))
+
+(defn any-appliable-attr?
+  "Checks if `token-type` supports given shape `attributes`."
+  [attributes token-type]
+  (seq (appliable-attrs attributes token-type)))
+
 ;; Events to apply / unapply tokens to shapes ------------------------------------------------------------
 
 (defn apply-token
@@ -95,8 +105,8 @@
                         objects (dsh/lookup-page-objects state)
 
                         shape-ids (or (->> (select-keys objects shape-ids)
-                                           (filter (fn [[_ element]]
-                                                     (seq (set/intersection attributes (shape-type->attributes (:type element))))))
+                                           (filter (fn [[_ shape]]
+                                                     (any-appliable-attr? attributes (:type shape))))
                                            (keys))
                                       [])
 

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -7,7 +7,6 @@
 (ns app.main.data.workspace.tokens.application
   (:require
    [app.common.data :as d]
-   [app.common.data.macros :as dm]
    [app.common.files.tokens :as cft]
    [app.common.text :as txt]
    [app.common.types.shape.layout :as ctsl]
@@ -30,54 +29,6 @@
    [potok.v2.core :as ptk]))
 
 (declare token-properties)
-
-;; Match shape by attributes ---------------------------------------------------
-
-(def position-attributes #{:x :y})
-
-(def generic-attributes
-  (set/union ctt/color-keys
-             ctt/stroke-width-keys
-             ctt/rotation-keys
-             ctt/sizing-keys
-             ctt/opacity-keys
-             position-attributes))
-
-(def rect-attributes
-  (set/union generic-attributes
-             ctt/border-radius-keys))
-
-(def frame-attributes
-  (set/union rect-attributes
-             ctt/spacing-keys))
-
-(def text-attributes
-  (set/union generic-attributes
-             ctt/typography-keys
-             ctt/number-keys))
-
-(defn shape-type->attributes
-  [type]
-  (case type
-    :bool    generic-attributes
-    :circle  generic-attributes
-    :rect    rect-attributes
-    :frame   frame-attributes
-    :image   rect-attributes
-    :path    generic-attributes
-    :svg-raw generic-attributes
-    :text    text-attributes
-    nil))
-
-(defn appliable-attrs
-  "Returns intersection of shape `attributes` for `token-type`."
-  [attributes token-type]
-  (set/intersection attributes (shape-type->attributes token-type)))
-
-(defn any-appliable-attr?
-  "Checks if `token-type` supports given shape `attributes`."
-  [attributes token-type]
-  (seq (appliable-attrs attributes token-type)))
 
 ;; Events to apply / unapply tokens to shapes ------------------------------------------------------------
 
@@ -104,7 +55,7 @@
 
                         shape-ids (or (->> (select-keys objects shape-ids)
                                            (filter (fn [[_ shape]]
-                                                     (any-appliable-attr? attributes (:type shape))))
+                                                     (ctt/any-appliable-attr? attributes (:type shape))))
                                            (keys))
                                       [])
 
@@ -504,6 +455,3 @@
 
 (defn get-token-properties [token]
   (get token-properties (:type token)))
-
-(defn token-attributes [token-type]
-  (dm/get-in token-properties [token-type :attributes]))

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -360,6 +360,44 @@
 
 ;; Map token types to different properties used along the cokde ---------------------------------------------
 
+;; Match shape by attributes
+
+(def position-attributes #{:x :y})
+
+(def generic-attributes
+  (set/union ctt/color-keys
+             ctt/stroke-width-keys
+             ctt/rotation-keys
+             ctt/sizing-keys
+             ctt/opacity-keys
+             position-attributes))
+
+(def rect-attributes
+  (set/union generic-attributes
+             ctt/border-radius-keys))
+
+(def frame-attributes
+  (set/union rect-attributes
+             ctt/spacing-keys))
+
+(def text-attributes
+  (set/union generic-attributes
+             ctt/typography-keys))
+
+(defn shape-type->attributes
+  [type]
+  (case type
+    :bool    generic-attributes
+    :circle  generic-attributes
+    :rect    rect-attributes
+    :frame   frame-attributes
+    :group   generic-attributes
+    :image   rect-attributes
+    :path    generic-attributes
+    :svg-raw generic-attributes
+    :text    text-attributes
+    nil))
+
 ;; FIXME: the values should be lazy evaluated, probably a function,
 ;; becasue on future we will need to translate that labels and that
 ;; can not be done statically

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -31,6 +31,46 @@
 
 (declare token-properties)
 
+;; Match shape by attributes ---------------------------------------------------
+
+(def position-attributes #{:x :y})
+
+(def generic-attributes
+  (set/union ctt/color-keys
+             ctt/stroke-width-keys
+             ctt/rotation-keys
+             ctt/sizing-keys
+             ctt/opacity-keys
+             position-attributes))
+
+(def rect-attributes
+  (set/union generic-attributes
+             ctt/border-radius-keys))
+
+(def frame-attributes
+  (set/union rect-attributes
+             ctt/spacing-keys))
+
+(def text-attributes
+  (set/union generic-attributes
+             ctt/typography-keys
+             ctt/number-keys))
+
+(defn shape-type->attributes
+  [type]
+  (case type
+    :bool    generic-attributes
+    :circle  generic-attributes
+    :rect    rect-attributes
+    :frame   frame-attributes
+    ;; TODO: Groups dont accept tokens yet
+    ;; :group   generic-attributes
+    :image   rect-attributes
+    :path    generic-attributes
+    :svg-raw generic-attributes
+    :text    text-attributes
+    nil))
+
 ;; Events to apply / unapply tokens to shapes ------------------------------------------------------------
 
 (defn apply-token
@@ -55,7 +95,8 @@
                         objects (dsh/lookup-page-objects state)
 
                         shape-ids (or (->> (select-keys objects shape-ids)
-                                           (filter (fn [[_ shape]] (not= (:type shape) :group)))
+                                           (filter (fn [[_ element]]
+                                                     (seq (set/intersection attributes (shape-type->attributes (:type element))))))
                                            (keys))
                                       [])
 
@@ -359,45 +400,6 @@
                             :page-id page-id})))))
 
 ;; Map token types to different properties used along the cokde ---------------------------------------------
-
-;; Match shape by attributes
-
-(def position-attributes #{:x :y})
-
-(def generic-attributes
-  (set/union ctt/color-keys
-             ctt/stroke-width-keys
-             ctt/rotation-keys
-             ctt/sizing-keys
-             ctt/opacity-keys
-             position-attributes))
-
-(def rect-attributes
-  (set/union generic-attributes
-             ctt/border-radius-keys))
-
-(def frame-attributes
-  (set/union rect-attributes
-             ctt/spacing-keys))
-
-(def text-attributes
-  (set/union generic-attributes
-             ctt/typography-keys
-             ctt/number-keys))
-
-(defn shape-type->attributes
-  [type]
-  (case type
-    :bool    generic-attributes
-    :circle  generic-attributes
-    :rect    rect-attributes
-    :frame   frame-attributes
-    :group   generic-attributes
-    :image   rect-attributes
-    :path    generic-attributes
-    :svg-raw generic-attributes
-    :text    text-attributes
-    nil))
 
 ;; FIXME: the values should be lazy evaluated, probably a function,
 ;; becasue on future we will need to translate that labels and that

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -382,7 +382,8 @@
 
 (def text-attributes
   (set/union generic-attributes
-             ctt/typography-keys))
+             ctt/typography-keys
+             ctt/number-keys))
 
 (defn shape-type->attributes
   [type]

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -63,8 +63,6 @@
     :circle  generic-attributes
     :rect    rect-attributes
     :frame   frame-attributes
-    ;; TODO: Groups dont accept tokens yet
-    ;; :group   generic-attributes
     :image   rect-attributes
     :path    generic-attributes
     :svg-raw generic-attributes

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -32,7 +32,11 @@
 (defn- key-in-map? [ks m]
   (some #(contains? m %) ks))
 
-(defn clean-separators [items]
+(defn clean-separators
+  "Cleans up `:separator` inside of `items`
+  Will clean consecutive items like `[:separator :separator {}]`
+  And will return nil for lists consisting only of `:separator` items."
+  [items]
   (let [items' (dedupe items)]
     (when-not (every? #(= % :separator) items')
       items')))

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -32,6 +32,11 @@
 (defn- key-in-map? [ks m]
   (some #(contains? m %) ks))
 
+(defn clean-separators [items]
+  (let [items' (dedupe items)]
+    (when-not (every? #(= % :separator) items')
+      items')))
+
 ;; Actions ---------------------------------------------------------------------
 
 (defn attribute-actions [token selected-shapes attributes]
@@ -221,24 +226,26 @@
             margin-items)))
 
 (defn sizing-attribute-actions [context-data]
-  (concat
-   (all-or-separate-actions {:attribute-labels {:width "Width"
-                                                :height "Height"}
-                             :hint (tr "workspace.tokens.size")
-                             :on-update-shape dwta/update-shape-dimensions}
-                            context-data)
-   [:separator]
-   (all-or-separate-actions {:attribute-labels {:layout-item-min-w "Min Width"
-                                                :layout-item-min-h "Min Height"}
-                             :hint (tr "workspace.tokens.min-size")
-                             :on-update-shape dwta/update-layout-sizing-limits}
-                            context-data)
-   [:separator]
-   (all-or-separate-actions {:attribute-labels {:layout-item-max-w "Max Width"
-                                                :layout-item-max-h "Max Height"}
-                             :hint (tr "workspace.tokens.max-size")
-                             :on-update-shape dwta/update-layout-sizing-limits}
-                            context-data)))
+  (->>
+   (concat
+    (all-or-separate-actions {:attribute-labels {:width "Width"
+                                                 :height "Height"}
+                              :hint (tr "workspace.tokens.size")
+                              :on-update-shape dwta/update-shape-dimensions}
+                             context-data)
+    [:separator]
+    (all-or-separate-actions {:attribute-labels {:layout-item-min-w "Min Width"
+                                                 :layout-item-min-h "Min Height"}
+                              :hint (tr "workspace.tokens.min-size")
+                              :on-update-shape dwta/update-layout-sizing-limits}
+                             context-data)
+    [:separator]
+    (all-or-separate-actions {:attribute-labels {:layout-item-max-w "Max Width"
+                                                 :layout-item-max-h "Max Height"}
+                              :hint (tr "workspace.tokens.max-size")
+                              :on-update-shape dwta/update-layout-sizing-limits}
+                             context-data))
+   (clean-separators)))
 
 (defn update-shape-radius-for-corners [value shape-ids attributes]
   (st/emit!
@@ -284,7 +291,7 @@
                         [:separator]
                         (generic-attribute-actions #{:x} "X" (assoc context-data :on-update-shape dwta/update-shape-position :hint (tr "workspace.tokens.axis")))
                         (generic-attribute-actions #{:y} "Y" (assoc context-data :on-update-shape dwta/update-shape-position)))
-                       (dedupe)))}))
+                       (clean-separators)))}))
 
 (defn default-actions [{:keys [token selected-token-set-name]}]
   (let [{:keys [modal]} (dwta/get-token-properties token)]

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -10,6 +10,7 @@
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.tokens :as cft]
+   [app.common.types.token :as ctt]
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.modal :as modal]
    [app.main.data.workspace.shape-layout :as dwsl]
@@ -322,7 +323,7 @@
                           (:name token)))}]))
 
 (defn- allowed-shape-attributes [shapes]
-  (reduce into #{} (map #(dwta/shape-type->attributes (:type %)) shapes)))
+  (reduce into #{} (map #(ctt/shape-type->attributes (:type %)) shapes)))
 
 (defn menu-actions [{:keys [type token selected-shapes] :as context-data}]
   (let [context-data (assoc context-data :allowed-shape-attributes (allowed-shape-attributes selected-shapes))

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
@@ -165,8 +165,7 @@
 (defn attributes-match-selection?
   [selected-shapes attrs]
   (some (fn [shape]
-          (let [shape-attrs (dwta/shape-type->attributes (:type shape))]
-            (some attrs shape-attrs)))
+          (dwta/any-appliable-attr? attrs (:type shape)))
         selected-shapes))
 
 (def token-types-with-status-icon

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
@@ -12,6 +12,7 @@
    [app.common.data :as d]
    [app.common.files.helpers :as cfh]
    [app.common.files.tokens :as cft]
+   [app.common.types.token :as ctt]
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.data.workspace.tokens.color :as dwtc]
    [app.main.refs :as refs]
@@ -165,7 +166,7 @@
 (defn attributes-match-selection?
   [selected-shapes attrs]
   (some (fn [shape]
-          (dwta/any-appliable-attr? attrs (:type shape)))
+          (ctt/any-appliable-attr? attrs (:type shape)))
         selected-shapes))
 
 (def token-types-with-status-icon

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.scss
@@ -85,6 +85,11 @@
   }
 }
 
+.token-pill-disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .token-pill-applied {
   --token-pill-background: var(--color-token-background);
   --token-pill-foreground: var(--color-token-foreground);

--- a/frontend/test/frontend_tests/tokens/context_menu_test.cljs
+++ b/frontend/test/frontend_tests/tokens/context_menu_test.cljs
@@ -1,0 +1,205 @@
+(ns frontend-tests.tokens.context-menu-test
+  (:require
+   [app.common.test-helpers.compositions :as tho]
+   [app.common.test-helpers.files :as thf]
+   [app.common.test-helpers.shapes :as ths]
+   [app.common.test-helpers.tokens :as tht]
+   [app.common.types.tokens-lib :as ctob]
+   [app.main.ui.workspace.tokens.management.context-menu :as wtcm]
+   [clojure.test :as t]))
+
+(defn setup-file []
+  (-> (thf/sample-file :file-1)
+      (tht/add-tokens-lib)
+      (tht/update-tokens-lib #(-> %
+                                  (ctob/add-set (ctob/make-token-set :name "test-token-set"))
+                                  (ctob/add-theme (ctob/make-token-theme :name "test-theme"
+                                                                         :sets #{"test-token-set"}))
+                                  (ctob/set-active-themes #{"/test-theme"})
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-radius"
+                                                                          :type :border-radius
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-color"
+                                                                          :type :color
+                                                                          :value "red"))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-spacing"
+                                                                          :type :spacing
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-sizing"
+                                                                          :type :sizing
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-rotation"
+                                                                          :type :rotation
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-opacity"
+                                                                          :type :opacity
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-dimensions"
+                                                                          :type :dimensions
+                                                                          :value 10))
+                                  (ctob/add-token-in-set "test-token-set"
+                                                         (ctob/make-token :name "token-number"
+                                                                          :type :number
+                                                                          :value 10))))
+      ;; app.main.data.workspace.tokens.application/generic-attributes
+      (tho/add-group :group1)
+      ;; app.main.data.workspace.tokens.application/rect-attributes
+      (tho/add-rect :rect1)
+      ;; app.main.data.workspace.tokens.application/frame-attributes
+      (tho/add-frame :frame1)
+      ;; app.main.data.workspace.tokens.application/text-attributes
+      (tho/add-text :text1 "Hello World!")))
+
+(defn token-menu-actions [shape-names token-name]
+  (let [file (setup-file)
+        token-set "test-token-set"
+        token (tht/get-token file token-set token-name)
+        selected-shapes (map #(ths/get-shape file %) shape-names)]
+    (wtcm/menu-actions
+     {:token token
+      :selected-shapes selected-shapes})))
+
+(defn token-menu-action-labels [actions]
+  (mapv #(if (keyword? %) % (:title %)) actions))
+
+(t/deftest border-radius-items
+  (t/testing "shows radius items for selection of supported shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1] "token-radius")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["All" "Top Right" "Bottom Right" "Top Left" "Bottom Left"]))))
+
+  (t/testing "shows radius items for mixed selection"
+    (let [actions (token-menu-actions [:frame1 :text1] "token-radius")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["All" "Top Right" "Bottom Right" "Top Left" "Bottom Left"]))))
+
+  (t/testing "hides radius for unrelated shapes"
+    (let [actions (token-menu-actions [:text1 :group1] "token-radius")]
+      (t/is (empty? actions)))))
+
+(t/deftest color-items
+  (t/testing "shows color items for selection of all shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1 :group1 :text1] "token-color")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["Fill" "Stroke"])))))
+
+(t/deftest spacing-items
+  (t/testing "shows spacing items for selection of supported shapes"
+    (let [actions (token-menu-actions [:frame1] "token-spacing")
+          action-titles (mapv #(if (keyword? %) % (:title %)) actions)]
+      (t/is (= action-titles ["All" "Column Gap" "Row Gap"
+                              :separator
+                              "All" "Horizontal" "Vertical"
+                              "Padding top" "Padding right" "Padding bottom" "Padding left"
+                              :separator
+                              "All" "Horizontal" "Vertical"
+                              "Margin top" "Margin right" "Margin bottom" "Margin left"]))))
+
+  (t/testing "shows radius items for mixed selection"
+    (let [actions (token-menu-actions [:frame1 :text1] "token-spacing")
+          action-titles (mapv #(if (keyword? %) % (:title %)) actions)]
+      (t/is (= action-titles ["All" "Column Gap" "Row Gap"
+                              :separator
+                              "All" "Horizontal" "Vertical"
+                              "Padding top" "Padding right" "Padding bottom" "Padding left"
+                              :separator
+                              "All" "Horizontal" "Vertical"
+                              "Margin top" "Margin right" "Margin bottom" "Margin left"]))))
+
+  (t/testing "hides radius for unrelated shapes"
+    (let [actions (token-menu-actions [:text1 :group1] "token-radius")]
+      (t/is (empty? actions)))))
+
+(t/deftest sizing-items
+  (t/testing "shows sizing items for selection of all shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1 :group1 :text1] "token-sizing")
+          action-titles (mapv #(if (keyword? %) % (:title %)) actions)]
+
+      (t/is (= action-titles ["All" "Width" "Height"
+                              :separator
+                              "All" "Min Width" "Min Height"
+                              :separator
+                              "All" "Max Width" "Max Height"])))))
+
+(t/deftest rotation-items
+  (t/testing "shows color items for selection of all shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1 :group1 :text1] "token-rotation")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["Rotation"])))))
+
+(t/deftest dimensions-items
+  (t/testing "shows `generic-attributes` dimension items for group"
+    (let [actions (token-menu-actions [:group1] "token-dimensions")
+          action-titles (mapv #(if (keyword? %) % (select-keys % [:title :submenu])) actions)]
+      (t/is (= action-titles [{:title "Sizing", :submenu :sizing}
+                              :separator
+                              {:title "Stroke Width"}
+                              :separator
+                              {:title "X"}
+                              {:title "Y"}]))))
+
+  (t/testing "shows `rect-attributes` dimension items for rect"
+    (let [actions (token-menu-actions [:rect1] "token-dimensions")
+          action-titles (mapv #(if (keyword? %) % (select-keys % [:title :submenu])) actions)]
+      (t/is (= action-titles [{:title "Sizing", :submenu :sizing}
+                              :separator
+                              {:title "Border Radius", :submenu :border-radius}
+                              :separator
+                              {:title "Stroke Width"}
+                              :separator
+                              {:title "X"}
+                              {:title "Y"}]))))
+
+  (t/testing "shows all attribute dimension items for frame"
+    (let [actions (token-menu-actions [:frame1] "token-dimensions")
+          action-titles (mapv #(if (keyword? %) % (select-keys % [:title :submenu])) actions)]
+      (t/is (= action-titles [{:title "Sizing", :submenu :sizing}
+                              {:title "Spacing", :submenu :spacing}
+                              :separator
+                              {:title "Border Radius", :submenu :border-radius}
+                              :separator
+                              {:title "Stroke Width"}
+                              :separator
+                              {:title "X"}
+                              {:title "Y"}]))))
+
+  (t/testing "shows `text-attributes` dimension items for text"
+    (let [actions (token-menu-actions [:text1] "token-dimensions")
+          action-titles (mapv #(if (keyword? %) % (select-keys % [:title :submenu])) actions)]
+      (t/is (= action-titles [{:title "Sizing", :submenu :sizing}
+                              :separator
+                              {:title "Stroke Width"}
+                              :separator
+                              {:title "X"}
+                              {:title "Y"}])))))
+
+(t/deftest number-items
+  (t/testing "shows all number attribute items for text"
+    (let [actions (token-menu-actions [:text1] "token-number")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["Rotation" "Line Height"]))))
+
+  (t/testing "shows non text attributes for non text shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1 :group1] "token-number")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["Rotation"])))))
+
+(t/deftest stroke-width-items
+  (t/testing "shows stroke width items for all shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1 :group1 :text1] "token-dimensions")
+          stroke-width-action (first (filter #(and (map? %) (= (:title %) "Stroke Width")) actions))]
+      (t/is (some? stroke-width-action))
+      (t/is (= (:title stroke-width-action) "Stroke Width")))))
+
+(t/deftest opacity-items
+  (t/testing "shows opacity items for all shapes"
+    (let [actions (token-menu-actions [:frame1 :rect1 :group1 :text1] "token-opacity")
+          action-titles (mapv :title actions)]
+      (t/is (= action-titles ["Opacity"])))))

--- a/frontend/test/frontend_tests/tokens/context_menu_test.cljs
+++ b/frontend/test/frontend_tests/tokens/context_menu_test.cljs
@@ -126,7 +126,11 @@
                               :separator
                               "All" "Min Width" "Min Height"
                               :separator
-                              "All" "Max Width" "Max Height"])))))
+                              "All" "Max Width" "Max Height"]))))
+
+  (t/testing "shows no sizing items for groups"
+    (let [actions (token-menu-actions [:group1] "token-sizing")]
+      (t/is (nil? actions)))))
 
 (t/deftest rotation-items
   (t/testing "shows color items for selection of all shapes"
@@ -135,16 +139,6 @@
       (t/is (= action-titles ["Rotation"])))))
 
 (t/deftest dimensions-items
-  (t/testing "shows `generic-attributes` dimension items for group"
-    (let [actions (token-menu-actions [:group1] "token-dimensions")
-          action-titles (mapv #(if (keyword? %) % (select-keys % [:title :submenu])) actions)]
-      (t/is (= action-titles [{:title "Sizing", :submenu :sizing}
-                              :separator
-                              {:title "Stroke Width"}
-                              :separator
-                              {:title "X"}
-                              {:title "Y"}]))))
-
   (t/testing "shows `rect-attributes` dimension items for rect"
     (let [actions (token-menu-actions [:rect1] "token-dimensions")
           action-titles (mapv #(if (keyword? %) % (select-keys % [:title :submenu])) actions)]
@@ -178,7 +172,11 @@
                               {:title "Stroke Width"}
                               :separator
                               {:title "X"}
-                              {:title "Y"}])))))
+                              {:title "Y"}]))))
+
+  (t/testing "not attributes for groups as they are not supported yet"
+    (let [actions (token-menu-actions [:group1] "token-dimensions")]
+      (t/is (nil? actions)))))
 
 (t/deftest number-items
   (t/testing "shows all number attribute items for text"

--- a/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
@@ -195,7 +195,7 @@
             rect-1 (cths/get-shape file :rect-1)
             rect-2 (cths/get-shape file :rect-2)
             events [(dwta/apply-token {:shape-ids [(:id rect-1)]
-                                       :attributes #{:color}
+                                       :attributes #{:fill}
                                        :token (toht/get-token file "color.primary")
                                        :on-update-shape dwta/update-fill})
                     (dwta/apply-token {:shape-ids [(:id rect-1)]
@@ -203,7 +203,7 @@
                                        :token (toht/get-token file "color.primary")
                                        :on-update-shape dwta/update-stroke-color})
                     (dwta/apply-token {:shape-ids [(:id rect-2)]
-                                       :attributes #{:color}
+                                       :attributes #{:fill}
                                        :token (toht/get-token file "color.secondary")
                                        :on-update-shape dwta/update-fill})
                     (dwta/apply-token {:shape-ids [(:id rect-2)]
@@ -214,25 +214,25 @@
          store done events
          (fn [new-state]
            (let [file' (ths/get-file-from-state new-state)
-                 token-target' (toht/get-token file' "rotation.medium")
+                 primary-target (toht/get-token file' "color.primary")
+                 secondary-target (toht/get-token file' "color.secondary")
                  rect-1' (cths/get-shape file' :rect-1)
                  rect-2' (cths/get-shape file' :rect-2)]
              (t/testing "regular color"
                (t/is (some? (:applied-tokens rect-1')))
-
-               (t/is (= (:fill (:applied-tokens rect-1')) (:name token-target')))
+               (t/is (= (:fill (:applied-tokens rect-1')) (:name primary-target)))
                (t/is (= (get-in rect-1' [:fills 0 :fill-color]) "#ff0000"))
 
-               (t/is (= (:stroke (:applied-tokens rect-1')) (:name token-target')))
+               (t/is (= (:stroke-color (:applied-tokens rect-1')) (:name primary-target)))
                (t/is (= (get-in rect-1' [:strokes 0 :stroke-color]) "#ff0000")))
              (t/testing "color with alpha channel"
                (t/is (some? (:applied-tokens rect-2')))
 
-               (t/is (= (:fill (:applied-tokens rect-2')) (:name token-target')))
+               (t/is (= (:fill (:applied-tokens rect-2')) (:name secondary-target)))
                (t/is (= (get-in rect-2' [:fills 0 :fill-color]) "#ff0000"))
                (t/is (= (get-in rect-2' [:fills 0 :fill-opacity]) 0.5))
 
-               (t/is (= (:stroke (:applied-tokens rect-2')) (:name token-target')))
+               (t/is (= (:stroke-color (:applied-tokens rect-2')) (:name secondary-target)))
                (t/is (= (get-in rect-2' [:strokes 0 :stroke-color]) "#ff0000"))
                (t/is (= (get-in rect-2' [:strokes 0 :stroke-opacity]) 0.5))))))))))
 
@@ -270,33 +270,40 @@
   (t/testing "applies padding token to shapes with layout"
     (t/async
       done
-      (let [dimensions-token {:name "padding.sm"
-                              :value "100"
-                              :type :spacing}
+      (let [spacing-token {:name "padding.sm"
+                           :value "100"
+                           :type :spacing}
             file (-> (setup-file-with-tokens)
                      (ctho/add-frame :frame-1)
                      (ctho/add-frame :frame-2 {:layout :grid})
                      (update-in [:data :tokens-lib]
-                                #(ctob/add-token-in-set % "Set A" (ctob/make-token dimensions-token))))
+                                #(ctob/add-token-in-set % "Set A" (ctob/make-token spacing-token))))
             store (ths/setup-store file)
             frame-1 (cths/get-shape file :frame-1)
             frame-2 (cths/get-shape file :frame-2)
             events [(dwta/apply-token {:shape-ids [(:id frame-1) (:id frame-2)]
-                                       :attributes #{:padding}
+                                       :attributes #{:p1 :p2 :p3 :p4}
                                        :token (toht/get-token file "padding.sm")
                                        :on-update-shape dwta/update-layout-padding})]]
         (tohs/run-store-async
          store done events
          (fn [new-state]
            (let [file' (ths/get-file-from-state new-state)
-                 token-target' (toht/get-token file' "dimensions.sm")
+                 token-target' (toht/get-token file' "padding.sm")
                  frame-1' (cths/get-shape file' :frame-1)
                  frame-2' (cths/get-shape file' :frame-2)]
              (t/testing "shape `:applied-tokens` got updated"
-               (t/is (= (:spacing (:applied-tokens frame-1')) (:name token-target')))
-               (t/is (= (:spacing (:applied-tokens frame-2')) (:name token-target'))))
+               (t/is (= (:p1 (:applied-tokens frame-1')) (:name token-target')))
+               (t/is (= (:p2 (:applied-tokens frame-1')) (:name token-target')))
+               (t/is (= (:p3 (:applied-tokens frame-1')) (:name token-target')))
+               (t/is (= (:p4 (:applied-tokens frame-1')) (:name token-target')))
+
+               (t/is (= (:p1 (:applied-tokens frame-2')) (:name token-target')))
+               (t/is (= (:p2 (:applied-tokens frame-2')) (:name token-target')))
+               (t/is (= (:p3 (:applied-tokens frame-2')) (:name token-target')))
+               (t/is (= (:p4 (:applied-tokens frame-2')) (:name token-target'))))
              (t/testing "shapes padding got updated"
-               (t/is (= (:layout-padding frame-2') {:padding 100})))
+               (t/is (= (:layout-padding frame-2') {:p1 100 :p2 100 :p3 100 :p4 100})))
              (t/testing "shapes without layout get ignored"
                (t/is (nil? (:layout-padding frame-1')))))))))))
 


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/8

### Summary


https://github.com/user-attachments/assets/54c00a80-11d8-47f2-b2a8-7f94f6d0fddd



Tokens will now be highlighted as unsupported when the given selected shapes dont support the token.
E.g.: typography attributes cannot be applied on a rectangle.

Context menus will also only show the attributes that matches the current selection.

When multiple types are selected the common attributes can be selected, but now the token doesn't get applied anymore to unsupported objects
E.g.: Text & Rectangle are selected, applying border-radius token will only apply it to the rectangle shape.

Further changes:

- Unit tests for context menus
- Updates tests with previous implementations that now broke due to supported attribute matching (it's not allowed anymore to pass arbitrary attributes via the actions)

### Steps to reproduce 

1. Add various token types and check if they can be applied to the supported shapes
2. Nothing should happen to unsupported shapes
3. Everything else should behave as before

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
