### PR TITLE
:bug: Fix show 'add new property' from menu when a variant is selected

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -361,6 +361,7 @@
         main-instance?      (ctk/main-instance? shape)
 
         component-id        (:component-id shape)
+        variant-id          (:variant-id shape)
         library-id          (:component-file shape)
 
         local-component?    (= library-id current-file-id)
@@ -441,6 +442,9 @@
              (st/emit! (dwv/add-new-variant id))
              (st/emit! (dwv/transform-in-variant id))))
 
+        do-add-new-property
+        #(st/emit! (dwv/add-new-property variant-id {:property-value "Value 1"}))
+
         do-show-local-component
         #(st/emit! (dwl/go-to-local-component :id component-id))
 
@@ -497,5 +501,8 @@
                       (when (and variants? (or (not multi) same-variant?) main-instance?)
                         {:title (tr "workspace.shape.menu.add-variant")
                          :shortcut :create-component
-                         :action do-add-variant})]]
+                         :action do-add-variant})
+                      (when (and variants? same-variant? main-instance? variant-id)
+                        {:title (tr "workspace.shape.menu.add-variant-property")
+                         :action do-add-new-property})]]
     (filter (complement nil?) menu-entries)))


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11716](https://tree.taiga.io/project/penpot/task/11716)

### Summary

Via menu, from the design tab, the user should be able to add a new property while the component or one of its variants is selected.

It works when the component is selected but not when one of the variants is selected.

### Steps to reproduce

Select a variant, and try to add a new property from the design tab.