### PR TITLE
:tada: Switch several variant copies at the same time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### :sparkles: New features & Enhancements
 - Show current Penpot version [Taiga #11603](https://tree.taiga.io/project/penpot/us/11603)
+- Switch several variant copies at the same time [Taiga #11411](https://tree.taiga.io/project/penpot/us/11411)
 
 ### :bug: Bugs fixed
 

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -50,7 +50,6 @@
 (def property-max-length 60)
 (def value-prefix "Value ")
 
-
 (defn properties-to-name
   "Transform the properties into a name, with the values separated by comma"
   [properties]
@@ -58,7 +57,6 @@
        (map :value)
        (remove str/empty?)
        (str/join ", ")))
-
 
 (defn next-property-number
   "Returns the next property number, to avoid duplicates on the property names"
@@ -100,7 +98,6 @@
          remaining      (drop (count properties) cpath)]
      (add-new-props assigned remaining))))
 
-
 (defn properties-map->formula
   "Transforms a map of properties to a formula of properties omitting the empty ones"
   [properties]
@@ -109,7 +106,6 @@
                (when (not (str/blank? value))
                  (str name "=" value))))
        (str/join ", ")))
-
 
 (defn properties-formula->map
   "Transforms a formula of properties to a map of properties"
@@ -120,7 +116,6 @@
        (mapv (fn [[k v]]
                {:name (str/trim k)
                 :value (str/trim v)}))))
-
 
 (defn valid-properties-formula?
   "Checks if a formula is valid"
@@ -138,20 +133,17 @@
   (let [upd-names (set (map :name upd-props))]
     (filterv #(not (contains? upd-names (:name %))) prev-props)))
 
-
 (defn find-properties-to-update
   "Compares two property maps to find which properties should be updated"
   [prev-props upd-props]
   (filterv #(some (fn [prop] (and (= (:name %) (:name prop))
                                   (not= (:value %) (:value prop)))) prev-props) upd-props))
 
-
 (defn find-properties-to-add
   "Compares two property maps to find which properties should be added"
   [prev-props upd-props]
   (let [prev-names (set (map :name prev-props))]
     (filterv #(not (contains? prev-names (:name %))) upd-props)))
-
 
 (defn- split-base-name-and-number
   "Extract the number in parentheses from an item, if present, and return both the base name and the number"
@@ -191,7 +183,6 @@
                  (conj acc {:name (update-number-in-repeated-item (mapv :name acc) (:name prop))
                             :value (:value prop)}))
                [])))
