### PR TITLE
:bug: Fix deleting a variant from assets panel

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -311,7 +311,7 @@
   {::mf/wrap-props false}
   [{:keys [file-id is-local components listing-thumbs? open? force-open?
            reverse-sort? selected on-asset-click on-assets-delete
-           on-clear-selection open-status-ref count-variants]}]
+           on-clear-selection open-status-ref delete-component count-variants]}]
 
   (let [input-ref                (mf/use-ref nil)
 
@@ -393,7 +393,7 @@
              (if (or multi-components? multi-assets?)
                (on-assets-delete)
                (st/emit! (dwu/start-undo-transaction undo-id)
-                         (dwl/delete-component {:id current-component-id})
+                         (delete-component current-component-id)
                          (dwl/sync-file file-id file-id :components current-component-id)
                          (dwu/commit-undo-transaction undo-id))))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11854

### Summary

Deleting a variants component from Assets tab removes only one variant instead of the entire component

### Steps to reproduce 
1. Create a variant
2. Go to assets panel
3. Delete it on the contextual menu
4. It should be completely removed

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
