### PR TITLE
:bug: Fix Restoring a variant from another file makes it overlap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 - Fix multi level library dependencies [Taiga #12155](https://tree.taiga.io/project/penpot/issue/12155)
 - Fix component context menu options order in assets tab [Taiga #11941](https://tree.taiga.io/project/penpot/issue/11941)
 - Fix error updating library [Taiga #12218](https://tree.taiga.io/project/penpot/issue/12218)
+- Fix Restoring a variant in another file makes it overlap the existing variant [Taiga #12049](https://tree.taiga.io/project/penpot/issue/12049)
 
 ## 2.10.0
 

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -710,11 +710,14 @@
             (fn [ids]
               (let [parent-ids (when update-layout?
                                  (map #(-> (get objects %) :parent-id) ids))]
-                (rx/of
-                 (dws/select-shapes ids)
-                 dwz/zoom-to-selected-shape
+                (rx/concat
+                 (rx/of
+                  (dws/select-shapes ids)
+                  dwz/zoom-to-selected-shape)
                  (when update-layout?
-                   (ptk/data-event :layout/update {:ids parent-ids})))))
+                   (->> (rx/of (ptk/data-event :layout/update {:ids parent-ids}))
+                       ;; Delay so the navigation can finish
+                        (rx/delay 250))))))
 
             redirect-to-page
             (fn [page-id ids]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12049

### Summary

When you restore a shared variant from the component copy used in another file, it’s restored, but its position overlaps with the rest of the existing variants.

### Steps to reproduce 

See taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
