### PR TITLE
:bug: Fix restoring component inside flex

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -375,7 +375,7 @@
                      (rx/filter (ptk/type? ::workspace-initialized))
                      (rx/observe-on :async)
                      (rx/take 1)
-                     (rx/map #(dwl/go-to-local-component :id component-id))))
+                     (rx/map #(dwl/go-to-local-component :id component-id :update-layout? (:update-layout rparams)))))
 
               (when (:board-id rparams)
                 (->> stream

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -87,7 +87,7 @@
            (dom/stop-propagation event)
            (if is-local
              (st/emit! (dwl/go-to-local-component :id component-id))
-             (st/emit! (dwl/go-to-component-file file-id component)))))
+             (st/emit! (dwl/go-to-component-file file-id component false)))))
 
         on-drop
         (mf/use-fn
@@ -537,7 +537,7 @@
            (if is-local
              (st/emit! (dwl/go-to-local-component :id current-component-id))
              (let [component (d/seek #(= (:id %) current-component-id) components)]
-               (st/emit! (dwl/go-to-component-file file-id component))))))
+               (st/emit! (dwl/go-to-component-file file-id component false))))))
 
         on-asset-click
         (mf/use-fn (mf/deps groups on-asset-click) (partial on-asset-click groups))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -433,7 +433,8 @@
               (st/emit! (dwl/go-to-local-component {:id (first ids)
                                                     :additional-ids (rest ids)}))
               (st/emit! (dwl/go-to-component-file (:component-file shape)
-                                                  (first duplicated-comps))))))
+                                                  (first duplicated-comps)
+                                                  false)))))
 
         select-malformed-comps
         (mf/use-fn
@@ -442,7 +443,7 @@
            (let [ids (map :id malformed-comps)]
              (if (= current-file-id (:component-file shape))
                (st/emit! (dwl/go-to-local-component :id (first ids) :additional-ids (rest ids)))
-               (st/emit! (dwl/go-to-component-file (:component-file shape) (first malformed-comps)))))))
+               (st/emit! (dwl/go-to-component-file (:component-file shape) (first malformed-comps) false))))))
 
         switch-component
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11840

### Summary

Restoring a component that was inside a flex on another file doesn't update the size of the flex

### Steps to reproduce 
1. Create a new file and mark is as shared library
2. On the library, create a board with flex and fit-content
3. Add two components C1 and C2 to the flex
4. Create another file, and add the library to it
5. Instanciate C1 on the file
6. Go back to the library, and delete the original component C1
7. Go back to the file, and on the context menu select "restore component"
8. The library will open on a new tab, C1 is restored, and the flex board should have the right size

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
