### PR TITLE
:sparkles: Improve legibility on import token notification details

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/import_export.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/import_export.cljs
@@ -47,7 +47,7 @@
     (ntf/show {:content (tr "workspace.tokens.unknown-token-type-message")
                :detail (->> (for [[token-type tokens] type->tokens]
                               (tr "workspace.tokens.unknown-token-type-section" token-type (count tokens)))
-                            (str/join "\n"))
+                            (str/join "<br>"))
                :type :toast
                :level :info})))
 

--- a/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.cljs
+++ b/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.cljs
@@ -71,4 +71,5 @@
          [:div {:on-click on-toggle-detail}
           (tr "workspace.notification-pill.detail")]]
         (when show-detail
-          [:div {:class (stl/css :error-detail-content)} detail])])]))
+          [:div {:class (stl/css :error-detail-content)
+                 :dangerouslySetInnerHTML #js {:__html detail}}])])]))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11355

### Summary

As an addition to the referenced issue, the details content must be legible, so each string must be separated 

Expected result
![Screenshot from 2025-07-08 14-02-26](https://github.com/user-attachments/assets/465f7b57-18e1-4ade-b0a7-99b5f052245e)

### Steps to reproduce 

Upload a JSON file with unsupported tokens and check the notification details message

Example
[tokens-unsupported.json](https://github.com/user-attachments/files/21122519/tokens-unsupported.json)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
