### PR TITLE
:wrench: Allow line height values from 0 to 1

### DIFF
--- a/render-wasm/src/shapes/text.rs
+++ b/render-wasm/src/shapes/text.rs
@@ -475,7 +475,7 @@ impl Paragraph {
                 .unwrap_or(&self.children[0]);
 
             let mut strut_style = skia::textlayout::StrutStyle::default();
-            let line_height = self.line_height.max(1.0);
+            let line_height = self.line_height.max(0.0);
             strut_style.set_font_size(reference_child.font_size);
             strut_style.set_height(line_height);
             strut_style.set_height_override(true);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12247

### Summary

We should allow line-height values from 0 to 1. There's an issue in the current render and the code it generates, that does not apply correctly line height values below 0, that will be fixed separately (https://tree.taiga.io/project/penpot/issue/12252)

### Steps to reproduce 

- Write a text with multiple lines and set line-height to 0. Al lines should be in the same position.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.