### PR TITLE
:sparkles: Show create variant shortcut also for stand-alone components

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -876,6 +876,11 @@
              (when can-swap? (st/emit! (dwsp/open-specialized-panel :component-swap)))
              (tm/schedule-on-idle #(dom/focus! (dom/get-element search-id))))))
 
+        transform-into-variant
+        (mf/use-fn
+         (mf/deps id)
+         #(st/emit! (dwv/transform-in-variant id)))
+
         create-variant
         (mf/use-fn
          (mf/deps id)
@@ -936,10 +941,10 @@
                                :on-click on-click-variant-title-help
                                :icon "help"}])
 
-           (when (and is-variant? main-instance?)
+           (when main-instance?
              [:> icon-button* {:variant "ghost"
                                :aria-label (tr "workspace.shape.menu.add-variant")
-                               :on-click create-variant
+                               :on-click (if is-variant? create-variant transform-into-variant)
                                :icon "variant"}])])]
 
        (when open?


### PR DESCRIPTION
### Related Ticket

Taiga [#11900](https://tree.taiga.io/project/penpot/task/11900)

### Summary

A shortcut for creating variant is now displayed in the design tab when selecting stand-alone components, too.

### Steps to reproduce

This action has the same icon, but under the hood it performs a different action, which is transforming a stand-alone component into a component with variants. Check that it works this way, and that the behavior for the previous use cases (selecting a component with already has variants, or just a variant) still work as before, which is adding variants.