### PR TITLE
:bug: Add validation for text shapes with wrong register of overrides

### DIFF
--- a/common/src/app/common/files/repair.cljc
+++ b/common/src/app/common/files/repair.cljc
@@ -491,6 +491,19 @@
         (pcb/with-library-data file-data)
         (pcb/update-component (:id shape) repair-component))))
 
+(defmethod repair-error :invalid-text-touched
+  [_ {:keys [shape page-id] :as error} file-data _]
+  (let [repair-shape
+        (fn [shape]
+          ;; Add content group
+          (log/debug :hint "  -> add :content-group to :touched-groups")
+          (update shape :touched ctk/set-touched-group :content-group))]
+
+    (log/dbg :hint "repairing shape :invalid-text-touched" :id (:id shape) :name (:name shape) :page-id page-id)
+    (-> (pcb/empty-changes nil page-id)
+        (pcb/with-file-data file-data)
+        (pcb/update-shapes [(:id shape)] repair-shape))))
+
 (defmethod repair-error :misplaced-slot
   [_ {:keys [shape page-id] :as error} file-data _]
   (let [repair-shape


### PR DESCRIPTION
### Related Ticket

[🔴 bug: updating a component using design tokens resets modifications](https://tree.taiga.io/project/penpot/issue/11701)

### Summary

Warning: this fix does not directly resolves the bug. There is one file that has been left in an inconsistent state, and this is the cause of the reset when updating the main. To fix it you need to execute `debug.repair(true)` in the dev console. If the same situation occurs in other file you need to do the same.

From now on, if an operation would cause the inconsistency, we can detect it in the moment. In preproduction environments it will cause an error 500, and in production we can monitor it.

### Steps to reproduce 

Load the BugReport.zip attached to the issue. Change anything in the main component, and see that all colors of texts in copies have been reset.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
