### PR TITLE
:bug: Fix setting shape size to zero

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - Misleading affordance in saved versions [Taiga #11887](https://tree.taiga.io/project/penpot/issue/11887)
 - Fix pasting RTF text crashes penpot [Taiga #11717](https://tree.taiga.io/project/penpot/issue/11717)
 - Fix navigation arrows in Libraries & Templates carousel [Taiga #10609](https://tree.taiga.io/project/penpot/issue/10609)
+- Fix applying tokens with zero value to size [Taiga #11618](https://tree.taiga.io/project/penpot/issue/11618)
 
 ## 2.9.0
 

--- a/common/src/app/common/types/modifiers.cljc
+++ b/common/src/app/common/types/modifiers.cljc
@@ -466,7 +466,12 @@
    (dm/assert! (#{:width :height} attr))
    (dm/assert! (number? value))
 
-   (let [{:keys [proportion proportion-lock]} shape
+   (let [;; Avoid havig shapes with zero size
+         value (if (< (mth/abs value) 0.01)
+                 0.01
+                 value)
+
+         {:keys [proportion proportion-lock]} shape
          size (select-keys (:selrect shape) [:width :height])
          new-size (if-not (and (not ignore-lock?) proportion-lock)
                     (assoc size attr value)


### PR DESCRIPTION
### Related Ticket

[Dimension not changing when the raw value is 0 (0.01)](https://tree.taiga.io/project/penpot/issue/11618)

### Summary

Shapes are not allowed to have zero size (width or height). For manual user interaction this is being enforced in the numeric input. But if the size is assigned by other means (for example by applying a dimension token of value 0), it's changed without control, and then the behavior is erratic.

### Steps to reproduce 

See Taiga issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
