### PR TITLE
:sparkles: Enhance (version control): Add milestone lock feature to prevent accidental deletion and bad actor interventions

### DIFF
--- a/backend/src/app/migrations.clj
+++ b/backend/src/app/migrations.clj
@@ -438,7 +438,10 @@
     :fn (mg/resource "app/migrations/sql/0138-mod-file-data-fragment-table.sql")}
 
    {:name "0139-mod-file-change-table.sql"
-    :fn (mg/resource "app/migrations/sql/0139-mod-file-change-table.sql")}])
+    :fn (mg/resource "app/migrations/sql/0139-mod-file-change-table.sql")}
+
+   {:name "0140-add-locked-by-column-to-file-change-table"
+    :fn (mg/resource "app/migrations/sql/0140-add-locked-by-column-to-file-change-table.sql")}])
 
 (defn apply-migrations!
   [pool name migrations]

--- a/backend/src/app/migrations/sql/0140-add-locked-by-column-to-file-change-table.sql
+++ b/backend/src/app/migrations/sql/0140-add-locked-by-column-to-file-change-table.sql
@@ -1,0 +1,11 @@
+-- Add locked_by column to file_change table for version locking feature
+-- This allows users to lock their own saved versions to prevent deletion by others
+
+ALTER TABLE file_change
+  ADD COLUMN locked_by uuid NULL REFERENCES profile(id) ON DELETE SET NULL DEFERRABLE;
+
+-- Create index for locked versions queries
+CREATE INDEX file_change__locked_by__idx ON file_change (locked_by) WHERE locked_by IS NOT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN file_change.locked_by IS 'Profile ID of user who has locked this version. Only the creator can lock/unlock their own versions. Locked versions cannot be deleted by others.';

--- a/backend/src/app/rpc/commands/files_snapshot.clj
+++ b/backend/src/app/rpc/commands/files_snapshot.clj
@@ -29,7 +29,7 @@
 
 (def sql:get-file-snapshots
   "WITH changes AS (
-      SELECT id, label, revn, created_at, created_by, profile_id
+      SELECT id, label, revn, created_at, created_by, profile_id, locked_by
         FROM file_change
        WHERE file_id = ?
          AND data IS NOT NULL
@@ -260,7 +260,7 @@
   [conn id]
   (db/get conn :file-change
           {:id id}
-          {::sql/columns [:id :file-id :created-by :deleted-at]
+          {::sql/columns [:id :file-id :created-by :deleted-at :profile-id :locked-by]
            ::db/for-update true}))
 
 (sv/defmethod ::update-file-snapshot
@@ -300,4 +300,111 @@
                               :snapshot-id id
                               :profile-id profile-id))
 
+                  ;; Check if version is locked by someone else
+                  (when (and (:locked-by snapshot)
+                             (not= (:locked-by snapshot) profile-id))
+                    (ex/raise :type :validation
+                              :code :snapshot-is-locked
+                              :hint "Cannot delete a locked version"
+                              :snapshot-id id
+                              :profile-id profile-id
+                              :locked-by (:locked-by snapshot)))
+
                   (delete-file-snapshot! conn id)))))
