### PR TITLE
:tada: Inspect tab layout switcher and computed feature

### DIFF
--- a/common/src/app/common/flags.cljc
+++ b/common/src/app/common/flags.cljc
@@ -131,7 +131,8 @@
     :hide-release-modal
     :subscriptions
     :subscriptions-old
-    :frontend-binary-fills})
+    :frontend-binary-fills
+    :inspect-styles})
 
 (def all-flags
   (set/union email login varia))

--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -4,6 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC
 
+@use "../ds/typography.scss" as *;
 @import "refactor/common-refactor.scss";
 
 .settings-bar-right {
@@ -106,6 +107,34 @@
   padding: $s-8 $s-24;
 }
 
+.inspect-tab-switcher {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-block: var(--sp-s);
+  padding-inline-end: var(--sp-m);
+}
+
+.inspect-tab-switcher-label {
+  @include use-typography("body-medium");
+  flex: 1;
+}
+
+.inspect-tab-switcher-controls {
+  display: flex;
+  align-items: center;
+  flex: 2;
+  gap: var(--sp-s);
+}
+
+.inspect-tab-switcher-controls-color-space {
+  flex: 1;
+}
+
+.inspect-tab-switcher-controls-tab {
+  flex: 2;
+}
+
 .inspect-content {
   flex: 1;
   overflow: hidden;
@@ -114,4 +143,8 @@
 .viewer-tab-switcher {
   --tabs-nav-padding-inline-start: 0;
   --tabs-nav-padding-inline-end: var(--sp-m);
+}
+
+.viewer-tab-switcher-layout {
+  display: grid;
 }

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -1,0 +1,61 @@
+(ns app.main.ui.inspect.styles
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [app.common.data.macros :as dm]
+   [app.common.types.component :as ctc]
+   [app.common.types.components-list :as ctkl]
+   [app.main.ui.inspect.styles.style-box :refer [style-box*]]
+   [rumext.v2 :as mf]))
+
+
+(def type->options
+  {:multiple [:fill :stroke :text :shadow :blur :layout-element]
+   :frame    [:visibility :geometry :fill :stroke :shadow :blur :layout :layout-element]
+   :group    [:visibility :geometry :svg :layout-element]
+   :rect     [:visibility :geometry :fill :stroke :shadow :blur :svg :layout-element]
+   :circle   [:visibility :geometry :fill :stroke :shadow :blur :svg :layout-element]
+   :path     [:visibility :geometry :fill :stroke :shadow :blur :svg :layout-element]
+   :text     [:visibility :geometry :text :shadow :blur :stroke :layout-element]
+   :variant  [:variant :geometry :fill :stroke :shadow :blur :layout :layout-element]})
+
+(defn- get-shape-type
+  [shapes first-shape first-component]
+  (cond
+    (and (= (count shapes) 1)
+         (or (ctc/is-variant-container? first-shape)
+             (ctc/is-variant? first-component)))
+    :variant
+
+    (= (count shapes) 1)
+    (:type first-shape)
+
+    :else
+    :multiple))
+
+(mf/defc styles-tab*
+  [{:keys [color-space shapes libraries file-id]}]
+  (let [data               (dm/get-in libraries [file-id :data])
+        first-shape        (first shapes)
+        first-component    (ctkl/get-component data (:component-id first-shape))
+        type               (get-shape-type shapes first-shape first-component)
+        options            (type->options type)]
+
+    [:div {:class (stl/css :element-options)}
+     (for [[idx option] (map-indexed vector options)]
+       [:> style-box* {:key idx :attribute option} color-space])]))
+
+
+;; WIP
+;; Panel list as stylebox children
+#_(case option
+    :geometry         [:> geometry-panel {}]
+    :layout           [:> layout-panel {}]
+    :layout-element   [:> layout-element-panel {}]
+    :fill             [:> fill-panel {:color-space color-space}]
+    :stroke           [:> stroke-panel {:color-space color-space}]
+    :text             [:> text-panel {:color-space color-space}]
+    :shadow           [:> shadow-panel {}]
+    :blur             [:> blur-panel {}]
+    :svg              [:> svg-panel {}]
+    :variant          [:> variant-panel* {}]
+    :visibility       [:> visibility-panel* {}])

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -1,0 +1,26 @@
+(ns app.main.ui.inspect.styles.style-box
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [rumext.v2 :as mf]))
+
+(defn- attribute->title
+  [type]
+  (case type
+    :variant    "Variant properties"
+    :token      "Token Sets & Themes"
+    :geometry   "Size & Position"
+    :fill       "Fill"
+    :stroke     "Stroke"
+    :text       "Text"
+    :shadow     "Shadow"
+    :layout     "Layout"
+    :layout-element "Layout Element"
+    :visibility "Visibility"
+    :svg        "SVG"
+    nil))
+
+(mf/defc style-box*
+  [{:keys [attribute children]}]
+  [:div {:class (stl/css :style-box)}
+   [:h3 {:class (stl/css :style-box-header)} (attribute->title attribute)]
+   [:div {:class (stl/css :style-box-content)} children]])

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1761,8 +1761,12 @@ msgid "inspect.subtitle.main"
 msgstr "Main component"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:59
-msgid "inspect.subtitle.variant"
-msgstr "Variant"
+msgid "inspect.tabs.switcher.label"
+msgstr "Layer info"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:101
+msgid "inspect.tabs.computed"
+msgstr "Computed"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:105
 msgid "inspect.tabs.code"
@@ -1819,6 +1823,10 @@ msgstr "Text"
 #: src/app/main/ui/inspect/right_sidebar.cljs:101
 msgid "inspect.tabs.info"
 msgstr "Info"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:101
+msgid "inspect.tabs.styles"
+msgstr "Styles"
 
 #: src/app/main/ui/dashboard/comments.cljs:95
 msgid "label.mark-all-as-read"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1768,6 +1768,14 @@ msgstr "Componente principal"
 msgid "inspect.subtitle.variant"
 msgstr "Variante"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:59
+msgid "inspect.tabs.switcher.label"
+msgstr "Información sobre la capa"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:101
+msgid "inspect.tabs.computed"
+msgstr "Calculado"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:105
 msgid "inspect.tabs.code"
 msgstr "Código"
@@ -1823,6 +1831,10 @@ msgstr "Texto"
 #: src/app/main/ui/inspect/right_sidebar.cljs:101
 msgid "inspect.tabs.info"
 msgstr "Información"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:101
+msgid "inspect.tabs.styles"
+msgstr "Estilos"
 
 #: src/app/main/ui/dashboard/comments.cljs:95
 msgid "label.mark-all-as-read"


### PR DESCRIPTION
### Related Ticket

Display tokens in the info tab
https://tree.taiga.io/project/penpot/us/9313

### Summary

- Created new config flag `inspect-styles`
- Created new tab `styles`
- Renamed `info` tab to `computed`

### Steps to reproduce 

- Add a new  `enable-inspect-styles` config flag to your `config.js`
- Test the new styles tab under the inspect section

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
