### PR TITLE
:tada: Reorder properties for a component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 - Switch several variant copies at the same time [Taiga #11411](https://tree.taiga.io/project/penpot/us/11411)
 - Invitations management improvements [Taiga #3479](https://tree.taiga.io/project/penpot/us/3479)
 - Alternative ways of creating variants - Button Viewport [Taiga #11931](https://tree.taiga.io/project/penpot/us/11931)
+- Reorder properties for a component [Taiga #10225](https://tree.taiga.io/project/penpot/us/10225)
 
 ### :bug: Bugs fixed
 

--- a/common/src/app/common/logic/variant_properties.cljc
+++ b/common/src/app/common/logic/variant_properties.cljc
@@ -81,6 +81,26 @@
                                        #(assoc % :variant-error value))))))
 
 
+(defn generate-reorder-variant-poperties
+  [changes variant-id from-pos to-space-between-pos]
+  (let [data               (pcb/get-library-data changes)
+        objects            (pcb/get-objects changes)
+        related-components (cfv/find-variant-components data objects variant-id)]
+    (reduce (fn [changes component]
+              (let [props   (:variant-properties component)
+                    props   (ctv/reorder-by-moving-to-position props from-pos to-space-between-pos)
+                    main-id (:main-instance-id component)
+                    name    (ctv/properties-to-name props)]
+                (-> changes
+                    (pcb/update-component (:id component)
+                                          #(assoc % :variant-properties props)
+                                          {:apply-changes-local-library? true})
+                    (pcb/update-shapes [main-id]
+                                       #(assoc % :variant-name name)))))
+            changes
+            related-components)))
+
+
 (defn generate-add-new-property
   [changes variant-id & {:keys [fill-values? editing? property-name property-value]}]
   (let [data               (pcb/get-library-data changes)

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -310,3 +310,27 @@
    the real name of the shape joined by the properties values separated by '/'"
   [variant]
   (cpn/merge-path-item (:name variant) (str/replace (:variant-name variant) #", " " / ")))
+
+(defn reorder-by-moving-to-position
+  "Reorder a vector by moving one of their items from some position to some space between positions.
+   It clamps the position numbers to a valid range."
+  [props from-pos to-space-between-pos]
+  (let [num-props  (count props)
+        num-spaces (inc num-props)
+
+        from-pos             (max 0 (min num-props from-pos))
+        to-space-between-pos (max 0 (min num-spaces to-space-between-pos))]
+
+    (if (= from-pos to-space-between-pos)
+      props
+      (let [elem         (nth props from-pos)
+            without-elem (-> []
+                             (into (subvec props 0 from-pos))
+                             (into (subvec props (inc from-pos))))
+            insert-pos   (if (< from-pos to-space-between-pos)
+                           (dec to-space-between-pos)
+                           to-space-between-pos)]
+        (-> []
+            (into (subvec without-elem 0 insert-pos))
+            (into [elem])
+            (into (subvec without-elem insert-pos)))))))

--- a/common/src/app/common/types/variant.cljc
+++ b/common/src/app/common/types/variant.cljc
@@ -315,11 +315,11 @@
   "Reorder a vector by moving one of their items from some position to some space between positions.
    It clamps the position numbers to a valid range."
   [props from-pos to-space-between-pos]
-  (let [num-props  (count props)
-        num-spaces (inc num-props)
+  (let [max-space-pos  (count props)
+        max-prop-pos   (dec max-space-pos)
 
-        from-pos             (max 0 (min num-props from-pos))
-        to-space-between-pos (max 0 (min num-spaces to-space-between-pos))]
+        from-pos             (max 0 (min max-prop-pos from-pos))
+        to-space-between-pos (max 0 (min max-space-pos to-space-between-pos))]
 
     (if (= from-pos to-space-between-pos)
       props

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -187,4 +187,20 @@
       (t/is (= (ctv/reorder-by-moving-to-position props 3 2) [{:name "border" :value "no"}
                                                               {:name "color" :value "blue"}
                                                               {:name "background" :value "none"}
-                                                              {:name "shadow" :value "yes"}])))))
+                                                              {:name "shadow" :value "yes"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 0 5) [{:name "color" :value "blue"}
+                                                              {:name "shadow" :value "yes"}
+                                                              {:name "background" :value "none"}
+                                                              {:name "border" :value "no"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 3 -1) [{:name "background" :value "none"}
+                                                               {:name "border" :value "no"}
+                                                               {:name "color" :value "blue"}
+                                                               {:name "shadow" :value "yes"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 5 -1) [{:name "background" :value "none"}
+                                                               {:name "border" :value "no"}
+                                                               {:name "color" :value "blue"}
+                                                               {:name "shadow" :value "yes"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props -1 5) [{:name "color" :value "blue"}
+                                                               {:name "shadow" :value "yes"}
+                                                               {:name "background" :value "none"}
+                                                               {:name "border" :value "no"}])))))

--- a/common/test/common_tests/variant_test.cljc
+++ b/common/test/common_tests/variant_test.cljc
@@ -159,3 +159,32 @@
 
     (t/testing "update-number-in-repeated-prop-names"
       (t/is (= (ctv/update-number-in-repeated-prop-names props) numbered-props)))))
+
+
+(t/deftest reorder-by-moving-to-position
+  (let [props [{:name "border" :value "no"}
+               {:name "color" :value "blue"}
+               {:name "shadow" :value "yes"}
+               {:name "background" :value "none"}]]
+
+    (t/testing "reorder-by-moving-to-position"
+      (t/is (= (ctv/reorder-by-moving-to-position props 0 2) [{:name "color" :value "blue"}
+                                                              {:name "border" :value "no"}
+                                                              {:name "shadow" :value "yes"}
+                                                              {:name "background" :value "none"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 0 3) [{:name "color" :value "blue"}
+                                                              {:name "shadow" :value "yes"}
+                                                              {:name "border" :value "no"}
+                                                              {:name "background" :value "none"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 0 4) [{:name "color" :value "blue"}
+                                                              {:name "shadow" :value "yes"}
+                                                              {:name "background" :value "none"}
+                                                              {:name "border" :value "no"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 3 0) [{:name "background" :value "none"}
+                                                              {:name "border" :value "no"}
+                                                              {:name "color" :value "blue"}
+                                                              {:name "shadow" :value "yes"}]))
+      (t/is (= (ctv/reorder-by-moving-to-position props 3 2) [{:name "border" :value "no"}
+                                                              {:name "color" :value "blue"}
+                                                              {:name "background" :value "none"}
+                                                              {:name "shadow" :value "yes"}])))))

--- a/frontend/playwright/ui/specs/workspace.spec.js
+++ b/frontend/playwright/ui/specs/workspace.spec.js
@@ -271,7 +271,7 @@ test("Bug 9066 - Problem with grid layout", async ({ page }) => {
   await workspacePage.clickToggableLayer("Group");
   await page.getByText("A", { exact: true }).click();
 
-  await workspacePage.rightSidebar.getByTestId("swap-component-btn").click();
+  await workspacePage.rightSidebar.getByTestId("component-pill-button").click();
 
   await page.getByTitle("C", { exact: true }).click();
 

--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -262,6 +262,28 @@
          (dch/commit-changes changes)
          (dwu/commit-undo-transaction undo-id))))))
 
+(defn reorder-variant-poperties
+  "Reorder properties by moving a property from some position to some space between positions"
+  [variant-id from-pos to-space-between-pos]
+  (ptk/reify ::reorder-variant-properties
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [page-id (:current-page-id state)
+            data    (dsh/lookup-file-data state)
+            objects (-> (dsh/get-page data page-id)
+                        (get :objects))
+
+            changes (-> (pcb/empty-changes it page-id)
+                        (pcb/with-library-data data)
+                        (pcb/with-objects objects)
+                        (clvp/generate-reorder-variant-poperties variant-id from-pos to-space-between-pos))
+
+            undo-id (js/Symbol)]
+        (rx/of
+         (dwu/start-undo-transaction undo-id)
+         (dch/commit-changes changes)
+         (dwu/commit-undo-transaction undo-id))))))
+
 (defn- set-variant-id
   "Sets the variant-id on a component"
   [component-id variant-id]

--- a/frontend/src/app/main/ui/hooks.cljs
+++ b/frontend/src/app/main/ui/hooks.cljs
@@ -65,10 +65,10 @@
 
 (def sortable-ctx (mf/create-context nil))
 
-(mf/defc sortable-container
-  [{:keys [children] :as props}]
+(mf/defc sortable-container*
+  [{:keys [children]}]
   (let [global-drag-end (mf/use-memo #(rx/subject))]
-    [:& (mf/provider sortable-ctx) {:value global-drag-end}
+    [:> (mf/provider sortable-ctx) {:value global-drag-end}
      children]))
 
 

--- a/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/colorpicker/gradients.cljs
@@ -356,7 +356,7 @@
                          :icon i/add}]]]
 
      [:div {:class (stl/css :gradient-stops-list)}
-      [:& h/sortable-container {}
+      [:> h/sortable-container* {}
        (for [[index stop] (d/enumerate stops)]
          [:> stop-input-row*
           {:key index

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -72,7 +72,7 @@
         highlighted    (hooks/use-equal-memo highlighted)
         root           (get objects uuid/zero)]
     [:div {:class (stl/css :element-list) :data-testid "layer-item"}
-     [:& hooks/sortable-container {}
+     [:> hooks/sortable-container* {}
       (for [[index id] (reverse (d/enumerate (:shapes root)))]
         (when-let [obj (get objects id)]
           (if (cfh/frame-shape? obj)

--- a/frontend/src/app/main/ui/workspace/sidebar/options.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options.cljs
@@ -23,7 +23,7 @@
    [app.main.ui.workspace.sidebar.options.drawing :as drawing]
    [app.main.ui.workspace.sidebar.options.menus.align :refer [align-options*]]
    [app.main.ui.workspace.sidebar.options.menus.bool :refer [bool-options*]]
-   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.grid-cell :as grid-cell]
    [app.main.ui.workspace.sidebar.options.menus.interactions :refer [interactions-menu]]
    [app.main.ui.workspace.sidebar.options.menus.layout-container :as layout-container]
@@ -89,7 +89,7 @@
   {::mf/private true}
   [{:keys [panel]}]
   (when (= (:type panel) :component-swap)
-    [:& component-menu {:shapes (:shapes panel) :swap-opened? true}]))
+    [:> component-menu* {:shapes (:shapes panel) :is-swap-opened true}]))
 
 (mf/defc design-menu*
   {::mf/private true}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -151,12 +151,11 @@
                                 (dw/set-annotations-id-for-create nil))
                               (dw/update-component-annotation component-id nil)
                               (rerender-fn)))]
-             (st/emit! (modal/show
-                        {:type :confirm
-                         :title (tr "modals.delete-component-annotation.title")
-                         :message (tr "modals.delete-component-annotation.message")
-                         :accept-label (tr "ds.confirm-ok")
-                         :on-accept on-accept})))))]
+             (st/emit! (modal/show {:type :confirm
+                                    :title (tr "modals.delete-component-annotation.title")
+                                    :message (tr "modals.delete-component-annotation.message")
+                                    :accept-label (tr "ds.confirm-ok")
+                                    :on-accept on-accept})))))]
 
     (mf/with-effect [shape-id state create-id creating?]
       (when-let [textarea (mf/ref-val textarea-ref)]
@@ -173,31 +172,28 @@
           (st/emit! (dw/set-annotations-id-for-create nil)))))
 
     (when (or creating? annotation)
-      [:div {:class (stl/css-case
-                     :component-annotation true
-                     :editing editing?
-                     :creating creating?)}
-       [:div {:class (stl/css-case
-                      :annotation-title true
-                      :expandeable (not (or editing? creating?))
-                      :expanded expanded?)
+      [:div {:class (stl/css-case :annotation true
+                                  :editing editing?
+                                  :creating creating?)}
+       [:div {:class (stl/css-case :annotation-title true
+                                   :expandeable (not (or editing? creating?))
+                                   :expanded expanded?)
               :on-click on-toggle-expand}
 
         (if (or editing? creating?)
-          [:span {:class (stl/css :annotation-text)}
+          [:span {:class (stl/css :annotation-title-name)}
            (if editing?
              (tr "workspace.options.component.edit-annotation")
              (tr "workspace.options.component.create-annotation"))]
 
           [:*
-           [:span {:class (stl/css-case
-                           :icon-arrow true
-                           :expanded expanded?)}
-            deprecated-icon/arrow]
-           [:span {:class (stl/css :annotation-text)}
+           [:> icon* {:icon-id (if expanded? i/arrow-down i/arrow-right)
+                      :class (stl/css :annotation-title-icon-arrow)
+                      :size "s"}]
+           [:span {:class (stl/css :annotation-title-name)}
             (tr "workspace.options.component.annotation")]])
 
-        [:div {:class (stl/css :icons-wrapper)}
+        [:div {:class (stl/css :annotation-title-actions)}
          (when (and ^boolean main-instance?
                     ^boolean expanded?)
            (if (or ^boolean editing?
@@ -207,40 +203,41 @@
                               (tr "labels.create")
                               (tr "labels.save"))
                      :on-click on-save
-                     :class (stl/css-case
-                             :icon true
-                             :icon-tick true
-                             :invalid invalid-text?)}
-               deprecated-icon/tick]
-              [:div {:class (stl/css :icon :icon-cross)
+                     :class (stl/css :annotation-title-icon-action)}
+               [:> icon* {:icon-id i/tick
+                          :class (stl/css-case :annotation-title-icon-ok true
+                                               :disabled invalid-text?)}]]
+              [:div {:class (stl/css :annotation-title-icon-action)
                      :title (tr "labels.discard")
                      :on-click on-discard}
-               deprecated-icon/close]]
+               [:> icon* {:icon-id i/close
+                          :class (stl/css :annotation-title-icon-nok)}]]]
 
              [:*
-              [:div {:class (stl/css :icon :icon-edit)
+              [:div {:class (stl/css :annotation-title-icon-action)
                      :title (tr "labels.edit")
                      :on-click on-edit}
-               deprecated-icon/curve]
-              [:div {:class (stl/css :icon :icon-trash)
+               [:> icon* {:icon-id i/curve
+                          :class (stl/css :annotation-title-icon-ok)}]]
+              [:div {:class (stl/css :annotation-title-icon-action)
                      :title (tr "labels.delete")
                      :on-click on-delete-annotation}
-               deprecated-icon/delete]]))]]
+               [:> icon* {:icon-id i/delete
+                          :class (stl/css :annotation-title-icon-nok)}]]]))]]
 
-       [:div {:class (stl/css-case :hidden (not expanded?))}
-        [:div {:class (stl/css :grow-wrap)}
-         [:div {:class (stl/css :texarea-copy)}]
-         [:textarea
-          {:ref textarea-ref
-           :id "annotation-textarea"
-           :data-debug annotation
-           :auto-focus (or editing? creating?)
-           :maxLength 300
-           :on-input adjust-textarea-size
-           :default-value annotation
-           :read-only (not (or creating? editing?))}]]
+       [:div {:class (stl/css-case :annotation-body-hidden (not expanded?))}
+        [:div {:class (stl/css :annotation-body)}
+         [:textarea {:ref textarea-ref
+                     :id "annotation-textarea"
+                     :class (stl/css :annotation-textarea)
+                     :data-debug annotation
+                     :auto-focus (or editing? creating?)
+                     :max-length 300
+                     :on-input adjust-textarea-size
+                     :default-value annotation
+                     :read-only (not (or creating? editing?))}]]
         (when (or editing? creating?)
-          [:div {:class (stl/css  :counter)} (str size "/300")])]])))
+          [:div {:class (stl/css :annotation-counter)} (str size "/300")])]])))
 
 (defn- get-variant-malformed-warning-message
   "Receive a list of booleans, one for each selected variant, indicating if that variant

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -399,6 +399,7 @@
 
         reorder-properties
         (mf/use-fn
+         (mf/deps variant-id)
          (fn [from-pos to-space-between-pos]
            (st/emit! (dwv/reorder-variant-poperties variant-id from-pos to-space-between-pos))))]
 
