### PR TITLE
:bug: Fix prop creation on variants move layer

### DIFF
--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -146,8 +146,8 @@
 (defn- create-new-properties-from-variant
   [shape min-props data container-name base-properties]
   (let [component (ctcl/get-component data (:component-id shape) true)
-
-        add-name? (not= (:name component) container-name)
+        component-full-name (cfh/merge-path-item (:path component) (:name component))
+        add-name? (not= component-full-name container-name)
         props     (ctv/merge-properties base-properties
                                         (:variant-properties component))
         new-props (- min-props


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11973

### Summary

Every time I dragged a layer to change the order, it created a new empty variant property as well.

### Steps to reproduce 
1. Create a variant with path (named for example icons/book)
2. Reorder its layers
3. Before the fix, that created a new property on the variant

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
