### PR TITLE
:bug: Fix move empty variant values to the end when component is selected

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -927,10 +927,12 @@
             [:div ":touched " (str (:touched shape))])])])))
 
 
-(defn- move-empty-items-to-end [v]
-  (let [non-empty-items (filterv (complement empty?) v)
-        empty-items     (filterv empty? v)]
-    (vec (concat non-empty-items empty-items))))
+(defn- move-empty-items-to-end
+  "Creates a new vector with the empty items at the end"
+  [v]
+  (-> []
+      (into (remove empty?) v)
+      (into (filter empty?) v)))
 
 
 (mf/defc variant-menu*
@@ -1070,7 +1072,7 @@
 
         (when-not multi?
           [:div {:class (stl/css :variant-property-list)}
-           (for [[pos property] (map vector (range) properties)]
+           (for [[pos property] (map-indexed vector properties)]
              (let [meta (->> (:value property)
                              (move-empty-items-to-end)
                              (replace {"" "--"})

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -927,6 +927,12 @@
             [:div ":touched " (str (:touched shape))])])])))
 
 
+(defn- move-empty-items-to-end [v]
+  (let [non-empty-items (filterv (complement empty?) v)
+        empty-items     (filterv empty? v)]
+    (vec (concat non-empty-items empty-items))))
+
+
 (mf/defc variant-menu*
   [{:keys [shapes]}]
   (let [multi?             (> (count shapes) 1)
@@ -1065,7 +1071,10 @@
         (when-not multi?
           [:div {:class (stl/css :variant-property-list)}
            (for [[pos property] (map vector (range) properties)]
-             (let [meta (str/join ", " (:value property))]
+             (let [meta (->> (:value property)
+                             (move-empty-items-to-end)
+                             (replace {"" "--"})
+                             (str/join ", "))]
                [:div {:key (str (:id shape) pos)
                       :class (stl/css :variant-property-row)}
                 [:> input-with-meta* {:value (:name property)


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11700](https://tree.taiga.io/project/penpot/task/11700)

### Summary

If the user leaves a value empty, this condition will be represented by a placeholder “---” and listed in the design tab at the end of the list of values when the component is selected.

### Steps to reproduce 

Add a new property to a component which has variants, and leave it empty for at least one of its variants. Then select the component and check the property values at the design tab.
