### PR TITLE
:bug: Add handler to correctly encode cljs dates to json

### DIFF
--- a/common/src/app/common/time.cljc
+++ b/common/src/app/common/time.cljc
@@ -426,3 +426,8 @@
         :encode/json format-duration
         ::oapi/type "string"
         ::oapi/format "duration"}})))
+
+#?(:cljs
+   (extend-protocol cljs.core/IEncodeJS
+     js/Date
+     (-clj->js [x] x)))


### PR DESCRIPTION
### Related Ticket

No ticket.

### Summary

New cljs dates are not correctly encoded as json.

### Steps to reproduce 

* Create a file with a tokens library and at least one theme.
* Export the tokens library as a single json file.

The `modified-at` field gets exported as `"modified-at": "Mon Aug 25 2025 12:48:11 GMT+0200 (hora de verano de Europa central)"`, and it gives error when importing back.

The correct format should be `"modified-at": "2025-08-25T12:46:43.780+02:00"`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
