### PR TITLE
:bug: Fix frames extrect calculation

### DIFF
--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -226,9 +226,9 @@ pub extern "C" fn use_shape(a: u32, b: u32, c: u32, d: u32) {
 
 #[no_mangle]
 pub extern "C" fn set_parent(a: u32, b: u32, c: u32, d: u32) {
-    with_current_shape_mut!(state, |shape: &mut Shape| {
+    with_state_mut!(state, {
         let id = uuid_from_u32_quartet(a, b, c, d);
-        shape.set_parent(id);
+        state.set_parent_for_current_shape(id);
     });
 }
 

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -1,5 +1,11 @@
 use crate::shapes::Shape;
+use crate::state::ShapesPool;
+use crate::uuid::Uuid;
+
+use crate::math::Matrix;
 use skia_safe::{self as skia, Rect};
+
+use std::collections::HashMap;
 
 use super::{tiles, RenderState, SurfaceId};
 
@@ -58,7 +64,13 @@ pub fn render_wasm_label(render_state: &mut RenderState) {
     canvas.draw_str(str, p, debug_font, &paint);
 }
 
-pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, intersected: bool) {
+pub fn render_debug_shape(
+    render_state: &mut RenderState,
+    element: &Shape,
+    intersected: bool,
+    shapes_pool: &ShapesPool,
+    modifiers: &HashMap<Uuid, Matrix>,
+) {
     let mut paint = skia::Paint::default();
     paint.set_style(skia::PaintStyle::Stroke);
     paint.set_color(if intersected {
@@ -68,7 +80,7 @@ pub fn render_debug_shape(render_state: &mut RenderState, element: &Shape, inter
     });
     paint.set_stroke_width(1.);
 
-    let rect = get_debug_rect(element.extrect());
+    let rect = get_debug_rect(element.extrect(shapes_pool, modifiers));
     render_state
         .surfaces
         .canvas(SurfaceId::Debug)

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -99,7 +99,9 @@ impl State {
     pub fn delete_shape(&mut self, id: Uuid) {
         // We don't really do a self.shapes.remove so that redo/undo keep working
         if let Some(shape) = self.shapes.get(&id) {
-            let tiles::TileRect(rsx, rsy, rex, rey) = self.render_state.get_tiles_for_shape(shape);
+            let tiles::TileRect(rsx, rsy, rex, rey) =
+                self.render_state
+                    .get_tiles_for_shape(shape, &self.shapes, &self.modifiers);
             for x in rsx..=rex {
                 for y in rsy..=rey {
                     let tile = tiles::Tile(x, y);
@@ -122,6 +124,31 @@ impl State {
         self.render_state.set_background_color(color);
     }
 
+    /// Sets the parent for the current shape and updates the parent's extended rectangle
+    ///
+    /// When a shape is assigned a new parent, the parent's extended rectangle needs to be
+    /// invalidated and recalculated to include the new child. This ensures that frames
+    /// and groups properly encompass their children.
+    pub fn set_parent_for_current_shape(&mut self, id: Uuid) {
+        let shape = {
+            let Some(shape) = self.current_shape_mut() else {
+                panic!("Invalid current shape")
+            };
+            shape.set_parent(id);
+            shape.clone()
+        };
+
+        if let Some(parent) = shape.parent_id.and_then(|id| self.shapes.get_mut(&id)) {
+            parent.invalidate_extrect();
+            parent.add_child(shape.id);
+        }
+    }
+
+    /// Sets the selection rectangle for the current shape and processes its ancestors
+    ///
+    /// When a shape's selection rectangle changes, all its ancestors need to have their
+    /// extended rectangles recalculated because the shape's bounds may have changed.
+    /// This ensures proper rendering of frames and groups containing the modified shape.
     pub fn set_selrect_for_current_shape(&mut self, left: f32, top: f32, right: f32, bottom: f32) {
         let shape = {
             let Some(shape) = self.current_shape_mut() else {
@@ -130,16 +157,14 @@ impl State {
             shape.set_selrect(left, top, right, bottom);
             shape.clone()
         };
-
-        // We don't need to update the tile for the root shape.
-        if !shape.id.is_nil() {
-            self.render_state.update_tile_for(&shape);
-        }
+        self.render_state
+            .process_shape_ancestors(&shape, &mut self.shapes, &self.modifiers);
     }
 
     pub fn update_tile_for_shape(&mut self, shape_id: Uuid) {
         if let Some(shape) = self.shapes.get(&shape_id) {
-            self.render_state.update_tile_for(shape);
+            self.render_state
+                .update_tile_for(shape, &self.shapes, &self.modifiers);
         }
     }
 
@@ -148,7 +173,8 @@ impl State {
             panic!("Invalid current shape")
         };
         if !shape.id.is_nil() {
-            self.render_state.update_tile_for(&shape.clone());
+            self.render_state
+                .update_tile_for(&shape.clone(), &self.shapes, &self.modifiers);
         }
     }
 
@@ -164,7 +190,7 @@ impl State {
 
     pub fn rebuild_modifier_tiles(&mut self) {
         self.render_state
-            .rebuild_modifier_tiles(&self.shapes, &self.modifiers);
+            .rebuild_modifier_tiles(&mut self.shapes, &self.modifiers);
     }
 
     pub fn font_collection(&self) -> &FontCollection {

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct Tile(pub i32, pub i32);
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct TileRect(pub i32, pub i32, pub i32, pub i32);
 
 impl TileRect {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11768

### Summary

Check this video with the problems of the actual version:

https://github.com/user-attachments/assets/a17944d6-7a9d-437b-af88-11d2dd0ca55a

And the proposed solution:

https://github.com/user-attachments/assets/bf4c0cba-8f61-4282-8392-f50797fc0f31

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
