### PR TITLE
:whale: Add "postgres" network alias to default docker network in devenv

### DIFF
--- a/docker/devenv/docker-compose.yaml
+++ b/docker/devenv/docker-compose.yaml
@@ -96,6 +96,10 @@ services:
       - ./files/postgresql.conf:/etc/postgresql.conf:z
       - ./files/postgresql_init.sql:/docker-entrypoint-initdb.d/init.sql:z
       - postgres_data_pg16:/var/lib/postgresql/data
+    networks:
+      default:
+        aliases:
+          - postgres
 
   redis:
     image: valkey/valkey:8.1


### PR DESCRIPTION
### Summary

This PR adds a network alias for the postgres service in the devenv. This allows connecting to it from other containers, and in particular simplifies setting up database interfaces in vscode or intellij when running in a devcontainer.

Note that this does NOT expose any new ports on the host to avoid potential clashes with existing pg installations.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
