### PR TITLE
:sparkles: Center team settings properly

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -1137,53 +1137,54 @@
     [:*
      [:& header {:section :dashboard-team-settings :team team}]
      [:section {:class (stl/css :dashboard-team-settings)}
-      [:div {:class (stl/css :block :info-block)}
-       [:div {:class (stl/css :team-icon)}
-        (when can-edit
-          [:button {:class (stl/css :update-overlay)
-                    :on-click on-image-click}
-           image-icon])
-        [:img {:class (stl/css :team-image)
-               :src (cfg/resolve-team-photo-url team)}]
-        (when can-edit
-          [:& file-uploader {:accept "image/jpeg,image/png"
-                             :multi false
-                             :ref finput
-                             :on-selected on-file-selected}])]
-       [:div {:class (stl/css :block-label)}
-        (tr "dashboard.team-info")]
-       [:div {:class (stl/css :block-text)}
-        (:name team)]]
+      [:div {:class (stl/css :settings-container)}
+       [:div {:class (stl/css :block :info-block)}
+        [:div {:class (stl/css :team-icon)}
+         (when can-edit
+           [:button {:class (stl/css :update-overlay)
+                     :on-click on-image-click}
+            image-icon])
+         [:img {:class (stl/css :team-image)
+                :src (cfg/resolve-team-photo-url team)}]
+         (when can-edit
+           [:& file-uploader {:accept "image/jpeg,image/png"
+                              :multi false
+                              :ref finput
+                              :on-selected on-file-selected}])]
+        [:div {:class (stl/css :block-label)}
+         (tr "dashboard.team-info")]
+        [:div {:class (stl/css :block-text)}
+         (:name team)]]
 
-      [:div {:class (stl/css :block)}
-       [:div {:class (stl/css :block-label)}
-        (tr "dashboard.team-members")]
+       [:div {:class (stl/css :block)}
+        [:div {:class (stl/css :block-label)}
+         (tr "dashboard.team-members")]
 
-       [:div {:class (stl/css :block-content)}
-        [:img {:class (stl/css :owner-icon)
-               :src (cfg/resolve-profile-photo-url owner)}]
-        [:span {:class (stl/css :block-text)}
-         (str (:name owner) " ("  (tr "labels.owner") ")")]]
+        [:div {:class (stl/css :block-content)}
+         [:img {:class (stl/css :owner-icon)
+                :src (cfg/resolve-profile-photo-url owner)}]
+         [:span {:class (stl/css :block-text)}
+          (str (:name owner) " ("  (tr "labels.owner") ")")]]
 
-       [:div {:class (stl/css :block-content)}
-        user-icon
-        [:span {:class (stl/css :block-text)}
-         (tr "dashboard.num-of-members" (count members))]]]
+        [:div {:class (stl/css :block-content)}
+         user-icon
+         [:span {:class (stl/css :block-text)}
+          (tr "dashboard.num-of-members" (count members))]]]
 
-      [:div {:class (stl/css :block)}
-       [:div {:class (stl/css :block-label)}
-        (tr "dashboard.team-projects")]
+       [:div {:class (stl/css :block)}
+        [:div {:class (stl/css :block-label)}
+         (tr "dashboard.team-projects")]
 
-       [:div {:class (stl/css :block-content)}
-        group-icon
-        [:span {:class (stl/css :block-text)}
-         (tr "labels.num-of-projects" (i18n/c (dec (:projects stats))))]]
+        [:div {:class (stl/css :block-content)}
+         group-icon
+         [:span {:class (stl/css :block-text)}
+          (tr "labels.num-of-projects" (i18n/c (dec (:projects stats))))]]
 
-       [:div {:class (stl/css :block-content)}
-        document-icon
-        [:span {:class (stl/css :block-text)}
-         (tr "labels.num-of-files" (i18n/c (:files stats)))]]]
+        [:div {:class (stl/css :block-content)}
+         document-icon
+         [:span {:class (stl/css :block-text)}
+          (tr "labels.num-of-files" (i18n/c (:files stats)))]]]
 
-      (when (contains? cfg/flags :subscriptions)
-        [:> team* {:is-owner (:is-owner permissions) :team team}])]]))
+       (when (contains? cfg/flags :subscriptions)
+         [:> team* {:is-owner (:is-owner permissions) :team team}])]]]))
 

--- a/frontend/src/app/main/ui/dashboard/team.scss
+++ b/frontend/src/app/main/ui/dashboard/team.scss
@@ -12,11 +12,18 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $s-24;
   width: 100%;
   border-top: $s-1 solid var(--panel-border-color);
   overflow-y: auto;
-  padding-inline: $s-24;
+  padding-inline-start: $s-20;
+  padding-block-start: $s-20;
+}
+
+.settings-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $s-24;
 }
 
 .block {
@@ -355,16 +362,17 @@
   gap: $s-24;
   width: 100%;
   height: 100%;
-  padding-top: $s-16;
+  padding-inline-start: $s-20;
+  padding-block-start: $s-20;
   border-top: $s-1 solid var(--panel-border-color);
   overflow-y: auto;
 }
 
 .webhooks-hero-container {
   display: grid;
-  gap: $s-32;
-  max-width: $s-1000;
-  width: $s-1000;
+  grid-template-rows: auto 1fr;
+  margin: $s-80 auto $s-20 auto;
+  gap: $s-24;
 }
 
 .webhooks-empty {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11487

### Summary

<img width="1230" height="650" alt="Screenshot from 2025-07-30 16-43-57" src="https://github.com/user-attachments/assets/18aabad4-f088-4076-87ae-7314bd7cffd9" />
<img width="2552" height="878" alt="Screenshot from 2025-07-30 17-04-56" src="https://github.com/user-attachments/assets/8e07906b-9481-48d8-ab3b-4b2c9d88d5cd" />
<img width="2552" height="878" alt="Screenshot from 2025-07-30 17-04-49" src="https://github.com/user-attachments/assets/cf003b78-4fe4-4f00-a7fd-d98d7778de85" />

### Steps to reproduce 

- Activate `enable-webhooks` flag to see this tab in the settings
- Check webhooks and settings content on team settings is properly centered

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
