### PR TITLE
:bug: Fix import of borderWidth

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -37,8 +37,6 @@
    :font-family     "fontFamilies"
    :font-size       "fontSizes"
    :letter-spacing  "letterSpacing"
-   :text-case       "textCase"
-   :text-decoration "textDecoration"
    :number          "number"
    :opacity         "opacity"
    :other           "other"
@@ -46,7 +44,9 @@
    :sizing          "sizing"
    :spacing         "spacing"
    :string          "string"
-   :stroke-width    "strokeWidth"})
+   :stroke-width    "borderWidth"
+   :text-case       "textCase"
+   :text-decoration "textDecoration"})
 
 (def dtcg-token-type->token-type
   (set/map-invert token-type->dtcg-token-type))


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/132

### Summary

Fixes wrong rename for strokeWidth

### Steps to reproduce 

- Import of tokens with borderWidth should work

[border-width.json](https://github.com/user-attachments/files/21661717/border-width.json)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
