### PR TITLE
:bug: Fix inner strokes with opacity using erode instead of multiple blending modes

### DIFF
--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -740,27 +740,18 @@ fn get_text_stroke_paints(stroke: &Stroke, bounds: &Rect, text_paint: &Paint) ->
                 set_paint_fill(&mut paint, &stroke.fill, bounds);
                 paints.push(paint);
             } else {
-                // outer
-                let mut paint = skia::Paint::default();
-                paint.set_style(skia::PaintStyle::Stroke);
-                paint.set_blend_mode(skia::BlendMode::DstATop);
-                paint.set_anti_alias(true);
-                paint.set_stroke_width(stroke.width * 2.0);
-                paints.push(paint);
-
-                let mut paint = skia::Paint::default();
+                let mut paint = text_paint.clone();
                 paint.set_style(skia::PaintStyle::Fill);
-                paint.set_blend_mode(skia::BlendMode::Clear);
-                paint.set_anti_alias(true);
+                paint.set_anti_alias(false);
+                set_paint_fill(&mut paint, &stroke.fill, bounds);
                 paints.push(paint);
 
-                // inner
                 let mut paint = skia::Paint::default();
-                paint.set_style(skia::PaintStyle::Stroke);
-                paint.set_stroke_width(stroke.width * 2.0);
-                paint.set_blend_mode(skia::BlendMode::Xor);
-                paint.set_anti_alias(true);
-                set_paint_fill(&mut paint, &stroke.fill, bounds);
+                let image_filter =
+                    skia_safe::image_filters::erode((stroke.width, stroke.width), None, None);
+                paint.set_image_filter(image_filter);
+                paint.set_anti_alias(false);
+                paint.set_blend_mode(skia::BlendMode::DstOut);
                 paints.push(paint);
             }
         }


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

The current inner text stroke with fill opacity has some issues when glyphs overlap:

<img width="1086" height="563" alt="image" src="https://github.com/user-attachments/assets/44428185-c33e-426e-becb-5e291735ad4e" />


Therefore, I've been testing out a new idea: the erode filter. No overlap anymore!

<img width="1287" height="526" alt="image" src="https://github.com/user-attachments/assets/b05406b7-0a5c-4343-917e-067635b0dc9f" />

<img width="1342" height="530" alt="image" src="https://github.com/user-attachments/assets/3cb3c737-9628-4d5a-aa08-80ca93c40645" />

<img width="1211" height="528" alt="image" src="https://github.com/user-attachments/assets/45638a01-d59c-46f0-9839-cf1eff29d0fd" />

However, we can see, if we compare strokes, that is not entirely perfect since it's a bit smoother, but in any case, it's better than what we currently have:

<img width="843" height="699" alt="image" src="https://github.com/user-attachments/assets/5e07b4b4-14ec-4116-8850-037764ddf7ab" />


### Steps to reproduce 

- Create a text with inner stroke
- Test it out with different fills

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
