### PR TITLE
:bug: Fix alert for bad formula not showing in copies of variants

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -86,7 +86,7 @@
          (fn [event]
            (dom/stop-propagation event)
            (if is-local
-             (st/emit! (dwl/go-to-local-component component-id))
+             (st/emit! (dwl/go-to-local-component :id component-id))
              (st/emit! (dwl/go-to-component-file file-id component)))))
 
         on-drop

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5492,27 +5492,23 @@ msgstr "This component has conflicting variants. Make sure each variation has a 
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:443
 msgid "workspace.options.component.variant.duplicated.copy.locate"
-msgstr "Go to main component"
+msgstr "Locate conflicting variants"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:954
 msgid "workspace.options.component.variant.duplicated.group.title"
 msgstr "Some variants have identical properties and values"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
-msgid "workspace.options.component.variant.duplicated.single.adjust"
-msgstr "Adjust the values so they can be retrieved."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
 msgid "workspace.options.component.variant.duplicated.single.all"
-msgstr "These variants have identical properties and values."
+msgstr "These variants have identical properties and values. Adjust the values so they can be retrieved."
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
 msgid "workspace.options.component.variant.duplicated.single.one"
-msgstr "This variant has identical properties and values to another variant."
+msgstr "This variant has identical properties and values to another variant. Adjust the values so they can be retrieved."
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
 msgid "workspace.options.component.variant.duplicated.single.some"
-msgstr "Some of these variants have identical properties and values."
+msgstr "Some of these variants have identical properties and values. Adjust the values so they can be retrieved."
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:957
 msgid "workspace.options.component.variant.malformed.group.locate"
@@ -5541,6 +5537,17 @@ msgstr "[property]=[value], [property]=[value]"
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:338
 msgid "workspace.options.component.variant.malformed.structure.title"
 msgstr "Try using the following structure:"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:475
+msgid "workspace.options.component.variant.malformed.copy"
+msgstr "This component has variants with invalid names. Make sure every variant is following the correct structure."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:478
+msgid "workspace.options.component.variant.malformed.locate"
+msgstr "Locate invalid variants"
+
+
+
 
 msgid "workspace.options.component.variants-help-modal.title"
 msgstr "How variants stay connected"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5492,7 +5492,7 @@ msgstr "Este componente tiene variantes en conflicto. Comprueba que cada variant
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:443
 msgid "workspace.options.component.variant.duplicated.copy.locate"
-msgstr "Ir al componente principal"
+msgstr "Localizar variantes en conflicto"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:957
 msgid "workspace.options.component.variant.duplicated.group.locate"
@@ -5503,20 +5503,16 @@ msgid "workspace.options.component.variant.duplicated.group.title"
 msgstr "Algunas variantes tienen propiedades y valores idénticos"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
-msgid "workspace.options.component.variant.duplicated.single.adjust"
-msgstr "Ajusta los valores para que puedan ser encontradas."
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
 msgid "workspace.options.component.variant.duplicated.single.all"
-msgstr "Estas variantes tienen propiedades y valores idénticos."
+msgstr "Estas variantes tienen propiedades y valores idénticos. Ajusta los valores para que puedan ser encontradas"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
 msgid "workspace.options.component.variant.duplicated.single.one"
-msgstr "Esta variante tiene propiedades y valores idénticos a los de otra variante."
+msgstr "Esta variante tiene propiedades y valores idénticos a los de otra variante. Ajusta los valores para que puedan ser encontradas"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:309
 msgid "workspace.options.component.variant.duplicated.single.some"
-msgstr "Algunas de estas variantes tienen propiedades y valores idénticos."
+msgstr "Algunas de estas variantes tienen propiedades y valores idénticos. Ajusta los valores para que puedan ser encontradas"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:957
 msgid "workspace.options.component.variant.malformed.group.locate"
@@ -5545,6 +5541,14 @@ msgstr "[propiedad]=[valor], [propiedad]=[valor]"
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:338
 msgid "workspace.options.component.variant.malformed.structure.title"
 msgstr "Prueba a utilizar la siguiente estructura:"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:475
+msgid "workspace.options.component.variant.malformed.copy"
+msgstr "Este componente tiene variantes con nombres no válidos. Asegúrate de que cada variante siga la estructura correcta."
+
+#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:478
+msgid "workspace.options.component.variant.malformed.locate"
+msgstr "Localizar variantes inválidas"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/constraints.cljs:163
 msgid "workspace.options.constraints"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11781

### Summary

When the variant has a bad formula, the copies should show a warning


### Steps to reproduce 

1. Create a variant
2. Set the name of a component as invalid, for example "aaaa"
3. Make a copy of the component
4. Check the warning on the design tab

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
