### PR TITLE
:recycle: Refactor token tabs component

### DIFF
--- a/frontend/playwright/ui/specs/tokens.spec.js
+++ b/frontend/playwright/ui/specs/tokens.spec.js
@@ -1006,9 +1006,16 @@ test.describe("Tokens: Themes modal", () => {
       const referenceTabButton =
         tokensUpdateCreateModal.getByTestId("reference-opt");
       await referenceTabButton.click();
+
+      // Empty reference tab should be disabled
+      await expect(saveButton).toBeDisabled();
+
       const compositeTabButton =
         tokensUpdateCreateModal.getByTestId("composite-opt");
       await compositeTabButton.click();
+
+      // Filled composite tab should be enabled
+      await expect(saveButton).toBeEnabled();
 
       // Verify all values are preserved after switching tabs
       await expect(fontSizeField).toHaveValue(originalValues.fontSize);


### PR DESCRIPTION
### Related Ticket

https://github.com/tokens-studio/penpot/issues/151

### Summary

- Extracts the tabs form wrapper to be re-used by other composite tokens (shadow-token)
- Fixes issues where emptied fields would re-trigger validation when switching tabs and not being able to save composite form

### Steps to reproduce

1. Edit/Create typography token
2. Fill field
3. Empty field
4. Switch tabs to reference and back
5. No validation warnings should show for the empty field

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
