### PR TITLE
:recycle: Remove redundant flag on text overrides

### DIFF
--- a/common/src/app/common/types/text.cljc
+++ b/common/src/app/common/types/text.cljc
@@ -83,21 +83,12 @@
    compare them, and returns a set with the type of differences.
    The possibilities are
      :text-content-text
-     :text-content-attribute,
-     :text-content-structure
-     :text-content-structure-same-attrs."
+     :text-content-attribute
+     :text-content-structure"
   [a b]
-  (let [diff-type (compare-text-content a b
-                                        {:text-cb      (fn [acc] (conj acc :text-content-text))
-                                         :attribute-cb (fn [acc _] (conj acc :text-content-attribute))})]
-    (if-not (contains? diff-type :text-content-structure)
-      diff-type
-      (let [;; get attrs of the first paragraph of the first paragraph-set
-            attrs (get-first-paragraph-text-attrs a)]
-        (if (and (equal-attrs? a attrs)
-                 (equal-attrs? b attrs))
-          #{:text-content-structure :text-content-structure-same-attrs}
-          diff-type)))))
+  (compare-text-content a b
+                        {:text-cb      (fn [acc] (conj acc :text-content-text))
+                         :attribute-cb (fn [acc _] (conj acc :text-content-attribute))}))
 
 (defn get-diff-attrs
   "Given two content text structures, conformed by maps and vectors,

--- a/common/test/common_tests/logic/text_touched_test.cljc
+++ b/common/test/common_tests/logic/text_touched_test.cljc
@@ -103,7 +103,7 @@
 
         file'       (thf/apply-changes file changes)
         copy-child' (ths/get-shape file' :copy-child)]
-    (t/is (= #{:content-group :text-content-structure :text-content-structure-same-attrs} (:touched copy-child')))))
+    (t/is (= #{:content-group :text-content-structure} (:touched copy-child')))))
 
 (t/deftest test-text-copy-changed-structure-diff-attrs
   (let [;; ==== Setup

--- a/common/test/common_tests/types/text_test.cljc
+++ b/common/test/common_tests/types/text_test.cljc
@@ -39,7 +39,7 @@
     (t/is (= #{:text-content-attribute} diff-attr))
     (t/is (= #{:text-content-text :text-content-attribute} diff-both))
     (t/is (= #{:text-content-structure} diff-structure))
-    (t/is (= #{:text-content-structure :text-content-structure-same-attrs} diff-structure-same-attrs))))
+    (t/is (= #{:text-content-structure} diff-structure-same-attrs))))
 
 
 (t/deftest test-get-diff-attrs


### PR DESCRIPTION
### Related Ticket


### Summary

There was a flag `text-content-structure-same-attrs` for text overrides. It was redundant and prone to errors. I've found a way to get rid of it

### Steps to reproduce 

Nothing. All should work as before

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
