### PR TITLE
:recycle: Refactor dropdown-menu and make dropdown visibility exclusive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fix missing font when copy&paste a chunk of text [Taiga #11522](https://tree.taiga.io/project/penpot/issue/11522)
 - Fix bad swap slot after two swaps [Taiga #11659](https://tree.taiga.io/project/penpot/issue/11659)
 - Fix missing package for the penport_exporter Docker image [GitHub #7205](https://github.com/penpot/penpot/issues/7025)
+- Fix issue where multiple dropdown menus could be opened simultaneously on the dashboard page [Taiga #11500](https://tree.taiga.io/project/penpot/issue/11500)
 
 ## 2.9.0 (Unreleased)
 

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -164,7 +164,7 @@
       (-> state
           (dissoc :selected-files)
           (dissoc :selected-project)
-          (update :dashboard-local dissoc :menu-open :menu-pos)))))
+          (update :dashboard-local dissoc :menu-pos)))))
 
 (defn toggle-file-select
   [{:keys [id project-id] :as file}]
@@ -180,34 +180,33 @@
           state)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Show grid menu
+;; Handle dropdowns
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn show-file-menu-with-position
-  [file-id pos]
-  (ptk/reify ::show-file-menu-with-position
-    ptk/UpdateEvent
-    (update [_ state]
-      (update state :dashboard-local assoc
-              :menu-open true
-              :menu-pos pos
-              :file-id file-id))))
+(defn hide-dropdown
+  ([]
+   (ptk/reify ::hide-dropdown
+     ptk/UpdateEvent
+     (update [_ state]
+       (update state :dashboard-local assoc
+               :menu-open false
+               :menu-pos nil
+               :menu-id nil)))))
 
-(defn show-file-menu
-  []
-  (ptk/reify ::show-file-menu
-    ptk/UpdateEvent
-    (update [_ state]
-      (update state :dashboard-local
-              assoc :menu-open true))))
+(defn show-dropdown
+  ([dropdown-id] (show-dropdown dropdown-id nil))
+  ([dropdown-id pos]
+   (ptk/reify ::show-dropdown
+     ptk/UpdateEvent
+     (update [_ state]
+       (update state :dashboard-local assoc
+               :menu-open true
+               :menu-id dropdown-id
+               :menu-pos pos)))))
 
-(defn hide-file-menu
-  []
-  (ptk/reify ::hide-file-menu
-    ptk/UpdateEvent
-    (update [_ state]
-      (update state :dashboard-local
-              assoc :menu-open false))))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Show grid menu
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn start-edit-file-name
   [file-id]
