### PR TITLE
:bug: Fix crash dragging external component into a variant without props

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -172,6 +172,10 @@
         objects        (pcb/get-objects changes)
         variant-id     (:id variant-container)
 
+        num-shapes     (->> variant-container
+                            :shapes
+                            count)
+
         ;; If we are cut-pasting a variant-container, this will be null
         ;; because it hasn't any shapes yet
         first-comp-id  (->> variant-container
@@ -198,7 +202,7 @@
                                0
                                shapes)
 
-        num-new-props  (if (or (zero? num-base-props)
+        num-new-props  (if (or (zero? num-shapes)
                                (< total-props num-base-props))
                          0
                          (- total-props num-base-props))
@@ -213,7 +217,7 @@
     (reduce
      (fn [changes shape]
        (let [component (ctcl/get-component data (:component-id shape) true)]
-         (if (or (zero? num-base-props)                  ;; do nothing if there are no base props
+         (if (or (zero? num-shapes)                      ;; do nothing if there are no shapes
                  (and (= variant-id (:variant-id shape)) ;; or we are only moving the shape inside its parent (it is
                       (not (:deleted component))))       ;; the same parent and the component isn't deleted)
            changes


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11778

### Summary

On a variant without properties, crash when dragging an external component to become part of the variant

### Steps to reproduce 
1. Create a variant
2. Edit the names of all its components on the layers tab to an invalid name, for example "aaa"
3. Create a new component
4. Drag the new component inside the variant

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
