### PR TITLE
:bug: Fix context menu on spacing tokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@
 - Fix conflicting shortcuts (remove dec/inc line height and letter spacing) [Taiga #12102](https://tree.taiga.io/project/penpot/issue/12102)
 - Fix conflicting shortcuts (remove text-align shortcuts) [Taiga #12047](https://tree.taiga.io/project/penpot/issue/12047)
 - Fix export file with empty tokens library [Taiga #12137](https://tree.taiga.io/project/penpot/issue/12137)
+- Fix context menu on spacing tokens [Taiga #12141](https://tree.taiga.io/project/penpot/issue/12141)
 
 ## 2.9.0
 

--- a/common/src/app/common/types/token.cljc
+++ b/common/src/app/common/types/token.cljc
@@ -139,6 +139,13 @@
 
 (def spacing-keys (schema-keys schema:spacing))
 
+(def ^:private schema:spacing-gap-padding
+  (-> (reduce mu/union [schema:spacing-gap
+                        schema:spacing-padding])
+      (mu/update-properties assoc :title "SpacingGapPaddingTokenAttrs")))
+
+(def spacing-gap-padding-keys (schema-keys schema:spacing-gap-padding))
+
 (def ^:private schema:dimensions
   (-> (reduce mu/union [schema:sizing
                         schema:spacing
@@ -320,9 +327,9 @@
   (set/union generic-attributes
              border-radius-keys))
 
-(def frame-attributes
+(def frame-with-layout-attributes
   (set/union rect-attributes
-             spacing-keys))
+             spacing-gap-padding-keys))
 
 (def text-attributes
   (set/union generic-attributes
@@ -330,12 +337,14 @@
              number-keys))
 
 (defn shape-type->attributes
-  [type]
+  [type is-layout]
   (case type
     :bool    generic-attributes
     :circle  generic-attributes
     :rect    rect-attributes
-    :frame   frame-attributes
+    :frame   (if is-layout
+               frame-with-layout-attributes
+               rect-attributes)
     :image   rect-attributes
     :path    generic-attributes
     :svg-raw generic-attributes
@@ -343,14 +352,14 @@
     nil))
 
 (defn appliable-attrs
-  "Returns intersection of shape `attributes` for `token-type`."
-  [attributes token-type]
-  (set/intersection attributes (shape-type->attributes token-type)))
+  "Returns intersection of shape `attributes` for `shape-type`."
+  [attributes shape-type is-layout]
+  (set/intersection attributes (shape-type->attributes shape-type is-layout)))
 
 (defn any-appliable-attr?
   "Checks if `token-type` supports given shape `attributes`."
-  [attributes token-type]
-  (seq (appliable-attrs attributes token-type)))
+  [attributes token-type is-layout]
+  (seq (appliable-attrs attributes token-type is-layout)))
 
 ;; Token attrs that are set inside content blocks of text shapes, instead
 ;; at the shape level.

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -487,7 +487,7 @@
                                                 (or
                                                  (and (ctsl/any-layout-immediate-child? objects shape)
                                                       (some ctt/spacing-margin-keys attributes))
-                                                 (ctt/any-appliable-attr? attributes (:type shape))))))
+                                                 (ctt/any-appliable-attr? attributes (:type shape) (:layout shape))))))
                           shape-ids (d/nilv (keys shapes)  [])
                           any-variant? (->> shapes vals (some ctk/is-variant?) boolean)
 

--- a/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/context_menu.cljs
@@ -341,7 +341,7 @@
                           (:id token)))}]))
 
 (defn- allowed-shape-attributes [shapes]
-  (reduce into #{} (map #(ctt/shape-type->attributes (:type %)) shapes)))
+  (reduce into #{} (map #(ctt/shape-type->attributes (:type %) (:layout %)) shapes)))
 
 (defn menu-actions [{:keys [type token selected-shapes] :as context-data}]
   (let [context-data (assoc context-data :allowed-shape-attributes (allowed-shape-attributes selected-shapes))
@@ -445,7 +445,8 @@
                   (if (some? type)
                     (submenu-actions-selection-actions context-data)
                     (selection-actions context-data))
-                  (default-actions context-data))]
+                  (default-actions context-data))
+        entries (clean-separators entries)]
     (for [[index {:keys [title action selected? hint submenu no-selectable] :as entry}] (d/enumerate entries)]
       [:* {:key (dm/str title " " index)}
        (cond

--- a/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/token_pill.cljs
@@ -191,7 +191,7 @@
    ;; Edge-case for allowing margin attribute on shapes inside layout parent
    (and selected-inside-layout? (set/subset? ctt/spacing-margin-keys attrs))
    (some (fn [shape]
-           (ctt/any-appliable-attr? attrs (:type shape)))
+           (ctt/any-appliable-attr? attrs (:type shape) (:layout shape)))
          selected-shapes)))
 
 (def token-types-with-status-icon

--- a/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
+++ b/frontend/test/frontend_tests/tokens/logic/token_actions_test.cljs
@@ -296,10 +296,10 @@
                  frame-1' (cths/get-shape file' :frame-1)
                  frame-2' (cths/get-shape file' :frame-2)]
              (t/testing "shape `:applied-tokens` got updated"
-               (t/is (= (:p1 (:applied-tokens frame-1')) (:name token-target')))
-               (t/is (= (:p2 (:applied-tokens frame-1')) (:name token-target')))
-               (t/is (= (:p3 (:applied-tokens frame-1')) (:name token-target')))
-               (t/is (= (:p4 (:applied-tokens frame-1')) (:name token-target')))
+               (t/is (= (:p1 (:applied-tokens frame-1')) nil))
+               (t/is (= (:p2 (:applied-tokens frame-1')) nil))
+               (t/is (= (:p3 (:applied-tokens frame-1')) nil))
+               (t/is (= (:p4 (:applied-tokens frame-1')) nil))
 
                (t/is (= (:p1 (:applied-tokens frame-2')) (:name token-target')))
                (t/is (= (:p2 (:applied-tokens frame-2')) (:name token-target')))


### PR DESCRIPTION
### Related Ticket

This PR fixes [this bug](https://tree.taiga.io/project/penpot/issue/12141)

### Summary

Check context menu options for:
- Simple boards
- layout boards
- boards as layout items
- layour boards as layout items

### Steps to reproduce 
Create one of each
- Simple boards
- layout boards
- boards as layout items
- layour boards as layout items

Create some spacing and dimension tokens. 

- On simple boards we can not apply spacing tokens
- On layout boards we can apply   **gaps** and **paddings**
- boards as layout items  **margins**
- layour boards as layout items   **margins** **gaps** and **paddings**

Check that those spacing options appear under dimension token context menu as well.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
