### PR TITLE
:bug: On a variants switch, keep the value of the rotation and its transformations

### DIFF
--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2020,12 +2020,21 @@
               skip-operations? (or skip-operations?
                                    (= attr-val (get current-shape attr)))
 
-
               ;; On a text-change, we want to force a position-data reset
               ;; so it's calculated again
               [roperations uoperations]
               (if (and (not skip-operations?) text-change?)
                 (add-update-attr-operations :position-data current-shape roperations uoperations nil)
+                [roperations uoperations])
+
+              ;; On a rotation operation we need to keep also the transformation matrixes
+              [roperations uoperations]
+              (if (and (not skip-operations?) (= attr :rotation))
+                (let [[roperations uoperations]
+                      (add-update-attr-operations
+                       :transform current-shape roperations uoperations (:transform previous-shape))]
+                  (add-update-attr-operations
+                   :transform-inverse current-shape roperations uoperations (:transform-inverse previous-shape)))
                 [roperations uoperations])
 
               [roperations' uoperations']


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11852

### Summary

When making a switch of an element with rotation, the rotation value is keep, but not the transformations

### Steps to reproduce 

1. make a rectangle and press ctrl+K twice so it turns into a set of variants
2. edit the rotation of them variants. Make it 20
3. create a copy of one of the variants and make its rotation 40
4. Switch the variant for another one
5. See how the switched variant's value says 40, but the object appears rotated as the mains, 20 degrees.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
