### PR TITLE
:lipstick: Align tokens panel vertically to the top

### DIFF
--- a/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.cljs
@@ -16,6 +16,6 @@
                             :detail theme-list}]))
    (when (seq set-names)
      (let [sets-list (str/join ", " set-names)]
-       [:> properties-row* {:class (stl/css :token-theme)
+       [:> properties-row* {:class (stl/css :token-sets)
                             :term (tr "inspect.tabs.styles.panel.tokens.active-sets")
                             :detail sets-list}]))])

--- a/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.scss
+++ b/frontend/src/app/main/ui/inspect/styles/panels/tokens_panel.scss
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) KALEIDOS INC
+
+.token-theme,
+.token-sets {
+  align-items: flex-start;
+  padding-block: var(--sp-s);
+}

--- a/frontend/src/app/main/ui/inspect/styles/properties_row.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/properties_row.cljs
@@ -19,7 +19,7 @@
 
 (mf/defc properties-row*
   {::mf/schema schema:properties-row}
-  [{:keys [term detail token property copiable]}]
+  [{:keys [class term detail token property copiable]}]
   (let [copiable? (or copiable false)
         detail? (not (or (nil? detail) (str/blank? detail)))
         detail (if detail? detail "-")
@@ -35,7 +35,7 @@
            (reset! copied* true)
            (wapi/write-to-clipboard copiable-value)
            (tm/schedule 1000 #(reset! copied* false))))]
-    [:dl {:class (stl/css :property-row)}
+    [:dl {:class [(stl/css :property-row) class]}
      [:dt {:class (stl/css :property-term)} term]
      [:dd {:class (stl/css :property-detail)}
       (if copiable?


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12074

### Summary

Align token panel rows to the top (other rows are horizontally aligned to the center)

### Steps to reproduce 

<img width="324" height="595" alt="image" src="https://github.com/user-attachments/assets/ca5b74f9-b46d-48d6-80de-6a511f7d9f5d" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
