### PR TITLE
:sparkles: Remove token when applying tyopgraphic asset style

### DIFF
--- a/common/src/app/common/logic/shapes.cljc
+++ b/common/src/app/common/logic/shapes.cljc
@@ -21,9 +21,12 @@
    [app.common.uuid :as uuid]
    [clojure.set :as set]))
 
+(def text-typography-attrs (set ctt/text-typography-attrs))
+
 (defn- generate-unapply-tokens
   "When updating attributes that have a token applied, we must unapply it, because the value
-   of the attribute now has been given directly, and does not come from the token."
+   of the attribute now has been given directly, and does not come from the token.
+  When applying a typography asset style we also unapply any typographic tokens."
   [changes objects changed-sub-attr]
   (let [new-objects     (pcb/get-objects changes)
         mod-obj-changes (->> (:redo-changes changes)
@@ -32,7 +35,11 @@
         text-changed-attrs
         (fn [shape]
           (let [new-shape (get new-objects (:id shape))
-                attrs (ctt/get-diff-attrs (:content shape) (:content new-shape))]
+                attrs (ctt/get-diff-attrs (:content shape) (:content new-shape))
+                ;; Unapply token when applying typography asset style
+                attrs (if (set/intersection text-typography-attrs attrs)
+                        (into attrs cto/typography-keys)
+                        attrs)]
             (apply set/union (map cto/shape-attr->token-attrs attrs))))
 
         check-attr (fn [shape changes attr]

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -252,37 +252,31 @@
             (dwsl/update-layout-child shape-ids props {:ignore-touched true
                                                        :page-id page-id}))))))))
 
+(defn generate-text-shape-update
+  [txt-attrs shape-ids page-id]
+  (let [update-node? (fn [node]
+                       (or (txt/is-text-node? node)
+                           (txt/is-paragraph-node? node)))
+        update-fn (fn [node _]
+                    (-> node
+                        (d/txt-merge txt-attrs)
+                        (cty/remove-typography-from-node)))]
+    (dwsh/update-shapes shape-ids
+                        #(txt/update-text-content % update-node? update-fn nil)
+                        {:ignore-touched true
+                         :page-id page-id})))
+
 (defn update-line-height
   ([value shape-ids attributes] (update-line-height value shape-ids attributes nil))
   ([value shape-ids _attributes page-id]
-   (let [update-node? (fn [node]
-                        (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))
-         update-fn (fn [node _]
-                     (-> node
-                         (d/txt-merge {:line-height value})
-                         (cty/remove-typography-from-node)))]
-     (when (number? value)
-       (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? update-fn nil)
-                           {:ignore-touched true
-                            :page-id page-id})))))
+   (when (number? value)
+     (generate-text-shape-update {:line-height value} shape-ids page-id))))
 
 (defn update-letter-spacing
   ([value shape-ids attributes] (update-letter-spacing value shape-ids attributes nil))
   ([value shape-ids _attributes page-id]
-   (let [update-node? (fn [node]
-                        (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))
-         update-fn (fn [node _]
-                     (-> node
-                         (d/txt-merge {:letter-spacing (str value)})
-                         (cty/remove-typography-from-node)))]
-     (when (number? value)
-       (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? update-fn nil)
-                           {:ignore-touched true
-                            :page-id page-id})))))
+   (when (number? value)
+     (generate-text-shape-update {:letter-spacing (str value)} shape-ids page-id))))
 
 (defn update-font-family
   ([value shape-ids attributes] (update-font-family value shape-ids attributes nil))
@@ -294,31 +288,15 @@
                       {:font-id (:id font)
                        :font-family (:family font)}
                       {:font-id (str uuid/zero)
-                       :font-family font-family})
-         update-node? (fn [node]
-                        (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))]
+                       :font-family font-family})]
      (when text-attrs
-       (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? d/txt-merge text-attrs)
-                           {:ignore-touched true
-                            :page-id page-id})))))
+       (generate-text-shape-update text-attrs shape-ids page-id)))))
 
 (defn update-font-size
   ([value shape-ids attributes] (update-font-size value shape-ids attributes nil))
   ([value shape-ids _attributes page-id]
-   (let [update-node? (fn [node]
-                        (or (txt/is-text-node? node)
-                            (txt/is-paragraph-node? node)))
-         update-fn (fn [node _]
-                     (-> node
-                         (d/txt-merge {:font-size (str value)})
-                         (cty/remove-typography-from-node)))]
-     (when (number? value)
-       (dwsh/update-shapes shape-ids
-                           #(txt/update-text-content % update-node? update-fn nil)
-                           {:ignore-touched true
-                            :page-id page-id})))))
+   (when (number? value)
+     (generate-text-shape-update {:font-size (str value)} shape-ids page-id))))
 
 ;; Events to apply / unapply tokens to shapes ------------------------------------------------------------
 


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/129

### Summary


https://github.com/user-attachments/assets/241148b3-ea26-4b61-b774-f5b38393a589



- Unapplies tokens when applying a typographic asset style
- Fixes missed logic for removing asset styles for applying typography token attributes by extracting and generalizing the text shape update function

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.