### PR TITLE
:wrench: Return always a shader on merge_fills for consistency

### DIFF
--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -231,7 +231,8 @@ pub fn merge_fills(fills: &[Fill], bounding_box: Rect) -> skia::Paint {
     let mut fills_paint = skia::Paint::default();
 
     if fills.is_empty() {
-        fills_paint.set_color(skia::Color::TRANSPARENT);
+        combined_shader = Some(skia::shaders::color(skia::Color::TRANSPARENT));
+        fills_paint.set_shader(combined_shader);
         return fills_paint;
     }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11691

### Summary

Minor fix to always use a shader, so an "empty" fill treats opacity correctly and chooses the correct inner stroke drawing method

### Steps to reproduce 

- Create a text with inner stroke
- Remove the fill (not transparent, remove it)
- The inner stroke should be visible
