### PR TITLE
:sparkles: Pick closest font-weight when applying font-weight token

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -333,10 +333,7 @@
                            (txt/is-paragraph-node? node)))
         update-fn (fn [node _]
                     (let [font (fonts/get-font-data (:font-id node))
-                          font-variant-id (or
-                                           (fonts/find-variant font font-variant)
-                                           ;; When variant with matching weight but not with matching style (italic) is found, use that one
-                                           (fonts/find-variant font (dissoc font-variant :style)))]
+                          font-variant-id (fonts/find-closest-variant font (:weight font-variant) (:style font-variant))]
                       (if font-variant-id
                         (-> node
                             (d/txt-merge (assoc font-variant :font-variant-id (:id font-variant-id)))

--- a/frontend/test/frontend_tests/fonts_test.cljs
+++ b/frontend/test/frontend_tests/fonts_test.cljs
@@ -1,0 +1,126 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.fonts-test
+  (:require
+   [app.main.fonts :as fonts]
+   [cljs.test :as t :include-macros true]))
+
+(def sample-font
+  {:id "sourcesanspro"
+   :name "Source Sans Pro"
+   :family "sourcesanspro"
+   :variants
+   [{:id "200"
+     :name "200"
+     :weight "200"
+     :style "normal"
+     :suffix "extralight"
+     :ttf-url "sourcesanspro-extralight.ttf"}
+    {:id "200italic"
+     :name "200 Italic"
+     :weight "200"
+     :style "italic"
+     :suffix "extralightitalic"
+     :ttf-url "sourcesanspro-extralightitalic.ttf"}
+    {:id "300"
+     :name "300"
+     :weight "300"
+     :style "normal"
+     :suffix "light"
+     :ttf-url "sourcesanspro-light.ttf"}
+    {:id "300italic"
+     :name "300 Italic"
+     :weight "300"
+     :style "italic"
+     :suffix "lightitalic"
+     :ttf-url "sourcesanspro-lightitalic.ttf"}
+    {:id "regular"
+     :name "400"
+     :weight "400"
+     :style "normal"
+     :ttf-url "sourcesanspro-regular.ttf"}
+    {:id "italic"
+     :name "400 Italic"
+     :weight "400"
+     :style "italic"
+     :ttf-url "sourcesanspro-italic.ttf"}
+    {:id "bold"
+     :name "700"
+     :weight "700"
+     :style "normal"
+     :ttf-url "sourcesanspro-bold.ttf"}
+    {:id "bolditalic"
+     :name "700 Italic"
+     :weight "700"
+     :style "italic"
+     :ttf-url "sourcesanspro-bolditalic.ttf"}
+    {:id "black"
+     :name "900"
+     :weight "900"
+     :style "normal"
+     :ttf-url "sourcesanspro-black.ttf"}
+    {:id "blackitalic"
+     :name "900 Italic"
+     :weight "900"
+     :style "italic"
+     :ttf-url "sourcesanspro-blackitalic.ttf"}]
+   :backend :builtin})
+
+(t/deftest find-closest-weight-variant-test
+  (t/testing "finds exact weight match"
+    (let [result (fonts/find-closest-variant sample-font "400" nil)]
+      (t/is (= "400" (:weight result)))
+      (t/is (= "normal" (:style result)))))
+
+  (t/testing "finds exact weight match with style"
+    (let [result (fonts/find-closest-variant sample-font "400" "italic")]
+      (t/is (= "400" (:weight result)))
+      (t/is (= "italic" (:style result)))))
+
+  (t/testing "chooses higher weight when exactly between two weights"
+    (let [result (fonts/find-closest-variant sample-font "350" nil)]
+      (t/is (= "400" (:weight result)))))
+
+  (t/testing "finds exact weight match with style"
+    (let [result (fonts/find-closest-variant sample-font "350" "italic")]
+      (t/is (= "400" (:weight result)))
+      (t/is (= "italic" (:style result)))))
+
+  (t/testing "finds closest weight below minimum available"
+    (let [result (fonts/find-closest-variant sample-font "0" nil)]
+      (t/is (= "200" (:weight result)))))
+
+  (t/testing "finds closest weight above maximum available"
+    (let [result (fonts/find-closest-variant sample-font "1000" nil)]
+      (t/is (= "900" (:weight result)))))
+
+  (t/testing "keeps the closest weight match when style is not found"
+    (let [font {:id "sourcesanspro"
+                :name "Source Sans Pro"
+                :family "sourcesanspro"
+                :variants
+                [{:id "200italic"
+                  :name "200 Italic"
+                  :weight "200"
+                  :style "italic"
+                  :suffix "extralightitalic"
+                  :ttf-url "sourcesanspro-extralightitalic.ttf"}
+                 {:id "300"
+                  :name "300"
+                  :weight "300"
+                  :style "normal"
+                  :suffix "light"
+                  :ttf-url "sourcesanspro-light.ttf"}
+                 {:id "300italic"
+                  :name "300 Italic"
+                  :weight "300"
+                  :style "italic"
+                  :suffix "lightitalic"
+                  :ttf-url "sourcesanspro-lightitalic.ttf"}]}
+          result (fonts/find-closest-variant font "200" nil)]
+      (t/is (= "200" (:weight result)))
+      (t/is (= "italic" (:style result))))))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7624,6 +7624,10 @@ msgstr "Import was successful. Some tokens were not included."
 msgid "workspace.tokens.unknown-token-type-section"
 msgstr "Type '%s' is not supported (%s)\n"
 
+#: frontend/src/app/main/data/workspace/tokens/application.cljs:364
+msgid "workspace.tokens.font-variant-not-found"
+msgstr "Error setting font weight/style. This font style does not exist in the current font"
+
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:133
 msgid "workspace.tokens.value-not-valid"
 msgstr "The value is not valid"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7517,6 +7517,10 @@ msgstr "La importación se ha realizado correctamente. Algunos tokens no se incl
 msgid "workspace.tokens.unknown-token-type-section"
 msgstr "El tipo '%s' no está soportado (%s)\n"
 
+#: frontend/src/app/main/data/workspace/tokens/application.cljs:364
+msgid "workspace.tokens.font-variant-not-found"
+msgstr "Error al configurar el font-weight/style de la fuente. Este estilo de fuente no existe en la fuente actual."
+
 #: src/app/main/ui/workspace/tokens/token_pill.cljs:133
 msgid "workspace.tokens.value-not-valid"
 msgstr "El valor no es válido"


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/137

### Summary


https://github.com/user-attachments/assets/8114a0a5-4ea0-4b17-ab83-14563c6a3f36



- Applies the closest found font variant to a font weight, instead of doing nothing when no font-weight matches the token value.
- Displays a warning when no exact match was found

### Steps to reproduce

1. Set a token value that doesnt match the current font and apply the font by clicking the token pill
2. The closest weight should be applied and a warning should be shown
3. Applying an exact match should not show a warning

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
