### PR TITLE
:bug: Fix focus the first property value when creating a variant

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -277,11 +277,11 @@
          (dwu/commit-undo-transaction undo-id))))))
 
 (defn- focus-property
-  [shape-id prop-num]
+  [variant-id]
   (ptk/reify ::focus-property
     ptk/EffectEvent
     (effect [_ _ _]
-      (dom/focus! (dom/get-element (str "variant-prop-" shape-id prop-num))))))
+      (dom/focus! (dom/get-element (str "variant-prop-" variant-id "-0"))))))
 
 (defn- resposition-and-resize-variant
   "Resize the variant container, and move the shape (that is a variant) to the right"
@@ -347,7 +347,7 @@
            (if multiselect?
              (dws/shift-select-shapes new-shape-id)
              (dws/select-shape new-shape-id)))
-          (->> (rx/of (focus-property new-shape-id prop-num))
+          (->> (rx/of (focus-property (:id variant-container)))
                (rx/delay 250))))))))
 
 (defn transform-in-variant


### PR DESCRIPTION
### Related Ticket

Taiga [#12096](https://tree.taiga.io/project/penpot/issue/12096)

### Summary

The first property value should be focused when creating a variant.

### Steps to reproduce 

When creating a new variant, using any available option (Ctrl+K, contextual menu, or design tab menu), check that the value of the first property is focused and ready for the user to introduce a value.