@@ -216,7 +215,7 @@
     (update [_ state]
       (update state :dashboard-local
               assoc :edition true
-              :file-id file-id))))
+              :menu-id file-id))))
 
 (defn stop-edit-file-name
   []

--- a/frontend/src/app/main/data/dashboard.cljs
+++ b/frontend/src/app/main/data/dashboard.cljs
@@ -164,7 +164,7 @@
       (-> state
           (dissoc :selected-files)
           (dissoc :selected-project)
-          (update :dashboard-local dissoc :menu-pos)))))
+          (update :dashboard-local dissoc :menu-open :menu-pos)))))
 
 (defn toggle-file-select
   [{:keys [id project-id] :as file}]
@@ -180,33 +180,34 @@
           state)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Handle dropdowns
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn hide-dropdown
-  ([]
-   (ptk/reify ::hide-dropdown
-     ptk/UpdateEvent
-     (update [_ state]
-       (update state :dashboard-local assoc
-               :menu-open false
-               :menu-pos nil
-               :menu-id nil)))))
-
-(defn show-dropdown
-  ([dropdown-id] (show-dropdown dropdown-id nil))
-  ([dropdown-id pos]
-   (ptk/reify ::show-dropdown
-     ptk/UpdateEvent
-     (update [_ state]
-       (update state :dashboard-local assoc
-               :menu-open true
-               :menu-id dropdown-id
-               :menu-pos pos)))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Show grid menu
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn show-file-menu-with-position
+  [file-id pos]
+  (ptk/reify ::show-file-menu-with-position
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :dashboard-local assoc
+              :menu-open true
+              :menu-pos pos
+              :file-id file-id))))
+
+(defn show-file-menu
+  []
+  (ptk/reify ::show-file-menu
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :dashboard-local
+              assoc :menu-open true))))
+
+(defn hide-file-menu
+  []
+  (ptk/reify ::hide-file-menu
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :dashboard-local
+              assoc :menu-open false))))
 
 (defn start-edit-file-name
   [file-id]
@@ -215,7 +216,7 @@
     (update [_ state]
       (update state :dashboard-local
               assoc :edition true
-              :menu-id file-id))))
+              :file-id file-id))))
 
 (defn stop-edit-file-name
   []

--- a/frontend/src/app/main/ui/components/dropdown_menu.cljs
+++ b/frontend/src/app/main/ui/components/dropdown_menu.cljs
@@ -8,45 +8,43 @@
   (:require
    [app.common.data :as d]
    [app.config :as cfg]
+   [app.main.store :as st]
    [app.util.dom :as dom]
    [app.util.globals :as globals]
    [app.util.keyboard :as kbd]
-   [app.util.object :as obj]
+   [beicon.v2.core :as rx]
    [goog.events :as events]
-   [goog.object :as gobj]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf])
   (:import goog.events.EventType))
 
 (mf/defc dropdown-menu-item*
-  {::mf/wrap-props false}
-  [props]
-  (let [props (-> (obj/clone props)
-                  (obj/set! "role" "menuitem"))]
+  [{:keys [focuseable] :rest props}]
+  (let [tab-index (if focuseable "0" "-1")
+        props     (mf/spread-props props {:role "menuitem" :tab-index tab-index})]
     [:> :li props]))
 
-(mf/defc dropdown-menu'
-  {::mf/wrap-props false}
-  [props]
-  (let [children   (gobj/get props "children")
-        on-close   (gobj/get props "on-close")
-        ref        (gobj/get props "container")
-        ids        (gobj/get props "ids")
-        list-class (gobj/get props "list-class")
-        ids        (filter some? ids)
-        on-click
-        (fn [event]
-          (let [target (dom/get-target event)
+(mf/defc internal-dropdown-menu*
+  {::mf/private true}
+  [{:keys [on-close children class id]}]
 
-                ;; MacOS ctrl+click sends two events: context-menu and click.
-                ;; In order to not have two handlings we ignore ctrl+click for this platform
-                mac-ctrl-click? (and (cfg/check-platform? :macos) (kbd/ctrl? event))]
-            (when (and (not mac-ctrl-click?)
-                       (not (.-data-no-close ^js target)))
-              (if ref
-                (let [parent (mf/ref-val ref)]
-                  (when-not (or (not parent) (.contains parent target))
-                    (on-close)))
-                (on-close)))))
+  (assert (fn? on-close) "missing `on-close` prop")
+
+  (let [on-click
+        (mf/use-fn
+         (mf/deps on-close)
+         (fn [event]
+           (let [target (dom/get-target event)
+                 ;; MacOS ctrl+click sends two events: context-menu and click.
+                 ;; In order to not have two handlings we ignore ctrl+click for this platform
+                 mac-ctrl-click? (and (cfg/check-platform? :macos) (kbd/ctrl? event))]
+             (when (and (not mac-ctrl-click?)
+                        (not (.-data-no-close ^js target))
+                        (fn? on-close))
+               (on-close event)))))
+
+        container
+        (mf/use-ref)
 
         on-keyup
         (fn [event]
@@ -55,35 +53,52 @@
 
         on-key-down
         (fn [event]
-          (let [first-id (dom/get-element (first ids))
-                first-element (dom/get-element first-id)
-                len (count ids)]
+          (when-let [container (mf/ref-val container)]
+            (let [entries (vec (dom/query-all container "[role=menuitem]"))]
 
-            (when (kbd/home? event)
-              (when first-element
-                (dom/focus! first-element)))
+              (cond
+                (kbd/up-arrow? event)
+                (let [selected (dom/get-active)
+                      index    (d/index-of-pred entries #(identical? % selected))
+                      target   (if (nil? index)
+                                 (peek entries)
+                                 (or (get entries (dec index)) (peek entries)))]
 
-            (when (kbd/up-arrow? event)
-              (let [actual-selected (dom/get-active)
-                    actual-id (dom/get-attribute actual-selected "id")
-                    actual-index (d/index-of ids actual-id)
-                    previous-id (if (= 0 actual-index)
-                                  (last ids)
-                                  (get ids (- actual-index 1) (last ids)))]
-                (dom/focus! (dom/get-element previous-id))))
+                  (dom/focus! target))
 
-            (when (kbd/down-arrow? event)
-              (let [actual-selected (dom/get-active)
-                    actual-id (dom/get-attribute actual-selected "id")
-                    actual-index (d/index-of ids actual-id)
-                    next-id (if (= (- len 1) actual-index)
-                              (first ids)
-                              (get ids (+ 1 actual-index) (first ids)))
-                    node-item (dom/get-element next-id)]
-                (dom/focus! node-item)))
+                (kbd/down-arrow? event)
+                (let [selected (dom/get-active)
+                      index    (d/index-of-pred entries #(identical? % selected))
+                      target   (if (nil? index)
+                                 (first entries)
+                                 (or (get entries (inc index)) (first entries)))]
+                  (dom/focus! target))
 
-            (when (kbd/tab? event)
-              (on-close))))]
+                (kbd/enter? event)
+                (let [selected (dom/get-active)]
+                  (dom/prevent-default event)
+                  (dom/click! selected))
+
+                (kbd/tab? event)
+                (on-close)))))]
+
+    (mf/with-effect [id]
+      (when id
+        (st/emit! (ptk/data-event :dropdown/open {:id id}))))
+
+    (mf/with-effect [on-close id]
+      (when id
+        (let [stream (->> st/stream
+                          (rx/filter (ptk/type? :dropdown/open))
+                          (rx/map deref)
+                          (rx/filter #(not= id (:id %)))
+                          (rx/take 1))
+              subs   (rx/subs! (fn []
+                                 (prn "aaaa")
+                                 (on-close))
+                               stream)]
+          (fn []
+            (rx/dispose! subs)))))
 
     (mf/with-effect []
       (let [keys [(events/listen globals/document EventType.CLICK on-click)
@@ -93,24 +108,10 @@
         #(doseq [key keys]
            (events/unlistenByKey key))))
 
-    [:ul {:class list-class :role "menu"} children]))
+    [:ul {:class class :role "menu" :ref container} children]))
 
-(mf/defc dropdown-menu
-  {::mf/props :obj}
-  [props]
+(mf/defc dropdown-menu*
+  [{:keys [show] :as props}]
+  (when show
+    [:> internal-dropdown-menu* props]))
 
-  (assert (fn? (gobj/get props "on-close")) "missing `on-close` prop")
-  (assert (boolean? (gobj/get props "show")) "missing `show` prop")
-
-  (let [show        (gobj/get props "show")
-        ids         (obj/get props "ids")
-        ids         (or ids
-                        (->> (obj/get props "children")
-                             (keep (fn [o]
-                                     (let [props (obj/get o "props")]
-                                       (obj/get props "id"))))))]
-
-    (when show
-      (mf/element
-       dropdown-menu'
-       (mf/spread-props props {:ids ids})))))

--- a/frontend/src/app/main/ui/components/dropdown_menu.cljs
+++ b/frontend/src/app/main/ui/components/dropdown_menu.cljs
@@ -19,8 +19,9 @@
   (:import goog.events.EventType))
 
 (mf/defc dropdown-menu-item*
-  [{:keys [focuseable] :rest props}]
-  (let [tab-index (if focuseable "0" "-1")
+  [{:keys [can-focus] :rest props}]
+  (let [can-focus (d/nilv can-focus true)
+        tab-index (if can-focus "0" "-1")
         props     (mf/spread-props props {:role "menuitem" :tab-index tab-index})]
     [:> :li props]))
 
@@ -93,10 +94,7 @@
                           (rx/map deref)
                           (rx/filter #(not= id (:id %)))
                           (rx/take 1))
-              subs   (rx/subs! (fn []
-                                 (prn "aaaa")
-                                 (on-close))
-                               stream)]
+              subs   (rx/subs! on-close stream)]
           (fn []
             (rx/dispose! subs)))))
 

--- a/frontend/src/app/main/ui/components/dropdown_menu.cljs
+++ b/frontend/src/app/main/ui/components/dropdown_menu.cljs
@@ -98,16 +98,19 @@
 (mf/defc dropdown-menu
   {::mf/props :obj}
   [props]
+
   (assert (fn? (gobj/get props "on-close")) "missing `on-close` prop")
   (assert (boolean? (gobj/get props "show")) "missing `show` prop")
 
-  (let [ids (obj/get props "ids")
-        ids (or ids
-                (->> (obj/get props "children")
-                     (keep (fn [o]
-                             (let [props (obj/get o "props")]
-                               (obj/get props "id"))))))]
-    (when (gobj/get props "show")
+  (let [show        (gobj/get props "show")
+        ids         (obj/get props "ids")
+        ids         (or ids
+                        (->> (obj/get props "children")
+                             (keep (fn [o]
+                                     (let [props (obj/get o "props")]
+                                       (obj/get props "id"))))))]
+
+    (when show
       (mf/element
        dropdown-menu'
        (mf/spread-props props {:ids ids})))))

--- a/frontend/src/app/main/ui/components/dropdown_menu.cljs
+++ b/frontend/src/app/main/ui/components/dropdown_menu.cljs
@@ -42,7 +42,7 @@
              (when (and (not mac-ctrl-click?)
                         (not (.-data-no-close ^js target))
                         (fn? on-close))
-               (on-close event)))))
+               (on-close)))))
 
         container
         (mf/use-ref)
@@ -94,7 +94,7 @@
                           (rx/map deref)
                           (rx/filter #(not= id (:id %)))
                           (rx/take 1))
-              subs   (rx/subs! on-close stream)]
+              subs   (rx/subs! nil nil on-close stream)]
           (fn []
             (rx/dispose! subs)))))
 

--- a/frontend/src/app/main/ui/dashboard/comments.cljs
+++ b/frontend/src/app/main/ui/dashboard/comments.cljs
@@ -84,7 +84,7 @@
                                           ::ev/origin "dashboard"})))))
 
     [:div {:class (stl/css :dashboard-comments-section)}
-     [:& dropdown {:show show? :on-close on-hide-comments}
+     [:& dropdown {:show show? :on-close on-hide-comments :dropdown-id "dashboard-comments"}
       [:div {:class (stl/css :dropdown :comments-section :comment-threads-section)}
        [:div {:class (stl/css :header)}
         [:h3 {:class (stl/css :header-title)} (tr "dashboard.notifications")]

--- a/frontend/src/app/main/ui/dashboard/file_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/file_menu.cljs
@@ -211,7 +211,7 @@
                         (rx/map deref)
                         (rx/filter #(not= "file-menu" (:id %)))
                         (rx/take 1))
-            subs   (rx/subs! on-close stream)]
+            subs   (rx/subs! nil nil on-close stream)]
         (fn []
           (rx/dispose! subs))))
 

--- a/frontend/src/app/main/ui/dashboard/file_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/file_menu.cljs
@@ -55,12 +55,13 @@
           projects))
 
 (mf/defc file-menu*
-  [{:keys [files on-edit on-menu-close top left navigate origin parent-id can-edit]}]
+  [{:keys [files on-edit on-menu-close top left navigate origin parent-id can-edit show]}]
 
   (assert (seq files) "missing `files` prop")
   (assert (fn? on-edit) "missing `on-edit` prop")
   (assert (fn? on-menu-close) "missing `on-menu-close` prop")
   (assert (boolean? navigate) "missing `navigate` prop")
+  (assert (boolean? show) "missing `show` prop")
 
   (let [is-lib-page?     (= :libraries origin)
         is-search-page?  (= :search origin)

--- a/frontend/src/app/main/ui/dashboard/file_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/file_menu.cljs
@@ -21,6 +21,7 @@
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
    [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (defn- get-project-name
@@ -55,13 +56,12 @@
           projects))
 
 (mf/defc file-menu*
-  [{:keys [files on-edit on-menu-close top left navigate origin parent-id can-edit show]}]
+  [{:keys [files on-edit on-menu-close top left navigate origin parent-id can-edit]}]
 
   (assert (seq files) "missing `files` prop")
   (assert (fn? on-edit) "missing `on-edit` prop")
   (assert (fn? on-menu-close) "missing `on-menu-close` prop")
   (assert (boolean? navigate) "missing `navigate` prop")
-  (assert (boolean? show) "missing `show` prop")
 
   (let [is-lib-page?     (= :libraries origin)
         is-search-page?  (= :search origin)
@@ -209,6 +209,7 @@
          (partial on-export-files :legacy-zip))]
 
     (mf/with-effect []
+      (st/emit! (ptk/data-event :dropdown/open {:id "file-menu"}))
       (->> (rp/cmd! :get-all-projects)
            (rx/map group-by-team)
            (rx/subs! #(reset! teams* %))))

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -128,7 +128,7 @@
                            :left (- (:x (:menu-pos @local)) 180)
                            :top (:y (:menu-pos @local))
                            :on-edit on-edit
-                           :on-menu-close on-menu-close
+                           :on-close on-menu-close
                            :on-import on-import}])]]))
 
 (mf/defc files-section*

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -249,7 +249,7 @@
 
         menu-open?
         (and (get state :menu-open)
-             (= file-id (:menu-id state)))
+             (= file-id (:file-id state)))
 
         selected?
         (contains? selected-files file-id)
