### PR TITLE
:bug: Fix wrong text auto width/height layout

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -791,6 +791,7 @@
            (rx/subs! (fn [_]
                        (clear-drawing-cache)
                        (request-render "pending-finished")
+                       (h/call wasm/internal-module "_update_shape_text_layout_for_all")
                        (.dispatchEvent ^js js/document event))))
       (do
         (clear-drawing-cache)

--- a/render-wasm/src/state/shapes_pool.rs
+++ b/render-wasm/src/state/shapes_pool.rs
@@ -78,4 +78,13 @@ impl ShapesPool {
         let idx = *self.shapes_uuid_to_idx.get(id)?;
         Some(&self.shapes[idx])
     }
+
+    #[allow(dead_code)]
+    pub fn iter(&self) -> std::slice::Iter<'_, Shape> {
+        self.shapes.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Shape> {
+        self.shapes.iter_mut()
+    }
 }

--- a/render-wasm/src/wasm/text.rs
+++ b/render-wasm/src/wasm/text.rs
@@ -385,6 +385,17 @@ pub extern "C" fn update_shape_text_layout_for(a: u32, b: u32, c: u32, d: u32) {
 }
 
 #[no_mangle]
+pub extern "C" fn update_shape_text_layout_for_all() {
+    with_state_mut!(state, {
+        for shape in state.shapes.iter_mut() {
+            if let Type::Text(text_content) = &mut shape.shape_type {
+                text_content.update_layout(shape.selrect);
+            }
+        }
+    });
+}
+
+#[no_mangle]
 pub extern "C" fn get_caret_position_at(x: f32, y: f32) -> i32 {
     with_current_shape!(state, |shape: &Shape| {
         if let Type::Text(text_content) = &shape.shape_type {


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #12185](https://tree.taiga.io/project/penpot/issue/12185)

### Summary

When a text is layout using a custom font, the text auto width or text auto height layouts doesn't work as expected. 

### Steps to reproduce 

1. Open file
2. First time text (with a custom font) is rendered it's layout is wrong

#### Current behavior
<img width="1121" height="663" alt="image" src="https://github.com/user-attachments/assets/6aa62602-ea13-4342-99aa-a88078e9e239" />

#### Expected behavior
<img width="1121" height="663" alt="Screenshot from 2025-10-01 12-24-14" src="https://github.com/user-attachments/assets/b54b7c15-0c9a-4cc3-b22f-c5d60c2576fb" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
