### PR TITLE
:bug: Fix token pill not showing position application on dimension to…

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -463,6 +463,7 @@
                      ctt/spacing-keys
                      ctt/sizing-keys
                      ctt/border-radius-keys
+                     ctt/axis-keys
                      ctt/stroke-width-keys)
     :on-update-shape update-shape-dimensions
     :modal {:key :tokens/dimensions


### PR DESCRIPTION


### Related Ticket

This PR resolves [this issue](https://tree.taiga.io/project/penpot/issue/11699)

### Summary

Dimension token should appear half applied on a shape with this token applied on any axis attr (X or Y)

### Steps to reproduce 
1. Create a dimension token.
2. Create a shape and select it.
3. Open context menu on token and apply token to X position.

Pill should appear "half-applied" purple and half circle icon.
### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
