### PR TITLE
:bug: Fix bad swap slot after two swaps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 - Fix problem with booleans selection [Taiga #11627](https://tree.taiga.io/project/penpot/issue/11627)
 - Fix missing font when copy&paste a chunk of text [Taiga #11522](https://tree.taiga.io/project/penpot/issue/11522)
+- Fix bad swap slot after two swaps [Taiga #11659](https://tree.taiga.io/project/penpot/issue/11659)
 
 ## 2.9.0 (Unreleased)
 

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1552,6 +1552,25 @@
 
     (update data :pages-index d/update-vals update-page)))
 
+(defmethod migrate-data "0010-fix-swap-slots-pointing-non-existent-shapes"
+  [data _]
+  (letfn [(fix-shape [page shape]
+            (let [shape-swap-slot (ctk/get-swap-slot shape)]
+              (if shape-swap-slot
+                (let [libs   (when (:libs data)
+                               (deref (:libs data)))
+                      ref-id (ctf/find-ref-id-for-swapped shape page libs)]
+                  (if (nil? ref-id)
+                    (ctk/remove-swap-slot shape)
+                    shape))
+                shape)))
+
+          (update-page [page]
+            (d/update-when page :objects d/update-vals (partial fix-shape page)))]
+    (-> data
+        (update :pages-index d/update-vals update-page))))
+
+
 (def available-migrations
   (into (d/ordered-set)
         ["legacy-2"
@@ -1617,4 +1636,5 @@
          "0007-clear-invalid-strokes-and-fills-v2"
          "0008-fix-library-colors-v4"
          "0009-clean-library-colors"
-         "0009-add-partial-text-touched-flags"]))
+         "0009-add-partial-text-touched-flags"
+         "0010-fix-swap-slots-pointing-non-existent-shapes"]))

--- a/common/src/app/common/files/migrations.cljc
+++ b/common/src/app/common/files/migrations.cljc
@@ -1555,15 +1555,13 @@
 (defmethod migrate-data "0010-fix-swap-slots-pointing-non-existent-shapes"
   [data _]
   (letfn [(fix-shape [page shape]
-            (let [shape-swap-slot (ctk/get-swap-slot shape)]
-              (if shape-swap-slot
-                (let [libs   (when (:libs data)
-                               (deref (:libs data)))
-                      ref-id (ctf/find-ref-id-for-swapped shape page libs)]
-                  (if (nil? ref-id)
-                    (ctk/remove-swap-slot shape)
-                    shape))
-                shape)))
+            (if (ctk/get-swap-slot shape)
+              (let [libs (some-> (:libs data) deref)
+                    ref-id (when libs (ctf/find-ref-id-for-swapped shape page libs))]
+                (if (nil? ref-id)
+                  (ctk/remove-swap-slot shape)
+                  shape))
+              shape))
 
           (update-page [page]
             (d/update-when page :objects d/update-vals (partial fix-shape page)))]

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2340,6 +2340,8 @@
         inside-comp? (ctn/in-any-component? objects parent)
 
         [new-shape changes]
+        ;; When we make a swap of an item, there can be copies which swap-slot points to that item
+        ;; so we want to assign the item id to the new instanciated copy, to mantain that reference
         (generate-instantiate-component changes
                                         objects
                                         (:id file)
@@ -2347,9 +2349,10 @@
                                         position
                                         page
                                         libraries
-                                        nil
+                                        (:id shape)
                                         (:parent-id shape)
                                         (:frame-id shape)
+                                        {(:id shape) (:id shape)} ;; keep the id of the original shape
                                         {:force-frame? true})
 
         new-shape (cond-> new-shape

--- a/common/test/common_tests/logic/swap_keeps_id_test.cljc
+++ b/common/test/common_tests/logic/swap_keeps_id_test.cljc
@@ -1,0 +1,37 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns common-tests.logic.swap-keeps-id-test
+  (:require
+   [app.common.test-helpers.components :as thc]
+   [app.common.test-helpers.compositions :as tho]
+   [app.common.test-helpers.files :as thf]
+   [app.common.test-helpers.shapes :as ths]
+   [clojure.test :as t]))
+
+
+(t/deftest test-swap-keeps-id
+  (let [;; ==== Setup
+        file      (-> (thf/sample-file :file1)
+
+                      (tho/add-frame :frame-rectangle)
+                      (ths/add-sample-shape :rectangle-shape :parent-label :frame-rectangle :type :rect)
+                      (thc/make-component :rectangle :frame-rectangle)
+
+                      (tho/add-frame :frame-circle)
+                      (ths/add-sample-shape :circle :parent-label :frame-circle :type :circle)
+                      (thc/make-component :circle :frame-circle)
+
+                      (thc/instantiate-component :rectangle :copy01))
+
+        copy   (ths/get-shape file :copy01)
+
+        ;; ==== Action
+        file'     (tho/swap-component file copy :circle {:new-shape-label :copy02 :keep-touched? true})
+
+        copy'     (ths/get-shape file' :copy02)]
+    ;; Both copies have the same id
+    (t/is (= (:id copy) (:id copy')))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11659

### Summary

Fix bug on which the swap slot on a copy can point to an id that doesn't exists

### Steps to reproduce 

See taiga isue

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [X] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [X] Check CI passes successfully.
- [X] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
