### PR TITLE
:sparkles: Allow font-families with surrounding quotation marks

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -30,6 +30,7 @@
    [app.main.store :as st]
    [beicon.v2.core :as rx]
    [clojure.set :as set]
+   [cuerdas.core :as str]
    [potok.v2.core :as ptk]))
 
 (declare token-properties)
@@ -284,7 +285,9 @@
 (defn update-font-family
   ([value shape-ids attributes] (update-font-family value shape-ids attributes nil))
   ([value shape-ids _attributes page-id]
-   (let [font-family (first value)
+   (let [font-family (-> (first value)
+                         ;; Strip quotes around font-family like `"Inter"`
+                         (str/trim #"[\"']"))
          font (some-> font-family
                       (fonts/find-font-family))
          text-attrs (if font


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/130

### Summary

Allows font-family tokens with quotation marks around them.
Very simple implementation again, so it wont care about unclosed quotes, commas inside quotes etc.

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
