### PR TITLE
:tada: Inspect styles tab attributes container box

### DIFF
--- a/frontend/src/app/main/ui/inspect/right_sidebar.scss
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.scss
@@ -51,6 +51,7 @@
 .shape-icon {
   @include flexCenter;
   height: $s-32;
+  --icon-stroke-color: var(--color-foreground-primary);
 }
 
 .layer-title {
@@ -117,6 +118,7 @@
 
 .inspect-tab-switcher-label {
   @include use-typography("body-medium");
+  color: var(--color-foreground-primary);
   flex: 1;
 }
 

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -1,26 +1,60 @@
 (ns app.main.ui.inspect.styles.style-box
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.foundations.assets.icon :refer [icon*]]
+   [app.util.i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
 (defn- attribute->title
   [type]
   (case type
-    :variant    "Variant properties"
-    :token      "Token Sets & Themes"
-    :geometry   "Size & Position"
-    :fill       "Fill"
-    :stroke     "Stroke"
-    :text       "Text"
-    :shadow     "Shadow"
-    :layout     "Layout"
-    :layout-element "Layout Element"
-    :visibility "Visibility"
-    :svg        "SVG"
+    :variant    (tr "inspect.tabs.styles.panel.variant")
+    :token      (tr "inspect.tabs.styles.panel.token")
+    :geometry   (tr "inspect.tabs.styles.panel.geometry")
+    :fill       (tr "inspect.tabs.styles.panel.fill")
+    :stroke     (tr "inspect.tabs.styles.panel.stroke")
+    :text       (tr "inspect.tabs.styles.panel.text")
+    :blur       (tr "inspect.tabs.styles.panel.blur")
+    :shadow     (tr "inspect.tabs.styles.panel.shadow")
+    :layout     (tr "inspect.tabs.styles.panel.layout")
+    :layout-element (tr "inspect.tabs.styles.panel.layout-element")
+    :visibility (tr "inspect.tabs.styles.panel.visibility")
+    :svg        (tr "inspect.tabs.styles.panel.svg")
     nil))
 
 (mf/defc style-box*
-  [{:keys [attribute children]}]
-  [:div {:class (stl/css :style-box)}
-   [:h3 {:class (stl/css :style-box-header)} (attribute->title attribute)]
-   [:div {:class (stl/css :style-box-content)} children]])
+  [{:keys [attribute shorthand children]}]
+  (let [expanded* (mf/use-state true)
+        expanded (deref expanded*)
+
+        title (attribute->title attribute)
+
+        toggle-panel
+        (mf/use-fn
+         (mf/deps expanded)
+         (fn []
+           (reset! expanded* (not expanded))))
+
+        copy-shorthand
+        (mf/use-fn
+         (fn []
+           (js/navigator.clipboard.writeText (str "Style: " title))))]
+    [:article {:class (stl/css :style-box)}
+     [:header {:class (stl/css :disclosure-header)}
+      [:button {:class (stl/css :disclosure-button)
+                :on-click toggle-panel
+                :title (tr "inspect.tabs.styles.panel.toggle-style" title)
+                :aria-label (tr "inspect.tabs.styles.panel.toggle-style" title)}
+       [:> icon* {:icon-id (if expanded "arrow-down" "arrow")
+                  :class (stl/css :disclosure-icon)
+                  :size "s"}]]
+      [:span {:class (stl/css :panel-title)} title]
+      (when shorthand
+        [:> icon-button* {:variant "ghost"
+                          :aria-label (tr "inspect.tabs.styles.panel.copy-style-shorthand")
+                          :on-click copy-shorthand
+                          :icon "clipboard"}])]
+     (when expanded
+       [:div {:class (stl/css :style-box-content) :inert true}
+        [:div {:class (stl/css :style-box-description)} children]])]))

--- a/frontend/src/app/main/ui/inspect/styles/style_box.scss
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.scss
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+@use "../../ds/typography.scss" as *;
+
+.style-box {
+  --title-gap: var(--sp-xs);
+  --title-padding: var(--sp-s);
+  --title-color: var(--color-foreground-primary);
+  --arrow-color: var(--color-foreground-secondary);
+
+  padding-block: var(--sp-s);
+}
+
+.disclosure-header {
+  display: flex;
+  gap: var(--title-gap);
+  padding-block: var(--title-padding);
+}
+
+.disclosure-button {
+  display: grid;
+  place-items: center;
+  color: var(--arrow-color);
+
+  appearance: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.panel-title {
+  @include use-typography("headline-small");
+  text-transform: capitalize;
+  flex: 1;
+  color: var(--title-color);
+}

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1861,6 +1861,58 @@ msgstr "Styles"
 msgid "inspect.tabs.switcher.label"
 msgstr "Layer info"
 
+#: src/app/main/ui/inspect/styles/style_box.cljs:10
+msgid "inspect.tabs.styles.panel.variant"
+msgstr "Variant properties"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:11
+msgid "inspect.tabs.styles.panel.token"
+msgstr "Token Sets & Themes"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.geometry"
+msgstr "Size & Position"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.fill"
+msgstr "Fill"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.stroke"
+msgstr "Stroke"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.text"
+msgstr "Text"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.shadow"
+msgstr "Shadow"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.layout"
+msgstr "Layout"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.layout-element"
+msgstr "Layout Element"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.visibility"
+msgstr "Visibility"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.blur"
+msgstr "Blur"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.svg"
+msgstr "SVG"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.toggle-style"
+msgstr "Toggle panel %s"
+
 #: src/app/main/ui/dashboard/comments.cljs:95
 msgid "label.mark-all-as-read"
 msgstr "Mark all as read"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1791,6 +1791,14 @@ msgstr "Componente principal"
 msgid "inspect.subtitle.variant"
 msgstr "Variante"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:59
+msgid "inspect.tabs.switcher.label"
+msgstr "Información sobre la capa"
+
+#: src/app/main/ui/inspect/right_sidebar.cljs:101
+msgid "inspect.tabs.computed"
+msgstr "Computado"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:111, src/app/main/ui/inspect/right_sidebar.cljs:116
 msgid "inspect.tabs.code"
 msgstr "Código"
@@ -1855,9 +1863,57 @@ msgstr "Información"
 msgid "inspect.tabs.styles"
 msgstr "Estilos"
 
-#: src/app/main/ui/inspect/right_sidebar.cljs:165
-msgid "inspect.tabs.switcher.label"
-msgstr "Información sobre la capa"
+#: src/app/main/ui/inspect/styles/style_box.cljs:10
+msgid "inspect.tabs.styles.panel.variant"
+msgstr "Propiedades de las variantes"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:11
+msgid "inspect.tabs.styles.panel.token"
+msgstr "Sets y temas de tokens"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.geometry"
+msgstr "Tamaño y posición"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.fill"
+msgstr "Relleno"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.stroke"
+msgstr "Borde"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.text"
+msgstr "Texto"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.shadow"
+msgstr "Sombra"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.layout"
+msgstr "Layout"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.layout-element"
+msgstr "Layout de elemento"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.visibility"
+msgstr "Visibilidad"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.blur"
+msgstr "Desenfoque"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.svg"
+msgstr "SVG"
+
+#: src/app/main/ui/inspect/styles/style_box.cljs:12
+msgid "inspect.tabs.styles.panel.toggle-style"
+msgstr "Alternar panel %s"
 
 #: src/app/main/ui/dashboard/comments.cljs:95
 msgid "label.mark-all-as-read"


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/us/9313

### Summary

- Creates the wrapper box for each shape properties type
  - Should display an specific title
  - Should be foldable
  - Should be able to copy a shorthand when possible (WIP)

### Steps to reproduce 

1. Open the `styles` tab under the inspect sidebar
2. Select a shape and ensure that display properties that make sense
3. Select a shape with tokens applied and check that there is a tokens panel.
3. Select a variant shape and check that there is a variants panel.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
