### PR TITLE
:bug: Fix flex layout everrides are not mantained on variant switch

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1952,7 +1952,7 @@
               skip-operations?
               (or
                ;; If the attribute is not valid for the destiny, don't copy it
-               (not (cts/is-allowed-attr? attr (:type current-shape)))
+               (not (cts/is-allowed-switch-keep-attr? attr (:type current-shape)))
 
                ;; If the values are already equal, don't copy them
                (= (get previous-shape attr) (get current-shape attr))

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -413,8 +413,7 @@
   (or (some :fill-image fills)
       (some :stroke-image strokes)))
 
-;; Valid attributes
-
+;; Valid attributes for keeping on a switch
 (def ^:private allowed-shape-attrs
   #{:page-id :component-id :component-file :component-root :main-instance
     :remote-synced :shape-ref :touched :blocked :collapsed :locked
@@ -424,17 +423,23 @@
     :plugin-data})
 
 (def ^:private allowed-shape-geom-attrs #{:x :y :width :height})
-(def ^:private allowed-shape-base-attrs #{:id :name :type :selrect :points :transform :transform-inverse :parent-id :frame-id})
+(def ^:private allowed-shape-base-attrs #{:id :name :type :selrect :points :transform
+                                          :transform-inverse :parent-id :frame-id})
 (def ^:private allowed-bool-attrs #{:shapes :bool-type :content})
 (def ^:private allowed-group-attrs #{:shapes})
-(def ^:private allowed-frame-attrs #{:shapes :hide-fill-on-export :show-content :hide-in-viewer})
+(def ^:private allowed-frame-attrs #{:shapes :hide-fill-on-export :show-content :hide-in-viewer
+                                     :layout :layout-flex-dir :layout-gap-type :layout-gap
+                                     :layout-align-items :layout-justify-content :layout-align-content
+                                     :layout-wrap-type :layout-padding-type :layout-padding
+                                     :layout-grid-dir :layout-justify-items :layout-grid-columns
+                                     :layout-grid-rows})
 (def ^:private allowed-image-attrs #{:metadata})
 (def ^:private allowed-svg-attrs #{:content})
 (def ^:private allowed-path-attrs #{:content})
 (def ^:private allowed-text-attrs #{:content})
 (def ^:private allowed-generic-attrs (set/union allowed-shape-attrs allowed-shape-geom-attrs allowed-shape-base-attrs))
 
-(defn is-allowed-attr?
+(defn is-allowed-switch-keep-attr?
   [attr type]
   (case type
     :group   (or (contains? allowed-group-attrs attr)

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -984,7 +984,9 @@
             (if keep-touched?
               (clv/generate-keep-touched changes new-shape shape orig-shapes page libraries ldata)
               [changes []])
-            all-parents (into all-parents parents-of-swapped)]
+            all-parents (-> all-parents
+                            (into parents-of-swapped)
+                            (conj (:id new-shape)))]
 
         (rx/of
          (dwu/start-undo-transaction undo-id)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11744

### Summary

If I create a two variants that are flex layouts, (I created them equally) and I make a copy of one of them, edit some of its flex properties (The gap and the padding for example) and then I switch from that variant to the other one, those flex changes are not preserved

### Steps to reproduce 

Create 2 rectangles and select them → Shift+A →You've created a flex layout with both of them
Cntrl+K to create a component. Cntrl+K to create a variant. Now I have two variants
Make a copy of the variant and edit the gap in between the rectangles
switch from one variant to the other one
See how the edited gap is not mantained

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