@@ -1226,6 +1227,7 @@
 
         reorder-properties
         (mf/use-fn
+         (mf/deps variant-id)
          (fn [from-pos to-space-between-pos]
            (st/emit! (dwv/reorder-variant-poperties variant-id from-pos to-space-between-pos))))
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -4,478 +4,27 @@
 //
 // Copyright (c) KALEIDOS INC
 
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/spacing.scss" as *;
 @use "ds/typography.scss" as t;
+
 @use "refactor/common-refactor.scss" as deprecated;
 
-.element-set {
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(8, var(--sp-xxxl));
-  column-gap: var(--sp-xs);
-}
-
-.element-content {
-  @include deprecated.flexColumn;
-  display: grid;
-  grid-template-columns: repeat(8, var(--sp-xxxl));
-  row-gap: var(--sp-m);
-  padding-top: deprecated.$s-4;
-  padding-bottom: deprecated.$s-8;
-}
-
-.element-title {
-  grid-column: span 8;
-  column-gap: var(--sp-xs);
-  display: flex;
-}
-
-.title-back {
-  @include deprecated.uppercaseTitleTipography;
-  display: flex;
-  align-items: center;
-  gap: deprecated.$s-4;
-  width: 100%;
-  height: deprecated.$s-32;
-  padding: 0;
-  border: 0;
-  border-radius: deprecated.$br-8;
-  background-color: var(--title-background-color);
-  color: var(--title-foreground-color);
-  cursor: pointer;
-}
-
-.title-spacing-component {
-  justify-content: flex-start;
-  gap: deprecated.$s-8;
-  flex-grow: 1;
-}
-
-.title-bar-variant {
-  flex-grow: 0;
-}
-
-.title-actions {
-  display: flex;
-  gap: var(--sp-xs);
-}
-
-.component-line {
-  grid-column: span 8;
-  width: 100%;
-  min-height: deprecated.$s-32;
-  border-radius: deprecated.$br-8;
-  display: flex;
-  gap: var(--sp-xs);
-}
-
-.component-wrapper {
-  display: flex;
-  flex-grow: 1;
-  gap: deprecated.$s-1;
-}
-
-.component-name-wrapper {
-  @include deprecated.buttonStyle;
-  cursor: default;
-  flex-grow: 1;
-  display: grid;
-  grid-template-columns: deprecated.$s-16 1fr;
-  gap: deprecated.$s-4;
-  padding: 0 deprecated.$s-8;
-  border-radius: deprecated.$br-8 0 0 deprecated.$br-8;
-  background-color: var(--assets-item-background-color);
-  color: var(--assets-item-name-foreground-color-hover);
-
-  &.without-menu {
-    width: 100%;
-    border-radius: deprecated.$br-8;
-  }
-
-  &:focus {
-    outline: deprecated.$s-1 solid var(--color-accent-primary);
-  }
-
-  &:hover:not(:disabled) {
-    background-color: var(--assets-item-background-color-hover);
-    color: var(--assets-item-name-foreground-color-hover);
-  }
-}
-
-.component-icon {
-  display: flex;
-  height: deprecated.$s-32;
-  align-items: center;
-  color: var(--icon-foreground);
-}
-
-.component-name-outside {
-  @include deprecated.flexColumn;
-  min-height: deprecated.$s-32;
-  padding: deprecated.$s-8 0 deprecated.$s-8 deprecated.$s-2;
-  border-radius: deprecated.$br-8 0 0 deprecated.$br-8;
-  overflow: hidden;
-  gap: 0;
-}
-
-.component-name {
-  @include deprecated.bodySmallTypography;
-  @include deprecated.textEllipsis;
-  direction: rtl;
-  text-align: left;
-  height: deprecated.$s-16;
-}
-
-.component-name-inside {
-  direction: ltr;
-  unicode-bidi: bidi-override;
-}
-
-.component-parent-name {
-  @include deprecated.bodySmallTypography;
-  @include deprecated.textEllipsis;
-  direction: rtl;
-  text-align: left;
-  height: deprecated.$s-16;
-  max-width: deprecated.$s-184;
-  color: var(--title-foreground-color);
-}
-
-.component-actions {
-  position: relative;
-  width: deprecated.$s-32;
-}
-
-.component-menu-btn {
-  @extend .button-secondary;
-  cursor: unset;
-  height: 100%;
-  width: 100%;
-  border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
-
-  &.selected {
-    @extend .button-icon-selected;
-  }
-}
-
-.copy-text {
-  @include deprecated.bodySmallTypography;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  color: var(--title-foreground-color);
-}
-
-.custom-select-dropdown {
-  @extend .dropdown-wrapper;
-  right: 0;
-  left: unset;
-  width: deprecated.$s-252;
-}
-
-.not-main {
-  top: deprecated.$s-48;
-}
-
-.dropdown-element {
-  @extend .dropdown-element-base;
-}
-
-.component-path {
-  display: flex;
-  align-items: center;
-  gap: deprecated.$s-4;
-  width: 100%;
-  height: deprecated.$s-32;
-  padding: 0;
-  border: 0;
-  background-color: var(--title-background-color);
-  color: var(--title-foreground-color);
-  cursor: pointer;
-}
-
-.path-name {
-  @include deprecated.bodySmallTypography;
-  @include deprecated.textEllipsis;
-  direction: rtl;
-  height: deprecated.$s-32;
-  padding: deprecated.$s-8 0 deprecated.$s-8 deprecated.$s-2;
-  margin-right: deprecated.$s-4;
-}
-
-.component-list-empty {
-  @include deprecated.bodySmallTypography;
-  margin: 0 deprecated.$s-4 0 deprecated.$s-8;
-  color: var(--color-foreground-secondary);
-}
-
-.component-item {
-  display: flex;
-  align-items: center;
-  margin-bottom: deprecated.$s-4;
-  padding: deprecated.$s-1 deprecated.$s-8 deprecated.$s-1 deprecated.$s-1;
-  gap: deprecated.$s-8;
-  font-size: deprecated.$s-12;
-  cursor: pointer;
-  width: 100%;
-  height: deprecated.$s-44;
-  border-radius: deprecated.$br-8;
-  background-color: var(--assets-item-background-color);
-  color: var(--assets-item-name-foreground-color);
-  border: deprecated.$s-1 solid transparent;
-
-  .variant-icon {
-    background-color: none;
-    padding: deprecated.$s-2;
-    flex: 0 0 deprecated.$s-16;
-  }
-
-  .component-name {
-    @include deprecated.textEllipsis;
-    width: 80%;
-  }
-
-  .component-img {
-    flex: 0 0 deprecated.$s-40;
-    background-color: var(--assets-component-background-color);
-    border-radius: deprecated.$br-6;
-    height: deprecated.$s-40;
-    width: deprecated.$s-40;
-    padding: deprecated.$s-2;
-  }
-
-  &.selected {
-    border: deprecated.$s-1 solid var(--assets-item-border-color);
-  }
-
-  &:hover {
-    color: var(--assets-item-name-foreground-color-hover);
-    background-color: var(--assets-item-background-color-hover);
-  }
-
-  &.disabled {
-    cursor: auto;
-    color: var(--assets-item-name-foreground-color-disabled);
-    background-color: var(--assets-item-background-color);
-
-    svg {
-      cursor: auto;
-    }
-  }
-}
-
-.component-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(deprecated.$s-96, 1fr));
-  gap: deprecated.$s-4;
-}
-
-.grid-cell {
-  @include deprecated.flexCenter;
-  place-items: center;
-  aspect-ratio: 1 / 1;
-  flex-wrap: wrap;
-  position: relative;
-  padding: deprecated.$s-8;
-  border-radius: deprecated.$br-8;
-  background-color: var(--assets-component-background-color);
-  overflow: hidden;
-  cursor: pointer;
-
-  .variant-icon {
-    background-color: var(--color-background-tertiary);
-  }
-
-  img {
-    height: auto;
-    width: auto;
-    max-height: 100%;
-    max-width: 100%;
-    pointer-events: none;
-    border: 0;
-  }
-
-  .component-img {
-    height: 100%;
-    width: 100%;
-    object-fit: contain;
-  }
-
-  .component-name {
-    @include deprecated.bodySmallTypography;
-    @include deprecated.textEllipsis;
-    display: none;
-    position: absolute;
-    left: deprecated.$s-4;
-    bottom: deprecated.$s-4;
-    height: calc(deprecated.$s-24 - deprecated.$s-2);
-    width: calc(100% - 2 * deprecated.$s-4);
-    padding: deprecated.$s-2 deprecated.$s-6;
-    column-gap: deprecated.$s-4;
-    border-radius: deprecated.$br-4;
-    background-color: var(--assets-item-name-background-color);
-    border: deprecated.$s-1 solid transparent;
-    color: var(--assets-item-name-foreground-color);
-    direction: rtl;
-  }
-
-  &:hover {
-    .component-name {
-      display: block;
-    }
-  }
-
-  &.selected {
-    border: deprecated.$s-2 solid var(--assets-item-border-color);
-
-    &::before {
-      content: " ";
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      border: deprecated.$s-4 solid var(--assets-component-second-border-selected);
-      border-radius: deprecated.$br-8;
-    }
-
-    .component-name {
-      color: var(--assets-item-name-foreground-color-hover);
-    }
-  }
-
-  &.disabled {
-    background: var(--assets-component-background-color-disabled);
-    cursor: auto;
-
-    svg {
-      cursor: auto;
-    }
-
-    .component-name {
-      background: linear-gradient(
-        to top,
-        var(--assets-component-background-color-disabled) 0%,
-        transparent 100%
-      );
-      color: var(--assets-item-name-foreground-color-hover);
-    }
-  }
-}
-
-.element-set-title {
-  @include deprecated.uppercaseTitleTipography;
-  display: flex;
-  align-items: center;
-  height: deprecated.$s-32;
-  padding-left: deprecated.$s-2;
-  color: var(--title-foreground-color);
-}
-
-// Component swap
-
-.component-swap {
-  padding-top: deprecated.$s-12;
-  grid-column: span 8;
-}
-
-.component-swap-content {
-  @include deprecated.flexColumn;
-  gap: deprecated.$s-16;
-}
-
-.fields-wrapper {
-  @include deprecated.flexColumn;
-  gap: deprecated.$s-4;
-}
-
-.search-field {
-  display: flex;
-  align-items: center;
-  height: deprecated.$s-32;
-  border-radius: deprecated.$br-8;
-  font-family: "worksans", "vazirmatn", sans-serif;
-  background-color: var(--input-background-color);
-}
-
-.library-name-wrapper {
-  display: grid;
-  grid-template-columns: 1fr auto;
-}
-
-.library-name {
-  @include deprecated.bodySmallTypography;
-  @include deprecated.textEllipsis;
-  color: var(--title-foreground-color);
-  padding: deprecated.$s-8 0 deprecated.$s-8 deprecated.$s-2;
-}
-
-.swap-wrapper {
-  @include deprecated.flexColumn;
-  gap: deprecated.$s-4;
-}
-
-.listing-options-wrapper {
-  width: 100%;
-}
-
-.listing-options {
-  display: flex;
-  align-items: center;
-}
-
-.component-group {
-  @include deprecated.bodySmallTypography;
-  display: grid;
-  grid-template-columns: 1fr deprecated.$s-12;
-  height: deprecated.$s-32;
-  cursor: pointer;
-  align-items: center;
-
-  .component-group-name {
-    @include deprecated.textEllipsis;
-    color: var(--assets-item-name-foreground-color);
-  }
-
-  &:hover {
-    color: var(--assets-item-name-foreground-color-hover);
-
-    .component-group-name {
-      color: var(--assets-item-name-foreground-color-hover);
-    }
-  }
-}
-
-.component-group-icon {
-  color: var(--icon-foreground);
-}
-
-.path-wrapper {
-  display: flex;
-  max-width: deprecated.$s-232;
-  padding: deprecated.$s-8 0 deprecated.$s-8 deprecated.$s-2;
-}
-
-.component-group-path {
-  @include deprecated.textEllipsis;
-  direction: rtl;
-  color: var(--assets-item-name-foreground-color-rest);
-}
-
-// Component annotation
-
+// component-annotation needs to be redesigned & refactored
 .component-annotation {
-  @include deprecated.bodySmallTypography;
+  @include t.use-typography("body-small");
   grid-column: span 8;
-  color: var(--entry-foreground-color);
-  border-radius: deprecated.$br-8;
+  color: var(--color-foreground-secondary);
+  border-radius: $br-8;
 
   .annotation-title {
     display: flex;
     align-items: center;
-    height: deprecated.$s-32;
+    height: $sz-32;
 
     &.expanded {
-      border-bottom: deprecated.$s-1 solid var(--entry-border-color-disabled);
+      border-bottom: $b-1 solid var(--color-background-quaternary);
     }
 
     &.expandeable {
@@ -489,19 +38,21 @@
     }
 
     .icon-arrow {
-      @include deprecated.flexCenter;
-      width: deprecated.$s-28;
-      height: deprecated.$s-32;
+      cursor: pointer;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: $sz-28;
+      height: $sz-32;
       display: flex;
       margin: 0;
       padding: 0;
-      cursor: pointer;
 
       svg {
         @extend .button-icon;
-        stroke: var(--icon-foreground);
-        width: deprecated.$s-16;
-        height: deprecated.$s-16;
+        stroke: var(--color-foreground-secondary);
+        width: $sz-16;
+        height: $sz-16;
       }
 
       &.expanded svg {
@@ -510,26 +61,27 @@
     }
 
     .icon {
-      @include deprecated.flexCenter;
-      width: deprecated.$s-28;
-      height: deprecated.$s-32;
-      border-radius: deprecated.$br-8;
+      cursor: pointer;
       display: none;
+      justify-content: center;
+      align-items: center;
+      width: $sz-28;
+      height: $sz-32;
+      border-radius: $br-8;
       margin: 0;
       padding: 0;
-      cursor: pointer;
 
       svg {
         @extend .button-icon;
-        stroke: var(--icon-foreground);
-        width: deprecated.$s-16;
-        height: deprecated.$s-16;
+        stroke: var(--color-foreground-secondary);
+        width: $sz-16;
+        height: $sz-16;
       }
 
       &.icon-tick:hover,
       &.icon-edit:hover {
         svg {
-          stroke: var(--icon-foreground-accept);
+          stroke: var(--color-accent-success);
         }
       }
 
@@ -537,21 +89,21 @@
         cursor: default;
 
         svg {
-          stroke: var(--icon-foreground);
+          stroke: var(--color-foreground-secondary);
         }
       }
 
       &.icon-cross:hover,
       &.icon-trash:hover {
         svg {
-          stroke: var(--icon-foreground-discard);
+          stroke: var(--color-accent-error);
         }
       }
     }
 
     .annotation-text {
       flex-grow: 1;
-      margin-left: deprecated.$s-12;
+      margin-left: var(--sp-m);
     }
 
     &:hover {
@@ -562,10 +114,10 @@
   }
 
   &.editing {
-    border: deprecated.$s-1 solid var(--input-border-color-success);
+    border: $b-1 solid var(--color-accent-primary);
 
     .annotation-title {
-      border-bottom: deprecated.$s-1 solid var(--entry-border-color-disabled);
+      border-bottom: $b-1 solid var(--entry-border-color-disabled);
 
       .icon {
         display: flex;
@@ -573,19 +125,19 @@
     }
 
     textarea {
-      min-height: deprecated.$s-252;
+      min-height: $sz-252;
     }
   }
 
   &.creating {
-    border: deprecated.$s-1 solid var(--input-border-color-success);
+    border: $b-1 solid var(--color-accent-primary);
 
     .annotation-title .icon {
       display: flex;
     }
 
     textarea {
-      min-height: deprecated.$s-252;
+      min-height: $sz-252;
     }
   }
 
@@ -598,10 +150,10 @@
   }
 
   .counter {
-    @include deprecated.bodySmallTypography;
+    @include t.use-typography("body-small");
     text-align: right;
-    color: var(--entry-foreground-color);
-    margin: 0 deprecated.$s-8 deprecated.$s-8 0;
+    color: var(--color-foreground-secondary);
+    margin: 0 var(--sp-s) var(--sp-s) 0;
   }
 
   // Auto growing text
@@ -617,9 +169,9 @@
     }
 
     textarea {
-      background-color: var(--input-background-color-active);
-      color: var(--input-foreground-color-active);
-      padding: deprecated.$s-12;
+      background-color: var(--color-background-primary);
+      color: var(--color-foreground-primary);
+      padding: var(--sp-m);
 
       border: none;
       overflow: hidden;
@@ -647,10 +199,448 @@
   }
 }
 
