### PR TITLE
:bug: Avoid crash in combobox with empty options

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/combobox.cljs
+++ b/frontend/src/app/main/ui/ds/controls/combobox.cljs
@@ -206,10 +206,12 @@
 
         selected-option
         (mf/with-memo [options selected-id]
-          (get-option options selected-id))
+          (when (d/not-empty? options)
+            (get-option options selected-id)))
 
         icon
-        (get selected-option :icon)]
+        (when selected-option
+          (get selected-option :icon))]
 
     (mf/with-effect [dropdown-options]
       (mf/set-ref-val! options-ref dropdown-options))

--- a/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/themes/create_modal.cljs
@@ -172,6 +172,7 @@
                        {:label group
                         :id group})
                      theme-groups)
+
         on-update-group
         (mf/use-fn
          (mf/deps on-change-field)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11489

### Summary

This solves one of the bugs in the task above (error when creating a new theme).

### Steps to reproduce 

- Create a new file.
- Go to tokens tab.
- Create a theme.

It crashes with error "No item 0 in vector of length 0".

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
