### PR TITLE
:bug: Fix rendering texts bigger than their selrects in mutiple tiles

### DIFF
--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -705,6 +705,7 @@ impl Shape {
             };
             max_stroke = max_stroke.max(width);
         }
+
         let mut rect = if let Some(path) = self.get_skia_path() {
             path.compute_tight_bounds()
                 .with_outset((max_stroke, max_stroke))
@@ -719,6 +720,12 @@ impl Shape {
             bounds_rect.join(stroke_rect);
             bounds_rect
         };
+
+        if let Type::Text(ref text_content) = self.shape_type {
+            let (width, height) = text_content.visual_bounds();
+            rect.right = rect.left + width;
+            rect.bottom = rect.top + height;
+        }
 
         for shadow in self.shadows.iter() {
             let (x, y) = shadow.offset;

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -175,6 +175,12 @@ impl TextContent {
     pub fn set_grow_type(&mut self, grow_type: GrowType) {
         self.grow_type = grow_type;
     }
+
+    pub fn visual_bounds(&self) -> (f32, f32) {
+        let mut paragraphs = self.to_paragraphs();
+        let height = auto_height(&mut paragraphs, self.width());
+        (self.width(), height)
+    }
 }
 
 impl Default for TextContent {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11020

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
