### PR TITLE
:bug: Do not render assets sidebar context menu if it is not open

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -178,17 +178,18 @@
           :class (stl/css-case :section-button true
                                :opened menu-open?)}
          i/filter-icon]]
-       [:> context-menu*
-        {:on-close on-menu-close
-         :selectable true
-         :selected section
-         :show menu-open?
-         :fixed true
-         :min-width true
-         :width size
-         :top 158
-         :left 18
-         :options options}]
+       (when menu-open?
+         [:> context-menu*
+          {:on-close on-menu-close
+           :selectable true
+           :selected section
+           :show true
+           :fixed true
+           :min-width true
+           :width size
+           :top 158
+           :left 18
+           :options options}])
        [:> icon-button* {:variant "ghost"
                          :aria-label (tr "workspace.assets.sort")
                          :on-click toggle-ordering


### PR DESCRIPTION
This commit is a workaround to an issue that happens when you performing multiple selection of several shapes (including components) and an exception is raised of max depth of updates. The issue is still not solved, we justo do not render the context menu when user performs the selection on the workspace.

That issue/exception happens only we have context-menu* component rendered independently of its visibility and dev-tools open

