### PR TITLE
:bug: Fix flick on design tab after variant switch

### DIFF
--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -987,16 +987,12 @@
             all-parents (-> all-parents
                             (into parents-of-swapped)
                             (conj (:id new-shape)))]
-
-        (rx/merge
-         (rx/of
-          (dwu/start-undo-transaction undo-id)
-          (dch/commit-changes changes)
-          (ptk/data-event :layout/update {:ids all-parents :undo-group undo-group})
-          (dwu/commit-undo-transaction undo-id)
-          (dws/deselect-all))
-         (->> (rx/of (dws/select-shape (:id new-shape) false))
-              (rx/delay 1)))))))
+        (rx/of
+         (dwu/start-undo-transaction undo-id)
+         (dch/commit-changes changes)
+         (ptk/data-event :layout/update {:ids all-parents :undo-group undo-group})
+         (dwu/commit-undo-transaction undo-id)
+         (dws/select-shape (:id new-shape) false))))))
 
 (defn component-multi-swap
   "Swaps several components with another one"

--- a/frontend/src/app/main/ui/ds/controls/select.cljs
+++ b/frontend/src/app/main/ui/ds/controls/select.cljs
@@ -102,6 +102,7 @@
         (mf/use-fn
          (mf/deps on-change)
          (fn [event]
+           (dom/stop-propagation event)
            (let [node  (dom/get-current-target event)
                  id    (dom/get-data node "id")]
              (reset! selected-id* id)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11729

### Summary

After a variant switch there was a flick on the design tab as the shape was unselected/selected again

### Steps to reproduce 
1. Create a variant with two components
2. Make a copy of component A
3. Switch it for B

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
