### PR TITLE
:sparkles: Add shortcut for creating variant to the shortcuts panel

### DIFF
--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -173,10 +173,10 @@
                           :subsections [:modify-layers]
                           :fn #(emit-when-no-readonly (dw/unmask-group))}
 
-   :create-component     {:tooltip (ds/meta "K")
-                          :command (ds/c-mod "k")
-                          :subsections [:modify-layers]
-                          :fn #(emit-when-no-readonly (dwv/add-component-or-variant))}
+   :create-component-variant {:tooltip (ds/meta "K")
+                              :command (ds/c-mod "k")
+                              :subsections [:modify-layers]
+                              :fn #(emit-when-no-readonly (dwv/add-component-or-variant))}
 
    :detach-component     {:tooltip (ds/meta-shift "K")
                           :command (ds/c-mod "shift+k")

--- a/frontend/src/app/main/ui/components/search_bar.cljs
+++ b/frontend/src/app/main/ui/components/search_bar.cljs
@@ -46,6 +46,7 @@
                    :size "s"
                    :class (stl/css :icon)}])
       [:input {:id id
+               :class (stl/css :search-input)
                :on-change handle-change
                :value value
                :auto-focus auto-focus

--- a/frontend/src/app/main/ui/components/search_bar.scss
+++ b/frontend/src/app/main/ui/components/search_bar.scss
@@ -18,6 +18,7 @@
 .icon {
   margin-left: $s-8;
   flex: 0 0 $s-16;
+  color: var(--color-foreground-primary);
 }
 
 .search-input-wrapper {
@@ -27,33 +28,36 @@
   border: $s-1 solid var(--search-bar-input-border-color);
   border-radius: $br-8;
   background-color: var(--search-bar-input-background-color);
-  input {
-    width: 100%;
-    height: 100%;
-    margin: 0 $s-8 0 $s-4;
-    border: 0;
-    background-color: var(--input-background-color);
-    font-size: $fs-12;
-    color: var(--input-foreground-color);
-    border-radius: $br-8;
-    &:focus {
-      outline: none;
-    }
-  }
+
   &:hover {
     border: $s-1 solid var(--input-border-color-hover);
     background-color: var(--input-background-color-hover);
-    input {
+    .search-input {
       background-color: var(--input-background-color-hover);
     }
   }
+
   &:focus-within {
     background-color: var(--input-background-color-active);
     color: var(--input-foreground-color-active);
     border: $s-1 solid var(--input-border-color-focus);
-    input {
+    .search-input {
       background-color: var(--input-background-color-active);
     }
+  }
+}
+
+.search-input {
+  width: 100%;
+  height: 100%;
+  margin: 0 $s-8 0 $s-4;
+  border: 0;
+  background-color: var(--input-background-color);
+  font-size: $fs-12;
+  color: var(--input-foreground-color);
+  border-radius: $br-8;
+  &:focus {
+    outline: none;
   }
 }
 
@@ -61,12 +65,10 @@
   @extend .button-tag;
   flex: 0 0 $s-32;
   height: 100%;
-  svg {
-    stroke: var(--icon-foreground);
-  }
+  color: var(--color-icon-default);
 }
 
 .search-box.has-children .search-input-wrapper {
-  border-radius: $br-2 $br-8 $br-8 $br-2;
+  border-radius: 0 $br-8 $br-8 0;
   margin-left: 0;
 }

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -589,7 +589,7 @@
         [:> menu-separator* {}]
 
         [:> menu-entry* {:title (tr "workspace.shape.menu.create-component")
-                         :shortcut (sc/get-tooltip :create-component)
+                         :shortcut (sc/get-tooltip :create-component-variant)
                          :on-click do-add-component}]
         (when (not single?)
           [:> menu-entry* {:title (tr "workspace.shape.menu.create-multiple-components")
@@ -609,7 +609,7 @@
        [:*
         [:> menu-separator*]
         [:> menu-entry* {:title (tr "workspace.shape.menu.add-variant")
-                         :shortcut (sc/get-tooltip :create-component)
+                         :shortcut (sc/get-tooltip :create-component-variant)
                          :on-click do-add-variant}]])
 
      (when (and (not single?) all-main? (not any-variant?))

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -513,7 +513,7 @@
                          :action do-update-component})
                       (when (and (or (not multi) same-variant?) main-instance?)
                         {:title (tr "workspace.shape.menu.add-variant")
-                         :shortcut :create-component
+                         :shortcut :create-component-variant
                          :action do-add-variant})
                       (when (and same-variant? main-instance? variant-id for-design-tab?)
                         {:title (tr "workspace.shape.menu.add-variant-property")

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -18,8 +18,8 @@
    [app.main.data.workspace.shortcuts]
    [app.main.store :as st]
    [app.main.ui.components.search-bar :refer [search-bar*]]
-   [app.main.ui.ds.foundations.assets.icon :as i]
-   [app.main.ui.icons :as deprecated-icon]
+   [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.foundations.assets.icon :as i :refer [icon*]]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.strings :refer [matches-search]]
@@ -293,8 +293,8 @@
   [:div {:class (if is-sub
                   (stl/css :subsection-title)
                   (stl/css :section-title))}
-   [:span {:class (stl/css-case :open is-visible
-                                :collapsed-shortcuts true)} deprecated-icon/arrow]
+   [:> icon* {:icon-id (if is-visible i/arrow-down i/arrow-right)
+              :size "s"}]
    [:span {:class (if is-sub
                     (stl/css :subsection-name)
                     (stl/css :section-name))} name]])
@@ -497,11 +497,13 @@
     [:div {:class (dm/str class " " (stl/css :shortcuts))}
      [:div {:class (stl/css :shortcuts-header)}
       [:div {:class (stl/css :shortcuts-title)} (tr "shortcuts.title")]
-      [:div {:class (stl/css :shortcuts-close-button)
-             :on-click close-fn}
-       deprecated-icon/close]]
-     [:div {:class (stl/css :search-field)}
+      [:> icon-button* {:variant "ghost"
+                        :icon i/close
+                        :class (stl/css :shortcuts-close-button)
+                        :on-click close-fn
+                        :aria-label (tr "labels.close")}]]
 
+     [:div {:class (stl/css :search-field)}
       [:> search-bar* {:on-change on-search-term-change-2
                        :on-clear on-search-clear-click
                        :value @filter-term

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -94,7 +94,7 @@
     (tr "shortcuts.clear-undo")
     (tr "shortcuts.copy")
     (tr "shortcuts.copy-link")
-    (tr "shortcuts.create-component")
+    (tr "shortcuts.create-component-variant")
     (tr "shortcuts.create-new-project")
     (tr "shortcuts.cut")
     (tr "shortcuts.decrease-zoom")

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -25,6 +25,7 @@
    [app.util.strings :refer [matches-search]]
    [clojure.set :as set]
    [clojure.string]
+   [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
 (mf/defc converted-chars*
@@ -251,7 +252,7 @@
         penultimate     (last short-char-list)]
     [:span {:class (stl/css :keys)}
      (for [chars short-char-list]
-       [:*
+       [:* {:key (str/join chars)}
         (for [char chars]
           [:> converted-chars* {:key (dm/str char "-" (name command))
                                 :char char
@@ -510,7 +511,8 @@
      (if match-any?
        [:div {:class (stl/css :shortcuts-list)}
         (for [section all-shortcuts]
-          [:> shortcut-section* {:section section
+          [:> shortcut-section* {:key (->> section second :id first)
+                                 :section section
                                  :manage-sections manage-sections
                                  :open-sections open-sections
                                  :filter-term filter-term}])]

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.scss
@@ -56,7 +56,7 @@
   flex-direction: column;
   height: 100%;
   padding: $s-12;
-  overflow-y: scroll;
+  overflow-y: auto;
   font-size: $fs-12;
   color: var(--title-foreground-color);
 

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.scss
@@ -15,64 +15,7 @@
 }
 
 .search-field {
-  display: flex;
-  align-items: center;
-  height: $s-32;
   margin: $s-16 $s-12 $s-4 $s-12;
-  border-radius: $br-8;
-  font-family: "worksans", "vazirmatn", sans-serif;
-  background-color: var(--color-background-tertiary);
-  .search-box {
-    align-items: center;
-    display: flex;
-    width: 100%;
-
-    .icon-wrapper {
-      display: flex;
-      svg {
-        @extend .button-icon-small;
-        stroke: var(--icon-foreground);
-      }
-    }
-
-    .input-text {
-      @include removeInputStyle;
-      height: $s-32;
-      width: 100%;
-      margin: 0;
-      padding: $s-4;
-      border: 0;
-      font-size: $fs-12;
-      color: var(--color-foreground-primary);
-      &::placeholder {
-        color: var(--color-foreground-secondary);
-      }
-      &:focus-visible {
-        border-color: var(--color-accent-primary-muted);
-      }
-    }
-    .clear-btn {
-      @include buttonStyle;
-      @include flexCenter;
-      height: $s-16;
-      width: $s-16;
-      .clear-icon {
-        @include flexCenter;
-        svg {
-          @extend .button-icon-small;
-          stroke: var(--icon-foreground);
-        }
-      }
-    }
-  }
-  .search-icon {
-    @include flexCenter;
-    width: $s-28;
-    svg {
-      @extend .button-icon-small;
-      stroke: var(--icon-foreground);
-    }
-  }
 }
 
 .shortcuts-header {
@@ -92,18 +35,9 @@
   }
 
   .shortcuts-close-button {
-    @extend .button-tertiary;
     position: absolute;
-    right: $s-2;
-    top: $s-2;
-    height: $s-28;
-    width: $s-28;
-    border-radius: $br-5;
-
-    svg {
-      @extend .button-icon;
-      stroke: var(--icon-foreground);
-    }
+    right: 0;
+    top: 0;
   }
 }
 
@@ -135,27 +69,13 @@
     padding: $s-8 0;
     cursor: pointer;
 
-    .collapsed-shortcuts {
-      @include flexCenter;
-      svg {
-        @extend .button-icon-small;
-        stroke: var(--icon-foreground);
-      }
-      &.open {
-        transform: rotate(90deg);
-      }
-    }
     .subsection-name,
     .section-name {
       padding-left: $s-4;
     }
+
     &:hover {
       color: var(--title-foreground-color-hover);
-      .collapsed-shortcuts {
-        svg {
-          stroke: var(--title-foreground-color-hover);
-        }
-      }
     }
   }
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3904,7 +3904,7 @@ msgstr "Copy properties"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:95
 msgid "shortcuts.create-component"
-msgstr "Create component"
+msgstr "Create component / variant"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:96
 msgid "shortcuts.create-new-project"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -3903,7 +3903,7 @@ msgid "shortcuts.copy-props"
 msgstr "Copy properties"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:95
-msgid "shortcuts.create-component"
+msgid "shortcuts.create-component-variant"
 msgstr "Create component / variant"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:96

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3903,7 +3903,7 @@ msgstr "Copiar propiedades"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:95
 msgid "shortcuts.create-component"
-msgstr "Crear componente"
+msgstr "Crear componente / variante"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:96
 msgid "shortcuts.create-new-project"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -3902,7 +3902,7 @@ msgid "shortcuts.copy-props"
 msgstr "Copiar propiedades"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:95
-msgid "shortcuts.create-component"
+msgid "shortcuts.create-component-variant"
 msgstr "Crear componente / variante"
 
 #: src/app/main/ui/workspace/sidebar/shortcuts.cljs:96


### PR DESCRIPTION
### Related Ticket

Taiga [#11818](https://tree.taiga.io/project/penpot/task/11818)

### Summary

- Add shortcut for creating a variant in the shortcuts panel.
- Refactor to replace the old `rumext` syntax with the new one.
- Add a unique key prop to each child in two iterations to avoid errors in the console.
- Replace old icons with the new ones from the DS.
- Remove unused CSS styles.

### Steps to reproduce

- Check that the shortcuts panel shows the shortcut for creating a variant.
- Check that there are no errors in the console when opening the shortcuts panel.