-.variant-property-row {
-  @include deprecated.flexRow;
-  justify-content: space-between;
+.swap-item-list {
+  --swap-item-foreground-color: var(--color-foreground-primary);
+  --swap-item-foreground-color-hover: var(--color-foreground-primary);
+  --swap-item-foreground-color-disabled: var(--color-foreground-disabled);
+  --swap-item-background-color: var(--color-background-tertiary);
+  --swap-item-background-color-hover: var(--color-background-quaternary);
+  --swap-item-border-color: transparent;
+  --swap-item-border-color-selected: var(--color-accent-primary);
+  --swap-item-thumbnail-background-color: var(--color-canvas);
+
+  @include t.use-typography("body-small");
+  display: flex;
+  align-items: center;
+  padding: 1px var(--sp-m) 1px 1px;
+  gap: var(--sp-s);
+  height: calc($sz-32 + $sz-12);
+  border-radius: $br-8;
+  background-color: var(--swap-item-background-color);
+  color: var(--swap-item-foreground-color);
+  border: $b-1 solid var(--swap-item-border-color);
+
+  .swap-item-thumbnail {
+    flex: 0 0 $sz-40;
+    background-color: var(--swap-item-thumbnail-background-color);
+    border-radius: $br-6;
+    height: $sz-40;
+    width: $sz-40;
+    padding: var(--sp-xxs);
+  }
+
+  .swap-item-name {
+    flex: 1;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .swap-item-variant-icon {
+    flex: 0 0 $sz-16;
+    background-color: none;
+  }
+
+  &.selected {
+    --swap-item-border-color: var(--swap-item-border-color-selected);
+  }
+
+  &:hover:not(:disabled) {
+    --swap-item-foreground-color: var(--swap-item-foreground-color-hover);
+    --swap-item-background-color: var(--swap-item-background-color-hover);
+  }
+
+  &:disabled {
+    --swap-item-foreground-color: var(--swap-item-foreground-color-disabled);
+  }
+}
+
+.swap-item-grid {
+  --swap-item-foreground-color: var(--color-foreground-primary);
+  --swap-item-foreground-color-hover: var(--color-foreground-primary);
+  --swap-item-background-color: var(--color-background-primary);
+  --swap-item-border-color: var(--color-accent-primary);
+  --swap-item-border-inner-color-selected: var(--color-background-primary);
+  --swap-item-thumbnail-background-color: var(--color-canvas);
+  --swap-item-thumbnail-background-color-disabled: var(--color-foreground-secondary);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  place-items: center;
+  aspect-ratio: 1 / 1;
+  flex-wrap: wrap;
+  position: relative;
+  padding: var(--sp-s);
+  border-radius: $br-8;
+  background-color: var(--swap-item-thumbnail-background-color);
+  overflow: hidden;
+
+  .swap-item-thumbnail {
+    height: 100%;
+    width: 100%;
+    object-fit: contain;
+  }
+
+  .swap-item-name {
+    @include t.use-typography("body-small");
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    display: none;
+    position: absolute;
+    left: var(--sp-xs);
+    bottom: var(--sp-xs);
+    height: var(--sp-xxl);
+    width: calc(100% - var(--sp-xs) - var(--sp-xs));
+    padding: var(--sp-xs);
+    column-gap: var(--sp-xs);
+    border-radius: $br-4;
+    border: $b-1 solid transparent;
+    background-color: var(--swap-item-background-color);
+    color: var(--swap-item-foreground-color);
+    direction: rtl;
+  }
+
+  .swap-item-variant-icon {
+    position: absolute;
+    right: var(--sp-xxs);
+    top: var(--sp-xxs);
+    background-color: var(--color-background-tertiary);
+  }
+
+  &:hover {
+    .swap-item-name {
+      display: block;
+    }
+  }
+
+  &.selected {
+    border: $b-2 solid var(--swap-item-border-color);
+
+    &::before {
+      content: " ";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border: calc($b-2 * 2) solid var(--swap-item-border-inner-color-selected);
+      border-radius: $br-8;
+    }
+
+    .swap-item-name {
+      color: var(--swap-item-foreground-color-hover);
+    }
+  }
+
+  &:disabled {
+    background: var(--swap-item-thumbnail-background-color-disabled);
+
+    .swap-item-name {
+      background: linear-gradient(
+        to top,
+        var(--swap-item-thumbnail-background-color-disabled) 0%,
+        transparent 100%
+      );
+      color: var(--swap-item-foreground-color-hover);
+    }
+  }
+}
+
+.swap-item-variant-icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: $sz-24;
+  width: $sz-24;
+  color: var(--color-accent-secondary);
+  border-radius: $br-8;
+}
+
+.swap-group {
+  @include t.use-typography("body-small");
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 1fr var(--sp-m);
+  height: $sz-32;
+  align-items: center;
+
+  &:hover {
+    .swap-group-icon {
+      color: var(--color-foreground-primary);
+    }
+  }
+}
+
+.swap-group-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-foreground-primary);
+}
+
+.swap-group-icon {
+  color: var(--color-foreground-secondary);
+}
+
+.swap {
+  padding-block-start: var(--sp-m);
+  grid-column: span 8;
+}
+
+.swap-title {
+  @include t.use-typography("headline-small");
+  display: flex;
+  align-items: center;
+  height: $sz-32;
+  padding-inline-start: var(--sp-xxs);
+  color: var(--color-foreground-secondary);
+}
+
+.swap-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-l);
+}
+
+.swap-filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+}
+
+.swap-library {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+}
+
+.swap-library-title {
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+
+.swap-library-name {
+  @include t.use-typography("body-small");
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-foreground-secondary);
+  padding: var(--sp-s) 0 var(--sp-s) var(--sp-xxs);
+}
+
+.swap-library-back {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-xs);
   width: 100%;
