### PR TITLE
:bug: Fix default color when neither fill nor background color is set

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -198,7 +198,7 @@
         background-color (:background page)
 
         text-color       (or fill-color (get-default-text-color {:frame frame
-                                                                 :background-color background-color}))
+                                                                 :background-color background-color}) color/black)
 
         fonts
         (-> (mf/use-memo (mf/deps content) #(get-fonts content))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11740

Follow up of https://github.com/penpot/penpot/pull/6998/files

### Summary

There's a case when there's neither fill nor background color present, so we default to black

### Steps to reproduce 

in an empty file

- create a text layer
- write something
- check that the color input of the text is not mixed
- check it does not crash

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
