### PR TITLE
:bug: Fix text width calculation

### DIFF
--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -148,7 +148,7 @@ impl TextContent {
     ) -> Vec<Vec<ParagraphBuilder>> {
         if self.grow_type() == GrowType::AutoWidth {
             set_paragraphs_width(f32::MAX, &mut paragraphs);
-            let max_width = auto_width(&mut paragraphs).ceil();
+            let max_width = auto_width(&mut paragraphs, self.width()).ceil();
             set_paragraphs_width(max_width, &mut paragraphs);
         } else {
             set_paragraphs_width(self.width(), &mut paragraphs);
@@ -638,24 +638,43 @@ impl From<&Vec<u8>> for RawTextData {
     }
 }
 
-pub fn auto_width(paragraphs: &mut [Vec<ParagraphBuilder>]) -> f32 {
-    paragraphs.iter_mut().fold(0.0, |auto_width, p| {
-        p.iter_mut().fold(auto_width, |auto_width, paragraph| {
-            let mut paragraph = paragraph.build();
-            paragraph.layout(f32::MAX);
-            f32::max(paragraph.max_intrinsic_width(), auto_width)
+pub fn get_built_paragraphs(
+    paragraphs: &mut [Vec<ParagraphBuilder>],
+    width: f32,
+) -> Vec<Vec<skia_safe::textlayout::Paragraph>> {
+    paragraphs
+        .iter_mut()
+        .map(|builders| {
+            builders
+                .iter_mut()
+                .map(|builder_handle| {
+                    let mut paragraph = builder_handle.build();
+                    paragraph.layout(width);
+                    paragraph
+                })
+                .collect()
         })
-    })
+        .collect()
 }
 
-pub fn max_width(paragraphs: &mut [Vec<ParagraphBuilder>]) -> f32 {
-    paragraphs.iter_mut().fold(0.0, |max_width, p| {
-        p.iter_mut().fold(max_width, |max_width, paragraph| {
-            let mut paragraph = paragraph.build();
-            paragraph.layout(f32::MAX);
-            f32::max(paragraph.max_width(), max_width)
+pub fn auto_width(paragraphs: &mut [Vec<ParagraphBuilder>], width: f32) -> f32 {
+    let built_paragraphs = get_built_paragraphs(paragraphs, width);
+
+    built_paragraphs
+        .iter()
+        .flatten()
+        .fold(0.0, |auto_width, p| {
+            f32::max(p.max_intrinsic_width(), auto_width)
         })
-    })
+}
+
+pub fn max_width(paragraphs: &mut [Vec<ParagraphBuilder>], width: f32) -> f32 {
+    let built_paragraphs = get_built_paragraphs(paragraphs, width);
+
+    built_paragraphs
+        .iter()
+        .flatten()
+        .fold(0.0, |max_width, p| f32::max(p.max_width(), max_width))
 }
 
 pub fn auto_height(paragraphs: &mut [Vec<ParagraphBuilder>], width: f32) -> f32 {

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -45,14 +45,14 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
 
         if let Type::Text(content) = &shape.shape_type {
             let mut paragraphs = content.get_skia_paragraphs();
-            m_width = max_width(&mut paragraphs);
+            m_width = max_width(&mut paragraphs, width);
 
             match content.grow_type() {
                 GrowType::AutoHeight => {
                     height = auto_height(&mut paragraphs, width).ceil();
                 }
                 GrowType::AutoWidth => {
-                    width = auto_width(&mut paragraphs).ceil();
+                    width = auto_width(&mut paragraphs, width).ceil();
                     height = auto_height(&mut paragraphs, width).ceil();
                 }
                 GrowType::Fixed => {}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11506

### Summary

After some changes introduced as part of including text decoration, we were not calculating correctly max_width and auto_width values, since we were not building the paragraphs correctly using the shape width

### Steps to reproduce 

- Write text creating a new text shape
- Select existing text shapes
- Select existing text shapes with different alignment
- Change auto width of existing text shapes 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.

