### PR TITLE
:bug: Fix swatch error on text without fills

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/text.cljs
@@ -104,12 +104,6 @@
           :shape shape
           :attrs (conj txt/text-fill-attrs :fills)})
 
-        fill-values
-        (if (not (contains? fill-values :fills))
-          ;; Old fill format
-          {:fills [fill-values]}
-          fill-values)
-
         text-values
         (merge
          (select-keys shape [:grow-type])


### PR DESCRIPTION
### Related Ticket

No issue

### Summary

This bug happends when you create a text and delect it without adding any text. 

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
