### PR TITLE
:bug: On component swap do not show secondary variants

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -779,3 +779,27 @@
   padding: 0;
   text-align: start;
 }
+
+.variant-icon {
+  @include flexCenter;
+  height: $s-24;
+  width: $s-24;
+  background-color: var(--color-background-tertiary);
+  border-radius: $br-8;
+  order: 3;
+
+  svg {
+    height: $s-12;
+    width: $s-12;
+    background-color: transparent;
+    margin: 0;
+
+    stroke: var(--color-accent-secondary);
+  }
+}
+
+.variant-mark-cell {
+  position: absolute;
+  right: $s-2;
+  top: $s-2;
+}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/11223

### Summary
When showing SWAP options, only show main component variant, not all the posibilities

### Steps to reproduce 
1. Create a variant with 2 components (red and blue squares)
2. Create an independent component (a grey circle), and a copy
3. Select the copy, and start a SWAP
4. On the list of items to swap to, you only see the main component of the variant (red), and an indicator that it is a variant

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