+
+;;; Lock/unlock version endpoints
+
+(def ^:private schema:lock-file-snapshot
+  [:map {:title "lock-file-snapshot"}
+   [:id ::sm/uuid]])
+
+(defn- lock-file-snapshot!
+  [conn snapshot-id profile-id]
+  (db/update! conn :file-change
+              {:locked-by profile-id}
+              {:id snapshot-id}
+              {::db/return-keys false})
+  nil)
+
+(sv/defmethod ::lock-file-snapshot
+  {::doc/added "1.20"
+   ::sm/params schema:lock-file-snapshot}
+  [cfg {:keys [::rpc/profile-id id]}]
+  (db/tx-run! cfg
+              (fn [{:keys [::db/conn]}]
+                (let [snapshot (get-snapshot conn id)]
+                  (files/check-edition-permissions! conn profile-id (:file-id snapshot))
+
+                  (when (not= (:created-by snapshot) "user")
+                    (ex/raise :type :validation
+                              :code :system-snapshots-cant-be-locked
+                              :hint "Only user-created versions can be locked"
+                              :snapshot-id id
+                              :profile-id profile-id))
+
+                  ;; Only the creator can lock their own version
+                  (when (not= (:profile-id snapshot) profile-id)
+                    (ex/raise :type :validation
+                              :code :only-creator-can-lock
+                              :hint "Only the version creator can lock it"
+                              :snapshot-id id
+                              :profile-id profile-id
+                              :creator-id (:profile-id snapshot)))
+
+                  ;; Check if already locked
+                  (when (:locked-by snapshot)
+                    (ex/raise :type :validation
+                              :code :snapshot-already-locked
+                              :hint "Version is already locked"
+                              :snapshot-id id
+                              :profile-id profile-id
+                              :locked-by (:locked-by snapshot)))
+
+                  (lock-file-snapshot! conn id profile-id)))))
+
+(def ^:private schema:unlock-file-snapshot
+  [:map {:title "unlock-file-snapshot"}
+   [:id ::sm/uuid]])
+
+(defn- unlock-file-snapshot!
+  [conn snapshot-id]
+  (db/update! conn :file-change
+              {:locked-by nil}
+              {:id snapshot-id}
+              {::db/return-keys false})
+  nil)
+
+(sv/defmethod ::unlock-file-snapshot
+  {::doc/added "1.20"
+   ::sm/params schema:unlock-file-snapshot}
+  [cfg {:keys [::rpc/profile-id id]}]
+  (db/tx-run! cfg
+              (fn [{:keys [::db/conn]}]
+                (let [snapshot (get-snapshot conn id)]
+                  (files/check-edition-permissions! conn profile-id (:file-id snapshot))
+
+                  (when (not= (:created-by snapshot) "user")
+                    (ex/raise :type :validation
+                              :code :system-snapshots-cant-be-unlocked
+                              :hint "Only user-created versions can be unlocked"
+                              :snapshot-id id
+                              :profile-id profile-id))
+
+                  ;; Only the creator can unlock their own version
+                  (when (not= (:profile-id snapshot) profile-id)
+                    (ex/raise :type :validation
+                              :code :only-creator-can-unlock
+                              :hint "Only the version creator can unlock it"
+                              :snapshot-id id
+                              :profile-id profile-id
+                              :creator-id (:profile-id snapshot)))
+
+                  ;; Check if not locked
+                  (when (not (:locked-by snapshot))
+                    (ex/raise :type :validation
+                              :code :snapshot-not-locked
+                              :hint "Version is not locked"
+                              :snapshot-id id
+                              :profile-id profile-id))
+
+                  (unlock-file-snapshot! conn id)))))

--- a/frontend/src/app/main/data/workspace/versions.cljs
+++ b/frontend/src/app/main/data/workspace/versions.cljs
@@ -148,6 +148,29 @@
                                  (fetch-versions)
                                  (ptk/event ::ev/event {::ev/name "pin-version"})))))))))
 
