### PR TITLE
:bug: Fix form not being saveable when editing composite token and sw…

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/form.cljs
@@ -277,7 +277,8 @@ on-get-token-value: Custom function to get the input value from the dom
 Custom component props:
 custom-input-token-value: Custom component for editing/displaying the token value
 custom-input-token-value-props: Custom props passed to the custom-input-token-value merged with the default props"
-  [{:keys [token
+  [{:keys [is-create
+           token
            token-type
            selected-token-set-id
            action
@@ -292,8 +293,7 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
            custom-input-token-value
            custom-input-token-value-props]
     :or {validate-token default-validate-token}}]
-  (let [create? (not (instance? ctob/Token token))
-        token (or token {:type token-type})
+  (let [token (or token {:type token-type})
         token-properties (dwta/get-token-properties token)
         tokens-in-selected-set (mf/deref refs/workspace-all-tokens-in-selected-set)
 
@@ -451,7 +451,7 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
 
         on-submit
         (mf/use-fn
-         (mf/deps create? validate-name validate-descripion token active-theme-tokens validate-token)
+         (mf/deps is-create validate-name validate-descripion token active-theme-tokens validate-token)
          (fn [e]
            (dom/prevent-default e)
            ;; We have to re-validate the current form values before submitting
@@ -478,7 +478,7 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
                     (rx/subs!
                      (fn [valid-token]
                        (st/emit!
-                        (if create?
+                        (if is-create
                           (dwtl/create-token {:name final-name
                                               :type token-type
                                               :value (:value valid-token)
@@ -534,9 +534,10 @@ custom-input-token-value-props: Custom props passed to the custom-input-token-va
     ;; Update the value when editing an existing token
     ;; so the user doesn't have to interact with the form to validate the token
     (mf/use-effect
-     (mf/deps create? resolved-tokens token token-resolve-result set-resolve-value)
+     (mf/deps is-create token resolved-tokens token-resolve-result set-resolve-value)
      (fn []
-       (when (and (not create?)
+       (when (and (not is-create)
+                  (:value token) ;; Don't retrigger this effect when switching tabs on composite tokens
                   (not token-resolve-result)
                   resolved-tokens)
          (-> (get resolved-tokens @token-name-ref)

--- a/frontend/src/app/main/ui/workspace/tokens/management/create/modals.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/create/modals.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data.macros :as dm]
+   [app.common.types.tokens-lib :as ctob]
    [app.main.data.modal :as modal]
    [app.main.refs :as refs]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
@@ -88,7 +89,8 @@
                        :icon i/close
                        :variant "action"
                        :aria-label (tr "labels.close")}]
-     [:> form-wrapper* {:token token
+     [:> form-wrapper* {:is-create (not (ctob/token? token))
+                        :token token
                         :action action
                         :selected-token-set-id selected-token-set-id
                         :token-type token-type


### PR DESCRIPTION
### Related Ticket

### Summary

- Raises prop if form is being edited or created to the consumer
- Fixes submit-hook being re-triggered when switching tabs and enabling submit on the form, despite empty value.
 (Composite form removes the `:value` from `token` when switching the tab, as it doesn't match the tab type)

### Steps to reproduce

1. Edit existing typography toke
2. Switch tabs
3. Form should be disabled
4. Enter value
5. If valid -> should be enabled

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
