### PR TITLE
:lipstick: Replace 'Verify new email' label with 'Confirm new email'

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2651,7 +2651,7 @@ msgstr "Big nudge"
 
 #: src/app/main/ui/settings/change_email.cljs:109
 msgid "modals.change-email.confirm-email"
-msgstr "Verify new email"
+msgstr "Confirm new email"
 
 #: src/app/main/ui/settings/change_email.cljs:97
 msgid "modals.change-email.info"


### PR DESCRIPTION
Closes #6829

Improves clarity by using more accurate and familiar terminology. Made content-only change to update the label from "Verify new email" to "Confirm new email"