@@ -264,7 +264,7 @@
         (= origin :libraries)
 
         on-menu-close
-        (mf/use-fn #(st/emit! (dd/hide-dropdown)))
+        (mf/use-fn #(st/emit! (dd/hide-file-menu)))
 
         on-select
         (mf/use-fn
@@ -290,7 +290,7 @@
         (mf/use-fn
          (mf/deps selected? selected-num)
          (fn [event]
-           (st/emit! (dd/hide-dropdown))
+           (st/emit! (dd/hide-file-menu))
            (when can-edit
              (let [offset     (dom/get-offset-position (dom/event->native-event event))
                    item-el    (mf/ref-val node-ref)
@@ -336,7 +336,8 @@
                          x              (:left points)]
                      (gpt/point x y))
                    client-position)]
-             (st/emit! (dd/show-dropdown file-id position)))))
+
+             (st/emit! (dd/show-file-menu-with-position file-id position)))))
 
         on-context-menu
         (mf/use-fn
@@ -409,7 +410,7 @@
 
       [:div {:class (stl/css :info-wrapper)}
        [:div {:class (stl/css :item-info)}
-        (if (and (= file-id (:menu-id state)) (:edition state))
+        (if (and (= file-id (:file-id state)) (:edition state))
           [:& inline-edition {:content (:name file)
                               :on-end edit
                               :max-length 250}]
@@ -440,8 +441,7 @@
                             :on-edit on-edit
                             :on-menu-close on-menu-close
                             :origin origin
-                            :parent-id (dm/str file-id "-action-menu")
-                            :show (and selected? menu-open?)}]])]]]]]))
+                            :parent-id (dm/str file-id "-action-menu")}]])]]]]]))
 
 (mf/defc grid*
   {::mf/props :obj}
@@ -464,7 +464,7 @@
         (use-import-file project-id on-finish-import)
 
         on-scroll
-        (mf/use-fn #(st/emit! (dd/hide-dropdown)))
+        (mf/use-fn #(st/emit! (dd/hide-file-menu)))
 
         on-drag-enter
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -439,7 +439,7 @@
                             :can-edit can-edit
                             :navigate true
                             :on-edit on-edit
-                            :on-menu-close on-menu-close
+                            :on-close on-menu-close
                             :origin origin
                             :parent-id (dm/str file-id "-action-menu")}]])]]]]]))
 

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -249,7 +249,7 @@
 
         menu-open?
         (and (get state :menu-open)
-             (= file-id (:file-id state)))
+             (= file-id (:menu-id state)))
 
         selected?
         (contains? selected-files file-id)
@@ -264,7 +264,7 @@
         (= origin :libraries)
 
         on-menu-close
-        (mf/use-fn #(st/emit! (dd/hide-file-menu)))
+        (mf/use-fn #(st/emit! (dd/hide-dropdown)))
 
         on-select
         (mf/use-fn
@@ -290,7 +290,7 @@
         (mf/use-fn
          (mf/deps selected? selected-num)
          (fn [event]
-           (st/emit! (dd/hide-file-menu))
+           (st/emit! (dd/hide-dropdown))
            (when can-edit
              (let [offset     (dom/get-offset-position (dom/event->native-event event))
                    item-el    (mf/ref-val node-ref)
@@ -336,8 +336,7 @@
                          x              (:left points)]
                      (gpt/point x y))
                    client-position)]
-
-             (st/emit! (dd/show-file-menu-with-position file-id position)))))
+             (st/emit! (dd/show-dropdown file-id position)))))
 
         on-context-menu
         (mf/use-fn
@@ -410,7 +409,7 @@
 
       [:div {:class (stl/css :info-wrapper)}
        [:div {:class (stl/css :item-info)}
-        (if (and (= file-id (:file-id state)) (:edition state))
+        (if (and (= file-id (:menu-id state)) (:edition state))
           [:& inline-edition {:content (:name file)
                               :on-end edit
                               :max-length 250}]
@@ -441,7 +440,8 @@
                             :on-edit on-edit
                             :on-menu-close on-menu-close
                             :origin origin
-                            :parent-id (dm/str file-id "-action-menu")}]])]]]]]))
+                            :parent-id (dm/str file-id "-action-menu")
+                            :show (and selected? menu-open?)}]])]]]]]))
 
 (mf/defc grid*
   {::mf/props :obj}
@@ -464,7 +464,7 @@
         (use-import-file project-id on-finish-import)
 
         on-scroll
-        (mf/use-fn #(st/emit! (dd/hide-file-menu)))
+        (mf/use-fn #(st/emit! (dd/hide-dropdown)))
 
         on-drag-enter
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/project_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/project_menu.cljs
@@ -117,15 +117,16 @@
             :handler on-delete})]]
 
     (mf/with-effect [show on-close]
-      (st/emit! (ptk/data-event :dropdown/open {:id "project-menu"}))
-      (let [stream (->> st/stream
-                        (rx/filter (ptk/type? :dropdown/open))
-                        (rx/map deref)
-                        (rx/filter #(not= "project-menu" (:id %)))
-                        (rx/take 1))
-            subs   (rx/subs! on-close stream)]
-        (fn []
-          (rx/dispose! subs))))
+      (when ^boolean show
+        (st/emit! (ptk/data-event :dropdown/open {:id "project-menu"}))
+        (let [stream (->> st/stream
+                          (rx/filter (ptk/type? :dropdown/open))
+                          (rx/map deref)
+                          (rx/filter #(not= "project-menu" (:id %)))
+                          (rx/take 1))
+              subs   (rx/subs! on-close stream)]
+          (fn []
+            (rx/dispose! subs)))))
 
     [:*
      [:> context-menu*

--- a/frontend/src/app/main/ui/dashboard/project_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/project_menu.cljs
@@ -124,7 +124,7 @@
                           (rx/map deref)
                           (rx/filter #(not= "project-menu" (:id %)))
                           (rx/take 1))
-              subs   (rx/subs! on-close stream)]
+              subs   (rx/subs! nil nil on-close stream)]
           (fn []
             (rx/dispose! subs)))))
 

--- a/frontend/src/app/main/ui/dashboard/project_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/project_menu.cljs
@@ -17,11 +17,12 @@
    [app.main.ui.dashboard.import :as udi]
    [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
+   [beicon.v2.core :as rx]
+   [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
 
 (mf/defc project-menu*
-  {::mf/props :obj}
-  [{:keys [project show on-edit on-menu-close top left on-import]}]
+  [{:keys [project show on-edit on-close top left on-import]}]
   (let [top  (or top 0)
         left (or left 0)
 
@@ -42,7 +43,8 @@
                      (with-meta project {:on-success on-duplicate-success}))))
 
         toggle-pin
-        #(st/emit! (dd/toggle-project-pin project))
+        (fn []
+          (st/emit! (dd/toggle-project-pin project)))
 
         on-move-success
         (fn [team-id]
@@ -63,25 +65,23 @@
                       (dcm/go-to-dashboard-recent :team-id team-id))))
 
         on-delete
