### PR TITLE
:tada: Show tokens on color inputs

### DIFF
--- a/common/src/app/common/colors.cljc
+++ b/common/src/app/common/colors.cljc
@@ -27,6 +27,7 @@
 (def new-warning "#fe4811")
 (def new-primary-light "#6911d4")
 (def background-quaternary "#2e3434")
+(def background-primary "#18181a")
 (def background-quaternary-light "#eef0f2")
 (def canvas "#E8E9EA")
 

--- a/common/src/app/common/colors.cljc
+++ b/common/src/app/common/colors.cljc
@@ -27,7 +27,6 @@
 (def new-warning "#fe4811")
 (def new-primary-light "#6911d4")
 (def background-quaternary "#2e3434")
-(def background-primary "#18181a")
 (def background-quaternary-light "#eef0f2")
 (def canvas "#E8E9EA")
 

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -535,4 +535,5 @@
    :line-height #{:line-height :number}
    :font-size #{:font-size}
    :letter-spacing #{:letter-spacing}
-   :fill #{:color}})
+   :fill #{:color}
+   :stroke-color #{:color}})

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -534,4 +534,5 @@
    :sided-margins #{:spacing :dimensions}
    :line-height #{:line-height :number}
    :font-size #{:font-size}
-   :letter-spacing #{:letter-spacing}})
+   :letter-spacing #{:letter-spacing}
+   :fill #{:color}})

