### PR TITLE
:bug: Fix navigation arrows in Libraries & Templates carousel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Fix parsing rx and ry SVG values for rect radius [Taiga #11861](https://tree.taiga.io/project/penpot/issue/11861)
 - Misleading affordance in saved versions [Taiga #11887](https://tree.taiga.io/project/penpot/issue/11887)
 - Fix pasting RTF text crashes penpot [Taiga #11717](https://tree.taiga.io/project/penpot/issue/11717)
+- Fix navigation arrows in Libraries & Templates carousel [Taiga #10609](https://tree.taiga.io/project/penpot/issue/10609)
 
 ## 2.9.0
 

--- a/frontend/src/app/main/ui/dashboard/templates.cljs
+++ b/frontend/src/app/main/ui/dashboard/templates.cljs
@@ -227,10 +227,18 @@
                                :right (> scroll-available client-width)}))))
 
         on-move-left
-        (mf/use-fn #(dom/scroll-by! (mf/ref-val content-ref) -300 0))
+        (mf/use-fn
+         (fn [event]
+           (if (kbd/right-arrow? event)
+             (dom/scroll-by! (mf/ref-val content-ref) 300 0)
+             (dom/scroll-by! (mf/ref-val content-ref) -300 0))))
 
         on-move-right
-        (mf/use-fn #(dom/scroll-by! (mf/ref-val content-ref) 300 0))
+        (mf/use-fn
+         (fn [event]
+           (if (kbd/left-arrow? event)
+             (dom/scroll-by! (mf/ref-val content-ref) -300 0)
+             (dom/scroll-by! (mf/ref-val content-ref) 300 0))))
 
         on-import-template
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10609

### Summary

Handle left and right arrow keydown events to trigger the corresponding carousel movement.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.