### PR TITLE
:recycle: Fix tab info not updating and suggested code refactor

### DIFF
--- a/frontend/src/app/main/ui/inspect/attributes/blur.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/blur.cljs
@@ -14,7 +14,7 @@
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(defn has-blur? [shape]
+(defn- has-blur? [shape]
   (:blur shape))
 
 (mf/defc blur-panel

--- a/frontend/src/app/main/ui/inspect/attributes/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/fill.cljs
@@ -14,9 +14,9 @@
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(def properties [:background :background-color :background-image])
+(def ^:private properties [:background :background-color :background-image])
 
-(defn has-fill? [shape]
+(defn- has-fill? [shape]
   (and
    (not (contains? #{:text :group} (:type shape)))
    (or (:fill-color shape)

--- a/frontend/src/app/main/ui/inspect/attributes/geometry.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/geometry.cljs
@@ -16,7 +16,7 @@
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(def properties
+(def ^:private properties
   [:width
    :height
    :left

--- a/frontend/src/app/main/ui/inspect/attributes/layout.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/layout.cljs
@@ -16,7 +16,7 @@
    [app.util.code-gen.style-css :as css]
    [rumext.v2 :as mf]))
 
-(def properties
+(def ^:private properties
   [:display
    :flex-direction
    :flex-wrap

--- a/frontend/src/app/main/ui/inspect/attributes/layout_element.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/layout_element.cljs
@@ -16,7 +16,7 @@
    [app.util.code-gen.style-css :as css]
    [rumext.v2 :as mf]))
 
-(def properties
+(def ^:private properties
   [:margin
    :max-height
    :min-height

--- a/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/shadow.cljs
@@ -14,16 +14,12 @@
    [app.main.ui.inspect.attributes.common :refer [color-row]]
    [app.util.code-gen.style-css :as css]
    [app.util.i18n :refer [tr]]
-   [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
-(defn has-shadow? [shape]
+(defn- has-shadow? [shape]
   (:shadow shape))
 
-(defn shape-copy-data [shape]
-  (str/join ", " (map css/shadow->css (:shadow shape))))
-
-(defn shadow-copy-data [shadow]
+(defn- shadow-copy-data [shadow]
   (css/shadow->css shadow))
 
 (mf/defc shadow-block [{:keys [shadow]}]

--- a/frontend/src/app/main/ui/inspect/attributes/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/stroke.cljs
@@ -13,9 +13,9 @@
    [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(def properties [:border])
+(def ^:private properties [:border])
 
-(defn stroke->color [shape]
+(defn- stroke->color [shape]
   {:color (:stroke-color shape)
    :opacity (:stroke-opacity shape)
    :gradient (:stroke-color-gradient shape)
@@ -23,7 +23,7 @@
    :file-id (:stroke-color-ref-file shape)
    :image (:stroke-image shape)})
 
-(defn has-stroke? [shape]
+(defn- has-stroke? [shape]
   (seq (:strokes shape)))
 
 (mf/defc stroke-block

--- a/frontend/src/app/main/ui/inspect/attributes/svg.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/svg.cljs
@@ -14,7 +14,7 @@
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
-(defn map->css [attr]
+(defn- map->css [attr]
   (->> attr
        (map (fn [[attr-key attr-value]] (str (d/name attr-key) ":" attr-value)))
        (str/join "; ")))

--- a/frontend/src/app/main/ui/inspect/attributes/text.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/text.cljs
@@ -23,19 +23,19 @@
    [okulary.core :as l]
    [rumext.v2 :as mf]))
 
-(defn has-text? [shape]
+(defn- has-text? [shape]
   (:content shape))
 
-(def file-typographies-ref
+(def ^:private file-typographies-ref
   (l/derived (l/in [:viewer :file :data :typographies]) st/state))
 
-(defn make-typographies-library-ref [file-id]
+(defn- make-typographies-library-ref [file-id]
   (let [get-library
         (fn [state]
           (get-in state [:viewer-libraries file-id :data :typographies]))]
     #(l/derived get-library st/state)))
 
-(defn copy-style-data
+(defn- copy-style-data
   [style & properties]
   (->> properties
        (map #(dm/str (d/name %) ": " (get style %) ";"))

--- a/frontend/src/app/main/ui/inspect/attributes/visibility.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/visibility.cljs
@@ -14,12 +14,12 @@
    [app.util.code-gen.style-css :as css]
    [rumext.v2 :as mf]))
 
-(def properties
+(def ^:private properties
   [:opacity
    :blend-mode
    :visibility])
 
-(defn has-visibility-props? [shape]
+(defn- has-visibility-props? [shape]
   (let [shape-type (:type shape)]
     (and
      (not (or (= shape-type :text) (= shape-type :group)))
@@ -44,7 +44,8 @@
 
 (mf/defc visibility-panel*
   [{:keys [objects shapes]}]
-  (let [shapes (mf/with-memo (filter has-visibility-props? shapes))]
+  (let [shapes (mf/with-memo [shapes]
+                 (filter has-visibility-props? shapes))]
 
     (when (seq shapes)
       [:div {:class (stl/css :attributes-block)}


### PR DESCRIPTION
### Related Ticket

Review of https://tree.taiga.io/project/penpot/issue/11283

### Summary

- Currently, switching between layers does not update the visibility section (see video on issue if needed). Removed `with-memo` from shape type retrieval.
- Updated all panels with code suggestion by @niwinz 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
