### PR TITLE
:wrench: Make watch script to compile debug.css

### DIFF
--- a/frontend/scripts/watch.js
+++ b/frontend/scripts/watch.js
@@ -5,6 +5,8 @@ import log from "fancy-log";
 import * as h from "./_helpers.js";
 import ppt from "pretty-time";
 
+const isDebug = process.env.NODE_ENV !== "production";
+
 const worker = h.startWorker();
 let sass = null;
 
@@ -15,6 +17,11 @@ async function compileSassAll() {
   sass = await h.compileSassAll(worker);
   let output = await h.concatSass(sass);
   await fs.writeFile("./resources/public/css/main.css", output);
+
+  if (isDebug) {
+    let debugCSS = await h.compileSassDebug(worker);
+    await fs.writeFile("./resources/public/css/debug.css", debugCSS);
+  }
 
   const end = process.hrtime(start);
   log.info("done: compile styles", `(${ppt(end)})`);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/11959

### Summary

This makes our `watch:app:assets` script to compile the `debug.css`, which is included by the app in local development.

### Steps to reproduce

1. Remove `frontend/resources/styles/debug.css`, if existing.
2. Start the dev env as usual
3. Open the network inspector and load penpot
4. Check the `debug.css` rquest

Expected behavior:

The request returns a CSS file with the following content:

```css
body {
  color: yellow;
}

.deprecated-icon {
  fill: red !important;
}
```

Actual behavior (without this fix):

The file does not exist and the request returns a 404.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

