### PR TITLE
:bug: Fix create a variant using the contextual menu

### DIFF
--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -568,7 +568,6 @@
   [{:keys [shapes]}]
   (let [single?                    (= (count shapes) 1)
         objects                    (deref refs/workspace-page-objects)
-        shapes                     (keep (d/getf objects) shapes)
         can-make-component         (every? true? (map #(ctn/valid-shape-for-component? objects %) shapes))
         heads                      (filter ctk/instance-head? shapes)
         components-menu-entries    (cmm/generate-components-menu-entries heads)


### PR DESCRIPTION
### Related Ticket

Taiga [#12042](https://tree.taiga.io/project/penpot/issue/12042)

### Summary

The user should be able to convert a component into a variant using the contextual menu. This menu can be opened from the layers panel or from the viewport.

### Steps to reproduce 

- Create a shape.
- Convert the shape into a component using the contextual menu.
- Convert the component into a variant using the contextual menu again.
