### PR TITLE
:bug: Don't allow a variant switch when that will provoke a components loop

### DIFF
--- a/common/src/app/common/files/helpers.cljc
+++ b/common/src/app/common/files/helpers.cljc
@@ -426,38 +426,15 @@
 
 (defn components-nesting-loop?
   "Check if a nesting loop would be created if the given shape is moved below the given parent"
-  [objects shape-id parent-id]
-  (let [xf-get-component-id (keep :component-id)
-
-        children            (get-children-with-self objects shape-id)
-        child-components    (into #{} xf-get-component-id children)
-
-        parents             (get-parents-with-self objects parent-id)
-        parent-components   (into #{} xf-get-component-id parents)]
-    (seq (set/intersection child-components parent-components))))
-
-(defn variants-nesting-loop?
-  "Check if a variants nesting loop would be created if the given shape is moved below the given parent"
-  [objects libraries shape parent pasting-cutted-mains?]
-  ;; If we are cut-pasting mains into its own variant, it is ok
-  (if (and pasting-cutted-mains?
-           (:is-variant-container parent)
-           (= (:variant-id shape) (:id parent)))
-    nil
-    (let [get-variant-id #(or (:variant-id %)
-                              (when (:is-variant-container %) (:id %))
-                              (when (:component-id %)
-                                (dm/get-in libraries [(:component-file %)
-                                                      :data
-                                                      :components
-                                                      (:component-id %)
-                                                      :variant-id])))
-          child-variant-ids  (into #{} (keep get-variant-id)
-                                   (get-children-with-self objects (:id shape)))
-          parent-variant-ids (into #{} (keep get-variant-id)
-                                   (get-parents-with-self objects (:id parent)))]
-      (seq (set/intersection child-variant-ids parent-variant-ids)))))
-
+  ([objects shape-id parent-id]
+   (let [children (get-children-with-self objects shape-id)
+         parents  (get-parents-with-self objects parent-id)]
+     (components-nesting-loop? children parents)))
+  ([children parents]
+   (let [xf-get-component-id (keep :component-id)
+         child-components    (into #{} xf-get-component-id children)
+         parent-components   (into #{} xf-get-component-id parents)]
+     (seq (set/intersection child-components parent-components)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ALGORITHMS & TRANSFORMATIONS FOR SHAPES

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -434,9 +434,9 @@
       (mapcat collect-main-shapes children objects)
       [])))
 
-(defn- invalid-structure-for-component?
+(defn invalid-structure-for-component?
   "Check if the structure generated nesting children in parent is invalid in terms of nested components"
-  [objects parent children pasting? all-comp-cut? libraries]
+  [objects parent children pasting? libraries]
   (let [; If the original shapes had been cutted, and we are pasting them now, they aren't
         ; in objects. We can add them to locate later
         objects (merge objects
@@ -457,11 +457,7 @@
         parent-in-component?    (in-any-component? objects parent)
         comps-nesting-loop?     (not (->> children
                                           (map #(cfh/components-nesting-loop? objects (:id %) (:id parent)))
-                                          (every? nil?)))
-
-        variants-nesting-loop? (not (->> children
-                                         (map #(cfh/variants-nesting-loop? objects libraries % parent (and pasting? all-comp-cut?)))
-                                         (every? nil?)))]
+                                          (every? nil?)))]
     (or
       ;;We don't want to change the structure of component copies
      (ctk/in-component-copy? parent)
@@ -470,8 +466,7 @@
      (and selected-main-instance? parent-in-component?)
       ;; Avoid placing a shape as a direct or indirect child of itself,
       ;; or inside its main component if it's in a copy.
-     comps-nesting-loop?
-     variants-nesting-loop?)))
+     comps-nesting-loop?)))
 
 (defn find-valid-parent-and-frame-ids
   "Navigate trough the ancestors until find one that is valid. Returns [ parent-id frame-id ]"
@@ -511,7 +506,7 @@
                                             true))
                   (every? :deleted)))]
        (if (or no-changes?
-               (and (not (invalid-structure-for-component? objects parent children pasting? all-comp-cut? libraries))
+               (and (not (invalid-structure-for-component? objects parent children pasting? libraries))
                     ;; If we are moving into a main component, no descendant can be main
                     (or (nil? any-main-descendant) (not (ctk/main-instance? parent)))
                     ;; If we are moving into a variant-container, all the items should be main

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5607,6 +5607,9 @@ msgstr "Swap component"
 msgid "workspace.options.component.swap.empty"
 msgstr "There are no assets in this library yet"
 
+msgid "workspace.component.swap.loop-error"
+msgstr "A component can't be a child of itself"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:973
 msgid "workspace.options.component.unlinked"
 msgstr "Unlinked"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5614,6 +5614,9 @@ msgstr "Intercambiar componente"
 msgid "workspace.options.component.swap.empty"
 msgstr "Aún no hay recursos en esta biblioteca"
 
+msgid "workspace.component.swap.loop-error"
+msgstr "Un componente no puede ser hijo de si mismo"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:973
 msgid "workspace.options.component.unlinked"
 msgstr "Desvinculado"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11967

(also fixes https://tree.taiga.io/project/penpot/issue/11975)

### Summary
1. Revert code that doesn't allow a variant to have inside copies of other variants from the same component
2. If a variant switch creates a components loop, show an error and don't do the switch

### Steps to reproduce 

1. Create a rect and an ellipse and a Board, and make them components
2. Combine them as variants
3. Add a copy of the rect inside the board
4. Make a copy of the board
5. On the copy of the board, select its copy of the rect, and switch it for an ellipse. This should work fine
6. On the copy of the board, select its copy of the ellipse, and switch it for a board. This should show an error, and don't do the switch

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