-
 
 (defn find-index-for-property-name
   "Finds the index of a name in a property map"

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -7,6 +7,7 @@
 (ns app.main.data.workspace.variants
   (:require
    [app.common.data :as d]
+   [app.common.data.macros :as dm]
    [app.common.files.changes-builder :as pcb]
    [app.common.files.helpers :as cfh]
    [app.common.files.variant :as cfv]
@@ -16,6 +17,7 @@
    [app.common.types.color :as clr]
    [app.common.types.component :as ctc]
    [app.common.types.components-list :as ctkl]
+   [app.common.types.file :as ctf]
    [app.common.types.shape.layout :as ctsl]
    [app.common.types.variant :as ctv]
    [app.common.uuid :as uuid]
@@ -652,4 +654,57 @@
     (watch [_ state _]
       (let [selected (dsh/lookup-selected state)]
         (rx/of (combine-as-variants selected options))))))
+
+(defn- variant-switch
+  "Switch the shape (that must be a variant copy head) for the closest one with the property value passed as parameter"
+  [shape {:keys [pos val] :as params}]
+  (ptk/reify ::variant-switch
+    ptk/WatchEvent
+    (watch [_ state _]
+      (let [libraries    (dsh/lookup-libraries state)
+            component-id (:component-id shape)
+            component    (ctf/get-component libraries (:component-file shape) component-id :include-deleted? false)]
+             ;; If the value is already val, do nothing
+        (when (not= val (dm/get-in component [:variant-properties pos :value]))
+          (let [current-page-objects   (dsh/lookup-page-objects state)
+                variant-id             (:variant-id component)
+                component-file-data    (dm/get-in libraries [(:component-file shape) :data])
+                component-page-objects (-> (dsh/get-page component-file-data (:main-instance-page component))
+                                           (get :objects))
+                variant-comps          (cfv/find-variant-components component-file-data component-page-objects variant-id)
+                target-props           (-> (:variant-properties component)
+                                           (update pos assoc :value val))
+                valid-comps            (->> variant-comps
+                                            (remove #(= (:id %) component-id))
+                                            (filter #(= (dm/get-in % [:variant-properties pos :value]) val))
+                                            (reverse))
+                nearest-comp           (apply min-key #(ctv/distance target-props (:variant-properties %)) valid-comps)
+                shape-parents          (cfh/get-parents-with-self current-page-objects (:parent-id shape))
+                nearest-comp-children  (cfh/get-children-with-self component-page-objects (:main-instance-id nearest-comp))
+                comps-nesting-loop?    (seq? (cfh/components-nesting-loop? nearest-comp-children shape-parents))
+
+                {:keys [on-error]
+                 :or {on-error rx/throw}} (meta params)]
+
+            ;; If there is no nearest-comp, do nothing
+            (when nearest-comp
+              (if comps-nesting-loop?
+                (do
+                  (on-error)
+                  (rx/empty))
+                (rx/of (dwl/component-swap shape (:component-file shape) (:id nearest-comp) true))))))))))
+
+(defn variants-switch
+  "Switch each shape (that must be a variant copy head) for the closest one with the property value passed as parameter"
+  [{:keys [shapes] :as params}]
+  (ptk/reify ::variants-switch
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (let [ids (into (d/ordered-set) (map :id shapes))
+            undo-id (js/Symbol)]
+        (rx/concat
+         (rx/of (dwu/start-undo-transaction undo-id))
+         (rx/from (map  #(variant-switch % params) shapes))
+         (rx/of (dwu/commit-undo-transaction undo-id)
+                (dws/select-shapes ids)))))))
 

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -700,11 +700,12 @@
   (ptk/reify ::variants-switch
     ptk/WatchEvent
     (watch [_ _ _]
-      (let [ids (into (d/ordered-set) (map :id shapes))
+      (let [ids (into (d/ordered-set) d/xf:map-id shapes)
             undo-id (js/Symbol)]
         (rx/concat
          (rx/of (dwu/start-undo-transaction undo-id))
-         (rx/from (map  #(variant-switch % params) shapes))
+         (->> (rx/from shapes)
+              (rx/map #(variant-switch % params)))
          (rx/of (dwu/commit-undo-transaction undo-id)
                 (dws/select-shapes ids)))))))
 

--- a/frontend/src/app/main/ui/ds/controls/select.cljs
+++ b/frontend/src/app/main/ui/ds/controls/select.cljs
@@ -183,7 +183,10 @@
         (get selected-option :icon)
 
         has-icon?
-        (some? icon)]
+        (some? icon)
+
+        dimmed?
+        (:dimmed selected-option)]
 
     (mf/with-effect [options]
       (mf/set-ref-val! options-ref options))
@@ -201,7 +204,7 @@
                     :size "s"
                     :aria-hidden true}])
        [:span {:class (stl/css-case :header-label true
-                                    :header-label-dimmed empty-selected-id?)}
+                                    :header-label-dimmed (or empty-selected-id? dimmed?))}
         (if ^boolean empty-selected-id? "--" label)]]
 
       [:> icon* {:icon-id i/arrow-down

--- a/frontend/src/app/main/ui/ds/controls/select.mdx
+++ b/frontend/src/app/main/ui/ds/controls/select.mdx
@@ -34,6 +34,9 @@ If we consider that empty options have a special meaning, we can move them to th
 Each option of `select*` may accept an `icon`, which must contain an [icon ID](../foundations/assets/icon.mdx).
 These are available in the `app.main.ds.foundations.assets.icon` namespace.
 
+### Dimmed
+Each option can have an optional parameter `dimmed` with value `true` to show the option dimmed
+
 
 ```clj
 (ns app.main.ui.foo
@@ -42,7 +45,7 @@ These are available in the `app.main.ds.foundations.assets.icon` namespace.
 ```
 
 ```clj
-[:> select*       
+[:> select*
     {:options [{ :label "Code"
                  :id "option-code"
                  :icon i/fill-content }
@@ -50,7 +53,8 @@ These are available in the `app.main.ds.foundations.assets.icon` namespace.
                  :id "option-design"
                  :icon i/pentool }
                { :label "Menu"
-                 :id "option-menu" } 
+                 :id "option-menu"
+                 :dimmed true }
                ]}]
 ```
 
@@ -58,8 +62,8 @@ These are available in the `app.main.ds.foundations.assets.icon` namespace.
 
 ### Where to use
 
-Used in a wide range of applications in the app, 
-to select among available text-based options, 
+Used in a wide range of applications in the app,
+to select among available text-based options,
 sometimes with icons that offers additional context.
 
 ### When to use
@@ -68,5 +72,5 @@ Consider using select when you have 5 or more options to choose from.
 
 ### Interaction / Behavior
 
-When the user clicks on the clickable area, a list of 
+When the user clicks on the clickable area, a list of
 options appears. When an option is chosen, the list is closed.

--- a/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
+++ b/frontend/src/app/main/ui/ds/controls/shared/options_dropdown.cljs
@@ -95,7 +95,7 @@
                     :icon (get option :icon)
                     :ref ref
                     :focused (= id focused)
-                    :dimmed false
+                    :dimmed (true? (:dimmed option))
                     :on-click on-click}]))))
 
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -461,9 +461,10 @@
              (let [error-msg (if (> (count shapes) 1)
                                (tr "workspace.component.switch.loop-error-multi")
                                (tr "workspace.component.swap.loop-error"))
+
                    mdata     {:on-error #(do
-                                           (st/emit! (ntf/error error-msg))
-                                           (reset! key* (uuid/next)))}
+                                           (reset! key* (uuid/next))
+                                           (st/emit! (ntf/error error-msg)))}
                    params    {:shapes shapes :pos pos :val val}]
                (st/emit! (dwv/variants-switch (with-meta params mdata)))))))]
 
