### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
     image: "penpotapp/frontend:${PENPOT_VERSION:-latest}"
     restart: always
     ports:
-      - 9001:8080
+      - 9001:80
 
     volumes:
       - penpot_assets:/opt/data/assets


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/6877

### Summary
Fixed an error where if the user self-hosts Penpot using `docker compose`, the problem came from the port mapping for `penpot-frontend`, where port `9001` on the host was pointing to port `8080` inside the container which returned refused the connection.

Changing it to port `80` solves the issue and allows the user to establish a connection.

### Steps to reproduce 

Enter the following commands in the terminal with docker installed:
1. `wget https://raw.githubusercontent.com/penpot/penpot/main/docker/images/docker-compose.yaml`
2. `docker compose -p penpot -f docker-compose.yaml up -d`

Then open in your browser the URL: `http://localhost:9001`

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