+(defn lock-version
+  [id]
+  (assert (uuid? id) "expected valid uuid for `id`")
+  (ptk/reify ::lock-version
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (->> (rp/cmd! :lock-file-snapshot {:id id})
+           (rx/map fetch-versions)
+           (rx/catch (fn [error]
+                       (js/console.error "Failed to lock version:" error)
+                       (rx/of (fetch-versions))))))))
+
+(defn unlock-version
+  [id]
+  (assert (uuid? id) "expected valid uuid for `id`")
+  (ptk/reify ::unlock-version
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (->> (rp/cmd! :unlock-file-snapshot {:id id})
+           (rx/map fetch-versions)
+           (rx/catch (fn [error]
+                       (js/console.error "Failed to unlock version:" error)
+                       (rx/of (fetch-versions))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; PLUGINS SPECIFIC EVENTS

--- a/frontend/src/app/main/errors.cljs
+++ b/frontend/src/app/main/errors.cljs
@@ -148,6 +148,38 @@
     (= code :vern-conflict)
     (st/emit! (ptk/event ::dw/reload-current-file))
 
+    (= code :snapshot-is-locked)
+    (let [message (tr "errors.version-locked")]
+      (st/async-emit!
+       (ntf/show {:content message
+                  :type :toast
+                  :level :error
+                  :timeout 3000})))
+
+    (= code :only-creator-can-lock)
+    (let [message (tr "errors.only-creator-can-lock")]
+      (st/async-emit!
+       (ntf/show {:content message
+                  :type :toast
+                  :level :error
+                  :timeout 3000})))
+
+    (= code :only-creator-can-unlock)
+    (let [message (tr "errors.only-creator-can-unlock")]
+      (st/async-emit!
+       (ntf/show {:content message
+                  :type :toast
+                  :level :error
+                  :timeout 3000})))
+
+    (= code :snapshot-already-locked)
+    (let [message (tr "errors.version-already-locked")]
+      (st/async-emit!
+       (ntf/show {:content message
+                  :type :toast
+                  :level :error
+                  :timeout 3000})))
+
     :else
     (st/async-emit! (rt/assign-exception error))))
 

--- a/frontend/src/app/main/ui/ds/product/user_milestone.cljs
+++ b/frontend/src/app/main/ui/ds/product/user_milestone.cljs
@@ -11,6 +11,7 @@
    [app.common.data :as d]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.controls.input :refer [input*]]
+   [app.main.ui.ds.foundations.assets.icon :as i]
    [app.main.ui.ds.foundations.typography :as t]
    [app.main.ui.ds.foundations.typography.text :refer [text*]]
    [app.main.ui.ds.product.avatar :refer [avatar*]]
@@ -25,6 +26,7 @@
    [:class {:optional true} :string]
    [:active {:optional true} :boolean]
    [:editing {:optional true} :boolean]
+   [:locked {:optional true} :boolean]
    [:user
     [:map
      [:name {:optional true} [:maybe :string]]
@@ -39,7 +41,7 @@
 
 (mf/defc user-milestone*
   {::mf/schema schema:milestone}
-  [{:keys [class active editing user label date
+  [{:keys [class active editing locked user label date
            onOpenMenu onFocusInput onBlurInput onKeyDownInput] :rest props}]
   (let [class (d/append-class class (stl/css-case :milestone true :is-selected active))
         props (mf/spread-props props {:class class :data-testid "milestone"})
@@ -60,7 +62,10 @@
          :on-focus onFocusInput
          :on-blur onBlurInput
          :on-key-down onKeyDownInput}]
-       [:> text*  {:as "span" :typography t/body-small :class (stl/css :name)} label])
+       [:div {:class (stl/css :name-wrapper)}
+        [:> text*  {:as "span" :typography t/body-small :class (stl/css :name)} label]
+        (when locked
+          [:> i/icon* {:icon-id i/lock :class (stl/css :lock-icon)}])])
 
      [:*
       [:time {:dateTime (dt/format date :iso)

--- a/frontend/src/app/main/ui/ds/product/user_milestone.scss
+++ b/frontend/src/app/main/ui/ds/product/user_milestone.scss
@@ -42,9 +42,21 @@
   justify-self: flex-end;
 }
 
+.name-wrapper {
+  display: flex;
+  align-items: baseline;
+}
+
 .name {
   grid-area: name;
   color: var(--color-foreground-primary);
+}
+
+.lock-icon {
+  margin-left: 8px;
+  transform: scale(0.8);
+  color: var(--color-foreground-secondary);
+  align-self: anchor-center;
 }
 
 .date {

--- a/frontend/src/app/main/ui/workspace/sidebar/versions.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/versions.cljs
@@ -76,7 +76,7 @@
        (reverse)))
 
 (mf/defc version-entry
-  [{:keys [entry profile on-restore-version on-delete-version on-rename-version editing?]}]
+  [{:keys [entry profile current-profile on-restore-version on-delete-version on-rename-version on-lock-version on-unlock-version editing?]}]
   (let [show-menu? (mf/use-state false)
 
         handle-open-menu
@@ -108,6 +108,20 @@
          (fn []
            (when on-delete-version
              (on-delete-version (:id entry)))))
+
+        handle-lock-version
+        (mf/use-callback
+         (mf/deps entry on-lock-version)
+         (fn []
+           (when on-lock-version
+             (on-lock-version (:id entry)))))
+
+        handle-unlock-version
+        (mf/use-callback
+         (mf/deps entry on-unlock-version)
+         (fn []
+           (when on-unlock-version
+             (on-unlock-version (:id entry)))))
 
         handle-name-input-focus
         (mf/use-fn
@@ -142,22 +156,44 @@
                                      :color (:color profile)}
                           :editing editing?
                           :date (:created-at entry)
+                          :locked (boolean (:locked-by entry))
                           :onOpenMenu handle-open-menu
                           :onFocusInput handle-name-input-focus
                           :onBlurInput handle-name-input-blur
                           :onKeyDownInput handle-name-input-key-down}]
 
      [:& dropdown {:show @show-menu? :on-close handle-close-menu}
-      [:ul {:class (stl/css :version-options-dropdown)}
-       [:li {:class (stl/css :menu-option)
-             :role "button"
-             :on-click handle-rename-version} (tr "labels.rename")]
-       [:li {:class (stl/css :menu-option)
-             :role "button"
-             :on-click handle-restore-version} (tr "labels.restore")]
-       [:li {:class (stl/css :menu-option)
-             :role "button"
-             :on-click handle-delete-version} (tr "labels.delete")]]]]))
+      (let [current-user-id   (:id current-profile)
+            version-creator-id (:profile-id entry)
+            locked-by-id      (:locked-by entry)
+            is-version-creator? (= current-user-id version-creator-id)
+            is-locked?         (some? locked-by-id)
+            is-locked-by-me?   (= current-user-id locked-by-id)
+            can-rename?        is-version-creator?
+            can-lock?          (and is-version-creator? (not is-locked?))
+            can-unlock?        (and is-version-creator? is-locked-by-me?)
+            can-delete?        (or (not is-locked?) (and is-locked? is-locked-by-me?))]
+        [:ul {:class (stl/css :version-options-dropdown)}
+         (when can-rename?
+           [:li {:class (stl/css :menu-option)
+                 :role "button"
+                 :on-click handle-rename-version} (tr "labels.rename")])
+         [:li {:class (stl/css :menu-option)
+               :role "button"
+               :on-click handle-restore-version} (tr "labels.restore")]
+         (cond
+           can-unlock?
+           [:li {:class (stl/css :menu-option)
+                 :role "button"
+                 :on-click handle-unlock-version} (tr "labels.unlock")]
+           can-lock?
+           [:li {:class (stl/css :menu-option)
+                 :role "button"
+                 :on-click handle-lock-version} (tr "labels.lock")])
+         (when can-delete?
+           [:li {:class (stl/css :menu-option)
+                 :role "button"
+                 :on-click handle-delete-version} (tr "labels.delete")])])]]))
 
 (mf/defc snapshot-entry
   [{:keys [index is-expanded entry on-toggle-expand on-pin-snapshot on-restore-snapshot]}]
@@ -311,6 +347,16 @@
          (fn [id]
            (st/emit! (dwv/pin-version id))))
 
