### PR TITLE
:bug: Fix new inline text styles not being applied correctly

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -812,7 +812,9 @@
     (effect [_ state _]
       (when (features/active-feature? state "text-editor/v2")
         (let [instance (:workspace-editor state)
-              styles (styles/attrs->styles attrs)]
+              attrs-to-override (some-> (editor.v2/getCurrentStyle instance) (styles/get-styles-from-style-declaration))
+              overriden-attrs (merge attrs-to-override attrs)
+              styles  (styles/attrs->styles overriden-attrs)]
           (editor.v2/applyStylesToSelection instance styles))))))
 
 (defn update-all-attrs


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11552

### Summary

This fixes applying inline styling in editor v2

https://github.com/user-attachments/assets/2174f9d8-e851-40dc-9c46-43396d43ff4e


### Steps to reproduce 

_Testing this is cumbersome because of [this bug](https://tree.taiga.io/project/penpot/issue/11903) of the editor losing focus when changing variant._

1. Create a new text shape and start typing
2. Change font size and/or font variant in the dropdown at the design tab
3. (you might need to refocus the text editor if you changed the variant)
4. Continue typing


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
