### PR TITLE
:sparkles: Enable wheel scrolling over templates-section in the dashboard

### DIFF
--- a/frontend/src/app/main/ui/dashboard/templates.cljs
+++ b/frontend/src/app/main/ui/dashboard/templates.cljs
@@ -17,6 +17,7 @@
    [app.main.store :as st]
    [app.main.ui.icons :as i]
    [app.util.dom :as dom]
+   [app.util.dom.normalize-wheel :as nw]
    [app.util.i18n :refer [tr]]
    [app.util.keyboard :as kbd]
    [app.util.storage :as storage]
@@ -206,6 +207,17 @@
          (fn [_event]
            (swap! collapsed* not)))
 
+        on-wheel
+        (mf/use-fn
+         (mf/deps content-ref)
+         (fn [^js event]
+           (let [event* (nw/normalize-wheel event)
+                 deltaY (.-spinY event*)
+                 deltaX (.-spinX event*)
+                 node (mf/ref-val content-ref)]
+             (when (> (abs deltaY) (abs deltaX))
+               (.scrollBy node #js {:left (* 300 deltaY) :mode "smooth"})))))
+
         on-scroll
         (mf/use-fn
          (fn [e]
@@ -258,6 +270,7 @@
 
      [:div {:class (stl/css :content)
             :on-scroll on-scroll
+            :on-wheel on-wheel
             :ref content-ref}
 
       (for [index (range (count templates))]


### PR DESCRIPTION
### Summary

This is just a little change to enable wheel-up/down scrolling over the horizontal "libraries & templates" section in the dashboard.

Emulating the default browser behaviour when scrolling proved to be a bit tricky, so I chose instead to have **discrete scrolling** with one wheel tick = one thumbnail. This is suboptimal for trackpad users, but for them, the previous left-to-right scrolling still works smoothly and continuously as expected.

I experimented with `requestAnimationFrame` in order to have smooth wheel scrolling, but I couldn't make it really work nicely with `scrollBy`. The issue seems to be that trackpad scrolling somehow tracks when the fingers are still on it.

Despite the shortcomings mentioned, I believe discrete scrolling to be an improvement over the previous situation for mouse users, hence this PR.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Check CI passes successfully.
