### PR TITLE
:bug: Fix padding of input field component

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
@@ -25,7 +25,7 @@
 
   background: var(--input-bg-color);
   border-radius: $br-8;
-  padding: 0 var(--sp-xs);
+  padding: 0 var(--sp-s);
   outline: $b-1 solid var(--input-outline-color);
 
   &:hover {

--- a/frontend/src/app/main/ui/ds/controls/utilities/token_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/token_field.scss
@@ -25,7 +25,7 @@
   inline-size: 100%;
   background: var(--token-field-bg-color);
   border-radius: $br-8;
-  padding: var(--sp-xs);
+  padding: var(--sp-s);
   outline: $b-1 solid var(--token-field-outline-color);
 
   &:hover {


### PR DESCRIPTION
### Related Ticket

No ticket

### Summary

While create new numeric input component, base input was modified by error, changing its internal padding. This pr fixes this. 
Good
<img width="60" height="46" alt="image (11)" src="https://github.com/user-attachments/assets/acf29a26-b523-4ef5-8846-84a234eebfc7" />
Bad
<img width="77" height="53" alt="image (10)" src="https://github.com/user-attachments/assets/511f7582-a4e1-4030-9026-f485e3999885" />

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
