### PR TITLE
:bug: Missing component copy options on the context menu

### DIFF
--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -568,6 +568,7 @@
   [{:keys [shapes]}]
   (let [single?                    (= (count shapes) 1)
         objects                    (deref refs/workspace-page-objects)
+        shapes                     (keep (d/getf objects) shapes)
         can-make-component         (every? true? (map #(ctn/valid-shape-for-component? objects %) shapes))
         heads                      (filter ctk/instance-head? shapes)
         components-menu-entries    (cmm/generate-components-menu-entries heads)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11960

### Summary

Missing component copy options on the context menu

### Steps to reproduce 

* Create a component
* Create a copy
* In the copy, change the background color (in order to display "reset overrides" and "update main component options"
right click on the copy
* The options "show main component", “detach instance”, “reset overrides” and “update main component” are missing

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
