### PR TITLE
:bug: Fixes resolved value previews in composite typography token form

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -929,16 +929,18 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
 
 (mf/defc typography-value-inputs*
   [{:keys [default-value on-blur on-update-value token-resolve-result]}]
-  (let [typography-inputs (mf/use-memo typography-inputs)
+  (let [composite-token? (not (ctt/typography-composite-token-reference? (:value token-resolve-result)))
+        typography-inputs (mf/use-memo typography-inputs)
         errors-by-key (sd/collect-typography-errors token-resolve-result)]
     [:div {:class (stl/css :nested-input-row)}
      (for [[k {:keys [label placeholder icon]}] typography-inputs]
        (let [value (get default-value k)
              token-resolve-result
-             (-> {:resolved-value (let [v (get-in token-resolve-result [:resolved-value k])]
-                                    (when-not (str/empty? v) v))
-                  :errors (get errors-by-key k)}
-                 (d/without-nils))
+             (when composite-token?
+               (-> {:resolved-value (let [v (get-in token-resolve-result [:resolved-value k])]
+                                      (when-not (str/empty? v) v))
+                    :errors (get errors-by-key k)}
+                   (d/without-nils)))
 
              input-ref (mf/use-ref)
 

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -852,7 +852,7 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
       {:placeholder (or placeholder (tr "workspace.tokens.token-font-family-value-enter"))
        :label label
        :aria-label aria-label
-       :value (or (:name font) default-value)
+       :default-value (or (:name font) default-value)
        :ref input-ref
        :on-blur on-blur
        :on-change on-update-value'


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/150

### Summary

- Fixes resolved values showing up when editing a typography composite token and switching tab (we disable passing the `:value` when the active tab doesn't match the token `:value` type)
- Fixes performance issue in font-family input introduced by https://github.com/penpot/penpot/pull/7316/files#diff-a344008393207d84af0f28384667d64775ebb508811976f520b71642a109999dL857-R857

### Steps to reproduce

1. Create a composite typography token
2. Create another an reference to this token and save it
3. edit the token and switch to individual tokens
4. resolved values are displayed in the empty inputs (the value is from the referenced token values)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
