### PR TITLE
:bug: Fix search shortcut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 - Fix nested variant in a component doesn't keep inherited overrides [Taiga #12299](https://tree.taiga.io/project/penpot/issue/12299)
 - Fix on copy instance inside a components chain touched are missing [Taiga #12371](https://tree.taiga.io/project/penpot/issue/12371)
 - Fix problem with multiple selection and shadows [Github #7437](https://github.com/penpot/penpot/issues/7437)
+- Fix search shortcut [Taiga #10265](https://tree.taiga.io/project/penpot/issue/10265)
+
 
 ## 2.11.0 (Unreleased)
 

--- a/frontend/src/app/main/data/dashboard/shortcuts.cljs
+++ b/frontend/src/app/main/data/dashboard/shortcuts.cljs
@@ -13,13 +13,16 @@
    [app.main.data.shortcuts :as ds]
    [app.main.store :as st]))
 
+;; Shortcuts definitions
 (def shortcuts
-  {:go-to-search       {:tooltip (ds/meta "F")
-                        :command (ds/c-mod "f")
-                        :subsections [:navigation-dashboard]
-                        :fn #(st/emit! (dcm/go-to-dashboard-search))}
+  {:toggle-theme    {:tooltip (ds/alt "M")
+                     :command (ds/a-mod "m")
+                     :subsections [:general-dashboard]
+                     :fn #(st/emit! (with-meta (du/toggle-theme)
+                                      {::ev/origin "dashboard:shortcuts"}))}})
 
-   :go-to-drafts       {:tooltip "G D"
+(def shortcuts-sidebar-navigation
+  {:go-to-drafts       {:tooltip "G D"
                         :command "g d"
                         :subsections [:navigation-dashboard]
                         :fn #(st/emit! (dcm/go-to-dashboard-files :project-id :default))}
@@ -27,20 +30,35 @@
    :go-to-libs         {:tooltip "G L"
                         :command "g l"
                         :subsections [:navigation-dashboard]
-                        :fn #(st/emit! (dcm/go-to-dashboard-libraries))}
+                        :fn #(st/emit! (dcm/go-to-dashboard-libraries))}})
 
-   :create-new-project {:tooltip "+"
+(def shortcut-search
+  {:go-to-search       {:tooltip (ds/meta "F")
+                        :command (ds/c-mod "f")
+                        :subsections [:navigation-dashboard]
+                        :fn #(st/emit! (dcm/go-to-dashboard-search))}})
+
+(def shortcut-create-new-project
+  {:create-new-project {:tooltip "+"
                         :command "+"
                         :subsections [:general-dashboard]
-                        :fn #(st/emit! (dd/create-element))}
+                        :fn #(st/emit! (dd/create-element))}})
 
-   :toggle-theme    {:tooltip (ds/alt "M")
-                     :command (ds/a-mod "m")
-                     :subsections [:general-dashboard]
-                     :fn #(st/emit! (with-meta (du/toggle-theme)
-                                      {::ev/origin "dashboard:shortcuts"}))}})
+;; Shortcuts combinations for files, drafts, libraries and fonts sections
+(def shortcuts-dashboard
+  (merge shortcuts
+         shortcuts-sidebar-navigation))
 
+(def shortcuts-projects
+  (merge shortcuts
+         shortcuts-sidebar-navigation
+         shortcut-search
+         shortcut-create-new-project))
 
+(def shortcuts-drafts-libraries
+  (merge shortcuts
+         shortcuts-sidebar-navigation
+         shortcut-search))
 
 (defn get-tooltip [shortcut]
   (assert (contains? shortcuts shortcut) (str shortcut))

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -267,7 +267,7 @@
                (filter :is-default)
                (first)))]
 
-    (hooks/use-shortcuts ::dashboard sc/shortcuts)
+    (hooks/use-shortcuts ::dashboard sc/shortcuts-dashboard)
 
     (mf/with-effect [team-id]
       (st/emit! (dd/initialize team-id))

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.main.data.common :as dcm]
    [app.main.data.dashboard :as dd]
+   [app.main.data.dashboard.shortcuts :as sc]
    [app.main.data.event :as ev]
    [app.main.data.project :as dpj]
    [app.main.refs :as refs]
@@ -182,6 +183,8 @@
     (mf/with-effect [project-id]
       (st/emit! (dpj/fetch-files project-id)
                 (dd/clear-selected-files)))
+
+    (hooks/use-shortcuts ::dashboard sc/shortcuts-drafts-libraries)
 
     [:*
      [:> header* {:team team

--- a/frontend/src/app/main/ui/dashboard/libraries.cljs
+++ b/frontend/src/app/main/ui/dashboard/libraries.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.main.data.dashboard :as dd]
+   [app.main.data.dashboard.shortcuts :as sc]
    [app.main.data.team :as dtm]
    [app.main.refs :as refs]
    [app.main.store :as st]
@@ -59,6 +60,8 @@
     (mf/with-effect [team-id]
       (st/emit! (dtm/fetch-shared-files team-id)
                 (dd/clear-selected-files)))
+
+    (hooks/use-shortcuts ::dashboard sc/shortcuts-drafts-libraries)
 
     [:*
      [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -11,6 +11,7 @@
    [app.common.time :as ct]
    [app.main.data.common :as dcm]
    [app.main.data.dashboard :as dd]
+   [app.main.data.dashboard.shortcuts :as sc]
    [app.main.data.event :as ev]
    [app.main.data.modal :as modal]
    [app.main.data.project :as dpj]
@@ -351,6 +352,8 @@
     (mf/with-effect [team-id]
       (st/emit! (dd/fetch-recent-files team-id)
                 (dd/clear-selected-files)))
+
+    (hooks/use-shortcuts ::dashboard sc/shortcuts-projects)
 
     (when (seq projects)
       [:*


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/10265

### Summary
I have isolated the search shortcut so that it only loads in the specific sections where we want it to be used

### Steps to reproduce 
ctrl + f should just work in recent, files and libraries sections.
 
### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [X] Provide a brief summary of the changes introduced.
- [X] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.
- [X] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
