### PR TITLE
:bug: Fix unexpected exception on processing old texts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.8.1 (Unreleased)
+
+### :bug: Bugs fixed
+
+- Fix unexpected exception on processing old texts [Github #6889](https://github.com/penpot/penpot/pull/6889)
+
+
 ## 2.8.0
 
 ### :rocket: Epics and highlights

--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -479,7 +479,7 @@
       ;; We don't have the fills attribute. It's an old text without color
       ;; so need to be black
       (and (nil? (:fills node)) (empty? color-attrs))
-      (update :fills conj txt/default-text-attrs)
+      (assoc :fills (:fills txt/default-text-attrs))
 
       ;; Remove duplicates from the fills
       :always


### PR DESCRIPTION
### Summary

Add a possible fix for a recurrent exception what reports fills with text-attributes.
There are no way to test it because we are unable to reproduce this on isolated environment. 