### PR TITLE
:wrench: Restore arm64 build of devenv

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -34,7 +34,7 @@ function build-devenv {
     fi
 
     # docker build -t $DEVENV_IMGNAME:latest .
-    docker buildx build --platform linux/amd64 --push -t $DEVENV_IMGNAME:latest .;
+    docker buildx build --platform linux/amd64,linux/arm64 --push -t $DEVENV_IMGNAME:latest .;
     docker pull $DEVENV_IMGNAME:latest;
 
     popd;


### PR DESCRIPTION
### Related Ticket

No ticket, this was prompted by a thread in Mattermost re: some partners not being able to run the devenv on Mac.