### PR TITLE
:bug: Fix wrong number of components in the library modal

### DIFF
--- a/frontend/src/app/main/ui/workspace/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/libraries.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.files.variant :as cfv]
    [app.common.types.components-list :as ctkl]
    [app.common.types.file :as ctf]
    [app.common.types.library :as ctl]
@@ -59,7 +60,8 @@
   (let [colors       (count (:colors data))
         graphics     0
         typographies (count (:typographies data))
-        components   (count (ctkl/components-seq data))
+        components   (count (->> (ctkl/components-seq data)
+                                 (remove #(cfv/is-secondary-variant? % data))))
         empty?       (and (zero? components)
                           (zero? graphics)
                           (zero? colors)


### PR DESCRIPTION
### Related Ticket

Taiga [#11999](https://tree.taiga.io/project/penpot/issue/11999)

### Summary

The number of components that appears in the library modal is not correct, because it counts all the components, no matter if they are variants inside a container or stand-alone components.

A variant container counts as a single component, so its children must be ignored.

### Steps to reproduce 

On the assets tab of the workspace, click on the "Manage library" button to open the modal. Check that it displays the correct number of components.