### PR TITLE
:bug: Auto-width changes to fixed when switching variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@
 - Fix component context menu options order in assets tab [Taiga #11941](https://tree.taiga.io/project/penpot/issue/11941)
 - Fix error updating library [Taiga #12218](https://tree.taiga.io/project/penpot/issue/12218)
 - Fix Restoring a variant in another file makes it overlap the existing variant [Taiga #12049](https://tree.taiga.io/project/penpot/issue/12049)
+- Fix auto-width changes to fixed when switching variants [Taiga #12172](https://tree.taiga.io/project/penpot/issue/12172)
 
 
 ## 2.10.1 (Unreleased)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@
 - Fix multi level library dependencies [Taiga #12155](https://tree.taiga.io/project/penpot/issue/12155)
 - Fix component context menu options order in assets tab [Taiga #11941](https://tree.taiga.io/project/penpot/issue/11941)
 - Fix error updating library [Taiga #12218](https://tree.taiga.io/project/penpot/issue/12218)
-- Fix Restoring a variant in another file makes it overlap the existing variant [Taiga #12049](https://tree.taiga.io/project/penpot/issue/12049)
+- Fix restoring a variant in another file makes it overlap the existing variant [Taiga #12049](https://tree.taiga.io/project/penpot/issue/12049)
 - Fix auto-width changes to fixed when switching variants [Taiga #12172](https://tree.taiga.io/project/penpot/issue/12172)
 
 

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2029,9 +2029,13 @@
               reset-pos-data? (and
                                (not skip-operations?)
                                (cfh/text-shape? previous-shape)
-                               (= attr :position-data)
+                               (or (= attr :position-data) (= attr :selrect))
                                (not= (:position-data previous-shape) (:position-data current-shape))
                                (touched :geometry-group))
+
+              skip-operations? (or skip-operations?
+                                   ;; If we are going to reset the position data, skip the selrect attr
+                                   (and reset-pos-data? (= attr :selrect)))
 
               attr-val
               (when-not skip-operations?


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12172

### Summary

The auto-width property of a text in a copy changes to fixed when switching.

### Steps to reproduce 

See taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
