### PR TITLE
:bug: Fix color of variant property names in the design tab

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -694,6 +694,7 @@
 }
 
 .variant-property-name {
+  color: var(--color-foreground-secondary);
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
### Related Ticket

Taiga [#11930](https://tree.taiga.io/project/penpot/issue/11930)

### Summary

The color of the property names when a copy of a variant is selected have been changed to match the design.