--- a/frontend/playwright/ui/specs/colorpicker.spec.js
+++ b/frontend/playwright/ui/specs/colorpicker.spec.js
@@ -93,7 +93,7 @@ test("Create a LINEAR gradient", async ({ page }) => {
   await expect(inputOpacityGlobal).toHaveValue("50");
   await expect(inputOpacityGlobal).toBeVisible();
 
-  await expect(workspacePage.page.getByText("Linear gradient")).toBeVisible();
+  await expect(workspacePage.page.getByText("Linear gradient").nth(1)).toBeVisible();
 });
 
 test("Create a RADIAL gradient", async ({ page }) => {
@@ -175,7 +175,7 @@ test("Create a RADIAL gradient", async ({ page }) => {
   await expect(inputOpacityGlobal).toHaveValue("50");
   await expect(inputOpacityGlobal).toBeVisible();
 
-  await expect(workspacePage.page.getByText("Radial gradient")).toBeVisible();
+  await expect(workspacePage.page.getByText("Radial gradient").nth(1)).toBeVisible();
 });
 
 test("Gradient stops limit", async ({ page }) => {

--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -46,7 +46,7 @@ const setupTokensFile = async (page, options = {}) => {
   } = options;
 
   const workspacePage = new WorkspacePage(page);
-  if (flags.length) {
+  if (flags.length > 0) {
     await workspacePage.mockConfigFlags(flags);
   }
 
@@ -879,7 +879,10 @@ test.describe("Tokens: Themes modal", () => {
   });
 
   test.describe("Tokens: Apply token", () => {
-    test("User applies color token to a shape", async ({ page }) => {
+    // When deleting the "enable-token-color" flag, permanently remove this test.
+    test("User applies color token to a shape without tokens on design-tab", async ({
+      page,
+    }) => {
       const { workspacePage, tokensSidebar, tokenContextMenuForToken } =
         await setupTokensFile(page);
 
@@ -903,7 +906,39 @@ test.describe("Tokens: Themes modal", () => {
         .click({ button: "right" });
       await tokenContextMenuForToken.getByText("Fill").click();
 
-            await workspacePage.page.getByLabel("Name: colors.black");
+      const inputColor = workspacePage.page.getByRole("textbox", {
+        name: "Color",
+      });
+      await expect(inputColor).toHaveValue("000000");
+    });
+
+    test("User applies color token to a shape", async ({ page }) => {
+      const { workspacePage, tokensSidebar, tokenContextMenuForToken } =
+        await setupTokensFile(page, { flags: ["enable-token-color"] });
+
+      await page.getByRole("tab", { name: "Layers" }).click();
+
+      await workspacePage.layers
+        .getByTestId("layer-row")
+        .filter({ hasText: "Button" })
+        .click();
+
+      const tokensTabButton = page.getByRole("tab", { name: "Tokens" });
+      await tokensTabButton.click();
+
+      await tokensSidebar
+        .getByRole("button")
+        .filter({ hasText: "Color" })
+        .click();
+
+      await tokensSidebar
+        .getByRole("button", { name: "colors.black" })
+        .click({ button: "right" });
+      await tokenContextMenuForToken.getByText("Fill").click();
+
+      await expect(
+        workspacePage.page.getByLabel("Name: colors.black"),
+      ).toBeVisible();
     });
 
     test("User applies typography token to a text shape", async ({ page }) => {
@@ -1021,9 +1056,7 @@ test.describe("Tokens: Themes modal", () => {
       await expect(letterSpacingField).toHaveValue(
         originalValues.letterSpacing,
       );
-      await expect(lineHeightField).toHaveValue(
-        originalValues.lineHeight,
-      );
+      await expect(lineHeightField).toHaveValue(originalValues.lineHeight);
       await expect(textCaseField).toHaveValue(originalValues.textCase);
       await expect(textDecorationField).toHaveValue(
         originalValues.textDecoration,

--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -903,10 +903,7 @@ test.describe("Tokens: Themes modal", () => {
         .click({ button: "right" });
       await tokenContextMenuForToken.getByText("Fill").click();
 
-      const inputColor = workspacePage.page.getByRole("textbox", {
-        name: "Color",
-      });
-      await expect(inputColor).toHaveValue("000000");
+            await workspacePage.page.getByLabel("Name: colors.black");
     });
 
     test("User applies typography token to a text shape", async ({ page }) => {

--- a/frontend/src/app/main/ui/components/reorder_handler.scss
+++ b/frontend/src/app/main/ui/components/reorder_handler.scss
@@ -8,16 +8,16 @@
   cursor: grab;
   display: flex;
   flex-direction: column;
-  height: calc(100% + var(--sp-m));
+  block-size: calc(100% + var(--sp-m));
   justify-content: center;
-  left: var(--reorder-left-position, calc(-1 * var(--sp-l)));
+  inset-inline-start: var(--reorder-left-position, -11px);
   position: absolute;
-  top: calc(-1 * (var(--sp-m) / 2));
+  inset-block-start: calc(-1 * (var(--sp-m) / 2));
   z-index: var(--z-index-panels);
 }
 
 .reorder-icon {
-  height: var(--sp-l);
+  block-size: var(--sp-l);
   pointer-events: none;
   visibility: var(--reorder-icon-visibility, hidden);
   --icon-stroke-color: var(--color-foreground-secondary);
@@ -28,15 +28,15 @@
   border-color: var(--color-accent-primary);
   margin: 0;
   position: absolute;
-  width: 100%;
+  inline-size: 100%;
 }
 
 .reorder-separator-top {
   display: var(--reorder-top-display, none);
-  top: calc(-1 * var(--sp-xxs));
+  inset-block-start: calc(-1 * var(--sp-xxs));
 }
 
 .reorder-separator-bottom {
   display: var(--reorder-bottom-display, none);
-  bottom: calc(-1 * var(--sp-xxs));
+  inset-block-end: calc(-1 * var(--sp-xxs));
 }

--- a/frontend/src/app/main/ui/ds/_sizes.scss
+++ b/frontend/src/app/main/ui/ds/_sizes.scss
@@ -18,7 +18,6 @@ $sz-32: px2rem(32);
 $sz-36: px2rem(36);
 $sz-40: px2rem(40);
 $sz-48: px2rem(48);
-$sz-80: px2rem(80);
 $sz-88: px2rem(88);
 $sz-120: px2rem(120);
 $sz-154: px2rem(154);

--- a/frontend/src/app/main/ui/ds/colors.scss
+++ b/frontend/src/app/main/ui/ds/colors.scss
@@ -52,7 +52,7 @@ $blue-950: #082c49;
 $cobalt-700: #1345aa;
 
 $black: #000;
-$gray-950: #18181a; // Used on colors.cljc
+$gray-950: #18181a;
 $gray-950-60: #18181a99;
 $gray-950-90: #18181ae6;
 $gray-900: #212426;

--- a/frontend/src/app/main/ui/ds/colors.scss
+++ b/frontend/src/app/main/ui/ds/colors.scss
@@ -52,7 +52,7 @@ $blue-950: #082c49;
 $cobalt-700: #1345aa;
 
 $black: #000;
-$gray-950: #18181a;
+$gray-950: #18181a; // Used on colors.cljc
 $gray-950-60: #18181a99;
 $gray-950-90: #18181ae6;
 $gray-900: #212426;

--- a/frontend/src/app/main/ui/ds/product/loader.scss
+++ b/frontend/src/app/main/ui/ds/product/loader.scss
@@ -4,6 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC
 
+@use "ds/_utils.scss" as *;
+
 @keyframes line-pencil {
   0% {
     transform: translateY(0);
@@ -44,8 +46,8 @@
     // Tips container
     .tips-container {
       text-align: center;
-      min-width: var(--sp-600);
-      max-width: var(--sp-800);
+      min-width: px2rem(600);
+      max-width: px2rem(800);
       display: flex;
       flex-direction: column;
       gap: var(--sp-s);

--- a/frontend/src/app/main/ui/ds/spacing.scss
+++ b/frontend/src/app/main/ui/ds/spacing.scss
@@ -14,8 +14,6 @@ $_sp-16: px2rem(16);
 $_sp-20: px2rem(20);
 $_sp-24: px2rem(24);
 $_sp-32: px2rem(32);
-$_sp-600: px2rem(600);
-$_sp-800: px2rem(800);
 
 :global(:root) {
   --sp-xxs: #{$_sp-2};
@@ -26,6 +24,4 @@ $_sp-800: px2rem(800);
   --sp-xl: #{$_sp-20};
   --sp-xxl: #{$_sp-24};
   --sp-xxxl: #{$_sp-32};
-  --sp-600: #{$_sp-600};
-  --sp-800: #{$_sp-800};
 }

--- a/frontend/src/app/main/ui/ds/utilities/swatch.cljs
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.cljs
@@ -9,11 +9,10 @@
   (:require-macros
    [app.main.style :as stl])
   (:require
-   [app.common.colors :as clr]
    [app.common.data.macros :as dm]
    [app.common.json :as json]
    [app.common.schema :as sm]
-  ;;  [app.common.types.color :as ct]
+   [app.common.types.color :as ct]
    [app.config :as cfg]
    [app.main.ui.ds.tooltip :refer [tooltip*]]
    [app.util.color :as uc]
@@ -60,8 +59,7 @@
 
 (def ^:private schema:swatch
   [:map {:title "SchemaSwatch"}
-  ;;  TODO: Review schema
-  ;;  [:background {:optional true} ct/schema:color]
+   [:background {:optional true} ct/schema:color]
    [:class {:optional true} :string]
    [:size {:optional true} [:enum "small" "medium" "large"]]
    [:active {:optional true} ::sm/boolean]
@@ -134,11 +132,8 @@
           [:span {:class (stl/css :swatch-image)
                   :style {:background-image (str/ffmt "url(%)" uri)}}])
         has-errors
-        [:span {:class (stl/css :swatch-opacity)}
-         [:span {:class (stl/css :swatch-solid-side)
-                 :style {:background clr/background-primary}}]
-         [:span {:class (stl/css :swatch-opacity-side)
-                 :style {:background clr/background-primary}}]]
+        [:span {:class (stl/css :swatch-error)}]
+
         :else
         [:span {:class (stl/css :swatch-opacity)}
          [:span {:class (stl/css :swatch-solid-side)

--- a/frontend/src/app/main/ui/ds/utilities/swatch.scss
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.scss
@@ -108,3 +108,7 @@
   flex: 1;
   display: block;
 }
+
+.swatch-error {
+  background: var(--color-background-primary);
+}

--- a/frontend/src/app/main/ui/ds/utilities/swatch.scss
+++ b/frontend/src/app/main/ui/ds/utilities/swatch.scss
@@ -20,7 +20,6 @@
   border: $b-1 solid var(--border-color);
   border-radius: var(--border-radius);
   overflow: hidden;
-
   &:focus {
     --border-color: var(--color-accent-primary);
   }

--- a/frontend/src/app/main/ui/workspace/colorpicker.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker.cljs
@@ -365,7 +365,7 @@
             :icon i/hsva
             :id "hsva"}])
 
-        show-tokens? (contains? #{:fill :stroke :color-selection} color-origin)]
+        show-tokens? (contains? #{:fill :stroke-color :color-selection} color-origin)]
 
     ;; Initialize colorpicker state
     (mf/with-effect []

--- a/frontend/src/app/main/ui/workspace/colorpicker.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker.cljs
@@ -47,7 +47,8 @@
    [cuerdas.core :as str]
    [okulary.core :as l]
    [potok.v2.core :as ptk]
-   [rumext.v2 :as mf]))
+   [rumext.v2 :as mf]
+   [rumext.v2.util :as mfu]))
 
 ;; --- Refs
 
@@ -93,13 +94,13 @@
       (dom/set-css-property! node "--saturation-grad-to" (format-hsl hsl-to)))))
 
 (mf/defc colorpicker
-  [{:keys [data disable-gradient disable-opacity disable-image on-change on-accept origin combined-tokens color-origin on-token-change]}]
+  [{:keys [data disable-gradient disable-opacity disable-image on-change on-accept origin combined-tokens color-origin on-token-change tab]}]
   (let [state                  (mf/deref refs/colorpicker)
         node-ref               (mf/use-ref)
 
         should-update?         (mf/use-var true)
         token-color            (contains? cfg/flags :token-color)
-        color-style*           (mf/use-state :direct-color)
+        color-style*           (mf/use-state (d/nilv tab :direct-color))
         color-style            (deref color-style*)
         toggle-token-color
         (mf/use-fn
@@ -726,12 +727,16 @@
            color-origin
            on-token-change
            on-close
+           tab
            on-accept]}]
   (let [vport       (mf/deref viewport)
         dirty?      (mf/use-var false)
         last-change (mf/use-var nil)
         position    (d/nilv position :left)
         style       (calculate-position vport position x y (some? (:gradient data)))
+        active-tokens (if (object? active-tokens)
+                        (mfu/bean active-tokens)
+                        active-tokens)
 
         on-change'
         (mf/use-fn
@@ -752,6 +757,10 @@
           (some-> tokens-lib
                   (ctob/get-active-themes-set-names)))
 
+        active-tokens (if (delay? active-tokens)
+                        @active-tokens
+                        active-tokens)
+
         color-tokens (:color active-tokens)
 
         grouped-tokens-by-set
@@ -762,7 +771,7 @@
                   (filter-active-sets active-sets-names)
                   (filter-non-empty-sets)
                   (group-sets)
-                  (combine-groups-with-resolved color-tokens)))]
+                  (combine-groups-with-resolved  color-tokens)))]
 
     (mf/with-effect []
       (st/emit! (st/emit! (dsc/push-shortcuts ::colorpicker sc/shortcuts)))
@@ -783,5 +792,6 @@
                       :on-token-change on-token-change
                       :on-change on-change'
                       :origin origin
+                      :tab tab
                       :color-origin color-origin
                       :on-accept on-accept}]]))

--- a/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/color_tokens.cljs
@@ -135,24 +135,11 @@
 
         on-token-pill-click
         (mf/use-fn
-         (mf/deps selected-shapes selected color-origin)
+         (mf/deps selected-shapes)
          (fn [event token]
            (dom/stop-propagation event)
            (when (seq selected-shapes)
-             (if (= :color-selection color-origin)
-               (on-token-change event token)
-               (let [attributes (if (= color-origin :stroke) #{:stroke-color} #{:fill})
-                     shape-ids (into #{} (map :id selected-shapes))]
-                 (if (or
-                      (and (= (:name token) has-stroke-tokens?) (= color-origin :stroke))
-                      (and (= (:name token) has-color-tokens?) (= color-origin :fill)))
-                   (st/emit! (dwta/unapply-token {:attributes attributes
-                                                  :token token
-                                                  :shape-ids shape-ids}))
-                   (st/emit! (dwta/apply-token {:shape-ids shape-ids
-                                                :attributes attributes
-                                                :token token
-                                                :on-update-shape dwta/update-fill-stroke}))))))))
+             (on-token-change event token))))
 
         create-token-on-set
         (mf/use-fn

--- a/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
@@ -52,6 +52,10 @@
        (str/join ", ")
        (str/ffmt "linear-gradient(90deg, %1)")))
 
+(defn- stop->hex-color
+  [stop]
+  (select-keys stop [:color :opacity]))
+
 (mf/defc stop-input-row*
   {::mf/private true}
   [{:keys [stop
@@ -156,7 +160,7 @@
      [:> color-row*
       {:disable-gradient true
        :disable-picker true
-       :color stop
+       :color (stop->hex-color stop)
        :index index
        :origin :gradient
        :on-change handle-change-stop-color

--- a/frontend/src/app/main/ui/workspace/libraries.scss
+++ b/frontend/src/app/main/ui/workspace/libraries.scss
@@ -454,7 +454,7 @@
 .sample-library-button {
   @include t.use-typography("headline-small");
   height: $sz-32;
-  width: $sz-80;
+  width: px2rem(80);
   margin: 0;
   border-radius: $br-8;
   white-space: nowrap;

--- a/frontend/src/app/main/ui/workspace/sidebar/options.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options.cljs
@@ -46,7 +46,7 @@
 
 (mf/defc single-shape-options*
   {::mf/private true}
-  [{:keys [shape page-id file-id libraries] :as props}]
+  [{:keys [shape page-id file-id libraries] :rest props}]
   (let [shape-type (dm/get-prop shape :type)
         shape-id   (dm/get-prop shape :id)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
@@ -108,6 +108,7 @@
                  color-operations   (get groups color)
                  ids    (into (d/ordered-set) xf:map-shape-id color-operations)]
              (st/emit! (dws/select-shapes ids)))))
+
         on-token-change
         (mf/use-fn
          (fn [_ token old-color]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
@@ -260,7 +260,6 @@
                                :applied-token fill-token-applied
                                :on-token-change on-token-change
                                :origin :fill
-                               :shape-type type
                                :select-on-focus (not disable-drag?)
                                :on-blur on-blur}]))])
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -38,8 +38,8 @@
    :stroke-cap-end])
 
 (mf/defc stroke-menu
-  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "show-caps" "applied-tokens" "shapes" "shapes-with-children"]))]}
-  [{:keys [ids type values show-caps disable-stroke-style applied-tokens shapes shapes-with-children] :as props}]
+  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "show-caps" "applied-tokens" "shapes" "objects"]))]}
+  [{:keys [ids type values show-caps disable-stroke-style applied-tokens shapes objects] :as props}]
   (let [label (case type
                 :multiple (tr "workspace.options.selection-stroke")
                 :group (tr "workspace.options.group-stroke")
@@ -210,7 +210,7 @@
                              :title (tr "workspace.options.stroke-color")
                              :index index
                              :shapes shapes
-                             :shapes-with-children shapes-with-children
+                             :objects objects
                              :show-caps show-caps
                              :on-color-change on-color-change
                              :on-color-detach on-color-detach

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -12,6 +12,7 @@
    [app.common.types.stroke :as cts]
    [app.main.data.workspace :as udw]
    [app.main.data.workspace.colors :as dc]
+   [app.main.data.workspace.tokens.application :as dwta]
    [app.main.store :as st]
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
@@ -37,8 +38,8 @@
    :stroke-cap-end])
 
 (mf/defc stroke-menu
-  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "show-caps"]))]}
-  [{:keys [ids type values show-caps disable-stroke-style] :as props}]
+  {::mf/wrap [#(mf/memo' % (mf/check-props ["ids" "values" "type" "show-caps" "applied-tokens" "shapes" "shapes-with-children"]))]}
+  [{:keys [ids type values show-caps disable-stroke-style applied-tokens shapes shapes-with-children] :as props}]
   (let [label (case type
                 :multiple (tr "workspace.options.selection-stroke")
                 :group (tr "workspace.options.group-stroke")
@@ -167,7 +168,14 @@
                    (reset! disable-drag true))
 
         on-blur (fn [_]
-                  (reset! disable-drag false))]
+                  (reset! disable-drag false))
+        on-detach-token
+        (mf/use-fn
+         (mf/deps ids)
+         (fn [token attrs]
+           (st/emit! (dwta/unapply-token {:attributes attrs
+                                          :token token
+                                          :shape-ids ids}))))]
 
     [:div {:class (stl/css :element-set)}
      [:div {:class (stl/css :element-title)}
@@ -201,6 +209,8 @@
                              :stroke value
                              :title (tr "workspace.options.stroke-color")
                              :index index
+                             :shapes shapes
+                             :shapes-with-children shapes-with-children
                              :show-caps show-caps
                              :on-color-change on-color-change
                              :on-color-detach on-color-detach
@@ -212,6 +222,8 @@
                              :on-stroke-cap-start-change on-stroke-cap-start-change
                              :on-stroke-cap-end-change on-stroke-cap-end-change
                              :on-stroke-cap-switch on-stroke-cap-switch
+                             :applied-tokens applied-tokens
+                             :on-detach-token on-detach-token
                              :on-remove on-remove
                              :on-reorder (handle-reorder index)
                              :disable-drag disable-drag

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -85,7 +85,6 @@
         token-name (:name token)
         resolved (:resolved-value token)
         not-active (and (some? active-tokens) (nil? token))
-        ;;  value (dwta/value->color resolved)
         id (dm/str (:id token) "-name")
         swatch-tooltip-content (cond
                                  not-active
@@ -104,6 +103,7 @@
                                 [:div
                                  [:span (dm/str (tr "workspace.tokens.token-name") ": ")]
                                  [:span {:class (stl/css :token-name-tooltip)} color-token]]))]
+
     [:div {:class (stl/css :color-info)}
      [:div {:class (stl/css-case :token-color-wrapper true
                                  :token-color-with-errors has-errors
@@ -137,12 +137,10 @@
          :icon i/tokens}]]]]))
 
 (mf/defc color-row*
-  ;; TODO: Add schema
   [{:keys [index color class disable-gradient disable-opacity disable-image disable-picker hidden
            on-change on-reorder on-detach on-open on-close on-remove origin on-detach-token
            disable-drag on-focus on-blur select-only select-on-focus on-token-change applied-token]}]
   (let [libraries        (mf/deref refs/files)
-        ;; ??
         on-change        (h/use-ref-callback on-change)
         on-token-change  (h/use-ref-callback on-token-change)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -69,7 +69,11 @@
 (mf/defc color-token-row*
   {::mf/private true}
   [{:keys [active-tokens color-token color on-swatch-click-token detach-token open-modal-from-token]}]
-  (let [active-tokens (if (delay? active-tokens)
+  (let [;; `active-tokens` may be provided as a `delay` (lazy computation). 
+        ;; In that case we must deref it (`@active-tokens`) to force evaluation 
+        ;; and obtain the actual value. If it’s already realized (not a delay), 
+        ;; we just use it directly.
+        active-tokens (if (delay? active-tokens)
                         @active-tokens
                         active-tokens)
 
@@ -126,13 +130,11 @@
       [:div {:class (stl/css :token-actions)}
        [:> icon-button*
         {:variant "action"
-         :class (stl/css :detach-btn2)
          :aria-label (tr "ds.inputs.token-field.detach-token")
          :on-click on-detach-token
          :icon i/detach}]
        [:> icon-button*
         {:variant "action"
-         :class (stl/css :detach-btn2)
          :aria-label (tr "ds.inputs.numeric-input.open-token-list-dropdown")
          :on-click open-modal-from-token
          :icon i/tokens}]]]]))
@@ -145,6 +147,9 @@
         libraries        (mf/deref refs/files)
         on-change        (h/use-ref-callback on-change)
         on-token-change  (h/use-ref-callback on-token-change)
+        color-without-hash (mf/use-memo
+                            (mf/deps color)
+                            #(-> color :color clr/remove-hash))
 
         file-id          (or (:ref-file color) (:file-id color))
         color-id         (or (:ref-id color) (:id color))
@@ -405,7 +410,7 @@
         [:span {:class (stl/css :color-input-wrapper)}
          [:> color-input* {:value (if has-multiple-colors
                                     ""
-                                    (-> color :color clr/remove-hash))
+                                    color-without-hash)
                            :placeholder (tr "settings.multiple")
                            :data-index index
                            :class (stl/css :color-input)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -12,6 +12,7 @@
    [app.common.types.color :as clr]
    [app.common.types.shape.attrs :refer [default-color]]
    [app.common.types.token :as tk]
+   [app.config :as cfg]
    [app.main.data.modal :as modal]
    [app.main.data.workspace.colors :as dwc]
    [app.main.refs :as refs]
@@ -140,7 +141,8 @@
   [{:keys [index color class disable-gradient disable-opacity disable-image disable-picker hidden
            on-change on-reorder on-detach on-open on-close on-remove origin on-detach-token
            disable-drag on-focus on-blur select-only select-on-focus on-token-change applied-token]}]
-  (let [libraries        (mf/deref refs/files)
+  (let [token-color      (contains? cfg/flags :token-color)
+        libraries        (mf/deref refs/files)
         on-change        (h/use-ref-callback on-change)
         on-token-change  (h/use-ref-callback on-token-change)
 
@@ -336,7 +338,7 @@
      (when (some? on-reorder)
        [:> reorder-handler* {:ref dref}])
      (cond
-       applied-token
+       (and token-color applied-token)
        [:> color-token-row* {:active-tokens tokens
                              :color-token applied-token
                              :color (dissoc color :ref-id :ref-file)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
@@ -282,6 +282,7 @@
     --token-actions-display: flex;
   }
 }
+
 .token-color-with-errors,
 .token-color-not-active {
   --token-color-wrapper-background-color: var(--color-background-primary);
@@ -315,12 +316,12 @@
 }
 
 .error-dot {
-  width: 4px;
-  height: 4px;
+  width: px2rem(4);
+  height: px2rem(4);
   border-radius: 50%;
   background-color: var(--color-foreground-error);
   margin-left: var(--sp-xs);
   position: absolute;
-  right: 1px;
-  top: 5px;
+  right: px2rem(1);
+  top: px2rem(5);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
@@ -4,14 +4,19 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "refactor/common-refactor.scss" as deprecated;
+@use "ds/typography.scss" as t;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/mixins.scss" as *;
+@use "ds/_utils.scss" as *;
 
 .color-data {
-  @include deprecated.flexRow;
-
-  position: relative;
-
   --reorder-left-position: calc(-1 * var(--sp-m) - var(--sp-xxs));
+
+  display: flex;
+  align-items: center;
+  gap: var(--sp-xs);
+  position: relative;
 
   &:hover {
     --reorder-icon-visibility: visible;
@@ -34,156 +39,288 @@
   --detach-icon-foreground-color: none;
 
   display: grid;
-  flex: 1;
   grid-template-columns: 1fr auto;
   align-items: center;
-  gap: deprecated.$s-2;
-  border-radius: deprecated.$s-8;
-  background-color: var(--input-details-color);
-  height: deprecated.$s-32;
+  flex: 1;
+  gap: var(--sp-xxs);
+  height: $sz-32;
+  border-radius: $br-8;
+  background-color: var(--color-background-primary);
 
   &:hover {
-    --detach-icon-foreground-color: var(--input-foreground-color-active);
-
-    .detach-btn,
-    .select-btn {
-      background-color: transparent;
-    }
+    --detach-icon-foreground-color: var(--color-foreground-primary);
   }
 }
 
 .color-name-wrapper {
-  @extend .input-element;
-  @include deprecated.bodySmallTypography;
+  --color-name-wrapper-background-color: var(--color-background-tertiary);
+  --color-name-wrapper-foreground-color: var(--color-foreground-primary);
+  --color-name-wrapper-boder-color: var(--color-background-tertiary);
+  @include t.use-typography("body-small");
+  @include textEllipsis;
+  display: flex;
+  align-items: center;
   flex-grow: 1;
-  width: 100%;
+  gap: var(--sp-xs);
+  height: $sz-32;
   min-width: 0;
-  border-radius: deprecated.$br-8 0 0 deprecated.$br-8;
+  width: 100%;
   padding: 0;
   margin-inline-end: 0;
-  gap: deprecated.$s-4;
+  border: $b-1 solid var(--color-name-wrapper-boder-color);
+  border-radius: $br-8;
+  background-color: var(--color-name-wrapper-background-color);
+  color: var(--color-name-wrapper-foreground-color);
+  border-radius: $br-8 0 0 $br-8;
 
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  input {
-    padding: 0;
-  }
-  .color-bullet-wrapper {
-    height: deprecated.$s-28;
-    padding: 0 deprecated.$s-2 0 deprecated.$s-8;
-    border-radius: deprecated.$br-8 0 0 deprecated.$br-8;
-    background-color: transparent;
-    display: flex;
-    align-items: center;
-    &:hover {
-      background-color: transparent;
-    }
-  }
-  .color-name {
-    @include deprecated.bodySmallTypography;
-    @include deprecated.textEllipsis;
-    padding-inline: deprecated.$s-6;
-    border-radius: deprecated.$br-8;
-    color: var(--input-foreground-color-active);
-  }
-  .detach-btn {
-    @extend .button-tertiary;
-    height: deprecated.$s-28;
-    width: deprecated.$s-28;
-    margin-inline-start: auto;
-    border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
-    display: none;
-  }
-  .detach-icon {
-    @extend .button-icon;
-    stroke: var(--detach-icon-foreground-color);
-  }
-  .color-input-wrapper {
-    @include deprecated.bodySmallTypography;
-    display: flex;
-    align-items: center;
-    height: deprecated.$s-28;
-    padding: 0 deprecated.$s-0;
-    width: 100%;
-    margin: 0;
-    flex-grow: 1;
-    background-color: var(--input-background-color);
-    color: var(--input-foreground-color);
-    border-radius: deprecated.$br-0;
-  }
   &.no-opacity {
-    border-radius: deprecated.$br-8;
+    border-radius: $br-8;
     .color-input-wrapper {
-      border-radius: deprecated.$br-8;
+      border-radius: $br-8;
     }
   }
+
   &:hover {
     --detach-icon-foreground-color: var(--input-foreground-color-active);
+    --color-name-wrapper-background-color: var(--color-background-quaternary);
+    --color-name-wrapper-boder-color: var(--color-background-quaternary);
 
-    background-color: var(--input-background-color-hover);
-    border: deprecated.$s-1 solid var(--input-border-color-hover);
-    .color-bullet-wrapper,
-    .color-name,
-    .detach-btn,
-    .color-input-wrapper {
-      background-color: var(--input-background-color-hover);
-    }
     .detach-btn {
-      display: flex;
+      display: grid;
     }
     &.editing {
-      background-color: var(--input-background-color-active);
-      .color-bullet-wrapper,
-      .color-name,
-      .detach-btn,
-      .color-input-wrapper {
-        background-color: var(--input-background-color-active);
-      }
+      --color-name-wrapper-background-color: var(--color-background-primary);
     }
+
     &:focus,
     &:focus-within {
-      background-color: var(--input-background-color-focus);
-      border: deprecated.$s-1 solid var(--input-border-color-focus);
+      --color-name-wrapper-background-color: var(--color-background-tertiary);
+      --color-name-wrapper-boder-color: var(--color-accent-primary);
     }
   }
 
   &:focus,
   &:focus-within {
-    background-color: var(--input-background-color-focus);
-    border: deprecated.$s-1 solid var(--input-border-color-focus);
+    --color-name-wrapper-background-color: var(--color-background-tertiary);
+    --color-name-wrapper-boder-color: var(--color-accent-primary);
     &:hover {
-      background-color: var(--input-background-color-hover);
-      border: deprecated.$s-1 solid var(--input-border-color-focus);
+      --color-name-wrapper-background-color: var(--color-background-quaternary);
     }
   }
 
   &.editing {
-    background-color: var(--input-background-color-active);
+    --color-name-wrapper-background-color: var(--color-background-primary);
     &:hover {
-      border: deprecated.$s-1 solid var(--input-border-color-active);
+      --color-name-wrapper-boder-color: var(--color-accent-primary);
     }
   }
 }
 
+.detach-btn {
+  display: none;
+  background: var(--color-name-wrapper-background-color);
+}
+
+.color-input-wrapper {
+  @include t.use-typography("body-small");
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  height: $sz-28;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background-color: var(--color-name-wrapper-background-color);
+  color: var(--color-name-wrapper-foreground-color);
+  border-radius: 0;
+}
+
+.color-name {
+  @include t.use-typography("body-small");
+  @include textEllipsis;
+  flex-grow: 1;
+  padding-inline: px2rem(6);
+  border-radius: $br-8;
+  color: var(--color-name-wrapper-foreground-color);
+}
+
+.color-bullet-wrapper {
+  display: flex;
+  align-items: center;
+  position: relative;
+  height: $sz-28;
+  padding: 0 var(--sp-xxs) 0 var(--sp-s);
+  border-radius: $br-8 0 0 $br-8;
+  background-color: transparent;
+  &:hover {
+    background-color: transparent;
+  }
+}
+
+.color-input {
+  @include textEllipsis;
+  border: none;
+  background: none;
+  outline: none;
+  height: $sz-28;
+  width: 100%;
+  flex-grow: 1;
+  margin: var(--sp-xxs) 0;
+  padding: 0 0 0 px2rem(6);
+  border-radius: $br-8;
+  color: var(--input-foreground-color-active);
+  &[disabled] {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}
+
 .library-name-wrapper {
-  border-radius: deprecated.$br-8;
+  border-radius: $br-8;
 }
 
 .opacity-element-wrapper {
-  @extend .input-element;
-  @include deprecated.bodySmallTypography;
-  width: deprecated.$s-60;
-  border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
-  .opacity-input {
-    padding: 0;
-    border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
-    min-width: deprecated.$s-28;
+  --opacity-input-background-color: var(--color-background-tertiary);
+  --opacity-input-boder-color: var(--color-background-tertiary);
+
+  @include t.use-typography("body-small");
+  display: flex;
+  align-items: center;
+  height: $sz-32;
+  width: px2rem(60);
+  border-radius: 0 $br-8 $br-8 0;
+  border: $b-1 solid var(--opacity-input-boder-color);
+  background-color: var(--opacity-input-background-color);
+
+  &:hover {
+    --opacity-input-background-color: var(--color-background-quaternary);
+    --opacity-input-boder-color: var(--color-background-quaternary);
+
+    .detach-btn {
+      display: grid;
+    }
+    &.editing {
+      --opacity-input-background-color: var(--color-background-primary);
+    }
+
+    &:focus,
+    &:focus-within {
+      --opacity-input-background-color: var(--color-background-tertiary);
+      --opacity-input-boder-color: var(--color-accent-primary);
+    }
   }
-  .icon-text {
-    @include deprecated.flexCenter;
-    height: deprecated.$s-32;
-    margin-inline-end: deprecated.$s-4;
-    margin-block-start: deprecated.$s-2;
+
+  &:focus,
+  &:focus-within {
+    --opacity-input-background-color: var(--color-background-tertiary);
+    --opacity-input-boder-color: var(--color-accent-primary);
+    &:hover {
+      --opacity-input-background-color: var(--color-background-quaternary);
+    }
   }
+
+  &.editing {
+    --opacity-input-background-color: var(--color-background-primary);
+    &:hover {
+      --opacity-input-boder-color: var(--color-accent-primary);
+    }
+  }
+}
+
+.opacity-input {
+  @include textEllipsis;
+  height: $sz-28;
+  min-width: $sz-28;
+  flex-grow: 1;
+  width: 100%;
+  padding: 0;
+  border-radius: 0 $br-8 $br-8 0;
+  border: none;
+  background: none;
+  outline: none;
+  margin: var(--sp-xxs) 0;
+  padding: 0 0 0 px2rem(6);
+  color: var(--color-foreground-primary);
+  &[disabled] {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}
+
+.icon-text {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: $sz-32;
+  margin-inline-end: var(--sp-xs);
+  margin-block-start: var(--sp-xxs);
+  color: var(--color-foreground-secondary);
+}
+
+// TOKEN ROW
+
+.token-color-wrapper {
+  --token-color-wrapper-background-color: var(--color-background-tertiary);
+  --token-color-wrapper-foreground-color: var(--color-token-foreground);
+  --token-color-wrapper-border-color: var(--color-token-border);
+  --token-actions-display: none;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-xs);
+  height: $sz-32;
+  min-width: 0;
+  width: 100%;
+  padding: 0;
+  margin-inline-end: 0;
+  background: var(--token-color-wrapper-background-color);
+  border: $b-1 solid var(--token-color-wrapper-border-color);
+  border-radius: $br-8;
+  &:hover {
+    --token-color-wrapper-background-color: var(--color-token-background);
+    --token-color-wrapper-foreground-color: var(--color-foreground-primary);
+    --token-color-wrapper-border-color: var(--color-token-background);
+    --token-actions-display: flex;
+  }
+}
+.token-color-with-errors,
+.token-color-not-active {
+  --token-color-wrapper-background-color: var(--color-background-primary);
+  --token-color-wrapper-foreground-color: var(--color-foreground-secondary);
+  --token-color-wrapper-border-color: var(--color-token-border);
+  &:hover {
+    --token-color-wrapper-background-color: var(--color-background-primary);
+    --token-color-wrapper-foreground-color: var(--color-foreground-secondary);
+    --token-color-wrapper-border-color: var(--color-token-background);
+    --token-actions-display: flex;
+  }
+}
+
+.token-name {
+  @include t.use-typography("body-small");
+  @include textEllipsis;
+  color: var(--token-color-wrapper-foreground-color);
+  height: $sz-32;
+  display: flex;
+  align-items: center;
+}
+
+.token-name-tooltip {
+  color: var(--color-foreground-primary);
+}
+
+.token-actions {
+  display: var(--token-actions-display);
+  justify-self: flex-end;
+  align-items: center;
+}
+
+.error-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background-color: var(--color-foreground-error);
+  margin-left: var(--sp-xs);
+  position: absolute;
+  right: 1px;
+  top: 5px;
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.scss
@@ -11,8 +11,6 @@
 @use "ds/_utils.scss" as *;
 
 .color-data {
-  --reorder-left-position: calc(-1 * var(--sp-m) - var(--sp-xxs));
-
   display: flex;
   align-items: center;
   gap: var(--sp-xs);
@@ -43,7 +41,7 @@
   align-items: center;
   flex: 1;
   gap: var(--sp-xxs);
-  height: $sz-32;
+  block-size: $sz-32;
   border-radius: $br-8;
   background-color: var(--color-background-primary);
 
@@ -62,9 +60,9 @@
   align-items: center;
   flex-grow: 1;
   gap: var(--sp-xs);
-  height: $sz-32;
-  min-width: 0;
-  width: 100%;
+  block-size: $sz-32;
+  min-inline-size: 0;
+  inline-size: 100%;
   padding: 0;
   margin-inline-end: 0;
   border: $b-1 solid var(--color-name-wrapper-boder-color);
@@ -126,8 +124,8 @@
   display: flex;
   align-items: center;
   flex-grow: 1;
-  height: $sz-28;
-  width: 100%;
+  block-size: $sz-28;
+  inline-size: 100%;
   padding: 0;
   margin: 0;
   background-color: var(--color-name-wrapper-background-color);
@@ -148,7 +146,7 @@
   display: flex;
   align-items: center;
   position: relative;
-  height: $sz-28;
+  block-size: $sz-28;
   padding: 0 var(--sp-xxs) 0 var(--sp-s);
   border-radius: $br-8 0 0 $br-8;
   background-color: transparent;
@@ -162,8 +160,8 @@
   border: none;
   background: none;
   outline: none;
-  height: $sz-28;
-  width: 100%;
+  block-size: $sz-28;
+  inline-size: 100%;
   flex-grow: 1;
   margin: var(--sp-xxs) 0;
   padding: 0 0 0 px2rem(6);
@@ -186,8 +184,8 @@
   @include t.use-typography("body-small");
   display: flex;
   align-items: center;
-  height: $sz-32;
-  width: px2rem(60);
+  block-size: $sz-32;
+  inline-size: px2rem(60);
   border-radius: 0 $br-8 $br-8 0;
   border: $b-1 solid var(--opacity-input-boder-color);
   background-color: var(--opacity-input-background-color);
@@ -229,10 +227,10 @@
 
 .opacity-input {
   @include textEllipsis;
-  height: $sz-28;
-  min-width: $sz-28;
+  block-size: $sz-28;
+  min-inline-size: $sz-28;
   flex-grow: 1;
-  width: 100%;
+  inline-size: 100%;
   padding: 0;
   border-radius: 0 $br-8 $br-8 0;
   border: none;
@@ -251,7 +249,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: $sz-32;
+  block-size: $sz-32;
   margin-inline-end: var(--sp-xs);
   margin-block-start: var(--sp-xxs);
   color: var(--color-foreground-secondary);
@@ -267,9 +265,9 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: var(--sp-xs);
-  height: $sz-32;
-  min-width: 0;
-  width: 100%;
+  block-size: $sz-32;
+  min-inline-size: 0;
+  inline-size: 100%;
   padding: 0;
   margin-inline-end: 0;
   background: var(--token-color-wrapper-background-color);
@@ -300,7 +298,7 @@
   @include t.use-typography("body-small");
   @include textEllipsis;
   color: var(--token-color-wrapper-foreground-color);
-  height: $sz-32;
+  block-size: $sz-32;
   display: flex;
   align-items: center;
 }
@@ -316,12 +314,12 @@
 }
 
 .error-dot {
-  width: px2rem(4);
-  height: px2rem(4);
+  inline-size: px2rem(4);
+  block-size: px2rem(4);
   border-radius: 50%;
   background-color: var(--color-foreground-error);
-  margin-left: var(--sp-xs);
+  margin-inline-start: var(--sp-xs);
   position: absolute;
-  right: px2rem(1);
-  top: px2rem(5);
+  inset-inline-end: px2rem(1);
+  inset-block-start: px2rem(5);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
@@ -9,6 +9,8 @@
   (:require
    [app.common.data :as d]
    [app.common.types.color :as ctc]
+   [app.main.data.workspace.tokens.application :as dwta]
+   [app.main.store :as st]
    [app.main.ui.components.numeric-input :refer [numeric-input*]]
    [app.main.ui.components.reorder-handler :refer [reorder-handler*]]
    [app.main.ui.components.select :refer [select]]
@@ -37,8 +39,12 @@
            disable-drag
            on-focus
            on-blur
+           applied-tokens
+           on-detach-token
            disable-stroke-style
-           select-on-focus]}]
+           select-on-focus
+           shapes
+           shapes-with-children]}]
 
   (let [on-drop
         (fn [_ data]
@@ -55,27 +61,29 @@
                                 :name (str "Border row" index)})
                         [nil nil])
 
+        stroke-color-token (:stroke-color applied-tokens)
+        stroke-width-token (:stroke-width applied-tokens)
         on-color-change-refactor
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-color-change)
          (fn [color]
            (on-color-change index color)))
 
         on-color-detach
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-color-detach)
          (fn [color]
            (on-color-detach index color)))
 
         on-remove
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-remove)
          #(on-remove index))
 
         stroke-width (:stroke-width stroke)
 
         on-width-change
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-stroke-width-change)
          #(on-stroke-width-change index %))
 
@@ -91,9 +99,21 @@
             {:value :outer :label (tr "workspace.options.stroke.outer")}]))
 
         on-alignment-change
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-stroke-alignment-change)
          #(on-stroke-alignment-change index (keyword %)))
+
+        on-token-change
+        (mf/use-fn
+         (mf/deps shapes shapes-with-children)
+         (fn [_ token]
+           (let [is-group (= :group (:type (first shapes)))
+                 shapes (if is-group
+                          shapes-with-children
+                          shapes)]
+             (st/emit! (dwta/toggle-token {:token token
+                                           :shapes shapes
+                                           :attrs #{:stroke-color}})))))
 
         stroke-style (or (:stroke-style stroke) :solid)
 
@@ -108,19 +128,25 @@
             {:value :mixed :label (tr "workspace.options.stroke.mixed")}]))
 
         on-style-change
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-stroke-style-change)
          #(on-stroke-style-change index (keyword %)))
 
         on-caps-start-change
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-stroke-cap-start-change)
          #(on-stroke-cap-start-change index (keyword %)))
 
         on-caps-end-change
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-stroke-cap-end-change)
          #(on-stroke-cap-end-change index (keyword %)))
+
+        on-detach-token-color
+        (mf/use-fn
+         (mf/deps on-detach-token)
+         (fn [token]
+           (on-detach-token token #{:stroke-color})))
 
         stroke-caps-options
         [{:value nil :label (tr "workspace.options.stroke-cap.none")}
@@ -135,7 +161,7 @@
          {:value :square :label (tr "workspace.options.stroke-cap.square") :icon :stroke-squared}]
 
         on-cap-switch
-        (mf/use-callback
+        (mf/use-fn
          (mf/deps index on-stroke-cap-switch)
          #(on-stroke-cap-switch index))]
 
@@ -156,8 +182,11 @@
                      :on-detach on-color-detach
                      :on-remove on-remove
                      :disable-drag disable-drag
+                     :applied-token stroke-color-token
+                     :on-detach-token on-detach-token-color
+                     :on-token-change on-token-change
                      :on-focus on-focus
-                     :origin :stroke
+                     :origin :stroke-color
                      :select-on-focus select-on-focus
                      :on-blur on-blur}]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
@@ -30,7 +30,8 @@
         shapes (mf/with-memo [shape] [shape])
 
         applied-tokens
-        (get shape :applied-tokens)
+        (when (seq (get shape :applied-tokens))
+          (get shape :applied-tokens))
 
         measure-values
         (select-keys shape measure-attrs)
@@ -127,7 +128,9 @@
      [:& stroke-menu {:ids ids
                       :type type
                       :show-caps true
-                      :values stroke-values}]
+                      :values stroke-values
+                      :shapes shapes
+                      :applied-tokens applied-tokens}]
 
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
      [:& blur-menu {:ids ids

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/bool.cljs
@@ -120,7 +120,9 @@
      [:> fill/fill-menu*
       {:ids ids
        :type type
-       :values shape}]
+       :values shape
+       :shapes shapes
+       :applied-tokens applied-tokens}]
 
      [:& stroke-menu {:ids ids
                       :type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
@@ -126,7 +126,9 @@
 
      [:& stroke-menu {:ids ids
                       :type type
-                      :values stroke-values}]
+                      :values stroke-values
+                      :shapes shapes
+                      :applied-tokens applied-tokens}]
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
      [:& blur-menu {:ids ids
                     :values (select-keys shape [:blur])}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/circle.cljs
@@ -120,7 +120,10 @@
      [:> fill/fill-menu*
       {:ids ids
        :type type
-       :values shape}]
+       :values shape
+       :shapes shapes
+       :applied-tokens applied-tokens}]
+
      [:& stroke-menu {:ids ids
                       :type type
                       :values stroke-values}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -149,7 +149,9 @@
 
      [:& stroke-menu {:ids ids
                       :type shape-type
-                      :values stroke-values}]
+                      :values stroke-values
+                      :shapes shapes
+                      :applied-tokens applied-tokens}]
      [:> color-selection-menu* {:type shape-type
                                 :shapes shapes-with-children
                                 :file-id file-id

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -143,7 +143,9 @@
      [:> fill/fill-menu*
       {:ids ids
        :type shape-type
-       :values shape}]
+       :values shape
+       :shapes shapes
+       :applied-tokens applied-tokens}]
 
      [:& stroke-menu {:ids ids
                       :type shape-type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -148,7 +148,7 @@
          :ids fill-ids
          :values fill-values
          :shapes shapes
-         :shapes-with-children shapes-with-children
+         :objects objects
          :applied-tokens fill-tokens}])
 
      (when-not (empty? stroke-ids)
@@ -156,7 +156,7 @@
                         :ids stroke-ids
                         :values stroke-values
                         :shapes shapes
-                        :shapes-with-children shapes-with-children
+                        :objects objects
                         :applied-tokens stroke-tokens}])
 
      [:> color-selection-menu*

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -99,7 +99,7 @@
         [blur-ids blur-values]
         (get-attrs shapes objects :blur)
 
-        [stroke-ids stroke-values]
+        [stroke-ids stroke-values stroke-tokens]
         (get-attrs shapes objects :stroke)
 
         [text-ids text-values]
@@ -152,7 +152,12 @@
          :applied-tokens fill-tokens}])
 
      (when-not (empty? stroke-ids)
-       [:& stroke-menu {:type type :ids stroke-ids :values stroke-values}])
+       [:& stroke-menu {:type type
+                        :ids stroke-ids
+                        :values stroke-values
+                        :shapes shapes
+                        :shapes-with-children shapes-with-children
+                        :applied-tokens stroke-tokens}])
 
      [:> color-selection-menu*
       {:type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/group.cljs
@@ -90,7 +90,7 @@
         [constraint-ids constraint-values]
         (get-attrs shapes objects :constraint)
 
-        [fill-ids fill-values]
+        [fill-ids fill-values fill-tokens]
         (get-attrs shapes objects :fill)
 
         [shadow-ids]
@@ -143,7 +143,13 @@
        [:& constraints-menu {:ids constraint-ids :values constraint-values}])
 
      (when-not (empty? fill-ids)
-       [:> fill/fill-menu* {:type type :ids fill-ids :values fill-values}])
+       [:> fill/fill-menu*
+        {:type type
+         :ids fill-ids
+         :values fill-values
+         :shapes shapes
+         :shapes-with-children shapes-with-children
+         :applied-tokens fill-tokens}])
 
      (when-not (empty? stroke-ids)
        [:& stroke-menu {:type type :ids stroke-ids :values stroke-values}])

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -475,6 +475,7 @@
                             :ids fill-ids
                             :values fill-values
                             :shapes shapes
