### PR TITLE
:fire: Remove app.common.time/duration usage on frontend

### DIFF
--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -119,9 +119,9 @@
      [o]
      (instance? Duration o)))
 
-(defn duration
-  [ms-or-obj]
-  #?(:clj
+#?(:clj
+   (defn duration
+     [ms-or-obj]
      (cond
        (string? ms-or-obj)
        (Duration/parse (str "PT" ms-or-obj))
@@ -134,10 +134,7 @@
        (Duration/ofMillis ms-or-obj)
 
        :else
-       (obj->duration ms-or-obj))
-
-     :cljs
-     (clj->js ms-or-obj)))
+       (obj->duration ms-or-obj))))
 
 #?(:clj
    (defn parse-duration
@@ -292,7 +289,7 @@
 
 (defn plus
   [d ta]
-  (let [ta (duration ta)]
+  (let [ta #?(:clj (duration ta) :cljs ta)]
     (cond
       #?@(:clj [(duration? d) (.plus ^Duration d ^TemporalAmount ta)])
 
@@ -307,7 +304,7 @@
 
 (defn minus
   [d ta]
-  (let [^TemporalAmount ta (duration ta)]
+  (let [ta #?(:clj (duration ta) :cljs ta)]
     (cond
       #?@(:clj [(duration? d) (.minus ^Duration d ^TemporalAmount ta)])
 

--- a/frontend/src/app/main/data/event.cljs
+++ b/frontend/src/app/main/data/event.cljs
@@ -31,9 +31,8 @@
 ;; Defines the maximum number of events that can go in a single batch.
 (def max-chunk-size 100)
 
-;; Defines the time window within events belong to the same session.
-(def session-timeout
-  (ct/duration {:minutes 30}))
+;; Defines the time window (in ms) within events belong to the same session.
+(def session-timeout (* 1000 60 30))
 
 ;; --- CONTEXT
 
@@ -248,7 +247,7 @@
                          (l/debug :hint "event enqueued")
                          (swap! buffer append-to-buffer event)))
 
-               (rx/switch-map #(rx/timer (inst-ms session-timeout)))
+               (rx/switch-map #(rx/timer session-timeout))
                (rx/take-until stopper)
                (rx/subs! (fn [_]
                            (l/debug :hint "session reinitialized")

--- a/frontend/src/app/util/http.cljs
+++ b/frontend/src/app/util/http.cljs
@@ -8,7 +8,6 @@
   "A http client with rx streams interface."
   (:require
    [app.common.data :as d]
-   [app.common.time :as ct]
    [app.common.transit :as t]
    [app.common.uri :as u]
    [app.config :as cfg]
@@ -215,4 +214,4 @@
          :uri url
          :response-type :text})
        (rx/map :body)
-       (c/with-cache {:key url :max-age (ct/duration {:hours 4})})))
+       (c/with-cache {:key url :max-age (* 1000 60 60 4)})))


### PR DESCRIPTION
Is broken and not necessary; duration class is no longer available on frontend code.

No specific tests are necessary, this fixes randomly appearing error that says unable to perform `inst-ms` on [object].