-        #(st/emit!
-          (modal/show
-           {:type :confirm
-            :title (tr "modals.delete-project-confirm.title")
-            :message (tr "modals.delete-project-confirm.message")
-            :accept-label (tr "modals.delete-project-confirm.accept")
-            :on-accept delete-fn}))
+        (fn []
+          (st/emit!
+           (modal/show {:type :confirm
+                        :title (tr "modals.delete-project-confirm.title")
+                        :message (tr "modals.delete-project-confirm.message")
+                        :accept-label (tr "modals.delete-project-confirm.accept")
+                        :on-accept delete-fn})))
 
-        file-input (mf/use-ref nil)
+        file-input
+        (mf/use-ref nil)
 
         on-import-files
-        (mf/use-callback
-         (fn []
-           (dom/click (mf/ref-val file-input))))
+        (fn [] (dom/click! (mf/ref-val file-input)))
 
         on-finish-import
-        (mf/use-callback
-         (fn []
-           (when (fn? on-import) (on-import))))
+        (mf/use-fn
+         (fn [] (when (fn? on-import) (on-import))))
 
         options
         [(when-not (:is-default project)
@@ -116,9 +116,20 @@
             :id      "project-delete"
             :handler on-delete})]]
 
+    (mf/with-effect [show on-close]
+      (st/emit! (ptk/data-event :dropdown/open {:id "project-menu"}))
+      (let [stream (->> st/stream
+                        (rx/filter (ptk/type? :dropdown/open))
+                        (rx/map deref)
+                        (rx/filter #(not= "project-menu" (:id %)))
+                        (rx/take 1))
+            subs   (rx/subs! on-close stream)]
+        (fn []
+          (rx/dispose! subs))))
+
     [:*
      [:> context-menu*
-      {:on-close on-menu-close
+      {:on-close on-close
        :show show
        :fixed (or (not= top 0) (not= left 0))
        :min-width true

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -114,10 +114,8 @@
         dstate     (mf/deref refs/dashboard-local)
         edit-id    (:project-for-edit dstate)
 
-        show-menu? (boolean (and (:menu-open dstate)
-                                 (= (:menu-id dstate) "dropdown-project-menu")))
-
-        local      (mf/use-state {:menu-pos nil
+        local      (mf/use-state {:menu-open false
+                                  :menu-pos nil
                                   :edition (= (:id project) edit-id)})
 
         [rowref limit]
@@ -149,14 +147,12 @@
                                   x              (:left points)]
                               (gpt/point x y))
                             client-position)]
-             (st/emit! (dd/show-dropdown "dropdown-project-menu"))
              (swap! local assoc
+                    :menu-open true
                     :menu-pos position))))
 
         on-menu-close
-        (mf/use-fn
-         (fn [_]
-           (st/emit! (dd/hide-dropdown))))
+        (mf/use-fn #(swap! local assoc :menu-open false))
 
         on-edit-open
         (mf/use-fn #(swap! local assoc :edition true))
@@ -271,7 +267,7 @@
         (when ^boolean can-edit
           [:> project-menu*
            {:project project
-            :show show-menu?
+            :show (:menu-open @local)
             :left (+ 24 (:x (:menu-pos @local)))
             :top (:y (:menu-pos @local))
             :on-edit on-edit-open

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -271,7 +271,7 @@
             :left (+ 24 (:x (:menu-pos @local)))
             :top (:y (:menu-pos @local))
             :on-edit on-edit-open
-            :on-menu-close on-menu-close
+            :on-close on-menu-close
             :on-import on-import}])]]]
 
      [:div {:class (stl/css :grid-container) :ref rowref}

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -114,8 +114,10 @@
         dstate     (mf/deref refs/dashboard-local)
         edit-id    (:project-for-edit dstate)
 
-        local      (mf/use-state {:menu-open false
-                                  :menu-pos nil
+        show-menu? (boolean (and (:menu-open dstate)
+                                 (= (:menu-id dstate) "dropdown-project-menu")))
+
+        local      (mf/use-state {:menu-pos nil
                                   :edition (= (:id project) edit-id)})
 
         [rowref limit]
@@ -147,12 +149,14 @@
                                   x              (:left points)]
                               (gpt/point x y))
                             client-position)]
+             (st/emit! (dd/show-dropdown "dropdown-project-menu"))
              (swap! local assoc
-                    :menu-open true
                     :menu-pos position))))
 
         on-menu-close
-        (mf/use-fn #(swap! local assoc :menu-open false))
+        (mf/use-fn
+         (fn [_]
+           (st/emit! (dd/hide-dropdown))))
 
         on-edit-open
         (mf/use-fn #(swap! local assoc :edition true))
@@ -267,7 +271,7 @@
         (when ^boolean can-edit
           [:> project-menu*
            {:project project
-            :show (:menu-open @local)
+            :show show-menu?
             :left (+ 24 (:x (:menu-pos @local)))
             :top (:y (:menu-pos @local))
             :on-edit on-edit-open

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -192,7 +192,7 @@
                         :left (:x (:menu-pos local))
                         :top (:y (:menu-pos local))
                         :on-edit on-edit-open
-                        :on-menu-close on-menu-close}]]))
+                        :on-close on-menu-close}]]))
 
 (mf/defc sidebar-search
   [{:keys [search-term team-id] :as props}]
@@ -275,9 +275,7 @@
   {::mf/wrap-props false}
   [{:keys [team profile teams] :rest props}]
   (let [on-create-click
-        (mf/use-fn #(do
-                      (prn "QQQQ")
-                      (st/emit! (modal/show :team-form {}))))
+        (mf/use-fn #(st/emit! (modal/show :team-form {})))
 
         on-team-click
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -800,9 +800,7 @@
              (reset! show-profile-menu* true))))
 
         on-close
-        (fn [event]
-          (dom/stop-propagation event)
-          (reset! show-profile-menu* false))
+        (mf/use-fn #(reset! show-profile-menu* false))
 
         handle-click-url
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -8,7 +8,6 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data.macros :as dm]
-   [app.common.spec :as us]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.main.data.auth :as da]
@@ -21,7 +20,7 @@
    [app.main.refs :as refs]
    [app.main.router :as rt]
    [app.main.store :as st]
-   [app.main.ui.components.dropdown-menu :refer [dropdown-menu
+   [app.main.ui.components.dropdown-menu :refer [dropdown-menu*
                                                  dropdown-menu-item*]]
    [app.main.ui.components.link :refer [link]]
    [app.main.ui.dashboard.comments :refer [comments-icon* comments-section]]
@@ -37,7 +36,6 @@
    [app.util.object :as obj]
    [app.util.timers :as ts]
    [beicon.v2.core :as rx]
-   [cljs.spec.alpha :as s]
    [cuerdas.core :as str]
    [goog.functions :as f]
    [potok.v2.core :as ptk]
@@ -273,47 +271,26 @@
                  :on-click on-clear-click}
         search-icon])]))
 
