### PR TITLE
:sparkles: Fix bugs on texts overrides

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1666,19 +1666,26 @@
 
 
 (defn- text-partial-change-value
-  [touched-shape untouched-shape touched]
+  [touched-content untouched-content touched]
   (cond
     (touched :text-content-structure-same-attrs)
-    ;; Keep the touched-shape structure and texts, update its attrs to make them like the untouched-shape
-    (cttx/copy-attrs-keys touched-shape (cttx/get-first-paragraph-text-attrs untouched-shape))
+    (if (touched :text-content-attribute)
+      ;; Both structure and attrs has been touched, keep the
+      ;; touched-content
+      touched-content
+      ;; Keep the touched-content structure and texts, update
+      ;; its attrs to make them like the untouched-content
+      (cttx/copy-attrs-keys touched-content (cttx/get-first-paragraph-text-attrs untouched-content)))
 
     (touched :text-content-text)
-    ;; Keep the texts touched in touched-shape copy the texts from dest over the attrs of untouched-shape
-    (cttx/copy-text-keys touched-shape untouched-shape)
+    ;; Keep the texts touched in touched-content, so copy the
+    ;; texts from touched-content into untouched-content
+    (cttx/copy-text-keys touched-content untouched-content)
 
     (touched :text-content-attribute)
-    ;; Keep the attrs touched in touched-shape copy the texts from untouched-shape over the attrs of touched-shape
-    (cttx/copy-text-keys untouched-shape touched-shape)))
+    ;; Keep the attrs touched in touched-content, so copy the
+    ;; texts from untouched-content into touched-content
+    (cttx/copy-text-keys untouched-content touched-content)))
 
 (defn- add-update-attr-operations
   [attr dest-shape roperations uoperations attr-val]

--- a/common/src/app/common/types/text.cljc
+++ b/common/src/app/common/types/text.cljc
@@ -148,7 +148,7 @@
   (cond
     (map? origin)
     (into {}
-          (for [k (keys origin) :when (not= k :key)] ;; We ignore :key because it is a draft artifact
+          (for [k (keys destiny) :when (not= k :key)] ;; We ignore :key because it is a draft artifact
             (cond
               (= :children k)
               [k (vec (map #(copy-text-keys %1 %2) (get origin k) (get destiny k)))]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11382

### Summary

Fix two bugs found on the design review

### Steps to reproduce 

1. On texts overrides, keep also vertical-align property
* Create a text component and a copy
* Change the text on the copy
* Change the vertical-align on the main
* The change of vertical align should be copied to the copy

2. Structure changes
* Create a text component with the text "hello world" and a copy
* On the copy, set each word in a different line
* Change the color on the main to red
* The color of the copy should be updated
* On the copy, change the color to blue
* Change the color on the main to green
* The color of the copy should NOT be updated

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
