### PR TITLE
:bug: Fix cut pasting a variant into its own parent

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -438,20 +438,25 @@
 
 (defn variants-nesting-loop?
   "Check if a variants nesting loop would be created if the given shape is moved below the given parent"
-  [objects libraries shape-id parent-id]
-  (let [get-variant-id #(or (:variant-id %)
-                            (when (:is-variant-container %) (:id %))
-                            (when (:component-id %)
-                              (dm/get-in libraries [(:component-file %)
-                                                    :data
-                                                    :components
-                                                    (:component-id %)
-                                                    :variant-id])))
-        child-variant-ids  (into #{} (keep get-variant-id)
-                                 (get-children-with-self objects shape-id))
-        parent-variant-ids (into #{} (keep get-variant-id)
-                                 (get-parents-with-self objects parent-id))]
-    (seq (set/intersection child-variant-ids parent-variant-ids))))
+  [objects libraries shape parent pasting-cutted-mains?]
+  ;; If we are cut-pasting mains into its own variant, it is ok
+  (if (and pasting-cutted-mains?
+           (:is-variant-container parent)
+           (= (:variant-id shape) (:id parent)))
+    nil
+    (let [get-variant-id #(or (:variant-id %)
+                              (when (:is-variant-container %) (:id %))
+                              (when (:component-id %)
+                                (dm/get-in libraries [(:component-file %)
+                                                      :data
+                                                      :components
+                                                      (:component-id %)
+                                                      :variant-id])))
+          child-variant-ids  (into #{} (keep get-variant-id)
+                                   (get-children-with-self objects (:id shape)))
+          parent-variant-ids (into #{} (keep get-variant-id)
+                                   (get-parents-with-self objects (:id parent)))]
+      (seq (set/intersection child-variant-ids parent-variant-ids)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11855

### Summary

Cut & Paste of a variant into a variants group creates a standalone component instead of re-adding it as a variant

### Steps to reproduce 

1. Create a variant
2. Cut (ctrl+k) one of its components
3. Select the variant container
4. Paste (ctrl+v)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