-(mf/defc teams-selector-dropdown-items
+(mf/defc teams-selector-dropdown*
   {::mf/wrap-props false}
-  [{:keys [team profile teams] :as props}]
-  (let [on-create-clicked
-        (mf/use-fn
-         #(st/emit! (modal/show :team-form {})))
+  [{:keys [team profile teams] :rest props}]
+  (let [on-create-click
+        (mf/use-fn #(do
+                      (prn "QQQQ")
+                      (st/emit! (modal/show :team-form {}))))
 
-        team-selected
+        on-team-click
         (mf/use-fn
          (fn [event]
            (let [team-id (-> (dom/get-current-target event)
                              (dom/get-data "value")
                              (uuid/parse))]
-             (st/emit! (dcm/go-to-dashboard-recent :team-id team-id)))))
+             (st/emit! (dcm/go-to-dashboard-recent :team-id team-id)))))]
 
-        handle-select-default
-        (mf/use-fn
-         (mf/deps profile team-selected)
-         (fn [event]
-           (when (kbd/enter? event)
-             (team-selected (:default-team-id profile) event))))
+    [:> dropdown-menu* props
 
-        handle-select-team
-        (mf/use-fn
-         (mf/deps team-selected)
-         (fn [event]
-           (when (kbd/enter? event)
-             (team-selected event))))
-
-        handle-creation-key-down
-        (mf/use-fn
-         (mf/deps on-create-clicked)
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-create-clicked event))))]
-
-    [:*
-     [:> dropdown-menu-item* {:on-click    team-selected
+     [:> dropdown-menu-item* {:on-click    on-team-click
                               :data-value  (:default-team-id profile)
-                              :on-key-down handle-select-default
-                              :id          "teams-selector-default-team"
                               :class       (stl/css :team-dropdown-item)}
       [:span {:class (stl/css :penpot-icon)} i/logo-icon]
 
@@ -322,12 +299,10 @@
         tick-icon)]
 
      (for [team-item (remove :is-default (vals teams))]
-       [:> dropdown-menu-item* {:on-click    team-selected
+       [:> dropdown-menu-item* {:on-click    on-team-click
                                 :data-value  (:id team-item)
-                                :on-key-down handle-select-team
-                                :id          (str "teams-selector-" (:id team-item))
                                 :class       (stl/css :team-dropdown-item)
-                                :key         (str "teams-selector-" (:id team-item))}
+                                :key         (str (:id team-item))}
         [:img {:src (cf/resolve-team-photo-url team-item)
                :class (stl/css :team-picture)
                :alt (:name team-item)}]
@@ -342,21 +317,14 @@
         (when (= (:id team-item) (:id team))
           tick-icon)])
 
-     [:hr {:role "separator"
-           :class (stl/css :team-separator)}]
-     [:> dropdown-menu-item* {:on-click    on-create-clicked
-                              :on-key-down handle-creation-key-down
-                              :id          "teams-selector-create-team"
+     [:hr {:role "separator" :class (stl/css :team-separator)}]
+     [:> dropdown-menu-item* {:on-click    on-create-click
                               :class       (stl/css :team-dropdown-item :action)}
       [:span {:class (stl/css :icon-wrapper)} add-icon]
       [:span {:class (stl/css :team-text)} (tr "dashboard.create-new-team")]]]))
 
-(s/def ::member-id ::us/uuid)
-(s/def ::leave-modal-form
-  (s/keys :req-un [::member-id]))
-
-(mf/defc team-options-dropdown
-  [{:keys [team profile] :as props}]
+(mf/defc team-options-dropdown*
+  [{:keys [team profile] :rest props}]
   (let [go-members     #(st/emit! (dcm/go-to-dashboard-members))
         go-invitations #(st/emit! (dcm/go-to-dashboard-invitations))
         go-webhooks    #(st/emit! (dcm/go-to-dashboard-webhooks))
@@ -449,225 +417,125 @@
              :title (tr "modals.delete-team-confirm.title")
              :message (tr "modals.delete-team-confirm.message")
              :accept-label (tr "modals.delete-team-confirm.accept")
-             :on-accept delete-fn})))
+             :on-accept delete-fn})))]
+    [:> dropdown-menu* props
 
-        handle-members
-        (mf/use-fn
-         (mf/deps go-members)
-         (fn [event]
-           (when (kbd/enter? event)
-             (go-members))))
-
-        handle-invitations
-        (mf/use-fn
-         (mf/deps go-invitations)
-         (fn [event]
-           (when (kbd/enter? event)
-             (go-invitations))))
-
-        handle-webhooks
-        (mf/use-fn
-         (mf/deps go-webhooks)
-         (fn [event]
-           (when (kbd/enter? event)
-             (go-webhooks))))
-
-        handle-settings
-        (mf/use-fn
-         (mf/deps go-settings)
-         (fn [event]
-           (when (kbd/enter? event)
-             (go-settings))))
-
-
-        handle-rename
-        (mf/use-fn
-         (mf/deps on-rename-clicked)
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-rename-clicked))))
-
-
-        handle-leave-and-close
-        (mf/use-fn
-         (mf/deps leave-and-close)
-         (fn [event]
-           (when (kbd/enter? event)
-             (leave-and-close))))
-
-        handle-leave-as-owner-clicked
-        (mf/use-fn
-         (mf/deps on-leave-as-owner-clicked)
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-leave-as-owner-clicked))))
-
-
-        handle-on-leave-clicked
-        (mf/use-fn
-         (mf/deps on-leave-clicked)
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-leave-clicked))))
-
-        handle-on-delete-clicked
-        (mf/use-fn
-         (mf/deps on-delete-clicked)
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-delete-clicked))))]
-
-    [:*
      [:> dropdown-menu-item* {:on-click    go-members
-                              :on-key-down handle-members
-                              :className   (stl/css :team-options-item)
-                              :id          "teams-options-members"
-                              :data-testid   "team-members"}
+                              :class       (stl/css :team-options-item)
+                              :data-testid "team-members"}
       (tr "labels.members")]
      [:> dropdown-menu-item* {:on-click    go-invitations
-                              :on-key-down handle-invitations
-                              :className   (stl/css :team-options-item)
-                              :id          "teams-options-invitations"
-                              :data-testid   "team-invitations"}
+                              :class       (stl/css :team-options-item)
+                              :data-testid "team-invitations"}
       (tr "labels.invitations")]
 
      (when (contains? cf/flags :webhooks)
-       [:> dropdown-menu-item* {:on-click    go-webhooks
-                                :on-key-down handle-webhooks
-                                :className   (stl/css :team-options-item)
-                                :id          "teams-options-webhooks"}
+       [:> dropdown-menu-item* {:on-click go-webhooks
+                                :class    (stl/css :team-options-item)}
         (tr "labels.webhooks")])
 
      [:> dropdown-menu-item* {:on-click    go-settings
-                              :on-key-down handle-settings
-                              :className   (stl/css :team-options-item)
-                              :id          "teams-options-settings"
-                              :data-testid   "team-settings"}
+                              :class       (stl/css :team-options-item)
+                              :data-testid "team-settings"}
       (tr "labels.settings")]
 
      [:hr {:class (stl/css :team-option-separator)}]
      (when can-rename?
        [:> dropdown-menu-item* {:on-click    on-rename-clicked
-                                :on-key-down handle-rename
-                                :id          "teams-options-rename"
-                                :className   (stl/css :team-options-item)
-                                :data-testid   "rename-team"}
+                                :class       (stl/css :team-options-item)
+                                :data-testid "rename-team"}
         (tr "labels.rename")])
 
      (cond
        (= (count members) 1)
-       [:> dropdown-menu-item* {:on-click    leave-and-close
-                                :on-key-down handle-leave-and-close
-                                :className   (stl/css :team-options-item)
-                                :id          "teams-options-leave-team"}
+       [:> dropdown-menu-item* {:on-click leave-and-close
+                                :class    (stl/css :team-options-item)}
         (tr "dashboard.leave-team")]
 
 
        (get-in team [:permissions :is-owner])
        [:> dropdown-menu-item* {:on-click    on-leave-as-owner-clicked
-                                :on-key-down handle-leave-as-owner-clicked
-                                :id          "teams-options-leave-team"
-                                :className   (stl/css :team-options-item)
-                                :data-testid   "leave-team"}
+                                :class       (stl/css :team-options-item)
+                                :data-testid  "leave-team"}
         (tr "dashboard.leave-team")]
 
        (> (count members) 1)
-       [:> dropdown-menu-item* {:on-click    on-leave-clicked
-                                :on-key-down handle-on-leave-clicked
-                                :className   (stl/css :team-options-item)
-                                :id          "teams-options-leave-team"}
+       [:> dropdown-menu-item* {:on-click on-leave-clicked
+                                :class    (stl/css :team-options-item)}
         (tr "dashboard.leave-team")])
 
      (when (get-in team [:permissions :is-owner])
        [:> dropdown-menu-item* {:on-click    on-delete-clicked
-                                :on-key-down handle-on-delete-clicked
-                                :id          "teams-options-delete-team"
-                                :className   (stl/css :team-options-item :warning)
-                                :data-testid   "delete-team"}
+                                :class       (stl/css :team-options-item :warning)
+                                :data-testid "delete-team"}
         (tr "dashboard.delete-team")])]))
 
 (mf/defc sidebar-team-switch
   [{:keys [team profile] :as props}]
-  (let [teams                 (mf/deref refs/teams)
-        teams-without-default (into {} (filter (fn [[_ v]] (= false (:is-default v))) teams))
-        team-ids              (map #(str "teams-selector-" %) (keys teams-without-default))
-        ids                   (concat ["teams-selector-default-team"] team-ids ["teams-selector-create-team"])
-        state                 (mf/deref refs/dashboard-local)
+  (let [teams (mf/deref refs/teams)
 
-        show-team-opts-ddwn?
-        (boolean (and (get state :menu-open)
-                      (= "dropdown-team-opts-menu" (:menu-id state))))
+        subscription
+        (get team :subscription)
 
-        show-teams-ddwn?
-        (boolean (and (get state :menu-open)
-                      (= "dropdown-teams-menu" (:menu-id state))))
+        subscription-type
+        (get-subscription-type subscription)
 
-        can-rename?           (or (get-in team [:permissions :is-owner]) (get-in team [:permissions :is-admin]))
-        options-ids           ["teams-options-members"
-                               "teams-options-invitations"
-                               (when (contains? cf/flags :webhooks)
-                                 "teams-options-webhooks")
-                               "teams-options-settings"
-                               (when can-rename?
-                                 "teams-options-rename")
-                               "teams-options-leave-team"
-                               (when (get-in team [:permissions :is-owner])
-                                 "teams-options-delete-team")]
+        show-team-options-menu*
+        (mf/use-state false)
 
+        show-team-options-menu?
+        (deref show-team-options-menu*)
 
-        ;; _ (prn "--------------- sidebar-team-switch")
-        ;; _ (app.common.pprint/pprint teams)
+        show-teams-menu*
+        (mf/use-state false)
 
-        handle-show-team-click
-        (fn [event]
-          (dom/stop-propagation event)
-          (st/emit! (dd/show-dropdown "dropdown-teams-menu")))
+        show-teams-menu?
+        (deref show-teams-menu*)
 
-        handle-show-team-keydown
-        (fn [event]
-          (when (or (kbd/space? event) (kbd/enter? event))
-            (dom/prevent-default event)
-            (st/emit! (dd/show-dropdown "dropdown-teams-menu")))
-          (ts/schedule-on-idle
-           (fn []
-             (let [first-element (dom/get-element (first ids))]
-               (when first-element
-                 (dom/focus! first-element))))))
+        on-show-teams-click
+        (mf/use-fn
+         (fn [event]
+           (dom/stop-propagation event)
+           (swap! show-teams-menu* not)))
 
-        handle-close-team
-        (fn [event]
-          (dom/stop-propagation event)
-          (st/emit! (dd/hide-dropdown)))
+        on-show-teams-keydown
+        (mf/use-fn
+         (fn [event]
+           (when (or (kbd/space? event)
+                     (kbd/enter? event))
+             (dom/prevent-default event)
+             (dom/stop-propagation event)
+             (some-> (dom/get-current-target event)
+                     (dom/click!)))))
 
-        handle-show-opts-click
-        (fn [event]
-          (dom/stop-propagation event)
-          (st/emit! (dd/show-dropdown "dropdown-team-opts-menu")))
+        close-team-options-menu
+        (mf/use-fn #(reset! show-team-options-menu* false))
 
-        handle-show-opts-keydown
-        (fn [event]
-          (when (or (kbd/space? event) (kbd/enter? event))
-            (dom/prevent-default event)
-            (st/emit! (dd/show-dropdown "dropdown-team-opts-menu"))
-            (ts/schedule-on-idle
-             (fn []
-               (let [first-element (dom/get-element (first options-ids))]
-                 (when first-element
-                   (dom/focus! first-element)))))))
+        on-show-options-click
+        (mf/use-fn
+         (fn [event]
+           (dom/stop-propagation event)
+           (swap! show-team-options-menu* not)))
 
-        close-team-opts-ddwn
-        (fn [event]
-          (dom/stop-propagation event)
-          (st/emit! (dd/hide-dropdown)))
+        on-show-options-keydown
+        (mf/use-fn
+         (fn [event]
+           (when (or (kbd/space? event)
+                     (kbd/enter? event))
+             (dom/prevent-default event)
+             (dom/stop-propagation event)
 
-        subscription          (:subscription team)
-        subscription-type     (get-subscription-type subscription)]
+             (some-> (dom/get-current-target event)
+                     (dom/click!)))))
+
+        close-teams-menu
+        (mf/use-fn #(reset! show-teams-menu* false))]
 
     [:div {:class (stl/css :sidebar-team-switch)}
      [:div {:class (stl/css :switch-content)}
       [:button {:class (stl/css :current-team)
-                :on-click handle-show-team-click
-                :on-key-down handle-show-team-keydown}
+                :on-click on-show-teams-click
+                :on-key-down on-show-teams-keydown}
        (cond
          (:is-default team)
          [:div {:class (stl/css :team-name)}
@@ -698,31 +566,28 @@
 
       (when-not (:is-default team)
         [:button {:class (stl/css :switch-options)
-                  :on-click handle-show-opts-click
+                  :on-click on-show-options-click
                   :aria-label "team-management"
                   :tab-index "0"
-                  :on-key-down handle-show-opts-keydown}
+                  :on-key-down on-show-options-keydown}
          menu-icon])]
 
      ;; Teams Dropdown
 
-     [:& dropdown-menu {:show show-teams-ddwn?
-                        :on-close handle-close-team
-                        :ids ids
-                        :dropdown-id "sidebar-teams-dropdown"
-                        :list-class (stl/css :dropdown :teams-dropdown)}
-      [:& teams-selector-dropdown-items {:ids ids
-                                         :team team
-                                         :profile profile
-                                         :teams teams}]]
+     [:> teams-selector-dropdown* {:show show-teams-menu?
+                                   :on-close close-teams-menu
+                                   :id "team-list"
+                                   :class (stl/css :dropdown :teams-dropdown)
+                                   :team team
+                                   :profile profile
+                                   :teams teams}]
 
-     [:& dropdown-menu {:show show-team-opts-ddwn?
-                        :on-close close-team-opts-ddwn
-                        :ids options-ids
-                        :dropdown-id "sidebar-team-options-dropdown"
-                        :list-class (stl/css :dropdown :options-dropdown)}
-      [:& team-options-dropdown {:team team
-                                 :profile profile}]]]))
+     [:> team-options-dropdown* {:show show-team-options-menu?
+                                 :on-close close-team-options-menu
+                                 :id "team-options"
+                                 :class (stl/css :dropdown :options-dropdown)
+                                 :team team
+                                 :profile profile}]]))
 
 (mf/defc sidebar-content*
   {::mf/private true
@@ -815,7 +680,7 @@
     (mf/use-layout-effect
      (mf/deps pinned-projects)
      (fn []
-       (let [dom   (mf/ref-val container)
+       (let [dom           (mf/ref-val container)
              client-height (obj/get dom "clientHeight")
              scroll-height (obj/get dom "scrollHeight")]
          (reset! overflow* (> scroll-height client-height)))))
@@ -887,23 +752,20 @@
 (mf/defc profile-section*
   {::mf/props :obj}
   [{:keys [profile team]}]
-  (let [;; show*  (mf/use-state false)
-        ;; show   (deref show*)
-        state    (mf/deref refs/dashboard-local)
+  (let [show-profile-menu* (mf/use-state false)
+        show-profile-menu? (deref show-profile-menu*)
 
-        show?
-        (boolean (and (get state :menu-open)
-                      (= "profile-section" (:menu-id state))))
-
-        photo  (cf/resolve-profile-photo-url profile)
+        photo
+        (cf/resolve-profile-photo-url profile)
 
         on-click
-        (fn [section event]
-          (dom/stop-propagation event)
-          (st/emit! (dd/hide-dropdown))
-          (if (keyword? section)
-            (st/emit! (rt/nav section))
-            (st/emit! section)))
+        (mf/use-fn
+         (fn [section event]
+           (dom/stop-propagation event)
+           (reset! show-profile-menu* false)
+           (if (keyword? section)
+             (st/emit! (rt/nav section))
+             (st/emit! section))))
 
         show-release-notes
         (mf/use-fn
@@ -931,24 +793,18 @@
         (mf/use-fn
          (fn [event]
            (dom/stop-propagation event)
-           (when-not show?
-             (st/emit! (dd/show-dropdown "profile-section")))))
+           (swap! show-profile-menu* not)))
 
         handle-key-down
-        (fn [event]
-          (when (kbd/enter? event)
-            (st/emit! (dd/show-dropdown "profile-section"))))
+        (mf/use-fn
+         (fn [event]
+           (when (kbd/enter? event)
+             (reset! show-profile-menu* true))))
 
         on-close
         (fn [event]
           (dom/stop-propagation event)
-          (st/emit! (dd/hide-dropdown)))
-
-        handle-key-down-profile
-        (mf/use-fn
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-click :settings-profile event))))
+          (reset! show-profile-menu* false))
 
         handle-click-url
         (mf/use-fn
@@ -957,39 +813,12 @@
                          (dom/get-data "url"))]
              (dom/open-new-window url))))
 
-        handle-keydown-url
-        (mf/use-fn
-         (fn [event]
-           (let [url (-> (dom/get-current-target event)
-                         (dom/get-data "url"))]
-             (when (kbd/enter? event)
-               (dom/open-new-window url)))))
-
-        handle-show-release-notes
-        (mf/use-fn
-         (mf/deps show-release-notes)
-         (fn [event]
-           (when (kbd/enter? event)
-             (show-release-notes))))
-
         handle-feedback-click
         (mf/use-fn #(on-click :settings-feedback %))
-
-        handle-feedback-keydown
-        (mf/use-fn
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-click :settings-feedback event))))
 
         handle-logout-click
         (mf/use-fn
          #(on-click (da/logout) %))
-
-        handle-logout-keydown
-        (mf/use-fn
-         (fn [event]
-           (when (kbd/enter? event)
-             (on-click (da/logout) event))))
 
         handle-set-profile
         (mf/use-fn
@@ -1011,7 +840,8 @@
                  :on-click on-power-up-click}
         [:div {:class (stl/css :penpot-free)}
          [:span (tr "dashboard.upgrade-plan.penpot-free")]
-         [:span {:class (stl/css :no-limits)} (tr "dashboard.upgrade-plan.no-limits")]]
+         [:span {:class (stl/css :no-limits)}
+          (tr "dashboard.upgrade-plan.no-limits")]]
         [:div {:class (stl/css :power-up)}
          (tr "subscription.dashboard.upgrade-plan.power-up")]])
 