+        handle-lock-version
+        (mf/use-fn
+         (fn [id]
+           (st/emit! (dwv/lock-version id))))
+
+        handle-unlock-version
+        (mf/use-fn
+         (fn [id]
+           (st/emit! (dwv/unlock-version id))))
+
         handle-change-filter
         (mf/use-fn
          (fn [filter]
@@ -368,9 +414,12 @@
                                   :entry entry
                                   :editing? (= (:id entry) editing)
                                   :profile (get profiles (:profile-id entry))
+                                  :current-profile profile
                                   :on-rename-version handle-rename-version
                                   :on-restore-version handle-restore-version-pinned
-                                  :on-delete-version handle-delete-version}]
+                                  :on-delete-version handle-delete-version
+                                  :on-lock-version handle-lock-version
+                                  :on-unlock-version handle-unlock-version}]
 
                :snapshot
                [:& snapshot-entry {:key idx-entry

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1380,6 +1380,22 @@ msgstr "Password should at least be 8 characters"
 msgid "errors.paste-data-validation"
 msgstr "Invalid data in clipboard"
 
+#: src/app/main/errors.cljs:152
+msgid "errors.version-locked"
+msgstr "This version is locked and cannot be deleted by others"
+
+#: src/app/main/errors.cljs:160
+msgid "errors.only-creator-can-lock"
+msgstr "Only the version creator can lock it"
+
+#: src/app/main/errors.cljs:168
+msgid "errors.only-creator-can-unlock"
+msgstr "Only the version creator can unlock it"
+
+#: src/app/main/errors.cljs:176
+msgid "errors.version-already-locked"
+msgstr "This version is already locked"
+
 #: src/app/main/data/auth.cljs:312, src/app/main/ui/auth/login.cljs:103, src/app/main/ui/auth/login.cljs:111
 msgid "errors.profile-blocked"
 msgstr "The profile is blocked"
@@ -2133,6 +2149,10 @@ msgstr "Libraries & Templates"
 msgid "labels.loading"
 msgstr "Loading…"
 
+#: src/app/main/ui/workspace/sidebar/versions.cljs:179
+msgid "labels.lock"
+msgstr "Lock"
+
 #: src/app/main/ui/viewer/header.cljs:208
 msgid "labels.log-or-sign"
 msgstr "Log in or sign up"
@@ -2452,6 +2472,10 @@ msgstr "Tutorials"
 #: src/app/main/data/workspace/tokens/errors.cljs:73
 msgid "labels.unknown-error"
 msgstr "Unknown error"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs:176
+msgid "labels.unlock"
+msgstr "Unlock"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:264
 msgid "labels.unpublish-multi-files"
@@ -7874,6 +7898,15 @@ msgstr "History"
 #: src/app/main/ui/ds/product/autosaved_milestone.cljs:66, src/app/main/ui/ds/product/user_milestone.cljs:73
 msgid "workspace.versions.version-menu"
 msgstr "Open version menu"
+
+msgid "workspace.versions.locked-by-other"
+msgstr "This version is locked by %s and cannot be modified"
+
+msgid "workspace.versions.locked-by-you"
+msgstr "This version is locked by you"
+
+msgid "workspace.versions.tooltip.locked-version"
+msgstr "Locked version - only the creator can modify it"
 
 #: src/app/main/ui/workspace/sidebar/versions.cljs:372
 #, markdown


### PR DESCRIPTION
# Screenshots

<img width="175" height="auto" alt="image" src="https://github.com/user-attachments/assets/0b2800e3-4643-42d8-a235-3cf4c03333f0" /><img width="175" height="auto" alt="image" src="https://github.com/user-attachments/assets/0d465303-17c0-44cd-b867-53a86d698d44" /><img width="175" height="auto" alt="image" src="https://github.com/user-attachments/assets/7a0203aa-ee30-4e7f-a696-d5c2a6783ca7" /><img width="175" height="auto" alt="image" src="https://github.com/user-attachments/assets/83ff07d4-e5a1-45ac-9f72-feb9140aa5e3" />
<i><b>Current (problem):</b> Point of view of user LC. important milestones are able to be deleted accidentally or intentionally by other user's. LC can delete MC's work, after 7 days it is lost forever. </i>

---
<img width="175" height="auto" alt="image" src="https://github.com/user-attachments/assets/be501f4f-462f-453e-8db5-896ce93ed9b4" />
<img width="175" height="auto" alt="final2" src="https://github.com/user-attachments/assets/2268d10c-d512-4ef2-a29d-ef63770fb04b" />
<img width="175" height="auto" alt="image" src="https://github.com/user-attachments/assets/4785c480-9f8c-4ad0-911d-49f682c74b7a" />
<img width="174" height="auto" alt="final1" src="https://github.com/user-attachments/assets/bbdd8cd5-4033-4e02-9c24-5f071a3a0aed" /><br>
<i><b>Enhancement (new):</b> Point of view of user UB. Important milestones are now protected with a simple lock feature. UB cannot delete (or rename) LC's work when it is locked. </i>

---

This PR implements a comprehensive version locking system that allows users to "lock" their saved versions to prevent deletion by other team members. The enhancement was requested on #6763. 

## Problem statement

- The need for good Version Control has been an significant theme in the penpot community -- see https://community.penpot.app/t/using-version-control-to-collaboratively-work-on-penpot/633/3 and https://tree.taiga.io/project/penpot/us/187?milestone=262806. Currently there has been a milestone system implemented that enables user's to save important versions of the project. This is a highly valuable feature, however there are scenarios where it can be lost:
- User A has saved a crucial "milestone" of a project. User B accidentally deletes it when meaning to restore the version. After 7 days, no records remain of User A's milestone and it is lost forever.
- User A has saved a crucial "milestone" of a project. User B is a bad actor and intentionally deletes the version. After 7 days, no records remain of User A's milestone and it is lost forever.
- Penpot's key competitor, Figma offers a git-style "branching" feature as a solution to the accidental deletion/ bad actor problem on their premium paid tier -- even if this feature were copied this could not be implemented without dramatic file changes -- leaving vulnerability to unforseen bugs.

## Solution
- The simplest solution is best. A "lock" feature for milestones. Now User A's "milestone" can be locked and it is protected from accidental deletion and bad actors.

### Key Features
- ✅ Only version creators can lock/unlock their own version milestones
- ✅ Only version creators can rename their own version
- ✅ Locked versions cannot be deleted by anyone except the creator  
- ✅ System snapshots cannot be locked (only user-created versions)
- ✅ Clear visual indicators and menu options in the UI, reuse of the "lock" icon
- ✅ Comprehensive authorization checks and error handling in the frontend and backend


### Implementation Overview
- **Database**: Added `locked_by` column to `file_change` table in new migration file `backend/src/app/migrations/sql/0140-add-locked-by-column-to-file-change-table.sql`
- **Backend**: New RPC endpoints for lock/unlock operations with authorization in `backend/src/app/rpc/commands/files_snapshot.clj`
- **Frontend**: Lock/unlock UI in version history sidebar with visual indicators gracefully handles conditional rendering of lock and rename features.

## Testing Instructions

### Core Functionality Tests

**Version Locking**
1. Create a user version ("Save Version")
2. Lock it via menu → "Lock"
3. Verify lock indicator appears
4. Unlock via menu → "Unlock"
5. **Expected**: Lock/unlock works, visual indicators update correctly

**Delete Protection**
1. Lock a version you created
2. Attempt to delete it
3. **Expected**: Deletion blocked with clear error message

**Authorization**
1. User A creates and locks a version
2. User B tries to lock/unlock/delete it
3. **Expected**: User B's options to rename and delete are hidden.

**System Snapshots**
1. Try to lock an auto-saved system snapshot
2. **Expected**: Operation fails with "system snapshots cannot be locked" error

**UI Verification**
- [x] Lock/unlock options appear only for your own user versions
- [x] Locked versions display lock icon consistently
- [x] Menu text changes appropriately ("Lock" ↔ "Unlock")
- [x] Error messages are clear and actionable (ensured backend prevents user B deleting User A locked milestone) -- frontend handles gracefully with hidden buttons, leads to gateway error pages if forced.