### PR TITLE
:wrench: Fix text default color and inner stroke opacity

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -470,18 +470,6 @@ impl RenderState {
 
                 text::render(self, &shape, &mut paragraphs, None, None);
 
-                if shape.has_visible_inner_strokes() {
-                    // Inner strokes paints need the text fill to apply correctly their blend modes
-                    // (e.g., SrcATop, DstOver)
-                    text::render(
-                        self,
-                        &shape,
-                        &mut paragraphs,
-                        Some(SurfaceId::Strokes),
-                        None,
-                    );
-                }
-
                 for stroke in shape.visible_strokes().rev() {
                     let mut stroke_paragraphs =
                         text_content.get_skia_stroke_paragraphs(stroke, &shape.selrect());

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -24,6 +24,9 @@ pub fn render(
         _ => 0.0,
     };
 
+    let layer_rec = skia_safe::canvas::SaveLayerRec::default();
+    canvas.save_layer(&layer_rec);
+
     for group in paragraphs {
         let mut group_offset_y = global_offset_y;
         let group_len = group.len();
@@ -36,15 +39,7 @@ pub fn render(
                 let mut paragraph_builder =
                     ParagraphBuilder::new(&builder.get_paragraph_style(), fonts);
                 let mut text_style: skia_safe::Handle<_> = builder.peek_style();
-                let current_paint = text_style.foreground().clone();
-                let blend_mode = current_paint.as_blend_mode();
-                let mut new_paint = paint.unwrap().clone();
-                if blend_mode != Some(skia_safe::BlendMode::SrcIn) {
-                    new_paint.set_stroke_width(current_paint.stroke_width());
-                    new_paint.set_style(skia_safe::PaintStyle::StrokeAndFill);
-                }
-                new_paint.set_anti_alias(true);
-                text_style.set_foreground_paint(&new_paint);
+                text_style.set_foreground_paint(paint.unwrap());
                 paragraph_builder.reset();
                 paragraph_builder.push_style(&text_style);
                 paragraph_builder.add_text(&text);
@@ -138,6 +133,8 @@ pub fn render(
             global_offset_y = group_offset_y;
         }
     }
+
+    canvas.restore();
 }
 
 pub fn calculate_text_decoration_rect(

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -980,6 +980,7 @@ impl Shape {
         self.visible_strokes().next().is_some()
     }
 
+    #[allow(dead_code)]
     pub fn has_visible_inner_strokes(&self) -> bool {
         self.visible_strokes().any(|s| s.kind == StrokeKind::Inner)
     }

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -230,6 +230,11 @@ pub fn merge_fills(fills: &[Fill], bounding_box: Rect) -> skia::Paint {
     let mut combined_shader: Option<skia::Shader> = None;
     let mut fills_paint = skia::Paint::default();
 
+    if fills.is_empty() {
+        fills_paint.set_color(skia::Color::TRANSPARENT);
+        return fills_paint;
+    }
+
     for fill in fills {
         let shader = get_fill_shader(fill, &bounding_box);
 


### PR DESCRIPTION
### Related Ticket

* https://tree.taiga.io/project/penpot/issue/11691 
* https://tree.taiga.io/project/penpot/issue/11570

### Summary

This PR fixes the issue for texts with empty fills + strokes and opacity blending. We can compare the different strokes with applied opacity (inner - center - outer):

<img width="1170" height="988" alt="image" src="https://github.com/user-attachments/assets/df4e495e-4bf4-40ce-8a03-8c66c4f0a558" />

When there's no fill, the text shape is transparent, it works with drop + inner shadows and with different fill types:

<img width="598" height="698" alt="image" src="https://github.com/user-attachments/assets/a5d31990-118d-4836-9d2f-e07961bdb490" />

However, as we can see, there's now a problem with inner strokes. While we've fixed the opacity issue, there's a thin glitch around the text shape, because it seems the blending is not being applied correctly:

<img width="1063" height="492" alt="image" src="https://github.com/user-attachments/assets/b012c383-2de1-4fe1-9077-199babbb70bd" />

Therefore, we need to find out how to remove the _glitchy_ border before continuing

### Steps to reproduce 

You can import this penpot file to test the examples from above:

[text_strokes.zip](https://github.com/user-attachments/files/21734646/text_strokes.zip)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