@@ -1034,86 +864,67 @@
               :alt (:fullname profile)}]
        [:span {:class (stl/css :profile-fullname)} (:fullname profile)]]
 
-      [:& dropdown-menu {:on-close on-close
-                         :show show?
-                         :dropdown-id "profile-section"
-                         :list-class (stl/css :profile-dropdown)}
-       [:li {:tab-index (if show? "0" "-1")
-             :class (stl/css :profile-dropdown-item)
-             :on-click handle-set-profile
-             :on-key-down handle-key-down-profile
-             :data-testid "profile-profile-opt"}
+      [:> dropdown-menu* {:on-close on-close
+                          :show show-profile-menu?
+                          :id "profile-menu"
+                          :class (stl/css :profile-dropdown)}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                :on-click handle-set-profile
+                                :data-testid "profile-profile-opt"}
         (tr "labels.your-account")]
 
        [:li {:class (stl/css :profile-separator)}]
 
-       [:li {:class (stl/css :profile-dropdown-item)
-             :tab-index (if show? "0" "-1")
-             :data-url "https://help.penpot.app"
-             :on-click handle-click-url
-             :on-key-down handle-keydown-url
-             :data-testid "help-center-profile-opt"}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                :data-url "https://help.penpot.app"
+                                :on-click handle-click-url
+                                :data-testid "help-center-profile-opt"}
         (tr "labels.help-center")]
 
