### PR TITLE
:bug: Fix create properties with a default value instead of an empty one

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -77,7 +77,7 @@
 
 
 (defn generate-add-new-property
-  [changes variant-id & {:keys [fill-values? property-name]}]
+  [changes variant-id & {:keys [fill-values? property-name property-value]}]
   (let [data               (pcb/get-library-data changes)
         objects            (pcb/get-objects changes)
         related-components (cfv/find-variant-components data objects variant-id)
@@ -95,13 +95,17 @@
 
                         update-props #(-> (d/nilv % [])
                                           (conj {:name property-name
-                                                 :value (if fill-values? (str ctv/value-prefix num) "")}))
+                                                 :value (cond fill-values?   (str ctv/value-prefix num)
+                                                              property-value property-value
+                                                              :else          "")}))
 
-                        update-name #(if fill-values?
-                                       (if (str/empty? %)
-                                         (str ctv/value-prefix num)
-                                         (str % ", " ctv/value-prefix num))
-                                       %)]
+                        update-name #(cond fill-values?   (if (str/empty? %)
+                                                            (str ctv/value-prefix num)
+                                                            (str % ", " ctv/value-prefix num))
+                                           property-value (if (str/empty? %)
+                                                            property-value
+                                                            (str % ", " property-value))
+                                           :else %)]
                     [(inc num)
                      (-> changes
                          (pcb/update-component (:id component)

--- a/common/test/common_tests/logic/variants_test.cljc
+++ b/common/test/common_tests/logic/variants_test.cljc
@@ -120,7 +120,45 @@
     (t/is (= (count (:variant-properties comp01')) 2))
     (t/is (= (count (:variant-properties comp02)) 1))
     (t/is (= (count (:variant-properties comp02')) 2))
-    (t/is (= (-> comp01' :variant-properties last :value) "Value 1"))))
+    (t/is (= (-> comp01' :variant-properties last :value) "Value 1"))
+    (t/is (= (-> comp02' :variant-properties last :value) "Value 2"))))
+
+
+
+(t/deftest test-add-new-property-with-the-same-value
+  (let [;; ==== Setup
+        file    (-> (thf/sample-file :file1)
+                    (thv/add-variant :v01 :c01 :m01 :c02 :m02))
+        v-id    (-> (ths/get-shape file :v01) :id)
+        page    (thf/current-page file)
+
+        comp01  (thc/get-component file :c01)
+        comp02  (thc/get-component file :c02)
+
+
+        ;; ==== Action
+        changes (-> (pcb/empty-changes nil)
+                    (pcb/with-page-id (:id page))
+                    (pcb/with-library-data (:data file))
+                    (pcb/with-objects (:objects page))
+                    (clvp/generate-add-new-property v-id {:property-value "Value 1"}))
+
+
+        file'   (thf/apply-changes file changes)
+
+
+
+        ;; ==== Get
+        comp01' (thc/get-component file' :c01)
+        comp02' (thc/get-component file' :c02)]
+
+    ;; ==== Check
+    (t/is (= (count (:variant-properties comp01)) 1))
+    (t/is (= (count (:variant-properties comp01')) 2))
+    (t/is (= (count (:variant-properties comp02)) 1))
+    (t/is (= (count (:variant-properties comp02')) 2))
+    (t/is (= (-> comp01' :variant-properties last :value) "Value 1"))
+    (t/is (= (-> comp02' :variant-properties last :value) "Value 1"))))
 
 
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -969,7 +969,7 @@
         menu-open?         (deref menu-open*)
 
         menu-entries       [{:title (tr "workspace.shape.menu.add-variant-property")
-                             :action #(st/emit! (dwv/add-new-property variant-id))}
+                             :action #(st/emit! (dwv/add-new-property variant-id {:property-value "Value 1"}))}
                             {:title (tr "workspace.shape.menu.add-variant")
                              :action #(st/emit! (dwv/add-new-variant (:id shape)))}]
 


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11730](https://tree.taiga.io/project/penpot/task/11730)

### Summary

Via menu, from the design tab, while the component is selected. This new property should propagate to the remaining variants with the default value (Value 1).

But we are using an empty value instead of "Value 1".

### Steps to reproduce 

Select a component with variants. In the design tab, try to add a new property.