### PR TITLE
:bug: Fix touchpad swipe back/forward #4246

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Fix problem when creating a layout from an existing layout [Taiga #11554](https://tree.taiga.io/project/penpot/issue/11554)
 - Fix title button from Title Case to Capitalize [Taiga #11476](https://tree.taiga.io/project/penpot/issue/11476)
 - Fix Main component receives focus and is selected when using 'Show Main Component' [Taiga #11402](https://tree.taiga.io/project/penpot/issue/11402)
+- Fix touchpad swipe leading to navigating back/forth [GitHub #4246](https://github.com/penpot/penpot/issues/4246)
 
 ## 2.8.0
 

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -28,6 +28,7 @@
    [app.main.ui.onboarding.team-choice :refer [onboarding-team-modal]]
    [app.main.ui.releases :refer [release-notes-modal]]
    [app.main.ui.static :as static]
+   [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.theme :as theme]
    [beicon.v2.core :as rx]
@@ -361,6 +362,8 @@
 
     ;; initialize themes
     (theme/use-initialize profile)
+
+    (dom/prevent-browser-gesture-navigation!)
 
     [:& (mf/provider ctx/current-route) {:value route}
      [:& (mf/provider ctx/current-profile) {:value profile}

--- a/frontend/src/app/util/dom.cljs
+++ b/frontend/src/app/util/dom.cljs
@@ -891,3 +891,12 @@
 (defn last-child
   [^js node]
   (.. node -lastChild))
+
+(defn prevent-browser-gesture-navigation!
+  []
+  ;; Prevent the browser from interpreting trackpad horizontal swipe as back/forth
+  ;;
+  ;; In theory We could disable this only for the workspace. However gets too unreliable.
+  ;; It is better to be safe and disable for the dashboard as well.
+  (set! (.. js/document -documentElement -style -overscrollBehaviorX) "none")
+  (set! (.. js/document -body -style -overscrollBehaviorX) "none"))


### PR DESCRIPTION
### Related Ticket

Github: #4246
Taiga: https://tree.taiga.io/project/penpot/issue/7454

### Summary

This is intentionally a fix for *most* of the cases. As commented on the code, users may still run into the original issue in some corner cases.

In my tests I need to go from the workspace to the dashboard and back very quickly for this to happen, and it doesn't even happen every time. I think having the ability to still use gestures on the dashboard justifies this quirk.

### Steps to reproduce

1. Go to the dashboard.
2. Open a document.
3. Use the trackpad to pan around.

The browser should *not* navigate back to the dashboard.

_Tested on MacOS + Google Chrome._

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable. ¹
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

¹ The following tests are failing in the `develop` branch, even without my patch:
```
[default] › playwright/ui/specs/subscriptions-dashboard.spec.js:85:3 › Subscriptions: team members and invitations › Team settings has susbscription name and no manage subscription link when is member 
[default] › playwright/ui/specs/variants.spec.js:114:1 › User duplicates a variant container 
```