### PR TITLE
:bug: Fix missing selection after swap

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -986,12 +986,15 @@
               [changes []])
             all-parents (into all-parents parents-of-swapped)]
 
-        (rx/of
-         (dwu/start-undo-transaction undo-id)
-         (dch/commit-changes changes)
-         (dws/select-shape (:id new-shape) true)
-         (ptk/data-event :layout/update {:ids all-parents :undo-group undo-group})
-         (dwu/commit-undo-transaction undo-id))))))
+        (rx/merge
+         (rx/of
+          (dwu/start-undo-transaction undo-id)
+          (dch/commit-changes changes)
+          (ptk/data-event :layout/update {:ids all-parents :undo-group undo-group})
+          (dwu/commit-undo-transaction undo-id)
+          (dws/deselect-all))
+         (->> (rx/of (dws/select-shape (:id new-shape) false))
+              (rx/delay 1)))))))
 
 (defn component-multi-swap
   "Swaps several components with another one"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11729

### Summary

When I select a component and then switch it for another variant, once that's done, the selection I originally had is gone

### Steps to reproduce 

Go to a component with variants and make a copy
Switch from one variant copy to another
See how you are no longer selecting the variant, nor anything

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