+  height: $sz-32;
+  padding: 0;
+  border: 0;
+  background-color: var(--color-background-primary);
+  color: var(--color-foreground-secondary);
+}
+
+.swap-library-back-name {
+  @include t.use-typography("body-small");
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  height: $sz-32;
+  padding: var(--sp-s) 0 var(--sp-s) var(--sp-xxs);
+}
+
+.swap-library-empty {
+  @include t.use-typography("body-small");
+  margin: 0 var(--sp-xs) 0 var(--sp-s);
+  color: var(--color-foreground-secondary);
+}
+
+.swap-library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(calc($sz-48 * 2), 1fr));
+  gap: var(--sp-xs);
+}
+
+.swap-library-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+}
+
+.component-section {
+  display: grid;
+  grid-template-columns: repeat(8, var(--sp-xxxl));
+  column-gap: var(--sp-xs);
+}
+
+.component-title {
+  grid-column: span 8;
+  column-gap: var(--sp-xs);
+  display: flex;
+}
+
+.component-title-swap {
+  @include t.use-typography("headline-small");
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-xs);
+  width: 100%;
+  height: $sz-32;
+  padding: 0;
+  border: 0;
+  border-radius: $br-8;
+  background-color: var(--color-background-primary);
+  color: var(--color-foreground-secondary);
+}
+
+.component-title-bar {
+  justify-content: flex-start;
+  gap: var(--sp-s);
+  flex-grow: 1;
+}
+
+.component-title-bar-title {
+  flex-grow: 0;
+}
+
+.component-title-bar-type {
+  @include t.use-typography("body-small");
+  height: 100%;
+  display: flex;
+  align-items: center;
+  color: var(--color-foreground-secondary);
+}
+
+.component-title-actions {
+  display: flex;
+  gap: var(--sp-xs);
+}
+
+.component-content {
+  grid-column: span 8;
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--sp-m);
+  padding-block-start: var(--sp-xs);
+  padding-block-end: var(--sp-s);
+}
+
+.component-pill {
+  border-radius: $br-8;
+  display: flex;
+  gap: var(--sp-xs);
+}
+
+.component-combine {
+  justify-content: center;
+}
+
+.pill {
+  display: flex;
+  flex-grow: 1;
+  gap: 1px;
+}
+
+.pill-btn {
+  flex-grow: 1;
+  display: grid;
+  grid-template-columns: var(--sp-l) 1fr;
+  gap: var(--sp-xs);
+  padding: 0 var(--sp-m) 0 var(--sp-s);
+  border: none;
+  border-radius: $br-8;
+  background-color: var(--color-background-tertiary);
+  color: var(--color-foreground-primary);
+
+  &.with-menu {
+    border-radius: $br-8 0 0 $br-8;
+  }
+
+  &:focus {
+    outline: $b-1 solid var(--color-accent-primary);
+  }
+
+  &:hover:not(:disabled) {
+    background-color: var(--color-background-quaternary);
+    color: var(--color-foreground-primary);
+  }
+}
+
+.pill-btn-icon {
+  display: flex;
+  height: $sz-32;
+  align-items: center;
+  color: var(--color-foreground-secondary);
+}
+
+.pill-btn-name {
+  display: flex;
+  flex-direction: column;
+  min-height: $sz-32;
+  padding: var(--sp-s) 0 var(--sp-s) var(--sp-xxs);
+  border-radius: $br-8 0 0 $br-8;
+  overflow: hidden;
+  gap: 0;
+}
+
+.pill-btn-text {
+  @include t.use-typography("body-small");
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+  height: $sz-16;
+}
+
+.pill-btn-subtext {
+  @include t.use-typography("body-small");
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+  height: $sz-16;
+  color: var(--color-foreground-secondary);
+}
+
+.pill-actions {
+  flex: 0 0 $sz-32;
+  position: relative;
+}
+
+.pill-actions-btn {
+  @extend .button-secondary;
+  cursor: unset;
+  height: 100%;
+  width: 100%;
+  border-radius: 0 $br-8 $br-8 0;
+
+  &.selected {
+    @extend .button-icon-selected;
+  }
+}
+
+.pill-actions-dropdown {
+  @extend .dropdown-wrapper;
+  right: 0;
+  left: unset;
+  width: $sz-252;
+
+  &.extended {
+    top: $sz-48;
+  }
+}
+
+.pill-actions-dropdown-item {
+  @extend .dropdown-element-base;
 }
 
 .variant-property-list {
@@ -661,8 +651,34 @@
   gap: var(--sp-xs);
 }
 
