### PR TITLE
:bug: Fix combine variants move items

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -375,7 +375,8 @@
                            :r1 20
                            :r2 20
                            :r3 20
-                           :r4 20}
+                           :r4 20
+                           :layout-item-absolute true}
              flex-props   {:layout-item-h-sizing :auto
                            :layout-item-v-sizing :auto
                            :layout-padding {:p1 30 :p2 30 :p3 30 :p4 30}
@@ -433,6 +434,7 @@
 
           (rx/of
            (when duplicate? (add-new-variant main-instance-id))
+           (dwsh/update-shapes variant-vec #(dissoc % :layout-item-absolute))
            (dwu/commit-undo-transaction undo-id)
            (when flex?
              (ptk/data-event :layout/update {:ids [variant-id]})))))))))
@@ -605,9 +607,10 @@
                                                      (assoc :constraints-h :left)
                                                      (assoc :constraints-v :top)
                                                      (assoc :fixed-scroll false)))
+                   (dwsh/relocate-shapes #{variant-id} common-parent index)
                    (dwt/update-dimensions [variant-id] :width (+ (:width rect) 60))
                    (dwt/update-dimensions [variant-id] :height (+ (:height rect) 60))
-                   (dwsh/relocate-shapes #{variant-id} common-parent index)
+
                    (dwu/commit-undo-transaction undo-id)))))
 
              redirect-to-page


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11859

### Summary

Combine variants move items when the original items were on a flex/grid

### Steps to reproduce 

1. Create a flex board, with align-to-right
2. Add a component to the board
3. Add a component outside the board
4. Combine both as variants

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
