### PR TITLE
:globe_with_meridians: Convert translation single word to label

### DIFF
--- a/frontend/src/app/main/ui/inspect/right_sidebar.cljs
+++ b/frontend/src/app/main/ui/inspect/right_sidebar.cljs
@@ -62,7 +62,7 @@
                           (and (not (ctk/is-variant? first-shape)) main-instance?))
                          (tr "inspect.subtitle.main")
                          (and (ctk/is-variant? first-shape) main-instance?)
-                         (tr "inspect.subtitle.variant")
+                         (tr "labels.variant")
                          (ctk/instance-head? first-shape)
                          (tr "inspect.subtitle.copy"))
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -931,7 +931,7 @@
             [:span {:class (stl/css :copy-text)}
              (if main-instance?
                (if is-variant?
-                 (tr "workspace.options.component.variant")
+                 (tr "labels.variant")
                  (tr "workspace.options.component.main"))
                (tr "workspace.options.component.copy"))]]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs
@@ -515,7 +515,7 @@
             i/menu]]
 
           [:div {:class (stl/css :info-row)}
-           [:span {:class (stl/css :info-label)}  (tr "workspace.assets.typography.font-variant-id")]
+           [:span {:class (stl/css :info-label)}  (tr "labels.variant")]
            [:span {:class (stl/css :info-content)} (:font-variant-id typography)]]
 
           [:div {:class (stl/css :info-row)}

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1789,10 +1789,6 @@ msgstr "Copy"
 msgid "inspect.subtitle.main"
 msgstr "Main component"
 
-#: src/app/main/ui/inspect/right_sidebar.cljs:65
-msgid "inspect.subtitle.variant"
-msgstr "Variant"
-
 #: src/app/main/ui/inspect/right_sidebar.cljs:111, src/app/main/ui/inspect/right_sidebar.cljs:116
 msgid "inspect.tabs.code"
 msgstr "Code"
@@ -2582,6 +2578,10 @@ msgstr "Your account"
 #, unused
 msgid "labels.youtube"
 msgstr "YouTube"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
+msgid "labels.variant"
+msgstr "Variant"
 
 #: src/app/main/ui/ds/product/loader.cljs:21
 msgid "loader.tips.01.message"
@@ -4986,10 +4986,6 @@ msgstr "Font"
 msgid "workspace.assets.typography.font-size"
 msgstr "Size"
 
-#: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:518
-msgid "workspace.assets.typography.font-variant-id"
-msgstr "Variant"
-
 #: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:540
 msgid "workspace.assets.typography.go-to-edit"
 msgstr "Go to style library file to edit"
@@ -5562,10 +5558,6 @@ msgstr "There are no assets in this library yet"
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:973
 msgid "workspace.options.component.unlinked"
 msgstr "Unlinked"
-
-#: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:929
-msgid "workspace.options.component.variant"
-msgstr "Variant"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:499
 msgid "workspace.options.component.variant.duplicated.copy.locate"


### PR DESCRIPTION
### Summary

This PR converts a duplicated single word into the `labels` scope in translations

### Steps to reproduce 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
