### PR TITLE
:bug: Fix media translation on text nodes on paste

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ on-premises instances** that want to keep up to date.
 - Fix entering long project name [Taiga #11417](https://tree.taiga.io/project/penpot/issue/11417)
 - Fix slow color picker [Taiga #11019](https://tree.taiga.io/project/penpot/issue/11019)
 - Fix tooltip position after click [Taiga #11405](https://tree.taiga.io/project/penpot/issue/11405)
+- Fix incorrect media translation on paste text with fill images [Github #6845](https://github.com/penpot/penpot/pull/6845)
 
 ## 2.7.2
 

--- a/common/src/app/common/text.cljc
+++ b/common/src/app/common/text.cljc
@@ -170,19 +170,6 @@
         item))
     root)))
 
-(defn xform-nodes
-  "The same as transform but instead of receiving a funcion, receives
-  a transducer."
-  [xf root]
-  (let [rf (fn [_ v] v)]
-    (walk/postwalk
-     (fn [item]
-       (let [rf (xf rf)]
-         (if (is-node? item)
-           (d/nilv (rf nil item) item)
-           item)))
-     root)))
-
 (defn update-text-content
   [shape pred-fn update-fn attrs]
   (let [update-attrs-fn #(update-fn % attrs)


### PR DESCRIPTION
### Summary

Right now, when you copy text with image fill, the media-id is not properly translated. This PR fixes that

Merge with **SQUASH**

### How to reproduce

- create a text shape, select a text and add image fill
- copy shape and paste it on other file
- on debug helpers you can observe that pasted media is the same (without PR changes) or a different one (with PR changes)