### PR TITLE
:bug: Fix combine as variants from assets tab selects wrong components

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -821,6 +821,13 @@
   (let [path-split (split-path path)]
     (merge-path-item (first path-split) name)))
 
+(defn inside-path? [child parent]
+  (let [child-path  (split-path child)
+        parent-path (split-path parent)]
+    (and (<= (count parent-path) (count child-path))
+         (= parent-path (take (count parent-path) child-path)))))
+
+
 
 (defn split-by-last-period
   "Splits a string into two parts:

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/components.cljs
@@ -460,7 +460,7 @@
              (st/emit! (dwu/start-undo-transaction undo-id))
              (run! st/emit!
                    (->> components
-                        (filter #(str/starts-with? (:path %) path))
+                        (filter #(cfh/inside-path? (:path %) path))
                         (map #(dwv/rename-comp-or-variant-and-main
                                (:id %)
                                (cmm/rename-group % path last-path)))))
@@ -491,7 +491,7 @@
              (st/emit! (dwu/start-undo-transaction undo-id))
              (run! st/emit!
                    (->> components
-                        (filter #(str/starts-with? (:path %) path))
+                        (filter #(cfh/inside-path? (:path %) path))
                         (map #(dwv/rename-comp-or-variant-and-main (:id %) (cmm/ungroup % path)))))
              (st/emit! (dwu/commit-undo-transaction undo-id)))))
 
@@ -501,7 +501,7 @@
          (fn [path]
            (on-clear-selection)
            (let [comps   (->> components
-                              (filter #(str/starts-with? (:path %) path)))
+                              (filter #(cfh/inside-path? (:path %) path)))
                  ids     (into #{} (map :main-instance-id comps))
                  page-id (->> comps first :main-instance-page)]
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11890

### Summary

Combine as variants from the assets panel combine too many components

### Steps to reproduce 

1. Create 4 components
2. Rename them to: `aa/bb/01` `aa/bb/02` `aa/bb - cc/03` `aa/bb - dd/04`
3. On the assets pannel, on the group `aa/bb`, open the contextual menu and select `Combine as variants`
4. All 4 components are combined. Only `aa/bb/01` `aa/bb/02` should combine

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
