### PR TITLE
:sparkles: Treat empty names as a malformed formula

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -71,7 +71,7 @@
         component (ctcl/get-component data component-id true)
         main-id   (:main-instance-id component)]
     (-> changes
-        (pcb/update-shapes [main-id] (if (str/blank? value)
+        (pcb/update-shapes [main-id] (if (nil? value)
                                        #(dissoc % :variant-error)
                                        #(assoc % :variant-error value))))))
 

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -135,25 +135,27 @@
 
 
 (defn update-error
-  "Updates the error in a component"
-  [component-id value]
-  (ptk/reify ::update-error
-    ptk/WatchEvent
-    (watch [it state _]
-      (let [page-id    (:current-page-id state)
-            data       (dsh/lookup-file-data state)
-            objects    (-> (dsh/get-page data page-id)
-                           (get :objects))
+  "Sets or unsets an error for a component"
+  ([component-id]
+   (update-error component-id nil))
+  ([component-id value]
+   (ptk/reify ::update-error
+     ptk/WatchEvent
+     (watch [it state _]
+       (let [page-id    (:current-page-id state)
+             data       (dsh/lookup-file-data state)
+             objects    (-> (dsh/get-page data page-id)
+                            (get :objects))
 
-            changes    (-> (pcb/empty-changes it page-id)
-                           (pcb/with-library-data data)
-                           (pcb/with-objects objects)
-                           (clvp/generate-set-variant-error component-id value))
-            undo-id    (js/Symbol)]
-        (rx/of
-         (dwu/start-undo-transaction undo-id)
-         (dch/commit-changes changes)
-         (dwu/commit-undo-transaction undo-id))))))
+             changes    (-> (pcb/empty-changes it page-id)
+                            (pcb/with-library-data data)
+                            (pcb/with-objects objects)
+                            (clvp/generate-set-variant-error component-id value))
+             undo-id    (js/Symbol)]
+         (rx/of
+          (dwu/start-undo-transaction undo-id)
+          (dch/commit-changes changes)
+          (dwu/commit-undo-transaction undo-id)))))))
 
 
 (defn remove-property

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -73,7 +73,7 @@
                (if (ctv/valid-properties-formula? name)
                  (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties (ctv/properties-formula->map name))
                            (dwv/remove-empty-properties variant-id)
-                           (dwv/update-error component-id nil))
+                           (dwv/update-error component-id))
                  (st/emit! (dwv/update-properties-names-and-values component-id variant-id variant-properties {})
                            (dwv/remove-empty-properties variant-id)
                            (dwv/update-error component-id name)))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -339,7 +339,7 @@
            (let [value (d/nilv (str/trim value) "")]
              (doseq [id component-ids]
                (st/emit! (dwv/update-property-value id pos value))
-               (st/emit! (dwv/update-error id nil))))))
+               (st/emit! (dwv/update-error id))))))
 
         update-property-name
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

Taiga issue [#11763](https://tree.taiga.io/project/penpot/task/11763)

### Summary

An empty variant name is equivalent to a failed formula. It should trigger the message that informs of invalid names.
The result of all variants having wrong formulas (including empty names) is a component without properties.

### Steps to reproduce 

Try to edit the formula for a variant and left it empty.