### PR TITLE
:bug: Handle empty paragraph on entire selected text deletion

### DIFF
--- a/frontend/text-editor/src/editor/content/dom/Editor.js
+++ b/frontend/text-editor/src/editor/content/dom/Editor.js
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) KALEIDOS INC
+ */
+
+import { isElement } from "./Element.js";
+
+export const TAG = "DIV";
+export const TYPE = "editor";
+export const QUERY = `[data-itype="${TYPE}"]`;
+
+/**
+ * Returns true if passed node is the editor element.
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isEditor(node) {
+  if (!node) return false;
+  if (!isElement(node, TAG)) return false;
+  if (node.dataset.itype !== TYPE) return false;
+  return true;
+}

--- a/frontend/text-editor/src/editor/content/dom/TextNode.js
+++ b/frontend/text-editor/src/editor/content/dom/TextNode.js
@@ -9,6 +9,7 @@
 import { isInline } from "./Inline.js";
 import { isLineBreak } from "./LineBreak.js";
 import { isParagraph } from "./Paragraph.js";
+import { isEditor } from "./Editor.js";
 import { isRoot } from "./Root.js";
 
 /**
@@ -60,5 +61,6 @@ export function getClosestTextNode(node) {
   if (isInline(node)) return node.firstChild;
   if (isParagraph(node)) return node.firstChild.firstChild;
   if (isRoot(node)) return node.firstChild.firstChild.firstChild;
+  if (isEditor(node)) return node.firstChild.firstChild.firstChild.firstChild;
   throw new Error("Cannot find a text node");
 }

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -1519,6 +1519,7 @@ export class SelectionController extends EventTarget {
 
     const startNode = getClosestTextNode(this.#range.startContainer);
     const endNode = getClosestTextNode(this.#range.endContainer);
+
     const startOffset = this.#range.startOffset;
     const endOffset = this.#range.endOffset;
 


### PR DESCRIPTION
### Related Ticket

I saw this problem while reviewing this other issue https://tree.taiga.io/project/penpot/issue/9256 

### Summary

In Firefox, when selecting all text in a text area (CTRL + A) and then removing it, it broke. I couldn't reproduce the similar behavior at Chrome. This fixes the issue in Firefox and in Chrome it keeps working as expected.

For what I've seen, the problem seems to be that when doing CTRL + A, is the text editor container the one being returned by the Selection API on Firefox. That's why it behaves differently. The Selection API returns the editor as start and end containers, and a startOffset of 0 and an endOffset of 1.

I've reviewed if we were setting properly the user-select css property in the containers correctly and it seems that's fine, so maybe we should try to handle this scenario in particular.

### Steps to reproduce 

- Create a text area
- Write some text
- Select the whole text
- Remove the text
- No error should rise

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
