### PR TITLE
:bug: Add migration for fix undecoded path content

### DIFF
--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1319,18 +1319,35 @@
         (d/update-when :components d/update-vals update-container)
         (d/without-nils))))
 
-(defmethod migrate-data "0003-convert-path-content"
+(defmethod migrate-data "0003-convert-path-content-v2"
   [data _]
   (some-> cfeat/*new* (swap! conj "fdata/path-data"))
 
-  (letfn [(update-object [object]
-            (if (or (cfh/bool-shape? object)
-                    (cfh/path-shape? object))
-              (update object :content path/content)
-              object))
+  (let [decode-segments
+        (sm/decoder path/schema:segments sm/json-transformer)
 
-          (update-container [container]
-            (d/update-when container :objects d/update-vals update-object))]
+        update-object
+        (fn [object]
+          (if (or (cfh/bool-shape? object)
+                  (cfh/path-shape? object))
+            (let [content (get object :content)
+                  content (cond
+                            (path/content? content)
+                            content
+
+                            (nil? content)
+                            (path/content [])
+
+                            :else
+                            (-> content
+                                (decode-segments)
+                                (path/content)))]
+              (assoc object :content content))
+            object))
+
+        update-container
+        (fn [container]
+          (d/update-when container :objects d/update-vals update-object))]
 
     (-> data
         (update :pages-index d/update-vals update-container)
@@ -1558,7 +1575,7 @@
          "0002-normalize-bool-content-v2"
          "0002-clean-shape-interactions"
          "0003-fix-root-shape"
-         "0003-convert-path-content"
+         "0003-convert-path-content-v2"
          "0004-clean-shadow-color"
          "0005-deprecate-image-type"
          "0006-fix-old-texts-fills"

--- a/common/src/app/common/types/path.cljc
+++ b/common/src/app/common/types/path.cljc
@@ -26,6 +26,9 @@
 (def ^:const bool-style-properties bool/style-properties)
 (def ^:const default-bool-fills bool/default-fills)
 
+(def schema:content impl/schema:content)
+(def schema:segments impl/schema:segments)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TRANSFORMATIONS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -48,9 +51,9 @@
   [data]
   (impl/from-string data))
 
-(defn check-path-content
+(defn check-content
   [content]
-  (impl/check-content-like content))
+  (impl/check-content content))
 
 (defn get-byte-size
   "Get byte size of a path content"
@@ -76,7 +79,7 @@
 (defn apply-content-modifiers
   "Apply delta modifiers over the path content"
   [content modifiers]
-  (assert (impl/check-content-like content))
+  (assert (impl/check-content content))
 
   (letfn [(apply-to-index [content [index params]]
             (if (contains? content index)

--- a/common/src/app/common/types/path/impl.cljc
+++ b/common/src/app/common/types/path/impl.cljc
@@ -507,18 +507,6 @@
                                        (= (:command e1) :move-to))))}
    schema:segment])
 
-(def schema:content-like
-  [:sequential schema:segment])
-
-(def check-content-like
-  (sm/check-fn schema:content-like))
-
-(def check-segment
-  (sm/check-fn schema:segment))
-
-(def ^:private check-segments
-  (sm/check-fn schema:segments))
-
 (defn path-data?
   [o]
   (instance? PathData o))
@@ -526,37 +514,43 @@
 (declare from-string)
 (declare from-plain)
 
-;; Mainly used on backend: features/components_v2.clj
-(sm/register! ::path/segment schema:segment)
-(sm/register! ::path/segments schema:segments)
+(def schema:content
+  (sm/type-schema
+   {:type ::path/content
+    :compile
+    (fn [_ _ _]
+      (let [decoder   (delay (sm/decoder schema:segments sm/json-transformer))
+            generator (->> (sg/generator schema:segments)
+                           (sg/filter not-empty)
+                           (sg/fmap from-plain))]
+        {:pred path-data?
+         :type-properties
+         {:gen/gen generator
+          :encode/json identity
+          :decode/json (fn [s]
+                         (cond
+                           (string? s)
+                           (from-string s)
 
-(sm/register!
- {:type ::path/content
-  :compile
-  (fn [_ _ _]
-    (let [decoder   (delay (sm/decoder schema:segments sm/json-transformer))
-          generator (->> (sg/generator schema:segments)
-                         (sg/filter not-empty)
-                         (sg/fmap from-plain))]
-      {:pred path-data?
-       :type-properties
-       {:gen/gen generator
-        :encode/json identity
-        :decode/json (fn [s]
-                       (cond
-                         (string? s)
-                         (from-string s)
+                           (vector? s)
+                           (let [decode-fn (deref decoder)]
+                             (-> (decode-fn s)
+                                 (from-plain)))
 
-                         (vector? s)
-                         (let [decode-fn (deref decoder)]
-                           (-> (decode-fn s)
-                               (from-plain)))
+                           :else
+                           s))}}))}))
 
-                         :else
-                         s))}}))})
+(def check-plain-content
+  (sm/check-fn schema:segments))
 
-(def check-path-content
-  (sm/check-fn ::path/content))
+(def check-segment
+  (sm/check-fn schema:segment))
+
+(def ^:private check-segments
+  (sm/check-fn schema:segments))
+
+(def check-content
+  (sm/check-fn schema:content))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; CONSTRUCTORS & PREDICATES

--- a/common/src/app/common/types/path/impl.cljc
+++ b/common/src/app/common/types/path/impl.cljc
@@ -546,9 +546,6 @@
 (def check-segment
   (sm/check-fn schema:segment))
 
-(def ^:private check-segments
-  (sm/check-fn schema:segments))
-
 (def check-content
   (sm/check-fn schema:content))
 
@@ -611,7 +608,7 @@
 (defn from-plain
   "Create a PathData instance from plain data structures"
   [segments]
-  (assert (check-segments segments))
+  (assert (check-plain-content segments))
 
   (let [total  (count segments)
         buffer (buf/allocate (* total SEGMENT-BYTE-SIZE))]

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -246,7 +246,7 @@
   [:map {:title "BoolAttrs"}
    [:shapes [:vector {:gen/max 10 :gen/min 1} ::sm/uuid]]
    [:bool-type [::sm/one-of bool-types]]
-   [:content ::path/content]])
+   [:content path/schema:content]])
 
 (def ^:private schema:rect-attrs
   [:map {:title "RectAttrs"}])
@@ -271,7 +271,7 @@
 
 (def ^:private schema:path-attrs
   [:map {:title "PathAttrs"}
-   [:content ::path/content]])
+   [:content path/schema:content]])
 
 (def ^:private schema:text-attrs
   [:map {:title "TextAttrs"}

--- a/common/test/common_tests/types/shape_decode_encode_test.cljc
+++ b/common/test/common_tests/types/shape_decode_encode_test.cljc
@@ -113,10 +113,10 @@
      {:num 500})))
 
 (t/deftest shape-path-content-json-roundtrip
-  (let [encode (sm/encoder ::path/content (sm/json-transformer))
-        decode (sm/decoder ::path/content (sm/json-transformer))]
+  (let [encode (sm/encoder path/schema:content (sm/json-transformer))
+        decode (sm/decoder path/schema:content (sm/json-transformer))]
     (smt/check!
-     (smt/for [path-content (sg/generator ::path/content)]
+     (smt/for [path-content (sg/generator path/schema:content)]
        (let [path-content-1 (encode path-content)
              path-content-2 (json-roundtrip path-content-1)
              path-content-3 (decode path-content-2)]

--- a/frontend/src/app/main/data/workspace/path/changes.cljs
+++ b/frontend/src/app/main/data/workspace/path/changes.cljs
@@ -19,8 +19,8 @@
   "Generates changes to update the new content of the shape"
   [it objects page-id shape old-content new-content]
 
-  (assert (path/check-path-content old-content))
-  (assert (path/check-path-content new-content))
+  (assert (path/content? old-content))
+  (assert (path/content? new-content))
 
   (let [shape-id (:id shape)
 

--- a/frontend/src/app/main/data/workspace/path/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/path/drawing.cljs
@@ -305,7 +305,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (let [content (some-> (dm/get-in state [:workspace-drawing :object :content])
-                            (path/check-path-content))]
+                            (path/check-content))]
         (if (> (count content) 1)
           (assoc-in state [:workspace-drawing :object :initialized?] true)
           state)))


### PR DESCRIPTION
### Summary

There are cases on out prod db where we have path content with undecoded path data in plain format. Something like `[{:command "close-path"}]`  where we need the command to be a keyword.

This PR modifies the already existing migration (with new name) and puts a decode step. It also fixes an other issue reported several times when file has `content` as `nil`.

### How to test

The main test is to ensure that we don't delete correct, already existing paths. To test the concrete case is a bit difficult because you need to store an invalid path on db, which right now is a bit difficult. This PR fixes old data.

Also, the basic path edition should be working as expected