### PR TITLE
:bug: Fix broken import file type drodown options

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
@@ -36,7 +36,7 @@
    [:on-click fn?]
    [:options [:vector schema:option]]
    [:selected :any]
-   [:focused :any]
+   [:focused {:optional true} :any]
    [:empty-to-end {:optional true} :boolean]])
 
 (def ^:private

--- a/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
@@ -52,14 +52,14 @@
         selected-option @selected-option*
         show-dropdown? (mf/use-state false)
 
-        js-options (mf/use-memo
-                    (mf/deps options)
-                    #(clj->js
-                      (mapv (fn [option]
-                              {:id (str (:value option))
-                               :label (:label option)
-                               :aria-label (:label option)})
-                            options)))
+        file-type-options (mf/use-memo
+                           (mf/deps options)
+                           #(mapv (fn [option]
+                                    {:id (str (:value option))
+                                     :label (:label option)
+                                     :aria-label (:label option)})
+                                  options))
+
         button-text (if text-render
                       (text-render selected-option)
                       (:label selected-option))
@@ -108,7 +108,7 @@
                   :aria-label "Show options"}]
 
      [:& dropdown {:show @show-dropdown? :on-close close-dropdown}
-      [:> options-dropdown* {:options js-options
+      [:> options-dropdown* {:options file-type-options
                              :selected (str (:value selected-option))
                              :on-click handle-option-click
                              :set-ref (fn [_] nil)}]]]))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11520

### Summary

Fix broken file type dropdown on import modal

### Steps to reproduce 

Go to the tokens tab.
Open the import modal
At the bottom, display the list of file types

Expected: display 3 options on the dropdown
Current: ERROR

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