+.variant-property {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  --reorder-left-position: calc(-1 * var(--sp-m) - var(--sp-xxs));
+
+  &:hover {
+    --reorder-icon-visibility: visible;
+  }
+
+  &.dnd-over-top {
+    --reorder-top-display: block;
+  }
+
+  &.dnd-over-bot {
+    --reorder-bottom-display: block;
+  }
+}
+
+.variant-property-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-xs);
+}
+
 .variant-property-container {
-  @include t.use-typography("body-small");
   display: grid;
   grid-template-columns: repeat(8, var(--sp-xxxl));
   gap: var(--sp-xs);
@@ -679,6 +695,7 @@
 }
 
 .variant-property-name {
+  @include t.use-typography("body-small");
   color: var(--color-foreground-secondary);
   display: block;
   overflow: hidden;
@@ -686,16 +703,16 @@
   white-space: nowrap;
 }
 
-.variant-warning-wrapper {
-  @include deprecated.bodySmallTypography;
+.variant-warning {
+  @include t.use-typography("body-small");
   grid-column: span 8;
 
-  border: 1px solid var(--color-background-quaternary);
-  border-radius: deprecated.$s-8;
-  padding: deprecated.$s-12;
+  border: $b-1 solid var(--color-background-quaternary);
+  border-radius: $br-8;
+  padding: var(--sp-m);
   display: flex;
   flex-direction: column;
-  gap: deprecated.$s-8;
+  gap: var(--sp-s);
 }
 
 .variant-warning-highlight {
@@ -707,69 +724,12 @@
 }
 
 .variant-warning-button {
-  @include deprecated.bodySmallTypography;
+  @include t.use-typography("body-small");
+  cursor: pointer;
   background-color: transparent;
   border: none;
   appearance: none;
   color: var(--color-accent-primary);
-  cursor: pointer;
   padding: 0;
   text-align: start;
-}
-
-.variant-icon {
-  @include deprecated.flexCenter;
-  height: deprecated.$s-24;
-  width: deprecated.$s-24;
-  color: var(--color-accent-secondary);
-  border-radius: deprecated.$s-8;
-}
-
-.variant-mark-cell {
-  position: absolute;
-  right: deprecated.$s-2;
-  top: deprecated.$s-2;
-}
-
-.combine-variant-button {
-  @include deprecated.buttonStyle;
-  @include deprecated.uppercaseTitleTipography;
-  grid-column: span 8;
-  cursor: default;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: deprecated.$s-8;
-  border-radius: deprecated.$br-8;
-  background-color: var(--assets-item-background-color);
-  color: var(--color-foreground-secondary);
-  cursor: pointer;
-
-  &:hover {
-    background-color: var(--assets-item-background-color-hover);
-    color: var(--color-foreground-primary);
-  }
-
-  &:focus {
-    outline: deprecated.$s-1 solid var(--color-accent-primary);
-  }
-}
-
-.variant-item {
-  @include deprecated.flexColumn;
-  position: relative;
-
-  --reorder-left-position: calc(-1 * var(--sp-m) - var(--sp-xxs));
-
-  &:hover {
-    --reorder-icon-visibility: visible;
-  }
-
-  &.dnd-over-top {
-    --reorder-top-display: block;
-  }
-
-  &.dnd-over-bot {
-    --reorder-bottom-display: block;
-  }
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -6,197 +6,168 @@
 
 @use "ds/_borders.scss" as *;
 @use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
 @use "ds/spacing.scss" as *;
 @use "ds/typography.scss" as t;
 
 @use "refactor/common-refactor.scss" as deprecated;
 
-// component-annotation needs to be redesigned & refactored
-.component-annotation {
+.annotation {
   @include t.use-typography("body-small");
   grid-column: span 8;
   color: var(--color-foreground-secondary);
   border-radius: $br-8;
-
-  .annotation-title {
-    display: flex;
-    align-items: center;
-    height: $sz-32;
-
-    &.expanded {
-      border-bottom: $b-1 solid var(--color-background-quaternary);
-    }
-
-    &.expandeable {
-      cursor: pointer;
-    }
-
-    div {
-      display: flex;
-      align-items: center;
-      line-height: 2.5;
-    }
-
-    .icon-arrow {
-      cursor: pointer;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: $sz-28;
-      height: $sz-32;
-      display: flex;
-      margin: 0;
-      padding: 0;
-
-      svg {
-        @extend .button-icon;
-        stroke: var(--color-foreground-secondary);
-        width: $sz-16;
-        height: $sz-16;
-      }
-
-      &.expanded svg {
-        transform: rotate(90deg);
-      }
-    }
-
-    .icon {
-      cursor: pointer;
-      display: none;
-      justify-content: center;
-      align-items: center;
-      width: $sz-28;
-      height: $sz-32;
-      border-radius: $br-8;
-      margin: 0;
-      padding: 0;
-
-      svg {
-        @extend .button-icon;
-        stroke: var(--color-foreground-secondary);
-        width: $sz-16;
-        height: $sz-16;
-      }
-
-      &.icon-tick:hover,
-      &.icon-edit:hover {
-        svg {
-          stroke: var(--color-accent-success);
-        }
-      }
-
-      &.icon-tick.invalid:hover {
-        cursor: default;
-
-        svg {
-          stroke: var(--color-foreground-secondary);
-        }
-      }
-
-      &.icon-cross:hover,
-      &.icon-trash:hover {
-        svg {
-          stroke: var(--color-accent-error);
-        }
-      }
-    }
-
-    .annotation-text {
-      flex-grow: 1;
-      margin-left: var(--sp-m);
-    }
-
-    &:hover {
-      .icon {
-        display: flex;
-      }
-    }
-  }
 
   &.editing {
     border: $b-1 solid var(--color-accent-primary);
 
     .annotation-title {
       border-bottom: $b-1 solid var(--entry-border-color-disabled);
-
-      .icon {
-        display: flex;
-      }
     }
 
-    textarea {
-      min-height: $sz-252;
+    .annotation-title-icon-action {
+      display: flex;
+    }
+
+    .annotation-title-name {
+      margin-inline-start: var(--sp-m);
+    }
+
+    .annotation-textarea {
+      min-block-size: $sz-252;
     }
   }
 
   &.creating {
     border: $b-1 solid var(--color-accent-primary);
 
-    .annotation-title .icon {
+    .annotation-title .annotation-title-icon-action {
       display: flex;
     }
 
-    textarea {
-      min-height: $sz-252;
+    .annotation-title-name {
+      margin-inline-start: var(--sp-m);
+    }
+
+    .annotation-textarea {
+      min-block-size: $sz-252;
     }
   }
+}
 
-  .hidden {
-    display: none;
+.annotation-title {
+  display: flex;
+  align-items: center;
+  block-size: $sz-32;
 
-    svg {
-      display: none;
-    }
+  &.expanded {
+    border-bottom: $b-1 solid var(--color-background-quaternary);
   }
 
-  .counter {
-    @include t.use-typography("body-small");
-    text-align: right;
+  &.expandeable {
+    cursor: pointer;
+  }
+
+  &:hover {
+    .annotation-title-icon-action {
+      display: flex;
+    }
+  }
+}
+
+.annotation-title-name {
+  flex-grow: 1;
+}
+
+.annotation-title-icon-arrow {
+  margin: 0 var(--sp-xs);
+}
+
+.annotation-title-actions {
+  display: flex;
+  align-items: center;
+  line-height: 2.5;
+}
+
+.annotation-title-icon-action {
+  cursor: pointer;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  inline-size: $sz-28;
+  block-size: $sz-32;
+  border-radius: $br-8;
+  margin: 0;
+  padding: 0;
+}
+
+.annotation-title-icon-ok:hover {
+  color: var(--color-accent-success);
+
+  &.disabled {
+    cursor: default;
     color: var(--color-foreground-secondary);
-    margin: 0 var(--sp-s) var(--sp-s) 0;
   }
+}
 
-  // Auto growing text
-  .grow-wrap {
-    // easy way to plop the elements on top of each other and have them both sized based on the tallest one's height
-    display: grid;
+.annotation-title-icon-nok:hover {
+  color: var(--color-accent-error);
+}
 
-    &:after {
-      // The space is needed to preventy jumpy behavior
-      content: attr(data-replicated-value) " ";
-      white-space: pre-wrap;
-      visibility: hidden;
-    }
+.annotation-body-hidden {
+  display: none;
+}
 
-    textarea {
-      background-color: var(--color-background-primary);
-      color: var(--color-foreground-primary);
-      padding: var(--sp-m);
+// Auto growing text
+.annotation-body {
+  // easy way to plop the elements on top of each other and have them both sized based on the tallest one's height
+  display: grid;
 
-      border: none;
-      overflow: hidden;
-      outline: none;
+  &:after {
+    // The space is needed to preventy jumpy behavior
+    content: attr(data-replicated-value) " ";
+    white-space: pre-wrap;
+    visibility: hidden;
 
-      -webkit-box-shadow: none;
-      -moz-box-shadow: none;
-      box-shadow: none;
+    /* Identical styling required!! */
+    font: inherit;
+    overflow-wrap: anywhere;
 
-      resize: none;
-      /*remove the resize handle on the bottom right*/
-    }
+    padding: var(--sp-m);
 
-    textarea,
-    &:after {
-      /* Identical styling required!! */
-      font: inherit;
-      overflow-wrap: anywhere;
-
-      padding: 10px;
-
-      /* Place on top of each other */
-      grid-area: 1 / 1 / 2 / 2;
-    }
+    /* Place on top of each other */
+    grid-area: 1 / 1 / 2 / 2;
   }
+}
+
+.annotation-textarea {
+  background-color: var(--color-background-primary);
+  color: var(--color-foreground-primary);
+  padding: var(--sp-m);
+
+  border: none;
+  overflow: hidden;
+  outline: none;
+
+  box-shadow: none;
+
+  resize: none;
+
+  /* Identical styling required!! */
+  font: inherit;
+  overflow-wrap: anywhere;
+
+  padding: var(--sp-m);
+
+  /* Place on top of each other */
+  grid-area: 1 / 1 / 2 / 2;
+}
+
+.annotation-counter {
+  @include t.use-typography("body-small");
+  text-align: right;
+  color: var(--color-foreground-secondary);
+  margin: 0 var(--sp-s) var(--sp-s) 0;
 }
 
 .swap-item-list {
@@ -212,9 +183,9 @@
   @include t.use-typography("body-small");
   display: flex;
   align-items: center;
-  padding: 1px var(--sp-m) 1px 1px;
+  padding: px2rem(1) var(--sp-m) px2rem(1) px2rem(1);
   gap: var(--sp-s);
-  height: calc($sz-32 + $sz-12);
+  block-size: calc($sz-32 + $sz-12);
   border-radius: $br-8;
   background-color: var(--swap-item-background-color);
   color: var(--swap-item-foreground-color);
@@ -224,8 +195,8 @@
     flex: 0 0 $sz-40;
     background-color: var(--swap-item-thumbnail-background-color);
     border-radius: $br-6;
-    height: $sz-40;
-    width: $sz-40;
+    block-size: $sz-40;
+    inline-size: $sz-40;
     padding: var(--sp-xxs);
   }
 
@@ -273,13 +244,14 @@
   flex-wrap: wrap;
   position: relative;
   padding: var(--sp-s);
+  border: none;
   border-radius: $br-8;
   background-color: var(--swap-item-thumbnail-background-color);
   overflow: hidden;
 
   .swap-item-thumbnail {
-    height: 100%;
-    width: 100%;
+    block-size: 100%;
+    inline-size: 100%;
     object-fit: contain;
   }
 
@@ -291,10 +263,10 @@
     text-align: left;
     display: none;
     position: absolute;
-    left: var(--sp-xs);
-    bottom: var(--sp-xs);
-    height: var(--sp-xxl);
-    width: calc(100% - var(--sp-xs) - var(--sp-xs));
+    inset-inline-start: var(--sp-xs);
+    inset-block-end: var(--sp-xs);
+    block-size: var(--sp-xxl);
+    inline-size: calc(100% - var(--sp-s));
     padding: var(--sp-xs);
     column-gap: var(--sp-xs);
     border-radius: $br-4;
@@ -306,8 +278,8 @@
 
   .swap-item-variant-icon {
     position: absolute;
-    right: var(--sp-xxs);
-    top: var(--sp-xxs);
+    inset-inline-end: var(--sp-xxs);
+    inset-block-start: var(--sp-xxs);
     background-color: var(--color-background-tertiary);
   }
 
@@ -323,10 +295,10 @@
     &::before {
       content: " ";
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
+      inset-block-start: 0;
+      inset-block-end: 0;
       border: calc($b-2 * 2) solid var(--swap-item-border-inner-color-selected);
       border-radius: $br-8;
     }
@@ -354,8 +326,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: $sz-24;
-  width: $sz-24;
+  block-size: $sz-24;
+  inline-size: $sz-24;
   color: var(--color-accent-secondary);
   border-radius: $br-8;
 }
@@ -365,7 +337,7 @@
   cursor: pointer;
   display: grid;
   grid-template-columns: 1fr var(--sp-m);
-  height: $sz-32;
+  block-size: $sz-32;
   align-items: center;
 
   &:hover {
@@ -395,7 +367,7 @@
   @include t.use-typography("headline-small");
   display: flex;
   align-items: center;
-  height: $sz-32;
+  block-size: $sz-32;
   padding-inline-start: var(--sp-xxs);
   color: var(--color-foreground-secondary);
 }
@@ -437,8 +409,8 @@
   display: flex;
   align-items: center;
   gap: var(--sp-xs);
-  width: 100%;
-  height: $sz-32;
+  inline-size: 100%;
+  block-size: $sz-32;
   padding: 0;
   border: 0;
   background-color: var(--color-background-primary);
@@ -451,7 +423,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   direction: rtl;
-  height: $sz-32;
+  block-size: $sz-32;
   padding: var(--sp-s) 0 var(--sp-s) var(--sp-xxs);
 }
 
@@ -491,8 +463,8 @@
   display: flex;
   align-items: center;
   gap: var(--sp-xs);
-  width: 100%;
-  height: $sz-32;
+  inline-size: 100%;
+  block-size: $sz-32;
   padding: 0;
   border: 0;
   border-radius: $br-8;
@@ -512,7 +484,7 @@
 
 .component-title-bar-type {
   @include t.use-typography("body-small");
-  height: 100%;
+  block-size: 100%;
   display: flex;
   align-items: center;
   color: var(--color-foreground-secondary);
@@ -545,7 +517,7 @@
 .pill {
   display: flex;
   flex-grow: 1;
-  gap: 1px;
+  gap: px2rem(1);
 }
 
 .pill-btn {
@@ -575,7 +547,7 @@
 
 .pill-btn-icon {
   display: flex;
-  height: $sz-32;
+  block-size: $sz-32;
   align-items: center;
   color: var(--color-foreground-secondary);
 }
@@ -583,7 +555,7 @@
 .pill-btn-name {
   display: flex;
   flex-direction: column;
-  min-height: $sz-32;
+  min-block-size: $sz-32;
   padding: var(--sp-s) 0 var(--sp-s) var(--sp-xxs);
   border-radius: $br-8 0 0 $br-8;
   overflow: hidden;
@@ -597,7 +569,7 @@
   white-space: nowrap;
   direction: rtl;
   text-align: left;
-  height: $sz-16;
+  block-size: $sz-16;
 }
 
 .pill-btn-subtext {
@@ -607,7 +579,7 @@
   white-space: nowrap;
   direction: rtl;
   text-align: left;
-  height: $sz-16;
+  block-size: $sz-16;
   color: var(--color-foreground-secondary);
 }
 
@@ -619,8 +591,8 @@
 .pill-actions-btn {
   @extend .button-secondary;
   cursor: unset;
-  height: 100%;
-  width: 100%;
+  block-size: 100%;
+  inline-size: 100%;
   border-radius: 0 $br-8 $br-8 0;
 
   &.selected {
@@ -630,12 +602,12 @@
 
 .pill-actions-dropdown {
   @extend .dropdown-wrapper;
-  right: 0;
-  left: unset;
-  width: $sz-252;
+  inline-size: $sz-252;
+  inset-inline-end: 0;
+  inset-inline-start: unset;
 
   &.extended {
-    top: $sz-48;
+    inset-block-start: $sz-48;
   }
 }
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.scss
@@ -754,3 +754,22 @@
     outline: deprecated.$s-1 solid var(--color-accent-primary);
   }
 }
+
+.variant-item {
+  @include deprecated.flexColumn;
+  position: relative;
+
+  --reorder-left-position: calc(-1 * var(--sp-m) - var(--sp-xxs));
+
+  &:hover {
+    --reorder-icon-visibility: visible;
+  }
+
+  &.dnd-over-top {
+    --reorder-top-display: block;
+  }
+
+  &.dnd-over-bot {
+    --reorder-bottom-display: block;
+  }
+}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
@@ -250,7 +250,7 @@
                              :icon i/remove}]]
 
           (some? fills)
-          [:& h/sortable-container {}
+          [:> h/sortable-container* {}
            (for [value fills]
              (let [mdata (meta value)
                    index (get mdata :index)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
@@ -812,7 +812,7 @@
       [:button {:class (stl/css :add-column) :on-click add-track} deprecated-icon/add]]
 
      (when expanded?
-       [:& h/sortable-container {}
+       [:> h/sortable-container* {}
         [:div {:class (stl/css :grid-tracks-info-container)}
          (for [[index column] (d/enumerate column-values)]
            [:& grid-track-info {:key (dm/str index "-" (d/name type))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
@@ -356,7 +356,7 @@
                               :icon i/remove}]]]]
 
          (some? shadows)
-         [:& h/sortable-container {}
+         [:> h/sortable-container* {}
           [:div {:class (stl/css :element-set-content)}
            (for [{:keys [::index id] :as shadow} shadows]
              [:> shadow-entry*

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -203,7 +203,7 @@
                              :on-click handle-remove-all
                              :icon i/remove}]]
           (seq strokes)
-          [:& h/sortable-container {}
+          [:> h/sortable-container* {}
            (for [[index value] (d/enumerate (:strokes values []))]
              [:& stroke-row {:key (dm/str "stroke-" index)
                              :stroke value

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/frame.cljs
@@ -12,7 +12,7 @@
    [app.main.refs :as refs]
    [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-menu]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu variant-menu*]]
+   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu* component-variant-main*]]
    [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-menu* exports-attrs]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
@@ -107,10 +107,10 @@
                          :type shape-type
                          :shapes shapes}]
 
-     [:& component-menu {:shapes shapes}]
+     [:> component-menu* {:shapes shapes}]
 
      (when is-variant?
-       [:> variant-menu* {:shapes shapes}])
+       [:> component-variant-main* {:shapes shapes}])
 
      [:& layout-container-menu
       {:type shape-type

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -22,7 +22,7 @@
    [app.main.refs :as refs]
    [app.main.ui.workspace.sidebar.options.menus.blur :refer [blur-attrs blur-menu]]
    [app.main.ui.workspace.sidebar.options.menus.color-selection :refer [color-selection-menu*]]
-   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu]]
+   [app.main.ui.workspace.sidebar.options.menus.component :refer [component-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.constraints :refer [constraint-attrs constraints-menu]]
    [app.main.ui.workspace.sidebar.options.menus.exports :refer [exports-attrs exports-menu*]]
    [app.main.ui.workspace.sidebar.options.menus.fill :as fill]
@@ -234,7 +234,7 @@
 
         merge-token-values
         (fn [acc shape-attrs applied-tokens]
-          "Merges token values across all shape attributes.  
+          "Merges token values across all shape attributes.
            For each shape attribute, its corresponding token attributes are merged
            into the accumulator. If applied tokens are empty, the accumulator is returned unchanged."
           (if (seq applied-tokens)
@@ -455,7 +455,7 @@
          :shapes shapes}])
 
      (when (some? components)
-       [:& component-menu {:shapes components}])
+       [:> component-menu* {:shapes components}])
 
      [:& layout-container-menu
       {:type type

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -202,7 +202,7 @@
         editing-page-id (mf/deref refs/editing-page-item)
         current-page-id (mf/use-ctx ctx/current-page-id)]
     [:ul {:class (stl/css :page-list)}
-     [:& hooks/sortable-container {}
+     [:> hooks/sortable-container* {}
       (for [[index page-id] (d/enumerate pages)]
         [:& page-item-wrapper
          {:page-id page-id

--- a/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/sidebar.cljs
@@ -51,7 +51,7 @@
       (when-not token-set-new-path
         [:> tsetslist/inline-add-button*])
 
-      [:> h/sortable-container {}
+      [:> h/sortable-container* {}
        [:> tsets/sets-list*
         {:tokens-lib tokens-lib
          :new-path token-set-new-path


### PR DESCRIPTION
### Related Ticket

Taiga [#10225](https://tree.taiga.io/project/penpot/us/10225)

### Summary

Implement the ability of reordering the properties of a variant from the component section of the design tab by dragging & dropping.

Also, a big refactor has been made to reorder and simplify the component structure and implement the new SCSS guidelines. It affects the whole component section (including the swap panel and excluding the annotation subsection) in the design tab.

### Steps to reproduce 

- Select a component with variants. On the component section of the design tab, check that a handler appears on the left of any property when hovering. Also check that dragging & dropping it causes the property to move to another position on the list.
- Same when a single variant is selected.
- Check that the component section in the design tab works and looks as expected.