### PR TITLE
:wrench: Improve image parsing performance

### DIFF
--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -301,34 +301,6 @@ pub extern "C" fn set_children() {
 }
 
 #[no_mangle]
-pub extern "C" fn store_image(
-    a1: u32,
-    b1: u32,
-    c1: u32,
-    d1: u32,
-    a2: u32,
-    b2: u32,
-    c2: u32,
-    d2: u32,
-) {
-    with_state_mut!(state, {
-        let image_id = uuid_from_u32_quartet(a2, b2, c2, d2);
-        let image_bytes = mem::bytes();
-
-        if let Err(msg) = state.render_state_mut().add_image(image_id, &image_bytes) {
-            eprintln!("{}", msg);
-        }
-
-        mem::free_bytes();
-    });
-
-    with_state_mut!(state, {
-        let shape_id = uuid_from_u32_quartet(a1, b1, c1, d1);
-        state.update_tile_for_shape(shape_id);
-    });
-}
-
-#[no_mangle]
 pub extern "C" fn is_image_cached(a: u32, b: u32, c: u32, d: u32) -> bool {
     with_state_mut!(state, {
         let id = uuid_from_u32_quartet(a, b, c, d);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/task/12165

### Summary

Use heap32 to set image bytes and refactor

### Steps to reproduce 

Load heavy images and compare loading time

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.

