### PR TITLE
:bug: Fix adjust focus in select component

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/select.scss
+++ b/frontend/src/app/main/ui/ds/controls/select.scss
@@ -54,10 +54,6 @@
   appearance: none;
 }
 
-.focused {
-  --select-outline-color: var(--color-accent-primary);
-}
-
 .arrow {
   color: var(--select-icon-fg-color);
   transform: rotate(90deg);


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11722](https://tree.taiga.io/project/penpot/task/11722)

### Summary

The dropdown of the select component appears as focused when clicking on it, as well as the selected option. This is not consistent with the other components. The focus should only appear in the dropdown when using the arrow keys, and never on the component.

### Steps to reproduce 

Select a copy of a component with variants and try to change the value of any of their properties.