### PR TITLE
:bug: Fix sync errors when there is a broken swap slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 - Fix problem with export size [Github #7160](https://github.com/penpot/penpot/issues/7160)
 - Fix multi level library dependencies [Taiga #12155](https://tree.taiga.io/project/penpot/issue/12155)
 - Fix component context menu options order in assets tab [Taiga #11941](https://tree.taiga.io/project/penpot/issue/11941)
+- Fix error updating library [Taiga #12218](https://tree.taiga.io/project/penpot/issue/12218)
 
 ## 2.10.0
 

--- a/common/src/app/common/types/component.cljc
+++ b/common/src/app/common/types/component.cljc
@@ -256,7 +256,7 @@
 
 (defn group->swap-slot
   [group]
-  (parse-uuid (subs (name group) 10)))
+  (parse-uuid (subs (name group) 10)))  ;; 10 is the length of "swap-slot-"
 
 (defn get-swap-slot
   "If the shape has a :touched group in the form :swap-slot-<uuid>, get the id."


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12218

### Summary

An error 500 occurs when updating libraries in one file.

### Steps to reproduce 

See related ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