@@ -474,7 +475,7 @@
               options (cond-> (get-options (:name prop))
                         mixed-value?
                         (conj {:id mixed-label, :label mixed-label :dimmed true}))]
-          [:div {:key (str (:id shape) pos mixed-value?)
+          [:div {:key (str pos mixed-value?)
                  :class (stl/css :variant-property-container)}
 
            [:div {:class (stl/css :variant-property-name-wrapper)

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5627,7 +5627,10 @@ msgid "workspace.options.component.swap.empty"
 msgstr "There are no assets in this library yet"
 
 msgid "workspace.component.swap.loop-error"
-msgstr "Components can't be nested inside themselves"
+msgstr "Components can't be nested inside themselves."
+
+msgid "workspace.component.switch.loop-error-multi"
+msgstr "Some copies could not be switched. Components can't be nested inside themselves."
 
 #: src/app/main/ui/workspace/sidebar/options/menus/component.cljs:973
 msgid "workspace.options.component.unlinked"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -5114,7 +5114,10 @@ msgid "workspace.assets.ungroup"
 msgstr "Desagrupar"
 
 msgid "workspace.component.swap.loop-error"
-msgstr "Los componentes no pueden anidarse dentro de sí mismos"
+msgstr "Los componentes no pueden anidarse dentro de sí mismos."
+
+msgid "workspace.component.switch.loop-error-multi"
+msgstr "Algunas copias no se han podido intercambiar. Los componentes no pueden anidarse dentro de sí mismos."
 
 #: src/app/main/ui/workspace/context_menu.cljs:791
 msgid "workspace.context-menu.grid-cells.area"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/us/11411

### Summary

 Switch several variant copies at the same time

### Steps to reproduce 

1. Create a component with variant
2. Create two copies of the first variant
3. Select both copies
4. Change a variant property to make a switch of both at the same time

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
