### PR TITLE
:bug: Fix design review bugs on variants advanced retrieve

### DIFF
--- a/common/src/app/common/logic/variants.cljc
+++ b/common/src/app/common/logic/variants.cljc
@@ -99,7 +99,9 @@
          (= prev-swap-slot swap-ref-id)
           (pcb/update-shapes
            [(:id orig-swapped-child)]
-           #(ctk/set-swap-slot % (:shape-ref related-shape-in-new))))
+           #(-> %
+                (ctk/remove-swap-slot)
+                (ctk/set-swap-slot (:shape-ref related-shape-in-new)))))
 
         ;; Delete new non-swapped item
         (cls/generate-delete-shapes ldata page objects (d/ordered-set (:id related-shape-in-new)) {:allow-altering-copies true})
@@ -167,42 +169,51 @@
                             (:id orig-ref-shape))
 
         ;; Creates a map to quickly find a child of the orig-ref-shape by its shape-path
-        o-ref-shapes-p-map  (into {} (map (juxt :id :shape-path)) o-ref-shapes-wp)]
-    ;; Process each touched children of the original-shape
-    (reduce
-     (fn [changes orig-child-touched]
-       (let [;; If the orig-child-touched was swapped, get its swap-slot
-             swap-slot      (ctk/get-swap-slot orig-child-touched)
+        o-ref-shapes-p-map  (into {} (map (juxt :id :shape-path)) o-ref-shapes-wp)
 
-             ;; orig-child-touched is in a copy. Get the referenced shape on the main component
-             ;; If there is a swap slot, we will get the referenced shape in another way
-             orig-ref-shape (when-not swap-slot
-                              ;; TODO Maybe just get it from o-ref-shapes-wp
-                              (ctf/find-ref-shape nil container libraries orig-child-touched))
 
-             orig-ref-id    (if swap-slot
-                              ;; If there is a swap slot, find the referenced shape id
-                              (ctf/find-ref-id-for-swapped orig-child-touched container libraries)
-                              ;; If there is not a swap slot, get the id from the orig-ref-shape
-                              (:id orig-ref-shape))
+        ;; Process each touched children of the original-shape
+        [changes parents-of-swapped]
+        (reduce
+         (fn [[changes parent-of-swapped] orig-child-touched]
+           (let [;; If the orig-child-touched was swapped, get its swap-slot
+                 swap-slot      (ctk/get-swap-slot orig-child-touched)
 
-             ;; Get the shape path of the referenced main
-             shape-path     (get o-ref-shapes-p-map orig-ref-id)
-             ;; Get its related shape in the children of new-shape: the one that
-             ;; has the same shape-path
-             related-shape-in-new  (get new-shapes-map shape-path)]
-         ;; If there is a related shape, keep its data
-         (if related-shape-in-new
-           (if swap-slot
-             ;; If the orig-child-touched was swapped, keep it
-             (keep-swapped-item changes related-shape-in-new orig-child-touched
-                                ldata page orig-ref-id)
-             ;; If the orig-child-touched wasn't swapped, copy
-             ;; the touched attributes into it
-             (cll/update-attrs-on-switch
-              changes related-shape-in-new orig-child-touched
-              new-shape original-shape orig-ref-shape container))
-           changes)))
-     changes
-     orig-touched)))
+                 ;; orig-child-touched is in a copy. Get the referenced shape on the main component
+                 ;; If there is a swap slot, we will get the referenced shape in another way
+                 orig-ref-shape (when-not swap-slot
+                                  ;; TODO Maybe just get it from o-ref-shapes-wp
+                                  (ctf/find-ref-shape nil container libraries orig-child-touched))
+
+                 orig-ref-id    (if swap-slot
+                                  ;; If there is a swap slot, find the referenced shape id
+                                  (ctf/find-ref-id-for-swapped orig-child-touched container libraries)
+                                  ;; If there is not a swap slot, get the id from the orig-ref-shape
+                                  (:id orig-ref-shape))
+
+                 ;; Get the shape path of the referenced main
+                 shape-path     (get o-ref-shapes-p-map orig-ref-id)
+                 ;; Get its related shape in the children of new-shape: the one that
+                 ;; has the same shape-path
+                 related-shape-in-new  (get new-shapes-map shape-path)
+                 parents-of-swapped (if related-shape-in-new
+                                      (conj parent-of-swapped (:parent-id related-shape-in-new))
+                                      parent-of-swapped)
+                 ;; If there is a related shape, keep its data
+                 changes
+                 (if related-shape-in-new
+                   (if swap-slot
+                     ;; If the orig-child-touched was swapped, keep it
+                     (keep-swapped-item changes related-shape-in-new orig-child-touched
+                                        ldata page orig-ref-id)
+                     ;; If the orig-child-touched wasn't swapped, copy
+                     ;; the touched attributes into it
+                     (cll/update-attrs-on-switch
+                      changes related-shape-in-new orig-child-touched
+                      new-shape original-shape orig-ref-shape container))
+                   changes)]
+             [changes parents-of-swapped]))
+         [changes []]
+         orig-touched)]
+    [changes parents-of-swapped]))
 

--- a/common/src/app/common/test_helpers/compositions.cljc
+++ b/common/src/app/common/test_helpers/compositions.cljc
@@ -300,9 +300,9 @@
                                      {}
                                      (true? keep-touched?))
 
-        changes (if keep-touched?
-                  (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries (:data file))
-                  changes)
+        [changes _] (if keep-touched?
+                      (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries (:data file))
+                      [changes nil])
 
 
         file' (thf/apply-changes file changes)]

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -979,9 +979,11 @@
                 (cll/generate-component-swap objects shape ldata page libraries id-new-component
                                              index target-cell keep-props-values keep-touched?))
 
-            changes (if keep-touched?
-                      (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries ldata)
-                      changes)]
+            [changes parents-of-swapped]
+            (if keep-touched?
+              (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries ldata)
+              [changes []])
+            all-parents (into all-parents parents-of-swapped)]
 
         (rx/of
          (dwu/start-undo-transaction undo-id)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11539

### Summary

Fix advanced retrieve issues detected on the design review

### Steps to reproduce 

See Taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.


