### PR TITLE
:lipstick: Implement (p)print methods / protocols for several types

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -8,6 +8,7 @@
   (:require
    #?(:clj [app.common.fressian :as fres])
    #?(:clj [clojure.data.json :as json])
+   #?(:clj [clojure.pprint :as pp])
    [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
@@ -186,7 +187,13 @@
                                    "name" (clj->js name)
                                    "description" (clj->js description)
                                    "modified-at" (clj->js modified-at)
-                                   "tokens" (clj->js tokens)))])
+                                   "tokens" (clj->js tokens)))
+
+             cljs.core/IPrintWithWriter
+             (-pr-writer [^TokenSet this writer opts]
+                         (-write writer "#penpot/token-set ")
+                         (-pr-writer (deref this) writer opts))])
+
   INamedItem
   (get-name [_]
     name)
@@ -250,6 +257,20 @@
 
   (get-tokens-map [_]
     tokens))
+
+#?(:clj
+   (do
+     (defmethod print-method TokenSet [^TokenSet this ^java.io.Writer w]
+       (.write w "#penpot/token-set ")
+       (print-method (deref this) w))
+
+     (defmethod print-dup TokenSet [^TokenSet this ^java.io.Writer w]
+       (print-method this w))
+
+     (defmethod pp/simple-dispatch TokenSet [^TokenSet obj]
+       (.write *out* "#penpot/token-set ")
+       (pp/pprint-newline :miser)
+       (pp/pprint (deref obj)))))
 
 (defn token-set?
   [o]
@@ -1201,7 +1222,26 @@ Will return a value that matches this schema:
   (validate [_]
     (and (valid-token-sets? sets)
          (valid-token-themes? themes)
-         (valid-active-token-themes? active-themes))))
+         (valid-active-token-themes? active-themes)))
+
+  #?@(:cljs [cljs.core/IPrintWithWriter
+             (-pr-writer [this writer opts]
+                         (-write writer "#penpot/tokens-lib ")
+                         (-pr-writer (deref this) writer opts))]))
+
+#?(:clj
+   (do
+     (defmethod print-method TokensLib [^TokensLib this ^java.io.Writer w]
+       (.write w "#penpot/tokens-lib ")
+       (print-method (deref this) w))
+
+     (defmethod print-dup TokensLib [^TokensLib this ^java.io.Writer w]
+       (print-method this w))
+
+     (defmethod pp/simple-dispatch TokensLib [^TokensLib obj]
+       (.write *out* "#penpot/tokens-lib ")
+       (pp/pprint-newline :miser)
+       (pp/pprint (deref obj)))))
 
 (defn get-hidden-theme
   [tokens-lib]


### PR DESCRIPTION
## Context

Currently,

```clojure
(let [tokens-lib (get-in @st/state [:files some-file :data :tokens-lib])]
  (pprint tokens-lib))
```

produces

```
#object[app.common.types.tokens-lib.TokensLib]
```

and the same happens for `TokenSets`. When printing to file one obtains "unreadable form" characters `#<`. Instead we want to print tags `#penpot/tokens-lib` and `#penpot/token-set`.

## Summary of changes

This PR improves pretty-printing both in clojure and clojurescript by:

- Adding `print-method`, `print-dup` and `pprint/simple-dispatch` implementations for `TokenSet` and `TokensLib`
- Implementing `cljs.core/IPrintWithWriter` for `TokenSet` and `TokensLib`
- ~Additionally adding `print-method`, `print-dup` and `pprint/simple-dispatch` implementations for `PathData`, for consistency with the tag in cljs which is already implemented.~

## Open questions

1. The implementation is not complete for cljs, since the dispatch mechanism for `pprint` is rather cumbersome and I didn't think `a.c.t.tokens-lib` to be the proper place for something like this:

```clojure
(ns app.some.namespace
  (:require [cljs.pprint :as pp]))

(defmulti pprint-dispatch
  (fn [obj]
    (if (instance? TokensLib obj)
      :tokens-lib
      (pp/type-dispatcher obj))))

(defmethod pprint-dispatch :tokens-lib
  [^TokensLib obj]
  (-write *out* "#penpot/tokens-lib ")
  (pp/pprint-newline :miser)
  (pp/pprint (deref obj)))

(defmethod pprint-dispatch :default
  [obj]
  (pp/simple-dispatch obj))
  
(pp/set-pprint-dispatch pprint-dispatch)
```

2. I saw some instances of:

```clojure
(extend-protocol fez/IEdn 
  ... )
```

but didn't find obvious places where this was actually used, so I left that out. Should I include it for both types?

3. There seems to be some inconsistency in the use of tags. Sometimes it's `app/something`, sometimes `penpot/something`. I find the former to be too generic, maybe we should change all uses? I just don't know what that might break.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
