### PR TITLE
:bug: Fix paste RTF crashes text editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,8 +30,8 @@
 - Fix issue where Alt + arrow keys shortcut interferes with letter-spacing when moving text layers [Taiga #11552](https://tree.taiga.io/project/penpot/issue/11771)
 - Fix consistency issues on how font variants are visualized [Taiga #11499](https://tree.taiga.io/project/penpot/us/11499)
 - Fix parsing rx and ry SVG values for rect radius [Taiga #11861](https://tree.taiga.io/project/penpot/issue/11861)
--  Misleading affordance in saved versions [Taiga #11887](https://tree.taiga.io/project/penpot/issue/11887)
-
+- Misleading affordance in saved versions [Taiga #11887](https://tree.taiga.io/project/penpot/issue/11887)
+- Fix pasting RTF text crashes penpot [Taiga #11717](https://tree.taiga.io/project/penpot/issue/11717)
 
 ## 2.9.0
 

--- a/frontend/text-editor/src/editor/TextEditor.js
+++ b/frontend/text-editor/src/editor/TextEditor.js
@@ -517,8 +517,8 @@ export class TextEditor extends EventTarget {
   }
 }
 
-export function createRootFromHTML(html, style) {
-  const fragment = mapContentFragmentFromHTML(html, style);
+export function createRootFromHTML(html, style = undefined) {
+  const fragment = mapContentFragmentFromHTML(html, style || undefined);
   const root = createRoot([], style);
   root.replaceChildren(fragment);
   resetInertElement();

--- a/frontend/text-editor/src/editor/content/dom/Style.js
+++ b/frontend/text-editor/src/editor/content/dom/Style.js
@@ -9,8 +9,10 @@
 import { getFills } from "./Color.js";
 
 const DEFAULT_FONT_SIZE = "16px";
+const DEFAULT_FONT_SIZE_VALUE = parseFloat(DEFAULT_FONT_SIZE);
 const DEFAULT_LINE_HEIGHT = "1.2";
 const DEFAULT_FONT_WEIGHT = "400";
+
 /**
  * Merges two style declarations. `source` -> `target`.
  *
@@ -220,10 +222,13 @@ export function setStyle(element, styleName, styleValue, styleUnit) {
  */
 function getStyleFontSize(styleValueAsNumber, styleValue) {
   if (styleValue.endsWith("pt")) {
-    return (styleValueAsNumber * 1.3333).toFixed();
+    const baseSize = 1.3333;
+    return (styleValueAsNumber * baseSize).toFixed();
   } else if (styleValue.endsWith("em")) {
+    const baseSize = DEFAULT_FONT_SIZE_VALUE;
     return (styleValueAsNumber * baseSize).toFixed();
   } else if (styleValue.endsWith("%")) {
+    const baseSize = DEFAULT_FONT_SIZE_VALUE;
     return ((styleValueAsNumber / 100) * baseSize).toFixed();
   }
   return styleValueAsNumber.toFixed();


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #11717](https://tree.taiga.io/project/penpot/issue/11717)

### Summary

Penpot crashes when pasting RTF text.

### Steps to reproduce 

1. Create a blank file
2. Put some RTF (formatted) text in the clipboard.
3. In Penpot, paste the text (Ctrl + V / Cmd + V)

#### Expected results:

Text is pasted with no issues.

#### Actual result:

Penpot crashes. In the console, a "baseSize is not defined" error message is printed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
