### PR TITLE
:bug: Fix problem when double click on hidden shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ on-premises instances** that want to keep up to date.
 - Update google fonts (at 2025/05/19) [Taiga 10792](https://tree.taiga.io/project/penpot/us/10792)
 - Add tooltip component to DS [Taiga 9220](https://tree.taiga.io/project/penpot/us/9220)
 - Allow multi file token export [Taiga #10144](https://tree.taiga.io/project/penpot/us/10144)
+- Fix problem when double click on hidden shapes [Taiga #11314](https://tree.taiga.io/project/penpot/issue/11314)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/hooks.cljs
@@ -286,7 +286,8 @@
                (fn [mod? ids]
                  (let [sorted-ids
                        (into (d/ordered-set)
-                             (comp (remove #(dm/get-in objects [% :blocked]))
+                             (comp (remove (partial cfh/hidden-parent? objects))
+                                   (remove #(dm/get-in objects [% :blocked]))
                                    (remove (partial cfh/svg-raw-shape? objects)))
                              (ctt/sort-z-index objects ids {:bottom-frames? mod?}))]
                    (mf/set-ref-val! sorted-ids-cache (assoc cached-ids [mod? ids] sorted-ids))
@@ -355,7 +356,6 @@
                hover-shape
                (->> ids
                     (remove remove-hover?)
-                    (remove (partial cfh/hidden-parent? objects))
                     (remove #(and mod? (no-fill-nested-frames? %)))
                     (filter #(or (empty? focus) (cpf/is-in-focus? objects focus %)))
                     (first)
@@ -366,7 +366,6 @@
                (when show-measures?
                  (->> ids
                       (remove remove-measure?)
-                      (remove (partial cfh/hidden-parent? objects))
                       (remove #(and mod? (no-fill-nested-frames? %)))
                       (filter #(or (empty? focus) (cpf/is-in-focus? objects focus %)))
                       (first)


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/11314

### Summary
When a parent is hidden, double click stills can edit some children

### Steps to reproduce 

- Create a frame and add some children
- Hide the frame
- Double click on the children and they can be edited

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
