### PR TITLE
:bug: Fix token option schema

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
@@ -153,9 +153,10 @@
   [:map
    [:id {:optional true} :string]
    [:class {:optional true} :string]
-  ;;  [:value {:optional true} [:maybe [:or
-  ;;                            :int
-  ;;                            :string]]]
+   [:value {:optional true} [:maybe [:or
+                                     :int
+                                     :string
+                                     [:= :multiple]]]]
    [:default {:optional true} [:maybe :string]]
    [:placeholder {:optional true} :string]
    [:icon {:optional true} [:maybe schema:icon]]

--- a/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
@@ -149,7 +149,6 @@
 (def ^:private schema:icon
   [:and :string [:fn #(contains? icon-list %)]])
 
-;; TODO: Review schema props
 (def ^:private schema:numeric-input
   [:map
    [:id {:optional true} :string]
@@ -301,7 +300,6 @@
                (when (fn? on-change)
                  (on-change parsed))
 
-               ;; Comprar si es valor es necesario, sino borrar
                (mf/set-ref-val! raw-value* (fmt/format-number parsed))
                (update-input (fmt/format-number parsed)))
 

--- a/frontend/src/app/main/ui/ds/controls/shared/token_option.cljs
+++ b/frontend/src/app/main/ui/ds/controls/shared/token_option.cljs
@@ -18,11 +18,10 @@
   [:map
    [:id {:optiona true} :string]
    [:ref some?]
-   [:resolved {:optional true} [:or :number :string]]
+   [:resolved {:optional true} [:or :int :string]]
    [:name {:optional true} :string]
    [:on-click {:optional true} fn?]
    [:selected {:optional true} :boolean]
-   [:focused {:optional true} :boolean]
    [:focused {:optional true} :boolean]])
 
 (mf/defc token-option*


### PR DESCRIPTION
### Related Ticket

[Error on storybook](https://tree.taiga.io/project/penpot/issue/11893)

### Summary

The numeric input crashes on storybook when trying to open token dropdown.

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
