### PR TITLE
:bug: Display token themes as a string

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.cljs
@@ -10,11 +10,10 @@
   [{:keys [theme-paths set-names]}]
   [:div {:class (stl/css :tokens-panel)}
    (when (seq theme-paths)
-     (for [theme theme-paths]
-       [:> properties-row* {:key theme
-                            :class (stl/css :token-theme)
+     (let [theme-list (str/join ", " theme-paths)]
+       [:> properties-row* {:class (stl/css :token-theme)
                             :term (tr "inspect.tabs.styles.panel.tokens.active-themes")
-                            :detail theme}]))
+                            :detail theme-list}]))
    (when (seq set-names)
      (let [sets-list (str/join ", " set-names)]
        [:> properties-row* {:class (stl/css :token-theme)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/prhttps://tree.taiga.io/project/penpot/task/11877oject/penpot/task/11877

### Summary

Fixes the issue caused when having multiple token themes activated at the same time. When a user has multiple active themes, must be displayed as a concatenated theme path list instead of iterating over the themes and displaying a new entry.

❌ WRONG
<img width="329" height="242" alt="image" src="https://github.com/user-attachments/assets/f0309f32-cca5-47f2-9cb6-452fc818a91a" />

✅ RIGHT
<img width="319" height="138" alt="image" src="https://github.com/user-attachments/assets/98231c7d-c364-47ae-bd33-e07a78f001dd" />


### Steps to reproduce 

- Create and activate more than one token theme
- Ensure that are displayed as a path list.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
