### PR TITLE
:bug: Fix different fonts on texts shadows

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -550,7 +550,7 @@ impl RenderState {
                         let mut paragraphs_with_drop_shadows = text_content.to_paragraphs(
                             blur_filter.as_ref(),
                             blur_mask.as_ref(),
-                            Some(&drop_shadow),
+                            Some(drop_shadow),
                         );
                         shadows::render_text_drop_shadows(
                             self,
@@ -570,7 +570,7 @@ impl RenderState {
                                 &shape.selrect(),
                                 blur_filter.as_ref(),
                                 blur_mask.as_ref(),
-                                Some(&drop_shadow),
+                                Some(drop_shadow),
                                 count_inner_strokes,
                             );
                         shadows::render_text_drop_shadows(
@@ -606,7 +606,7 @@ impl RenderState {
                                 &shape.selrect(),
                                 blur_filter.as_ref(),
                                 blur_mask.as_ref(),
-                                Some(&inner_shadow),
+                                Some(inner_shadow),
                                 count_inner_strokes,
                             );
                         shadows::render_text_inner_shadows(
@@ -621,7 +621,7 @@ impl RenderState {
                     let mut paragraphs_with_inner_shadows = text_content.to_paragraphs(
                         blur_filter.as_ref(),
                         blur_mask.as_ref(),
-                        Some(&inner_shadow),
+                        Some(inner_shadow),
                     );
                     shadows::render_text_inner_shadows(
                         self,

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -59,7 +59,6 @@ pub fn render_stroke_drop_shadows(
                 filter.as_ref(),
                 None,
                 antialias,
-                None,
             )
         }
     }
@@ -82,7 +81,6 @@ pub fn render_stroke_inner_shadows(
                 filter.as_ref(),
                 None,
                 antialias,
-                None,
             )
         }
     }
@@ -92,11 +90,13 @@ pub fn render_text_drop_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
     paragraphs: &mut [Vec<ParagraphBuilder>],
-    antialias: bool,
 ) {
-    for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_drop_shadow(render_state, shape, shadow, paragraphs, antialias);
-    }
+    text::render(
+        render_state,
+        shape,
+        paragraphs,
+        Some(SurfaceId::DropShadows),
+    );
 }
 
 // Render text paths (unused)
@@ -122,50 +122,16 @@ pub fn render_text_path_stroke_drop_shadows(
     }
 }
 
-pub fn render_text_drop_shadow(
-    render_state: &mut RenderState,
-    shape: &Shape,
-    shadow: &Shadow,
-    paragraphs: &mut [Vec<ParagraphBuilder>],
-    antialias: bool,
-) {
-    let paint = shadow.get_drop_shadow_paint(antialias, shape.image_filter(1.).as_ref());
-
-    text::render(
-        render_state,
-        shape,
-        paragraphs,
-        Some(SurfaceId::DropShadows),
-        Some(&paint),
-    );
-}
-
 pub fn render_text_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,
     paragraphs: &mut [Vec<ParagraphBuilder>],
-    antialias: bool,
 ) {
-    for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
-        render_text_inner_shadow(render_state, shape, shadow, paragraphs, antialias);
-    }
-}
-
-pub fn render_text_inner_shadow(
-    render_state: &mut RenderState,
-    shape: &Shape,
-    shadow: &Shadow,
-    paragraphs: &mut [Vec<ParagraphBuilder>],
-    antialias: bool,
-) {
-    let paint = shadow.get_inner_shadow_paint(antialias, shape.image_filter(1.).as_ref());
-
     text::render(
         render_state,
         shape,
         paragraphs,
         Some(SurfaceId::InnerShadows),
-        Some(&paint),
     );
 }
 

