### PR TITLE
:bug: Subscription current period dates could be null

### DIFF
--- a/backend/src/app/srepl/cli.clj
+++ b/backend/src/app/srepl/cli.clj
@@ -205,9 +205,8 @@
    [:trial-start [:maybe ::sm/timestamp]]
    [:cancel-at [:maybe ::sm/timestamp]]
    [:canceled-at [:maybe ::sm/timestamp]]
-
-   [:current-period-end ::sm/timestamp]
-   [:current-period-start ::sm/timestamp]
+   [:current-period-end [:maybe ::sm/timestamp]]
+   [:current-period-start [:maybe ::sm/timestamp]]
    [:cancel-at-period-end :boolean]
 
    [:cancellation-details


### PR DESCRIPTION
<div align="center">

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjA2azdlYWtrMDd1NjdtNm9kdDI5azZ4MDExZWUxOW9vaWVjaWRtciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/o3XuiZ4h81IPvVfyJZ/giphy.gif)

</div>

`current-period-start` and `current-period-end` can be null if the invoice has not yet been created in stripe. This happens after the subscription is created, before the webhook is sent.

This is useful to be able to update the information in the Penpot user's profile (from penpot payments service) after the subscription has been created in Stripe without having to wait for the webhook to be sent. By doing this, we ensure that the interface shows the updated information, even if the subscription creation webhook has not yet been sent.