### PR TITLE
:bug: Fix sets shown without color tokens

### DIFF
--- a/frontend/src/app/main/ui/workspace/colorpicker.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker.cljs
@@ -673,7 +673,7 @@
    [{:set \"brand/dark\" :tokens [{:name \"background\"}]}]"
   [sets]
   (filter (fn [{:keys [tokens]}]
-            (seq tokens))
+            (some #(= (:type %) :color) tokens))
           sets))
 
 (defn- add-tokens-to-sets

--- a/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.cljs
@@ -277,7 +277,7 @@
              (reset! filter-term* value))))
         filtered-combined (filter-combined-tokens combined-tokens filter-term)
         sorted-tokens     (sort-combined-tokens filtered-combined)]
-    (if combined-tokens
+    (if (seq combined-tokens)
       [:div {:class (stl/css :color-tokens-section)}
        [:> input* {:placeholder "Search by token name"
                    :icon i/search


### PR DESCRIPTION
### Related Ticket

Fixes [this task](https://tree.taiga.io/project/penpot/task/12085)

### Summary

Sets without color tokens should not appear

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
