### PR TITLE
:bug: Fix when font-weight is a computed int (math resolver)

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -426,7 +426,8 @@
                  (into acc (zipmap vs (repeat k)))) {})))
 
 (defn parse-font-weight [font-weight]
-  (let [[_ variant italic] (->> (str/lower font-weight)
+  (let [[_ variant italic] (->> (str font-weight)
+                                (str/lower)
                                 (re-find #"^(.+?)\s*(italic)?$"))]
     {:variant variant
      :italic? (some? italic)}))


### PR DESCRIPTION
### Related Ticket

- `str/lower` doesn't convert to string, so the `re-find` would fail


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
