### PR TITLE
:bug: Fix empty values should not have dimmed text

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
@@ -49,7 +49,7 @@
 
 (mf/defc option*
   {::mf/private true}
-  [{:keys [id ref label icon aria-label on-click selected focused dimmed] :rest props}]
+  [{:keys [id ref label icon aria-label on-click selected focused] :rest props}]
   (let [class (stl/css-case :option true
                             :option-with-icon (some? icon)
                             :option-selected selected
@@ -72,9 +72,7 @@
          :aria-hidden (when label true)
          :aria-label  (when (not label) aria-label)}])
 
-     [:span {:class (stl/css-case :option-text true
-                                  :option-text-dimmed dimmed)}
-      label]
+     [:span {:class (stl/css :option-text)} label]
 
      (when selected
        [:> i/icon*
@@ -117,7 +115,6 @@
                       :aria-label aria-label
                       :ref ref
                       :focused (= id focused)
-                      :dimmed false
                       :on-click on-click}]))
 
      (when (seq options-blank)
@@ -138,5 +135,4 @@
                          :aria-label aria-label
                          :ref ref
                          :focused (= id focused)
-                         :dimmed true
                          :on-click on-click}]))])]))

--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.scss
@@ -67,10 +67,6 @@
   padding-inline-start: var(--sp-xxs);
 }
 
-.option-text-dimmed {
-  color: var(--options-dropdown-empty);
-}
-
 .option-icon {
   color: var(--options-dropdown-icon-fg-color);
 }


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11711](https://tree.taiga.io/project/penpot/task/11711)

### Summary

In the dropdown of the `select*` or the `combobox*` components, the empty value should have the same appearance that the rest. Otherwise the user could understand that that option is disabled.

### Steps to reproduce 

Select a variant. In the design tab, try to select a new value for a property which has empty values for any other variants of the same component.