-       [:li {:tab-index (if show? "0" "-1")
-             :class (stl/css :profile-dropdown-item)
-             :data-url "https://community.penpot.app"
-             :on-click handle-click-url
-             :on-key-down handle-keydown-url}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                :data-url "https://community.penpot.app"
+                                :on-click handle-click-url}
         (tr "labels.community")]
 
-       [:li {:tab-index (if show? "0" "-1")
-             :class (stl/css :profile-dropdown-item)
-             :data-url "https://www.youtube.com/c/Penpot"
-             :on-click handle-click-url
-             :on-key-down handle-keydown-url}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                :data-url "https://www.youtube.com/c/Penpot"
+                                :on-click handle-click-url}
         (tr "labels.tutorials")]
 
-       [:li {:tab-index (if show? "0" "-1")
-             :class (stl/css :profile-dropdown-item)
-             :on-click show-release-notes
-             :on-key-down handle-show-release-notes}
+       [:> dropdown-menu-item* {:tab-index "0"
+                                :class (stl/css :profile-dropdown-item)
+                                :on-click show-release-notes}
         (tr "labels.release-notes")]
 
        [:li {:class (stl/css :profile-separator)}]
 
-       [:li {:class     (stl/css :profile-dropdown-item)
-             :tab-index (if show? "0" "-1")
-             :data-url "https://penpot.app/libraries-templates"
-             :on-click handle-click-url
-             :on-key-down handle-keydown-url
-             :data-testid "libraries-templates-profile-opt"}
+       [:> dropdown-menu-item* {:class     (stl/css :profile-dropdown-item)
+                                :data-url "https://penpot.app/libraries-templates"
+                                :on-click handle-click-url
+                                :data-testid "libraries-templates-profile-opt"}
         (tr "labels.libraries-and-templates")]
 
-       [:li {:tab-index (if show? "0" "-1")
-             :class (stl/css :profile-dropdown-item)
-             :data-url "https://github.com/penpot/penpot"
-             :on-click handle-click-url
-             :on-key-down handle-keydown-url}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                :data-url "https://github.com/penpot/penpot"
+                                :on-click handle-click-url}
         (tr "labels.github-repo")]
 
-       [:li {:tab-index (if show? "0" "-1")
-             :class (stl/css :profile-dropdown-item)
-             :data-url "https://penpot.app/terms"
-             :on-click handle-click-url
-             :on-key-down handle-keydown-url}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                :data-url "https://penpot.app/terms"
+                                :on-click handle-click-url}
         (tr "auth.terms-of-service")]
 
        [:li {:class (stl/css :profile-separator)}]
 
        (when (contains? cf/flags :user-feedback)
-         [:li {:class (stl/css :profile-dropdown-item)
-               :tab-index (if show? "0" "-1")
-               :on-click handle-feedback-click
-               :on-key-down handle-feedback-keydown
-               :data-testid "feedback-profile-opt"}
+         [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item)
+                                  :on-click handle-feedback-click
+                                  :data-testid "feedback-profile-opt"}
           (tr "labels.give-feedback")])
 
-       [:li {:class (stl/css :profile-dropdown-item :item-with-icon)
-             :tab-index (if show? "0" "-1")
-             :on-click handle-logout-click
-             :on-key-down handle-logout-keydown
-             :data-testid "logout-profile-opt"}
+       [:> dropdown-menu-item* {:class (stl/css :profile-dropdown-item :item-with-icon)
+                                :on-click handle-logout-click
+                                :data-testid "logout-profile-opt"}
         exit-icon
         (tr "labels.logout")]]
 

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -304,7 +304,7 @@
        [:div {:class (stl/css :rol-selector)}
         [:span {:class (stl/css :rol-label)} (tr role)]])
 
