### PR TITLE
:sparkles: Add migrations handling on file snapshots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@
 
 - Fix unexpected exception on processing old texts [Github #6889](https://github.com/penpot/penpot/pull/6889)
 - Fix UI theme selection from main menu [Taiga #11567](https://tree.taiga.io/project/penpot/issue/11567)
+- Add missing migration information to file snapshots [Github #686](https://github.com/penpot/penpot/pull/6864)
 
 ## 2.8.0
 

--- a/backend/src/app/migrations.clj
+++ b/backend/src/app/migrations.clj
@@ -438,7 +438,10 @@
     :fn (mg/resource "app/migrations/sql/0138-mod-file-data-fragment-table.sql")}
 
    {:name "0139-mod-file-change-table.sql"
-    :fn (mg/resource "app/migrations/sql/0139-mod-file-change-table.sql")}])
+    :fn (mg/resource "app/migrations/sql/0139-mod-file-change-table.sql")}
+
+   {:name "0140-mod-file-change-table.sql"
+    :fn (mg/resource "app/migrations/sql/0140-mod-file-change-table.sql")}])
 
 (defn apply-migrations!
   [pool name migrations]

--- a/backend/src/app/migrations/sql/0140-mod-file-change-table.sql
+++ b/backend/src/app/migrations/sql/0140-mod-file-change-table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file_change
+ ADD COLUMN migrations text[];

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -81,7 +81,7 @@
         (update :migrations set/union diff)
         (vary-meta assoc ::migrated (not-empty diff)))))
 
-(defn- generate-migrations-from-version
+(defn generate-migrations-from-version
   "A function that generates new format migration from the old,
   version based migration system"
   [version]


### PR DESCRIPTION
### Summary

At the time of implementing snapshots, migrations were not taken into account. This PR fixes that old issue before it explodes in the face.

The main idea is persist in a row the applied migrations in the time of taking snapshots. So if we restore old snapshot, we can re-apply new migrations to it.

What happens with the already existing snapshots with no information about migrations? We use a safe-set of migrations that we know that should be already by applied in any way as initial set. So if snapshot has no migration on restoring it we use that set and then reapply all the other not applied migrations. In some cases this probably will apply twice some migrations because the safe set is the same for all snapshots, but as migrations are idempotent is pretty safe execute them twice.

**Important:**

This PR targets **staging** because we can't wait next release for make release it; so this PR should be checked exhaustively. 

### How to test

There are no specific way to test this. You need to have a file with a bunch of versions without migration information and check that you can proper restore that versions with changes from this PR. Also would be nice to check if the migrations information is properly stored on newly created snapshots.
