### PR TITLE
:globe_with_meridians: Recover lost variant translation

### DIFF
--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1790,9 +1790,8 @@ msgid "inspect.subtitle.main"
 msgstr "Main component"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:65
-#, fuzzy
 msgid "inspect.subtitle.variant"
-msgstr ""
+msgstr "Variant"
 
 #: src/app/main/ui/inspect/right_sidebar.cljs:111, src/app/main/ui/inspect/right_sidebar.cljs:116
 msgid "inspect.tabs.code"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1787,6 +1787,10 @@ msgstr "Copia"
 msgid "inspect.subtitle.main"
 msgstr "Componente principal"
 
+#: src/app/main/ui/inspect/right_sidebar.cljs:65
+msgid "inspect.subtitle.variant"
+msgstr "Variante"
+
 #: src/app/main/ui/inspect/right_sidebar.cljs:111, src/app/main/ui/inspect/right_sidebar.cljs:116
 msgid "inspect.tabs.code"
 msgstr "Código"


### PR DESCRIPTION
### Summary

This PR recovers a lost translation of the variant subtitle in the inspect tab

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
