### PR TITLE
:sparkles: Reuse workflows

### DIFF
--- a/.github/workflows/build-bundles.yml
+++ b/.github/workflows/build-bundles.yml
@@ -1,13 +1,6 @@
-name: Build and Upload Penpot Bundles non-prod
+name: Build and Upload Penpot Bundles
 
 on:
-  # Create bundler for every tag
-  push:
-    tags:
-      - '**' # Pattern matched against refs/tags
-  # Create bundler every hour between 5:00 and 20:00 on working days
-  schedule:
-    - cron: '0 5-20 * * 1-5'
   # Create bundler from manual action
   workflow_dispatch:
     inputs:
@@ -23,6 +16,12 @@ on:
         options:
           - individual
           - all
+  workflow_call:
+    inputs:
+      gh_ref:
+        description: 'Name of the branch'
+        type: string
+        required: true
 
 jobs:
   build-bundles:
@@ -38,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.gh_ref }}
 
       - name: Extract somer useful variables
         id: vars

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -1,0 +1,11 @@
+name: Build and Upload Penpot DEVELOP Bundles
+
+on:
+  schedule:
+    - cron: '16 5-20 * * 1-5'
+
+jobs:
+  build-develop-bundle:
+    uses: ./.github/workflows/build-bundles.yml
+    with:
+      gh_ref: "develop"

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -1,0 +1,11 @@
+name: Build and Upload Penpot STAGING Bundles
+
+on:
+  schedule:
+    - cron: '0 5 * * 1-5'
+
+jobs:
+  build-staging-bundle:
+    uses: ./.github/workflows/build-bundles.yml
+    with:
+      gh_ref: "staging"


### PR DESCRIPTION
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHh6bHJiaXJ3b3lqNnVyY2EyZHQ1OGd1amM0M2dpdjZybzQ4aWZ4aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zw7TzF0JxLVOZ9bnH6/giphy.gif)

This PR creates a structure to reuse workflows and be able to use different schedulers.

Due to several specific gotchas in github-actions:
- schedulers only work if they are placed in the default branch
- however, the gh-actions interface shows the `main` version of the files
- not sure when the gh-actions interface refreshes the workflow content, or how to trigger a refresh.

So, before this PR getting into `main` and having all branches in sync, we may have unexpected behaviours in the jobs.