### PR TITLE
:bug: Fix title for button when trying to remove last variant property

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -354,7 +354,7 @@
 
     [:*
      [:div {:class (stl/css :variant-property-list)}
-      (for [[pos prop] (map vector (range) properties)]
+      (for [[pos prop] (map-indexed vector properties)]
         [:div {:key (str variant-id "-" pos) :class (stl/css :variant-property-container)}
          [:*
           [:div {:class (stl/css :variant-property-name-wrapper)}
@@ -1073,10 +1073,11 @@
         (when-not multi?
           [:div {:class (stl/css :variant-property-list)}
            (for [[pos property] (map-indexed vector properties)]
-             (let [meta (->> (:value property)
-                             (move-empty-items-to-end)
-                             (replace {"" "--"})
-                             (str/join ", "))]
+             (let [last-prop? (<= (count properties) 1)
+                   meta       (->> (:value property)
+                                   (move-empty-items-to-end)
+                                   (replace {"" "--"})
+                                   (str/join ", "))]
                [:div {:key (str (:id shape) pos)
                       :class (stl/css :variant-property-row)}
                 [:> input-with-meta* {:value (:name property)
@@ -1085,11 +1086,13 @@
                                       :data-position pos
                                       :on-blur update-property-name}]
                 [:> icon-button* {:variant "ghost"
-                                  :aria-label (tr "workspace.shape.menu.remove-variant-property")
+                                  :aria-label (if last-prop?
+                                                (tr "workspace.shape.menu.remove-variant-property.last-property")
+                                                (tr "workspace.shape.menu.remove-variant-property"))
                                   :on-click remove-property
                                   :data-position pos
                                   :icon "remove"
-                                  :disabled (<= (count properties) 1)}]]))])
+                                  :disabled last-prop?}]]))])
 
         (if malformed?
           [:div {:class (stl/css :variant-warning-wrapper)}

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -6973,6 +6973,10 @@ msgstr "Remove layout"
 msgid "workspace.shape.menu.remove-variant-property"
 msgstr "Remove property"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:974
+msgid "workspace.shape.menu.remove-variant-property.last-property"
+msgstr "Variant should have at least one property"
+
 #: src/app/main/ui/workspace/context_menu.cljs:318
 msgid "workspace.shape.menu.rename"
 msgstr "Rename"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -6975,6 +6975,10 @@ msgstr "Eliminar layout"
 msgid "workspace.shape.menu.remove-variant-property"
 msgstr "Eliminar propiedad"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:974
+msgid "workspace.shape.menu.remove-variant-property.last-property"
+msgstr "La variante debe tener al menos una propiedad"
+
 #: src/app/main/ui/workspace/context_menu.cljs:318
 msgid "workspace.shape.menu.rename"
 msgstr "Renombrar"


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11715](https://tree.taiga.io/project/penpot/task/11715)

### Summary

When trying to delete the last property from the design tab, when the user hovers the delete button, the button title should say: “Variant should have at least one property.". Instead it says "Remove property".

### Steps to reproduce 

Select a component that have variants. Remove all the properties except the last one. Hover the remove button.