### PR TITLE
:bug: Fix error on validating file referential integrity when duplicating a page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,10 +32,11 @@
 - Fix toggle focus mode did not restore viewport and selection upon exit [GitHub #6280](https://github.com/penpot/penpot/issues/6820)
 - Fix problem when creating a layout from an existing layout [Taiga #11554](https://tree.taiga.io/project/penpot/issue/11554)
 - Fix title button from Title Case to Capitalize [Taiga #11476](https://tree.taiga.io/project/penpot/issue/11476)
-- Fix Main component receives focus and is selected when using 'Show Main Component' [Taiga #11402](https://tree.taiga.io/project/penpot/issue/11402)
 - Fix touchpad swipe leading to navigating back/forth [GitHub #4246](https://github.com/penpot/penpot/issues/4246)
 - Keep color data when copying from info tab into CSS [Taiga #11144](https://tree.taiga.io/project/penpot/issue/11144)
 - Update HSL values to modern syntax as defined in W3C CSS Color Module Level 4 [Taiga #11144](https://tree.taiga.io/project/penpot/issue/11144)
+- Fix main component receives focus and is selected when using 'Show Main Component' [Taiga #11402](https://tree.taiga.io/project/penpot/issue/11402)
+- Fix duplicating pages with mainInstance shapes nested inside groups [Taiga #10774](https://tree.taiga.io/project/penpot/issue/10774)
 
 ## 2.8.0
 

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -294,15 +294,14 @@
   ([page component library-data position]
    (make-component-instance page component library-data position {}))
   ([page component library-data position
-    {:keys [main-instance? force-id force-frame-id keep-ids?]
-     :or {main-instance? false force-id nil force-frame-id nil keep-ids? false}}]
+    {:keys [main-instance? force-id force-frame-id keep-ids? force-parent-id]
+     :or {main-instance? false force-id nil force-frame-id nil keep-ids? false force-parent-id nil}}]
    (let [component-page  (ctpl/get-page library-data (:main-instance-page component))
 
          component-shape (-> (get-shape component-page (:main-instance-id component))
                              (assoc :parent-id nil) ;; On v2 we force parent-id to nil in order to behave like v1
                              (assoc :frame-id uuid/zero)
                              (remove-swap-keep-attrs))
-
 
          orig-pos        (gpt/point (:x component-shape) (:y component-shape))
          delta           (gpt/subtract position orig-pos)
@@ -368,7 +367,7 @@
 
          [new-shape new-shapes _]
          (ctst/clone-shape component-shape
-                           frame-id
+                           (or force-parent-id frame-id)
                            (:objects component-page)
                            :update-new-shape update-new-shape
                            :force-id force-id

--- a/frontend/src/app/main/data/workspace/pages.cljs
+++ b/frontend/src/app/main/data/workspace/pages.cljs
@@ -174,12 +174,15 @@
             add-component-copy
             (fn [objs id shape]
               (let [component (ctkl/get-component fdata (:component-id shape))
+                    parent-id (when (not= (:parent-id shape) uuid/zero) (:parent-id shape))
                     [new-shape new-shapes]
                     (ctn/make-component-instance page
                                                  component
                                                  fdata
                                                  (gpt/point (:x shape) (:y shape))
-                                                 {:keep-ids? true :force-frame-id (:frame-id shape)})
+                                                 {:keep-ids? true
+                                                  :force-frame-id (:frame-id shape)
+                                                  :force-parent-id parent-id})
                     children (into {} (map (fn [shape] [(:id shape) shape]) new-shapes))
                     objs (assoc objs id new-shape)]
                 (merge objs children)))
@@ -201,10 +204,8 @@
                         (assoc :id id)
                         (assoc :objects
                                objects))
-
             changes (-> (pcb/empty-changes it)
                         (pcb/add-page id page))]
-
         (rx/of (dch/commit-changes changes))))))
 
 (s/def ::rename-page


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10774

### Summary

Duplicating a page with mainInstance shapes nested inside groups could result in broken parent/child relationships and schema validation errors. The duplication logic now ensures referential integrity between parent groups and their mainInstance children, so all parent-id and :shapes links are consistent after duplication.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