--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -521,7 +521,6 @@ pub fn render(
     shadow: Option<&ImageFilter>,
     paragraphs: Option<&mut Vec<Vec<ParagraphBuilder>>>,
     antialias: bool,
-    paint: Option<&skia::Paint>,
 ) {
     let scale = render_state.get_scale();
     let canvas = render_state
@@ -571,7 +570,6 @@ pub fn render(
                     shape,
                     paragraphs.expect("Text shapes should have paragraphs"),
                     Some(SurfaceId::Strokes),
-                    paint,
                 );
             }
             shape_type @ (Type::Path(_) | Type::Bool(_)) => {

--- a/render-wasm/src/render/text.rs
+++ b/render-wasm/src/render/text.rs
@@ -1,6 +1,5 @@
 use super::{RenderState, Shape, SurfaceId};
 use crate::shapes::VerticalAlign;
-use crate::utils::get_font_collection;
 use skia_safe::{textlayout::ParagraphBuilder, Paint, Path};
 
 pub fn render(
@@ -8,9 +7,7 @@ pub fn render(
     shape: &Shape,
     paragraphs: &mut [Vec<ParagraphBuilder>],
     surface_id: Option<SurfaceId>,
-    paint: Option<&Paint>,
 ) {
-    let fonts = get_font_collection();
     let canvas = render_state
         .surfaces
         .canvas(surface_id.unwrap_or(SurfaceId::Fills));
@@ -37,23 +34,8 @@ pub fn render(
         let mut group_offset_y = global_offset_y;
         let group_len = group.len();
 
-        for (index, builder) in group.iter_mut().enumerate() {
+        for builder in group.iter_mut() {
             let mut skia_paragraph = builder.build();
-
-            if paint.is_some() && index == 0 {
-                let text = builder.get_text().to_string();
-                let mut paragraph_builder =
-                    ParagraphBuilder::new(&builder.get_paragraph_style(), fonts);
-                let mut text_style: skia_safe::Handle<_> = builder.peek_style();
-                text_style.set_foreground_paint(paint.unwrap());
-                paragraph_builder.reset();
-                paragraph_builder.push_style(&text_style);
-                paragraph_builder.add_text(&text);
-                skia_paragraph = paragraph_builder.build();
-            } else if paint.is_some() && index > 0 {
-                continue;
-            }
-
             skia_paragraph.layout(paragraph_width);
             let paragraph_height = skia_paragraph.height();
             let xy = (shape.selrect().x(), shape.selrect().y() + group_offset_y);

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1152,6 +1152,34 @@ impl Shape {
             self.children_ids(include_hidden)
         }
     }
+
+    pub fn drop_shadow_paints(&self) -> Vec<skia_safe::Paint> {
+        let drop_shadows: Vec<&crate::shapes::shadows::Shadow> =
+            self.drop_shadows().filter(|s| !s.hidden()).collect();
+        drop_shadows
+            .into_iter()
+            .map(|shadow| {
+                let mut paint = skia_safe::Paint::default();
+                let filter = shadow.get_drop_shadow_filter();
+                paint.set_image_filter(filter);
+                paint
+            })
+            .collect()
+    }
+
+    pub fn inner_shadow_paints(&self) -> Vec<skia_safe::Paint> {
+        let inner_shadows: Vec<&crate::shapes::shadows::Shadow> =
+            self.inner_shadows().filter(|s| !s.hidden()).collect();
+        inner_shadows
+            .into_iter()
+            .map(|shadow| {
+                let mut paint = skia_safe::Paint::default();
+                let filter = shadow.get_inner_shadow_filter();
+                paint.set_image_filter(filter);
+                paint
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -232,6 +232,7 @@ pub fn merge_fills(fills: &[Fill], bounding_box: Rect) -> skia::Paint {
 
     if fills.is_empty() {
         combined_shader = Some(skia::shaders::color(skia::Color::TRANSPARENT));
+        fills_paint.set_color(skia::Color::TRANSPARENT);
         fills_paint.set_shader(combined_shader);
         return fills_paint;
     }

--- a/render-wasm/src/shapes/fills.rs
+++ b/render-wasm/src/shapes/fills.rs
@@ -232,7 +232,6 @@ pub fn merge_fills(fills: &[Fill], bounding_box: Rect) -> skia::Paint {
 
     if fills.is_empty() {
         combined_shader = Some(skia::shaders::color(skia::Color::TRANSPARENT));
-        fills_paint.set_color(skia::Color::TRANSPARENT);
         fills_paint.set_shader(combined_shader);
         return fills_paint;
     }

--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -200,7 +200,7 @@ fn propagate_transform(
         match content.grow_type() {
             GrowType::AutoHeight => {
                 let paragraph_width = shape_bounds_after.width();
-                let mut paragraphs = content.to_paragraphs(None, None);
+                let mut paragraphs = content.to_paragraphs(None, None, None);
                 let height = auto_height(&mut paragraphs, paragraph_width);
                 let resize_transform = math::resize_matrix(
                     &shape_bounds_after,
@@ -213,7 +213,7 @@ fn propagate_transform(
             }
             GrowType::AutoWidth => {
                 let paragraph_width = content.get_width();
-                let mut paragraphs = content.to_paragraphs(None, None);
+                let mut paragraphs = content.to_paragraphs(None, None, None);
                 let height = auto_height(&mut paragraphs, paragraph_width);
                 let resize_transform = math::resize_matrix(
                     &shape_bounds_after,

--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -163,7 +163,7 @@ impl TextContent {
                         blur,
                         blur_mask,
                         shadow,
-                        !leaf.is_transparent(),
+                        leaf.is_transparent(),
                     )
                 } else {
                     get_text_stroke_paints(
@@ -784,7 +784,6 @@ fn get_text_stroke_paints_with_shadows(
             let mut paint = skia_safe::Paint::default();
             paint.set_style(skia::PaintStyle::Fill);
             paint.set_anti_alias(true);
-            paint.set_stroke_width(stroke.width * 2.0);
 
             if let Some(blur) = blur {
                 paint.set_image_filter(blur.clone());
@@ -796,7 +795,7 @@ fn get_text_stroke_paints_with_shadows(
 
             paints.push(paint.clone());
 
-            if !is_transparent {
+            if is_transparent {
                 let image_filter = skia_safe::image_filters::erode(
                     (stroke.width, stroke.width),
                     paint.image_filter(),
@@ -821,9 +820,9 @@ fn get_text_stroke_paints_with_shadows(
             }
 
             if is_transparent {
-                paint.set_style(skia::PaintStyle::StrokeAndFill);
-            } else {
                 paint.set_style(skia::PaintStyle::Stroke);
+            } else {
+                paint.set_style(skia::PaintStyle::StrokeAndFill);
             }
 
             paints.push(paint);
@@ -844,7 +843,7 @@ fn get_text_stroke_paints_with_shadows(
 
             paints.push(paint.clone());
 
-            if !is_transparent {
+            if is_transparent {
                 let image_filter = skia_safe::image_filters::erode(
                     (stroke.width, stroke.width),
                     paint.image_filter(),

--- a/render-wasm/src/shapes/text_paths.rs
+++ b/render-wasm/src/shapes/text_paths.rs
@@ -20,7 +20,7 @@ impl TextPaths {
         let mut paths = Vec::new();
 
         let mut offset_y = self.bounds.y();
-        let mut paragraphs = self.to_paragraphs(None, None);
+        let mut paragraphs = self.to_paragraphs(None, None, None);
 
         for paragraphs in paragraphs.iter_mut() {
             for paragraph_builder in paragraphs.iter_mut() {

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -45,7 +45,7 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
         if let Type::Text(content) = &shape.shape_type {
             // 1. Reset Paragraphs
             let paragraph_width = content.get_width();
-            let mut paragraphs = content.to_paragraphs(None, None);
+            let mut paragraphs = content.to_paragraphs(None, None, None);
             let built_paragraphs = build_paragraphs_with_width(&mut paragraphs, paragraph_width);
 
             // 2. Max Width Calculation
@@ -57,12 +57,12 @@ pub extern "C" fn get_text_dimensions() -> *mut u8 {
             // 3. Width and Height Calculation
             match content.grow_type() {
                 GrowType::AutoHeight => {
-                    let mut paragraph_height = content.to_paragraphs(None, None);
+                    let mut paragraph_height = content.to_paragraphs(None, None, None);
                     height = auto_height(&mut paragraph_height, paragraph_width).ceil();
                 }
                 GrowType::AutoWidth => {
                     width = paragraph_width;
-                    let mut paragraph_height = content.to_paragraphs(None, None);
+                    let mut paragraph_height = content.to_paragraphs(None, None, None);
                     height = auto_height(&mut paragraph_height, paragraph_width).ceil();
                 }
                 GrowType::Fixed => {}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11943

### Summary

This PR fixes shadows in texts when having different text-leaf styles (such as different fonts). It still needs to fix an issue with inner and outer strokes with shadows and transparent backgrounds, that will be fixed as a separate issue.

### Steps to reproduce 

- Create a text with different fonts
- Add shadows
- Check they work as expected

<img width="891" height="513" alt="image" src="https://github.com/user-attachments/assets/9c3cb03d-efd5-44cc-9156-8f701082fe8f" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.

