### PR TITLE
:books: Fix broken link in self-hosting docs

### DIFF
--- a/docs/technical-guide/getting-started/index.md
+++ b/docs/technical-guide/getting-started/index.md
@@ -28,5 +28,6 @@ Use Docker if you already know the tool, if need full control of the process or 
 and do not want to depend on any external provider, or need to do any special customization.
 </p>
 
-Or you can try <a href="#unofficial-self-host-options">other options</a>,
-offered by Penpot community.
+Or you can try [other options][1], offered by Penpot community.
+
+[1]: /technical-guide/getting-started/unofficial-options/


### PR DESCRIPTION
Replaced broken Markdown link to the unofficial self-hosting section.

### Related Ticket

N/A

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Replaced broken Markdown link to the unofficial self-hosting section.

Previously: `#unofficial-self-host-options`
Now: `/technical-guide/getting-started/unofficial-options/`

### Steps to reproduce 

Click the broken link at the bottom of the [Self-hosting Guide](https://help.penpot.app/technical-guide/getting-started/) in the docs.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] ~~Include screenshots or videos, if applicable.~~
- [ ] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [ ] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
