### PR TITLE
:bug: Fix fast move with distance

### DIFF
--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -213,12 +213,12 @@
                           :fn #(emit-when-no-readonly (dw/vertical-order-selected :bottom))}
 
    :move-fast-up         {:tooltip (ds/shift ds/up-arrow)
-                          :command ["shift+up"]
+                          :command ["shift+up" "shift+alt+up" "alt+shift+up"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :up true))}
 
    :move-fast-down       {:tooltip (ds/shift ds/down-arrow)
-                          :command ["shift+down"]
+                          :command ["shift+down" "shift+alt+down" "alt+shift+down"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :down true))}
 

--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -213,22 +213,22 @@
                           :fn #(emit-when-no-readonly (dw/vertical-order-selected :bottom))}
 
    :move-fast-up         {:tooltip (ds/shift ds/up-arrow)
-                          :command ["shift+up" "shift+alt+up" "alt+shift+up"]
+                          :command ["shift+up" "shift+alt+up"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :up true))}
 
    :move-fast-down       {:tooltip (ds/shift ds/down-arrow)
-                          :command ["shift+down" "shift+alt+down" "alt+shift+down"]
+                          :command ["shift+down" "shift+alt+down"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :down true))}
 
    :move-fast-right      {:tooltip (ds/shift ds/right-arrow)
-                          :command ["shift+right" "shift+alt+right" "alt+shift+right"]
+                          :command ["shift+right" "shift+alt+right"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :right true))}
 
    :move-fast-left       {:tooltip (ds/shift ds/left-arrow)
-                          :command ["shift+left" "shift+alt+left" "alt+shift+left"]
+                          :command ["shift+left" "shift+alt+left"]
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dwt/move-selected :left true))}
 


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #12069](https://tree.taiga.io/project/penpot/issue/12069)

### Summary

There is a new feature for this release:

Up until now, if you select an item while presing alt, then hover over nearby elements, it tells you the distance in between them, but the ability to move your object was blocked.

Now you can move the objects while pressing alt. 
You can move them pixel by pixel in the x and y asxis, and also by pressing shift, the movement is incremental. BUT, this bug is because the incremental movement for the y axis is blocked

### Steps to reproduce 

Steps to reproduce the behavior:

1. Go to a file and create 2 rectangles
2. Select one of them and hover the other item whilst pressing alt
3. Without releasing, use the arrows in your keyboard to move the element
4. Without releasing, use the arrows in your keyboard + shift to move the element
5. See how it's only moving horizontally but not vertically

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