+                            :objects objects
                             :applied-tokens fill-tokens}])
 
      (when-not (empty? stroke-ids)
@@ -483,6 +484,7 @@
                         :show-caps show-caps?
                         :values stroke-values
                         :shapes shapes
+                        :objects objects
                         :disable-stroke-style has-text?
                         :applied-tokens stroke-tokens}])
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -214,21 +214,23 @@
 
         merge-token-values
         (fn [acc shape-attrs applied-tokens]
-          (reduce
-           (fn [accum shape-attr]
-             (let [token-attrs (tt/shape-attr->token-attrs shape-attr)]
-               (reduce
-                (fn [a t-attr]
-                  (let [new-val  (get applied-tokens t-attr)
-                        existing (get a t-attr ::not-found)]
-                    (cond
-                      (= existing ::not-found) (assoc a t-attr new-val)
-                      (= existing new-val)     a
-                      :else                    (assoc a t-attr :multiple))))
-                accum
-                token-attrs)))
-           acc
-           shape-attrs))
+          (if (seq applied-tokens)
+            (reduce
+             (fn [accum shape-attr]
+               (let [token-attrs (tt/shape-attr->token-attrs shape-attr)]
+                 (reduce
+                  (fn [a t-attr]
+                    (let [new-val  (get applied-tokens t-attr)
+                          existing (get a t-attr ::not-found)]
+                      (cond
+                        (= existing ::not-found) (assoc a t-attr new-val)
+                        (= existing new-val)     a
+                        :else                    (assoc a t-attr :multiple))))
+                  accum
+                  token-attrs)))
+             acc
+             shape-attrs)
+            acc))
 
         extract-attrs
         (fn [[ids values token-acc] {:keys [id type applied-tokens] :as shape}]
@@ -391,7 +393,7 @@
         [blur-ids blur-values]
         (get-attrs shapes objects :blur)
 
-        [stroke-ids stroke-values]
+        [stroke-ids stroke-values stroke-tokens]
         (get-attrs shapes objects :stroke)
 
         [exports-ids exports-values]
@@ -480,7 +482,9 @@
                         :ids stroke-ids
                         :show-caps show-caps?
                         :values stroke-values
-                        :disable-stroke-style has-text?}])
+                        :shapes shapes
+                        :disable-stroke-style has-text?
+                        :applied-tokens stroke-tokens}])
 
      (when-not (empty? shapes)
        [:> color-selection-menu*

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
@@ -127,7 +127,9 @@
      [:& stroke-menu {:ids ids
                       :type type
                       :show-caps true
-                      :values stroke-values}]
+                      :values stroke-values
+                      :shapes shapes
+                      :applied-tokens applied-tokens}]
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
      [:& blur-menu {:ids ids
                     :values (select-keys shape [:blur])}]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/path.cljs
