### PR TITLE
:sparkles: Add create variants in bulk interactions from assets tab

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -234,8 +234,8 @@
 
      (when group-open?
        [:*
-        [:div {:class-name (stl/css-case :asset-grid listing-thumbs?
-                                         :asset-enum (not listing-thumbs?))
+        [:div {:class (stl/css-case :asset-grid listing-thumbs?
+                                    :asset-enum (not listing-thumbs?))
                :on-drag-enter on-drag-enter
                :on-drag-leave on-drag-leave
                :on-drag-over dom/prevent-default
@@ -435,7 +435,7 @@
 
         rename-group
         (mf/use-fn
-         (mf/deps components)
+         (mf/deps components on-clear-selection)
          (fn [path last-path]
            (on-clear-selection)
            (let [undo-id (js/Symbol)]
@@ -466,7 +466,7 @@
 
         on-ungroup
         (mf/use-fn
-         (mf/deps components)
+         (mf/deps components on-clear-selection)
          (fn [path]
            (on-clear-selection)
            (let [undo-id (js/Symbol)]
@@ -479,7 +479,7 @@
 
         on-group-combine-variants
         (mf/use-fn
-         (mf/deps components)
+         (mf/deps components on-clear-selection)
          (fn [path]
            (on-clear-selection)
            (let [comps   (->> components

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/groups.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/groups.scss
@@ -6,6 +6,28 @@
 
 @import "refactor/common-refactor.scss";
 
+.group-title-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  &:hover {
+    cursor: pointer;
+
+    .title-menu {
+      display: block;
+    }
+  }
+}
+
+.group-title-wrapper > :first-child {
+  flex: 1 1 auto;
+}
+
+.title-menu {
+  display: none;
+}
+
 .group-title {
   padding-left: $s-4;
 }
@@ -39,6 +61,7 @@
   @include uppercaseTitleTipography;
   color: var(--modal-title-foreground-color);
 }
+
 .modal-close-btn {
   @extend .modal-close-btn-base;
 }
@@ -47,20 +70,24 @@
   @include bodySmallTypography;
   margin-bottom: $s-24;
 }
+
 .input-wrapper {
   @extend .input-with-label;
   @include bodySmallTypography;
   margin-bottom: $s-8;
 }
+
 .action-buttons {
   @extend .modal-action-btns;
 }
+
 .cancel-button {
   @extend .modal-cancel-btn;
 }
 
 .accept-btn {
   @extend .modal-accept-btn;
+
   &.danger {
     @extend .modal-danger-btn;
   }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -4929,6 +4929,10 @@ msgstr "Text Transform"
 msgid "workspace.assets.ungroup"
 msgstr "Ungroup"
 
+#: src/app/main/ui/workspace/sidebar/assets/groups.cljs:83
+msgid "workspace.assets.component-group-options"
+msgstr "Component group options"
+
 #: src/app/main/ui/workspace/context_menu.cljs:769
 msgid "workspace.context-menu.grid-cells.area"
 msgstr "Create area"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -4939,6 +4939,9 @@ msgstr "Transformar texto"
 msgid "workspace.assets.ungroup"
 msgstr "Desagrupar"
 
+msgid "workspace.assets.component-group-options"
+msgstr "Opciones del grupo de componentes"
+
 #: src/app/main/ui/workspace/context_menu.cljs:769
 msgid "workspace.context-menu.grid-cells.area"
 msgstr "Crear area"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/11796

### Summary

Add create variants in bulk interactions from assets tab

### Steps to reproduce 

1. Create two components named "button/one" and "button/two"
2. Go to the assets tab
3. Check that when you hover over the name of the group "button", a menu icon is shown, and clicking on it open the contextual menu
4. On the contextual menu of the group "button" press "Combine as variants". Both components should be combined into a variant

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
