### PR TITLE
:bug: Fix variants operations need several undo

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1128,7 +1128,7 @@
     ptk/WatchEvent
     (watch [_ state _]
       (let [orphans (set (into [] (keys (find-orphan-shapes state))))]
-        (rx/of (dwsh/relocate-shapes orphans uuid/zero 0 true))))))
+        (rx/of (dwsh/relocate-shapes orphans uuid/zero 0 {:ignore-parents true}))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Sitemap

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -423,7 +423,7 @@
 
 (defn rename-component
   "Rename the component with the given id, in the current file library."
-  [id new-name]
+  [id new-name & {:keys [undo-group]}]
   (dm/assert!
    "expected an uuid instance"
    (uuid? id))
@@ -440,7 +440,9 @@
           (rx/empty)
           (let [data    (dsh/lookup-file-data state)
                 changes (-> (pcb/empty-changes it)
-                            (cll/generate-rename-component id new-name data))]
+                            (cll/generate-rename-component id new-name data)
+                            (cond-> undo-group
+                              (pcb/set-undo-group undo-group)))]
             (rx/of (dch/commit-changes changes))))))))
 
 (defn rename-component-and-main-instance

--- a/frontend/src/app/main/data/workspace/shape_layout.cljs
+++ b/frontend/src/app/main/data/workspace/shape_layout.cljs
@@ -138,8 +138,9 @@
               (fn [data]
                 (->> (group-by :page-id data)
                      (map (fn [[page-id items]]
-                            (let [ids (reduce #(into %1 (:ids %2)) #{} items)]
-                              (update-layout-positions {:page-id page-id :ids ids})))))))
+                            (let [ids (reduce #(into %1 (:ids %2)) #{} items)
+                                  undo-group (-> items first :undo-group)]
+                              (update-layout-positions {:page-id page-id :ids ids :undo-group undo-group})))))))
              (rx/take-until stopper))))))
 
 (defn finalize-shape-layout


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11862

### Summary

Variants actions should be undone with a single ctrl+z

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
