### PR TITLE
:bug: Fix paragraph layout width on autowidth

### DIFF
--- a/frontend/src/app/render_wasm/serializers.cljs
+++ b/frontend/src/app/render_wasm/serializers.cljs
@@ -295,7 +295,8 @@
     "uppercase" 1
     "lowercase" 2
     "capitalize" 3
-    nil))
+    nil 0
+    0))
 
 (defn translate-text-decoration
   [text-decoration]
@@ -304,13 +305,15 @@
     "underline" 1
     "line-through" 2
     "overline" 3
-    nil))
+    nil 0
+    0))
 
 (defn translate-text-direction
   [text-direction]
   (case text-direction
     "ltr" 0
     "rtl" 1
+    nil 0
     0))
 
 (defn translate-font-style

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -511,7 +511,7 @@ impl RenderState {
                 });
 
                 let text_content = text_content.new_bounds(shape.selrect());
-                let mut paragraphs = text_content.get_skia_paragraphs(
+                let mut paragraphs = text_content.to_paragraphs(
                     shape.image_filter(1.).as_ref(),
                     shape.mask_filter(1.).as_ref(),
                 );
@@ -524,7 +524,7 @@ impl RenderState {
                 text::render(self, &shape, &mut paragraphs, None, None);
 
                 for stroke in shape.visible_strokes().rev() {
-                    let mut stroke_paragraphs = text_content.get_skia_stroke_paragraphs(
+                    let mut stroke_paragraphs = text_content.to_stroke_paragraphs(
                         stroke,
                         &shape.selrect(),
                         shape.image_filter(1.).as_ref(),

--- a/render-wasm/src/shapes/text_paths.rs
+++ b/render-wasm/src/shapes/text_paths.rs
@@ -1,7 +1,6 @@
 use crate::shapes::text::TextContent;
 use skia_safe::{
-    self as skia, textlayout::Paragraph as SkiaParagraph, textlayout::ParagraphBuilder,
-    FontMetrics, Point, Rect, TextBlob,
+    self as skia, textlayout::Paragraph as SkiaParagraph, FontMetrics, Point, Rect, TextBlob,
 };
 use std::ops::Deref;
 
@@ -17,16 +16,11 @@ impl TextPaths {
         Self(content)
     }
 
-    pub fn get_skia_paragraphs(&self) -> Vec<Vec<ParagraphBuilder>> {
-        let paragraphs = self.to_paragraphs(None, None);
-        self.collect_paragraphs(paragraphs)
-    }
-
     pub fn get_paths(&self, antialias: bool) -> Vec<(skia::Path, skia::Paint)> {
         let mut paths = Vec::new();
 
         let mut offset_y = self.bounds.y();
-        let mut paragraphs = self.get_skia_paragraphs();
+        let mut paragraphs = self.to_paragraphs(None, None);
 
         for paragraphs in paragraphs.iter_mut() {
             for paragraph_builder in paragraphs.iter_mut() {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11735

### Summary

We were not setting correctly the width when rendering the text into the canvas via paragraph API.

Note: there's still an issue with updating the visual selrect when the font changes, this will be addressed separately

### Steps to reproduce 

[screen-recorder-thu-aug-21-2025-19-25-14.webm](https://github.com/user-attachments/assets/f0b5a6b6-1f3f-474f-b61e-e55a54b43020)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
