### PR TITLE
:wrench: Use mask filter on text blurs

### DIFF
--- a/render-wasm/src/render/filters.rs
+++ b/render-wasm/src/render/filters.rs
@@ -1,4 +1,3 @@
-
 use skia_safe::ImageFilter;
 
 /// Composes two image filters, returning a combined filter if both are present,
@@ -22,4 +21,3 @@ pub fn compose_filters(
         (None, None) => None,
     }
 }
-

--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -6,9 +6,9 @@ use crate::shapes::{Corners, Fill, ImageFill, Path, Shape, Stroke, StrokeCap, St
 use skia_safe::{self as skia, textlayout::ParagraphBuilder, ImageFilter, RRect};
 
 use super::{RenderState, SurfaceId};
+use crate::render::filters::compose_filters;
 use crate::render::text::{self};
 use crate::render::{get_dest_rect, get_source_rect};
-use crate::render::filters::compose_filters;
 
 // FIXME: See if we can simplify these arguments
 #[allow(clippy::too_many_arguments)]

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -923,6 +923,21 @@ impl Shape {
         }
     }
 
+    pub fn mask_filter(&self, scale: f32) -> Option<skia::MaskFilter> {
+        if !self.blur.hidden {
+            match self.blur.blur_type {
+                BlurType::None => None,
+                BlurType::Layer => skia::MaskFilter::blur(
+                    skia::BlurStyle::Normal,
+                    self.blur.value * scale,
+                    Some(true),
+                ),
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn is_recursive(&self) -> bool {
         matches!(
             self.shape_type,

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -198,7 +198,7 @@ fn propagate_transform(
 
     if let Type::Text(content) = &shape.shape_type {
         if content.grow_type() == GrowType::AutoHeight {
-            let mut paragraphs = content.get_skia_paragraphs(None);
+            let mut paragraphs = content.get_skia_paragraphs(None, None);
             set_paragraphs_width(shape_bounds_after.width(), &mut paragraphs);
             let height = auto_height(&mut paragraphs, shape_bounds_after.width());
             let resize_transform = math::resize_matrix(

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -6,7 +6,7 @@ use skia_safe::{
     self as skia,
     paint::Paint,
     textlayout::{ParagraphBuilder, ParagraphStyle},
-    ImageFilter,
+    ImageFilter, MaskFilter,
 };
 use std::collections::HashSet;
 
@@ -93,7 +93,11 @@ impl TextContent {
         self.paragraphs.push(paragraph);
     }
 
-    pub fn to_paragraphs(&self, blur: Option<&ImageFilter>) -> Vec<Vec<ParagraphBuilder>> {
+    pub fn to_paragraphs(
+        &self,
+        blur: Option<&ImageFilter>,
+        blur_mask: Option<&MaskFilter>,
+    ) -> Vec<Vec<ParagraphBuilder>> {
         let fonts = get_font_collection();
         let fallback_fonts = get_fallback_fonts();
         let mut paragraph_group = Vec::new();
@@ -102,7 +106,8 @@ impl TextContent {
             let paragraph_style = paragraph.paragraph_to_style();
             let mut builder = ParagraphBuilder::new(&paragraph_style, fonts);
             for leaf in &paragraph.children {
-                let text_style = leaf.to_style(paragraph, &self.bounds, fallback_fonts, blur);
+                let text_style =
+                    leaf.to_style(paragraph, &self.bounds, fallback_fonts, blur, blur_mask);
                 let text = leaf.apply_text_transform();
                 builder.push_style(&text_style);
                 builder.add_text(&text);
@@ -118,6 +123,7 @@ impl TextContent {
         stroke: &Stroke,
         bounds: &Rect,
         blur: Option<&ImageFilter>,
+        blur_mask: Option<&MaskFilter>,
     ) -> Vec<Vec<ParagraphBuilder>> {
         let fallback_fonts = get_fallback_fonts();
         let fonts = get_font_collection();
@@ -129,10 +135,11 @@ impl TextContent {
 
             for leaf in paragraph.children.iter() {
                 let mut text_paint = merge_fills(&leaf.fills, *bounds);
-                if let Some(blur) = blur {
-                    text_paint.set_image_filter(blur.clone());
+                if let Some(blur_mask) = blur_mask {
+                    text_paint.set_mask_filter(blur_mask.clone());
                 }
-                let stroke_paints = get_text_stroke_paints(stroke, bounds, &text_paint, blur);
+                let stroke_paints =
+                    get_text_stroke_paints(stroke, bounds, &text_paint, blur, blur_mask);
                 let text: String = leaf.apply_text_transform();
 
                 for (paint_idx, stroke_paint) in stroke_paints.iter().enumerate() {
@@ -141,8 +148,13 @@ impl TextContent {
                         ParagraphBuilder::new(&paragraph_style, fonts)
                     });
                     let stroke_paint = stroke_paint.clone();
-                    let stroke_style =
-                        leaf.to_stroke_style(paragraph, &stroke_paint, fallback_fonts, blur);
+                    let stroke_style = leaf.to_stroke_style(
+                        paragraph,
+                        &stroke_paint,
+                        fallback_fonts,
+                        blur,
+                        blur_mask,
+                    );
                     builder.push_style(&stroke_style);
                     builder.add_text(&text);
                 }
@@ -172,8 +184,12 @@ impl TextContent {
         paragraphs
     }
 
-    pub fn get_skia_paragraphs(&self, blur: Option<&ImageFilter>) -> Vec<Vec<ParagraphBuilder>> {
-        self.collect_paragraphs(self.to_paragraphs(blur))
+    pub fn get_skia_paragraphs(
+        &self,
+        blur: Option<&ImageFilter>,
+        blur_mask: Option<&MaskFilter>,
+    ) -> Vec<Vec<ParagraphBuilder>> {
+        self.collect_paragraphs(self.to_paragraphs(blur, blur_mask))
     }
 
     pub fn get_skia_stroke_paragraphs(
@@ -181,8 +197,9 @@ impl TextContent {
         stroke: &Stroke,
         bounds: &Rect,
         blur: Option<&ImageFilter>,
+        blur_mask: Option<&MaskFilter>,
     ) -> Vec<Vec<ParagraphBuilder>> {
-        self.collect_paragraphs(self.to_stroke_paragraphs(stroke, bounds, blur))
+        self.collect_paragraphs(self.to_stroke_paragraphs(stroke, bounds, blur, blur_mask))
     }
 
     pub fn grow_type(&self) -> GrowType {
@@ -194,7 +211,7 @@ impl TextContent {
     }
 
     pub fn visual_bounds(&self) -> (f32, f32) {
-        let mut paragraphs = self.to_paragraphs(None);
+        let mut paragraphs = self.to_paragraphs(None, None);
         let height = auto_height(&mut paragraphs, self.width());
         (self.width(), height)
     }
@@ -384,13 +401,14 @@ impl TextLeaf {
         paragraph: &Paragraph,
         content_bounds: &Rect,
         fallback_fonts: &HashSet<String>,
-        blur: Option<&ImageFilter>,
+        _blur: Option<&ImageFilter>,
+        blur_mask: Option<&MaskFilter>,
     ) -> skia::textlayout::TextStyle {
         let mut style = skia::textlayout::TextStyle::default();
-
         let mut paint = merge_fills(&self.fills, *content_bounds);
-        if let Some(blur) = blur {
-            paint.set_image_filter(blur.clone());
+
+        if let Some(blur_mask) = blur_mask {
+            paint.set_mask_filter(blur_mask.clone());
         }
 
         style.set_foreground_paint(&paint);
@@ -429,8 +447,9 @@ impl TextLeaf {
         stroke_paint: &Paint,
         fallback_fonts: &HashSet<String>,
         blur: Option<&ImageFilter>,
+        blur_mask: Option<&MaskFilter>,
     ) -> skia::textlayout::TextStyle {
-        let mut style = self.to_style(paragraph, &Rect::default(), fallback_fonts, blur);
+        let mut style = self.to_style(paragraph, &Rect::default(), fallback_fonts, blur, blur_mask);
         style.set_foreground_paint(stroke_paint);
         style.set_font_size(self.font_size);
         style.set_letter_spacing(paragraph.letter_spacing);
@@ -731,6 +750,7 @@ fn get_text_stroke_paints(
     bounds: &Rect,
     text_paint: &Paint,
     blur: Option<&ImageFilter>,
+    blur_mask: Option<&MaskFilter>,
 ) -> Vec<Paint> {
     let mut paints = Vec::new();
 
@@ -809,17 +829,20 @@ fn get_text_stroke_paints(
             paint.set_blend_mode(skia::BlendMode::DstOver);
             paint.set_anti_alias(true);
             paint.set_stroke_width(stroke.width * 2.0);
-
             set_paint_fill(&mut paint, &stroke.fill, bounds);
-            if let Some(blur) = blur {
-                paint.set_image_filter(blur.clone());
+            if let Some(blur_mask) = blur_mask {
+                paint.set_mask_filter(blur_mask.clone());
             }
-
             paints.push(paint);
 
             let mut paint = skia::Paint::default();
+            paint.set_style(skia::PaintStyle::Fill);
             paint.set_blend_mode(skia::BlendMode::Clear);
+            paint.set_color(skia::Color::TRANSPARENT);
             paint.set_anti_alias(true);
+            if let Some(blur_mask) = blur_mask {
+                paint.set_mask_filter(blur_mask.clone());
+            }
             paints.push(paint);
         }
     }

--- a/render-wasm/src/shapes/text_paths.rs
+++ b/render-wasm/src/shapes/text_paths.rs
@@ -18,7 +18,7 @@ impl TextPaths {
     }
 
     pub fn get_skia_paragraphs(&self) -> Vec<Vec<ParagraphBuilder>> {
-        let paragraphs = self.to_paragraphs(None);
+        let paragraphs = self.to_paragraphs(None, None);
         self.collect_paragraphs(paragraphs)
     }
 

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -44,7 +44,10 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
         height = shape.selrect.height();
 
         if let Type::Text(content) = &shape.shape_type {
-            let mut paragraphs = content.get_skia_paragraphs(shape.image_filter(1.).as_ref());
+            let mut paragraphs = content.get_skia_paragraphs(
+                shape.image_filter(1.).as_ref(),
+                shape.mask_filter(1.).as_ref(),
+            );
             m_width = max_width(&mut paragraphs, width);
 
             match content.grow_type() {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11537

### Summary

This is a minor change related to the ongoing work of fixing blur on shapes. It uses mask_filter instead of image_filter on text paints to fix clipped layers.

### Steps to reproduce 

- Create a text and add an outer stroke
- Add blur
- Update blur values
- Remove shape fill 
- Use fill with opacity


Fill:

<img width="2110" height="852" alt="image" src="https://github.com/user-attachments/assets/ac9f4354-b1af-4988-987e-b3e07b17d13d" />

Fill with opacity:

<img width="2136" height="923" alt="image" src="https://github.com/user-attachments/assets/9049e09d-53da-4f24-a674-b7944279d1c1" />

No fill:

<img width="2112" height="1011" alt="image" src="https://github.com/user-attachments/assets/bfdd1e37-c0ee-4d29-b01f-b8aaf818dae2" />

Stroke with opacity:

<img width="2114" height="837" alt="image" src="https://github.com/user-attachments/assets/dd551bf8-04bc-4c9f-b692-82deba0df23f" />


### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
