### PR TITLE
:bug: Fix text-transform not unapplyng text-case token

### DIFF
--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -282,7 +282,7 @@
      (font-size-keys shape-attr)       #{shape-attr :typography}
      (letter-spacing-keys shape-attr)  #{shape-attr :typography}
      (font-family-keys shape-attr)     #{shape-attr :typography}
-     (text-case-keys shape-attr)       #{shape-attr :typography}
+     (= :text-transform shape-attr)    #{:text-case :typography}
      (text-decoration-keys shape-attr) #{shape-attr :typography}
      (font-weight-keys shape-attr)     #{shape-attr :typography}
 


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/146#issue-3387293195

### Summary

The attribute didn't match the name of the token type

### Steps to reproduce

1. Create a capitalize text case token
2. Apply the created token to a text layer
3. Click on lowercase button in the Design tab

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
