### PR TITLE
:bug: Fix current version on sidebar

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -889,7 +889,7 @@
         show-profile-menu? (deref show-profile-menu*)
         sub-menu*      (mf/use-state false)
         sub-menu       (deref sub-menu*)
-        version        (:full cf/version)
+        version        (:base cf/version)
 
         close-sub-menu
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

Little review for this us https://tree.taiga.io/project/penpot/us/11603?milestone=472805

### Summary

Now it only shows the base version in the sidebar instead of the full one.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
