### PR TITLE
:bug: Display stroke properties in inspect tab

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ### :sparkles: New features & Enhancements
 
 ### :bug: Bugs fixed
+- Display strokes information in inspect tab [Taiga #11154](https://tree.taiga.io/project/penpot/issue/11154)
 
 
 ## 2.9.0 (Unreleased)

--- a/frontend/src/app/main/ui/inspect/attributes.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes.cljs
@@ -27,13 +27,12 @@
    [rumext.v2 :as mf]))
 
 (def type->options
-  {:multiple [:fill :stroke :image :text :shadow :blur :layout-element]
+  {:multiple [:fill :stroke :text :shadow :blur :layout-element]
    :frame    [:visibility :geometry :fill :stroke :shadow :blur :layout :layout-element]
    :group    [:visibility :geometry :svg :layout-element]
    :rect     [:visibility :geometry :fill :stroke :shadow :blur :svg :layout-element]
    :circle   [:visibility :geometry :fill :stroke :shadow :blur :svg :layout-element]
    :path     [:visibility :geometry :fill :stroke :shadow :blur :svg :layout-element]
-   :image    [:visibility :image :geometry :fill :stroke :shadow :blur :svg :layout-element]
    :text     [:visibility :geometry :text :shadow :blur :stroke :layout-element]
    :variant  [:variant :geometry :fill :stroke :shadow :blur :layout :layout-element]})
 

--- a/frontend/src/app/util/code_gen/style_css.cljs
+++ b/frontend/src/app/util/code_gen/style_css.cljs
@@ -296,6 +296,7 @@ body {
        (format-css-property options))))
 
 (defn get-css-value
+  "Get the CSS value for a given property of a shape."
   ([objects shape property]
    (get-css-value objects shape property nil))
 

--- a/frontend/src/app/util/code_gen/style_css_formats.cljs
+++ b/frontend/src/app/util/code_gen/style_css_formats.cljs
@@ -25,6 +25,8 @@
    :background            :color
    :border                :border
    :border-radius         :string-or-size-array
+   :border-width          :border-width
+   :border-style          :border-style
    :box-shadow            :shadows
    :filter                :blur
    :gap                   :size-array
@@ -91,6 +93,14 @@
           (fmt/format-pixels width)
           (d/name style)
           (format-color color options)))
+
+(defmethod format-value :border-style
+  [_ value _options]
+  (d/name (:style value)))
+
+(defmethod format-value :border-width
+  [_ value _options]
+  (fmt/format-pixels (:width value)))
 
 (defmethod format-value :size-array
   [_ value _options]

--- a/frontend/src/app/util/code_gen/style_css_values.cljs
+++ b/frontend/src/app/util/code_gen/style_css_values.cljs
@@ -191,6 +191,16 @@
     (every? some? [r1 r2 r3 r4])
     [r1 r2 r3 r4]))
 
+(defmethod get-value :border-style
+  [_ stroke _ _]
+  (when-not (cgc/svg-markup? stroke)
+    (get-stroke-data stroke)))
+
+(defmethod get-value :border-width
+  [_ stroke _ _]
+  (when-not (cgc/svg-markup? stroke)
+    (get-stroke-data stroke)))
+
 (defmethod get-value :box-shadow
   [_ shape _ _]
   (when-not (cgc/svg-markup? shape)


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/11154

### Summary

- Display more information about strokes (borders) under the `info` tab.
- Create a copy button at the section title that copies the full shorthand.

### Steps to reproduce 

- create an element with an stroke
- go to inspect tab → info tab
- check the stroke section → there is no border-width or border-style information, only the color. But when the property is copied, all the info is copied:   border: 2px solid [#2e3434FF](https://github.com/penpot/penpot/compare/project/penpot/t/2e3434FF);

> [!WARNING]
> Test also shapes with multiple strokes

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
