### PR TITLE
:bug: Fix property name cannot be empty

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -996,11 +996,12 @@
         (mf/use-fn
          (mf/deps variant-id)
          (fn [event]
-           (let [new-name (dom/get-target-val event)
-                 pos (-> (dom/get-current-target event)
-                         (dom/get-data "position")
-                         int)]
-             (st/emit! (dwv/update-property-name variant-id pos new-name)))))
+           (let [value (dom/get-target-val event)
+                 pos   (-> (dom/get-current-target event)
+                           (dom/get-data "position")
+                           int)]
+             (when (seq value)
+               (st/emit! (dwv/update-property-name variant-id pos value))))))
 
         remove-property
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11723](https://tree.taiga.io/project/penpot/task/11723)

### Summary

The user cannot leave the property-name input in the design tab empty. We must solve this as we solve this kind of thing in the platform, keeping the previous value.

### Steps to reproduce

Select a component with variants. Try to remove the name of any property.