### PR TITLE
:bug: Fix auto height is fixed in the HTML inspect tab for text elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@
 - Fix export button width on inspect tab [Taiga #11394](https://tree.taiga.io/project/penpot/issue/11394)
 - Fix stroke width token application [Taiga #11724](https://tree.taiga.io/project/penpot/issue/11724)
 - Fix number token application on shape [Taiga #11331](https://tree.taiga.io/project/penpot/task/11331)
+- Fix auto height is fixed in the HTML inspect tab for text elements [Taiga #11680](https://tree.taiga.io/project/penpot/task/11680)
 
 ## 2.8.1
 

--- a/frontend/src/app/util/code_gen/style_css_values.cljs
+++ b/frontend/src/app/util/code_gen/style_css_values.cljs
@@ -116,13 +116,17 @@
   (let [root? (contains? (:root-shapes options) (:id shape))]
     (if (and root? (ctl/any-layout? shape))
       :fill
-      (get-shape-size shape objects :width))))
+      ;; Don't set fixed width for auto-width text shapes
+      (when-not (and (cfh/text-shape? shape) (= (:grow-type shape) :auto-width))
+        (get-shape-size shape objects :width)))))
 
 (defmethod get-value :height
   [_ shape objects options]
   (let [root? (contains? (:root-shapes options) (:id shape))]
     (when-not (and root? (ctl/any-layout? shape))
-      (get-shape-size shape objects :height))))
+      ;; Don't set fixed height for auto-height text shapes
+      (when-not (and (cfh/text-shape? shape) (= (:grow-type shape) :auto-height))
+        (get-shape-size shape objects :height)))))
 
 (defmethod get-value :flex-grow
   [_ shape _ options]


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