-     [:& dropdown {:show @show? :on-close on-hide}
+     [:& dropdown {:show @show? :on-close on-hide :dropdown-id (str "member-role-" (:id member))}
       [:ul {:class (stl/css :roles-dropdown)
             :role "listbox"}
        [:li {:on-click on-set-viewer
@@ -341,7 +341,7 @@
                  :on-click on-show}
         menu-icon]
 
-       [:& dropdown {:show @show? :on-close on-hide}
+       [:& dropdown {:show @show? :on-close on-hide :dropdown-id (str "member-actions-" (:id member))}
         [:ul {:class (stl/css :actions-dropdown)}
          (when is-you?
            [:li {:on-click on-leave
@@ -592,7 +592,7 @@
        [:div {:class (stl/css :rol-selector)}
         [:span {:class (stl/css :rol-label)} label]])
 
-     [:& dropdown {:show @show? :on-close on-hide}
+     [:& dropdown {:show @show? :on-close on-hide :dropdown-id "invitation-role-selector"}
       [:ul {:class (stl/css :roles-dropdown)}
        [:li {:data-role "admin"
              :class (stl/css :rol-dropdown-item)
@@ -692,7 +692,7 @@
                :on-click on-show}
       menu-icon]
 
-     [:& dropdown {:show @show? :on-close on-hide}
+     [:& dropdown {:show @show? :on-close on-hide :dropdown-id "invitation-actions"}
       [:ul {:class (stl/css :actions-dropdown :invitations-dropdown)}
        [:li {:on-click on-copy
              :class (stl/css :action-dropdown-item)}
@@ -982,7 +982,7 @@
        [:button {:class (stl/css :menu-btn)
                  :on-click on-show}
         menu-icon]
-       [:& dropdown {:show @show? :on-close on-hide}
+       [:& dropdown {:show @show? :on-close on-hide :dropdown-id "webhook-actions"}
         [:ul {:class (stl/css :webhook-actions-dropdown)}
          [:li {:on-click on-edit
                :class (stl/css :webhook-dropdown-item)} (tr "labels.edit")]

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -28,7 +28,7 @@
    [app.main.features :as features]
    [app.main.refs :as refs]
    [app.main.store :as st]
-   [app.main.ui.components.dropdown-menu :refer [dropdown-menu dropdown-menu-item*]]
+   [app.main.ui.components.dropdown-menu :refer [dropdown-menu* dropdown-menu-item*]]
    [app.main.ui.context :as ctx]
    [app.main.ui.dashboard.subscription :refer [main-menu-power-up* get-subscription-type]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
@@ -93,11 +93,12 @@
                (st/emit! (modal/show {:type :onboarding}))
                (st/emit! (modal/show {:type :release-notes :version version}))))))]
 
-    [:& dropdown-menu {:show true
-                       :on-close on-close
-                       :list-class (stl/css-case :sub-menu true
-                                                 :help-info plugins?
-                                                 :help-info-old (not plugins?))}
+    [:> dropdown-menu* {:show true
+                        ;; :id "workspace-help-menu"
+                        :on-close on-close
+                        :class (stl/css-case :sub-menu true
+                                             :help-info plugins?
+                                             :help-info-old (not plugins?))}
      [:> dropdown-menu-item* {:class (stl/css :submenu-item)
                               :on-click    nav-to-helpc-center
                               :on-key-down (fn [event]
@@ -182,10 +183,11 @@
   [{:keys [layout profile toggle-flag on-close toggle-theme]}]
   (let [show-nudge-options (mf/use-fn #(modal/show! {:type :nudge-option}))]
 
-    [:& dropdown-menu {:show true
-                       :list-class (stl/css-case :sub-menu true
-                                                 :preferences true)
-                       :on-close on-close}
+    [:> dropdown-menu* {:show true
+                        ;; :id "workspace-preferences-menu"
+                        :class (stl/css-case :sub-menu true
+                                             :preferences true)
+                        :on-close on-close}
      [:> dropdown-menu-item* {:on-click    toggle-flag
                               :class       (stl/css :submenu-item)
                               :on-key-down (fn [event]
@@ -312,10 +314,11 @@
                      (-> (dw/toggle-layout-flag :textpalette)
                          (vary-meta assoc ::ev/origin "workspace-menu")))))]
 
-    [:& dropdown-menu {:show true
-                       :list-class (stl/css-case :sub-menu true
-                                                 :view true)
-                       :on-close on-close}
+    [:> dropdown-menu* {:show true
+                        ;; :id "workspace-view-menu"
+                        :class (stl/css-case :sub-menu true
+                                             :view true)
+                        :on-close on-close}
 
      [:> dropdown-menu-item* {:class (stl/css :submenu-item)
                               :on-click    toggle-flag
@@ -430,10 +433,11 @@
         perms      (mf/use-ctx ctx/permissions)
         can-edit   (:can-edit perms)]
 
-    [:& dropdown-menu {:show true
-                       :list-class (stl/css-case :sub-menu true
-                                                 :edit true)
-                       :on-close on-close}
+    [:> dropdown-menu* {:show true
+                        ;; :id "workspace-edit-menu"
+                        :class (stl/css-case :sub-menu true
+                                             :edit true)
+                        :on-close on-close}
 
      [:> dropdown-menu-item* {:class (stl/css :submenu-item)
                               :on-click    select-all
@@ -592,10 +596,11 @@
            (when (kbd/enter? event)
              (on-export-frames event))))]
 
-    [:& dropdown-menu {:show true
-                       :list-class (stl/css-case :sub-menu true
-                                                 :file true)
-                       :on-close on-close}
+    [:> dropdown-menu* {:show true
+                        ;; :id "workspace-file-menu"
+                        :class (stl/css-case :sub-menu true
+                                             :file true)
+                        :on-close on-close}
 
      (if ^boolean shared?
        (when can-edit
@@ -690,9 +695,10 @@
     (let [plugins                  (preg/plugins-list)
           user-can-edit?           (:can-edit (deref refs/permissions))
           permissions-peek         (deref refs/plugins-permissions-peek)]
-      [:& dropdown-menu {:show true
-                         :list-class (stl/css-case :sub-menu true :plugins true)
-                         :on-close on-close}
+      [:> dropdown-menu* {:show true
+                          ;; :id "workspace-plugins-menu"
+                          :class (stl/css-case :sub-menu true :plugins true)
+                          :on-close on-close}
        [:> dropdown-menu-item* {:on-click    open-plugins
                                 :class       (stl/css :submenu-item)
                                 :on-key-down (fn [event]
@@ -840,9 +846,10 @@
                        :on-click open-menu
                        :icon "menu"}]
 
-     [:& dropdown-menu {:show show-menu?
-                        :on-close close-menu
-                        :list-class (stl/css :menu)}
+     [:> dropdown-menu* {:show show-menu?
+                         :id "workspace-menu"
+                         :on-close close-menu
+                         :class (stl/css :menu)}
       [:> dropdown-menu-item* {:class (stl/css :menu-item)
                                :on-click    on-menu-click
                                :on-key-down (fn [event]

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -11,7 +11,7 @@
    [app.config :as cf]
    [app.main.data.modal :as modal]
    [app.main.refs :as refs]
-   [app.main.ui.components.dropdown-menu :refer [dropdown-menu
+   [app.main.ui.components.dropdown-menu :refer [dropdown-menu*
                                                  dropdown-menu-item*]]
    [app.main.ui.components.title-bar :refer [title-bar]]
    [app.main.ui.context :as ctx]
@@ -123,9 +123,10 @@
                   :icon "import-export"
                   :variant "secondary"}
       (tr "workspace.tokens.tools")]
-     [:& dropdown-menu {:show show-menu?
-                        :on-close close-menu
-                        :list-class (stl/css :import-export-menu)}
+     [:> dropdown-menu* {:show show-menu?
+                         :on-close close-menu
+                         :id "tokens-menu"
+                         :class (stl/css :import-export-menu)}
       (when can-edit?
         [:> dropdown-menu-item* {:class (stl/css :import-export-menu-item)
                                  :on-click on-modal-show}

--- a/frontend/src/app/util/dom.cljs
+++ b/frontend/src/app/util/dom.cljs
@@ -469,6 +469,11 @@
   (when (some? node)
     (.focus node)))
 
+(defn click!
+  [^js node]
+  (when (some? node)
+    (.click node)))
+
 (defn focus?
   [^js node]
   (and node


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11500

### Summary

This PR changes the way dashboard dropdowns share their status as part of the dashboard-local state, to ensure that only one dropdown is opened at a time

### Steps to reproduce 

- Go to your dashboard
- Click on different dropdown menus (sidebar menus, project menus, etc)
- Check that when one dropdown opens, if there's any other dropdown opened, it closed
- All dropdowns close on scroll to keep consistency

[screen-recorder-wed-jul-30-2025-15-04-16.webm](https://github.com/user-attachments/assets/3b271f35-d560-43c9-bd97-93c99b6b53fc)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
