### PR TITLE
:bug: Break loop when no parent is present

### DIFF
--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -929,6 +929,7 @@ impl Shape {
                 // FIXME: This should panic! I've removed it temporarily until
                 // we fix the problems with shapes without parents.
                 // panic!("Parent can't be found");
+                break;
             }
         }
 
@@ -957,6 +958,7 @@ impl Shape {
                 // FIXME: This should panic! I've removed it temporarily until
                 // we fix the problems with shapes without parents.
                 // panic!("Parent can't be found");
+                break;
             }
         }
         matrix


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12189

### Summary

Until we tackle the issue above, this is a minor change to prevent an infinite loop

### Steps to reproduce 

- Load this penpot file: [test_texts_group.zip](https://github.com/user-attachments/files/22636023/test_texts_group.zip)
- Check it renders correctly and does not hang 
