### PR TITLE
:bug: Parse rx and ry SVG values correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### :heart: Community contributions (Thank you!)
 
 ### :sparkles: New features & Enhancements
+
 - Add defaults for artboard drawing [Taiga #494](https://tree.taiga.io/project/penpot/us/494?milestone=465047)
 - Continuous display of distances between elements when moving a layer with the keyboard [Taiga #1780](https://tree.taiga.io/project/penpot/us/1780)
 - New Number token - unitless values  [Taiga #10936](https://tree.taiga.io/project/penpot/us/10936)
@@ -28,6 +29,7 @@
 - Fix font size/variant not updated when editing a text [Taiga #11552](https://tree.taiga.io/project/penpot/issue/11552)
 - Fix issue where Alt + arrow keys shortcut interferes with letter-spacing when moving text layers [Taiga #11552](https://tree.taiga.io/project/penpot/issue/11771)
 - Fix consistency issues on how font variants are visualized [Taiga #11499](https://tree.taiga.io/project/penpot/us/11499)
+- Fix parsing rx and ry SVG values for rect radius [Taiga #11861](https://tree.taiga.io/project/penpot/issue/11861)
 
 ## 2.9.0 (Unreleased)
 

--- a/common/src/app/common/files/shapes_builder.cljc
+++ b/common/src/app/common/files/shapes_builder.cljc
@@ -269,6 +269,22 @@
    (d/parse-double width 1)
    (d/parse-double height 1)))
 
+(defn- parse-radius-attrs
+  [attrs]
+  (if (or (contains? attrs :rx) (contains? attrs :ry))
+    (let [rx-val (d/parse-double (:rx attrs) 0)
+          ry-val (d/parse-double (:ry attrs) 0)
+          radius (cond
+                   (and (contains? attrs :rx) (contains? attrs :ry))
+                   (min rx-val ry-val)
+                   (contains? attrs :rx)
+                   rx-val
+                   (contains? attrs :ry)
+                   ry-val
+                   :else 0)]
+      {:r1 radius :r2 radius :r3 radius :r4 radius})
+    {}))
+
 (defn create-rect-shape [name frame-id svg-data {:keys [attrs] :as data}]
   (let [transform (->> (csvg/parse-transform (:transform attrs))
                        (gmt/transform-in (gpt/point svg-data)))
@@ -280,7 +296,9 @@
                       (update :y - (:y origin)))
 
         props     (-> (dissoc attrs :x :y :width :height :rx :ry :transform)
-                      (csvg/attrs->props))]
+                      (csvg/attrs->props))
+
+        radius-attrs (parse-radius-attrs attrs)]
     (cts/setup-shape
      (-> (calculate-rect-metadata rect transform)
          (assoc :type :rect)
@@ -288,13 +306,10 @@
          (assoc :frame-id frame-id)
          (assoc :svg-viewbox vbox)
          (assoc :svg-attrs props)
-         ;; We need to ensure fills are empty on import process
-         ;; because setup-shape assings one by default.
+        ;; We need to ensure fills are empty on import process
+        ;; because setup-shape assings one by default.
          (assoc :fills [])
-         (cond-> (contains? attrs :rx)
-           (assoc :rx (d/parse-double (:rx attrs) 0)))
-         (cond-> (contains? attrs :ry)
-           (assoc :ry (d/parse-double (:ry attrs) 0)))))))
+         (merge radius-attrs)))))
 
 (defn- parse-circle-attrs
   [attrs]
@@ -507,6 +522,7 @@
                  (nil? tag) "node"
                  :else (dm/str tag))]
     (dm/str "svg-" suffix)))
+
 
 (defn parse-svg-element
   [frame-id svg-data {:keys [tag attrs hidden] :as element} unames]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11861

### Summary

We were missing rx-ry radius calculation 

### Steps to reproduce 

- Upload this svg image and check it renders a circle, not a rect: [image.svg](https://github.com/user-attachments/assets/853b96b3-9bbe-43c7-b01f-e5d38773944a)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
