### PR TITLE
:recycle: Remove the workaround for updating the subscripton name after subscribing

### DIFF
--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -6,7 +6,6 @@
    [app.main.data.auth :as da]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
-   [app.main.data.profile :as du]
    [app.main.refs :as refs]
    [app.main.repo :as rp]
    [app.main.router :as rt]
@@ -319,12 +318,6 @@
                                              (if (= success-modal-is-trial? "true")
                                                (tr "subscription.settings.enterprise-trial")
                                                (tr "subscription.settings.enterprise")))})
-           (du/update-profile-props {:subscription
-                                     (-> subscription
-                                         (assoc :type (if (= params-subscription "subscribed-to-penpot-unlimited")
-                                                        "unlimited"
-                                                        "enterprise"))
-                                         (assoc :status "trialing"))})
            (rt/nav :settings-subscription {} {::rt/replace true})))))
 
     [:section {:class (stl/css :dashboard-section)}


### PR DESCRIPTION
### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