@@ -120,7 +120,9 @@
      [:> fill/fill-menu*
       {:ids ids
        :type type
-       :values shape}]
+       :values shape
+       :shapes shapes
+       :applied-tokens applied-tokens}]
 
      [:& stroke-menu {:ids ids
                       :type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
@@ -126,7 +126,9 @@
 
      [:& stroke-menu {:ids ids
                       :type type
-                      :values stroke-values}]
+                      :shapes shapes
+                      :values stroke-values
+                      :applied-tokens applied-tokens}]
 
      [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/rect.cljs
@@ -120,7 +120,9 @@
      [:> fill/fill-menu*
       {:ids ids
        :type type
-       :values shape}]
+       :shapes shapes
+       :values shape
+       :applied-tokens applied-tokens}]
 
      [:& stroke-menu {:ids ids
                       :type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
@@ -194,7 +194,9 @@
 
        [:& stroke-menu {:ids ids
                         :type type
-                        :values stroke-values}]
+                        :values stroke-values
+                        :shapes shapes
+                        :applied-tokens applied-tokens}]
 
        [:> shadow-menu* {:ids ids :values (get shape :shadow)}]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/svg_raw.cljs
@@ -188,7 +188,9 @@
        [:> fill/fill-menu*
         {:ids ids
          :type type
-         :values fill-values}]
+         :values fill-values
+         :shapes shapes
+         :applied-tokens applied-tokens}]
 
        [:& stroke-menu {:ids ids
                         :type type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -180,7 +180,9 @@
      [:& stroke-menu {:ids ids
                       :type type
                       :values stroke-values
-                      :disable-stroke-style true}]
+                      :shapes shapes
+                      :disable-stroke-style true
+                      :applied-tokens applied-tokens}]
 
      (when (= :multiple (:fills fill-values))
        [:> color-selection-menu*

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -173,7 +173,9 @@
      [:> fill/fill-menu*
       {:ids ids
        :type type
-       :values fill-values}]
+       :values fill-values
+       :shapes shapes
+       :applied-tokens applied-tokens}]
 
      [:& stroke-menu {:ids ids
                       :type type

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1184,7 +1184,11 @@ msgstr "Detach token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:39
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "This token is not available in any active set or theme."
+msgstr "This token is not in any active set or has an invalid value."
+
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+msgid "color-row.token-color-row.deleted-token"
+msgstr "This token does not exists or has been deleted."
 
 #: src/app/main/data/auth.cljs:314
 msgid "errors.auth-provider-not-allowed"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1196,7 +1196,11 @@ msgstr "Desvincular token"
 
 #: src/app/main/ui/ds/controls/utilities/token_field.cljs:39
 msgid "ds.inputs.token-field.no-active-token-option"
-msgstr "Este token no está disponible en ningún set ni tema activo."
+msgstr "Este token no está disponible en ningún set o tiene un valor inválido."
+
+#: src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+msgid "color-row.token-color-row.deleted-token"
+msgstr "Este token no existe o ha sido borrado."
 
 #: src/app/main/data/auth.cljs:314
 msgid "errors.auth-provider-not-allowed"


### PR DESCRIPTION
### Related Ticket

This PR solves [this task](https://tree.taiga.io/project/penpot/task/11366)

### Summary

We have added a token pill to color inputs for fills and strokes on any shape. We have also added the token pill to group fill and group stroke. 

### Steps to reproduce 
Activate "enable-token-color" config flag to be able to see this.

1. Create some shapes, you can try with different shapes
2. Create color tokens
3. Apply those tokens to the shapes you hace created, 
4. Token pill should be visible on design-panel
<img width="507" height="160" alt="Screenshot from 2025-10-01 14-19-31" src="https://github.com/user-attachments/assets/d1d00c23-1c75-442f-b3fe-5c0ea39ede50" />
<img width="507" height="190" alt="Screenshot from 2025-10-01 14-19-42" src="https://github.com/user-attachments/assets/bdc0f353-f433-43a4-9754-07bb0c9f1658" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
