### PR TITLE
:bug: Fix request render after pending calls have finished on set-objects

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -783,8 +783,13 @@
            (rx/tap (fn [_] (request-render "set-objects")))
            (rx/reduce conj [])
            (rx/subs! (fn [_]
+                       (clear-drawing-cache)
+                       (request-render "pending-finished")
                        (.dispatchEvent ^js js/document event))))
-      (.dispatchEvent ^js js/document event))))
+      (do
+        (clear-drawing-cache)
+        (request-render "pending-finished")
+        (.dispatchEvent ^js js/document event)))))
 
 (defn process-object
   [shape]
@@ -804,8 +809,6 @@
               (recur (inc index) (into pending pending')))
             pending))]
     (perf/end-measure "set-objects")
-    (clear-drawing-cache)
-    (request-render "set-objects")
     (process-pending pending)))
 
 (defn clear-focus-mode

--- a/frontend/src/app/render_wasm/api/fonts.cljs
+++ b/frontend/src/app/render_wasm/api/fonts.cljs
@@ -224,8 +224,8 @@
 
 (defn add-emoji-font
   [fonts]
-  (conj fonts {:font-id " gfont-noto-color-emoji "
-               :font-variant-id " regular "
+  (conj fonts {:font-id "gfont-noto-color-emoji"
+               :font-variant-id "regular"
                :style 0
                :weight 400
                :is-emoji true}))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11643

### Summary

We were not requesting the render after pending fonts where loaded. Therefore, the cached tiles were not updated and used the default font. This fixes also the issue with some "emoji" not being rendered, which were caused by this issue.

The second commit is a fix after a bug introduced here, which was also related to emoji

### Steps to reproduce 

- Create a document with texts shapes of different fonts and weights, that are placed in different tiles
- Refresh the page and check they're always rendered with the correct font

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
