### PR TITLE
:bug: Detach styles from assets when applying tokens

### DIFF
--- a/common/src/app/common/types/typography.cljc
+++ b/common/src/app/common/types/typography.cljc
@@ -93,13 +93,16 @@
                                    remap-typography
                                    content)))))
 
+(defn remove-typography-from-node
+  "Remove the typography reference from a node."
+  [node]
+  (dissoc node :typography-ref-file :typography-ref-id))
+
 (defn remove-external-typographies
   "Change the shape so that any use of an external typography now is removed"
   [shape file-id]
-  (let [remove-ref-file #(dissoc % :typography-ref-file :typography-ref-id)]
-
-    (update shape :content
-            (fn [content]
-              (txt/transform-nodes #(not= (:typography-ref-file %) file-id)
-                                   remove-ref-file
-                                   content)))))
+  (update shape :content
+          (fn [content]
+            (txt/transform-nodes #(not= (:typography-ref-file %) file-id)
+                                 remove-typography-from-node
+                                 content))))

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -13,6 +13,7 @@
    [app.common.types.shape.radius :as ctsr]
    [app.common.types.token :as ctt]
    [app.common.types.tokens-lib :as ctob]
+   [app.common.types.typography :as cty]
    [app.main.data.event :as ev]
    [app.main.data.helpers :as dsh]
    [app.main.data.style-dictionary :as sd]
@@ -336,10 +337,14 @@
   ([value shape-ids _attributes page-id]
    (let [update-node? (fn [node]
                         (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))]
+                            (txt/is-paragraph-node? node)))
+         update-fn (fn [node _]
+                     (-> node
+                         (d/txt-merge {:line-height value})
+                         (cty/remove-typography-from-node)))]
      (when (number? value)
        (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? d/txt-merge {:line-height value})
+                           #(txt/update-text-content % update-node? update-fn nil)
                            {:ignore-touched true
                             :page-id page-id})))))
 
@@ -348,10 +353,14 @@
   ([value shape-ids _attributes page-id]
    (let [update-node? (fn [node]
                         (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))]
+                            (txt/is-paragraph-node? node)))
+         update-fn (fn [node _]
+                     (-> node
+                         (d/txt-merge {:letter-spacing (str value)})
+                         (cty/remove-typography-from-node)))]
      (when (number? value)
        (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? d/txt-merge {:letter-spacing (str value)})
+                           #(txt/update-text-content % update-node? update-fn nil)
                            {:ignore-touched true
                             :page-id page-id})))))
 
@@ -360,10 +369,14 @@
   ([value shape-ids _attributes page-id]
    (let [update-node? (fn [node]
                         (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))]
+                            (txt/is-paragraph-node? node)))
+         update-fn (fn [node _]
+                     (-> node
+                         (d/txt-merge {:font-size (str value)})
+                         (cty/remove-typography-from-node)))]
      (when (number? value)
        (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? d/txt-merge {:font-size (str value)})
+                           #(txt/update-text-content % update-node? update-fn nil)
                            {:ignore-touched true
                             :page-id page-id})))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11424

### Summary

When applying a color or typography token to a shape with styles attached, they should be detached.

### Steps to reproduce 

See Taiga issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
