### PR TITLE
:wrench: Always return shadows in reverse order

### DIFF
--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -13,7 +13,7 @@ pub fn render_fill_inner_shadows(
     surface_id: SurfaceId,
 ) {
     if shape.has_fills() {
-        for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+        for shadow in shape.inner_shadows_visible() {
             render_fill_inner_shadow(render_state, shape, shadow, antialias, surface_id);
         }
     }
@@ -38,7 +38,7 @@ pub fn render_stroke_inner_shadows(
     surface_id: SurfaceId,
 ) {
     if !shape.has_fills() {
-        for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+        for shadow in shape.inner_shadows_visible() {
             let filter = shadow.get_inner_shadow_filter();
             strokes::render(
                 render_state,
@@ -61,7 +61,7 @@ pub fn render_text_path_stroke_drop_shadows(
     stroke: &Stroke,
     antialias: bool,
 ) {
-    for shadow in shape.drop_shadows().rev().filter(|s| !s.hidden()) {
+    for shadow in shape.drop_shadows_visible() {
         let stroke_shadow = shadow.get_drop_shadow_filter();
         strokes::render_text_paths(
             render_state,
@@ -84,7 +84,7 @@ pub fn render_text_path_stroke_inner_shadows(
     stroke: &Stroke,
     antialias: bool,
 ) {
-    for shadow in shape.inner_shadows().rev().filter(|s| !s.hidden()) {
+    for shadow in shape.inner_shadows_visible() {
         let stroke_shadow = shadow.get_inner_shadow_filter();
         strokes::render_text_paths(
             render_state,

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1005,22 +1005,34 @@ impl Shape {
         self.shadows.clear();
     }
 
+    #[allow(dead_code)]
     pub fn drop_shadows(&self) -> impl DoubleEndedIterator<Item = &Shadow> {
         self.shadows
             .iter()
+            .rev()
             .filter(|shadow| shadow.style() == ShadowStyle::Drop)
     }
 
     pub fn drop_shadows_visible(&self) -> impl DoubleEndedIterator<Item = &Shadow> {
         self.shadows
             .iter()
+            .rev()
             .filter(|shadow| shadow.style() == ShadowStyle::Drop && !shadow.hidden())
     }
 
+    #[allow(dead_code)]
     pub fn inner_shadows(&self) -> impl DoubleEndedIterator<Item = &Shadow> {
         self.shadows
             .iter()
+            .rev()
             .filter(|shadow| shadow.style() == ShadowStyle::Inner)
+    }
+
+    pub fn inner_shadows_visible(&self) -> impl DoubleEndedIterator<Item = &Shadow> {
+        self.shadows
+            .iter()
+            .rev()
+            .filter(|shadow| shadow.style() == ShadowStyle::Inner && !shadow.hidden())
     }
 
     pub fn to_path_transform(&self) -> Option<Matrix> {
@@ -1201,8 +1213,8 @@ impl Shape {
     }
 
     pub fn drop_shadow_paints(&self) -> Vec<skia_safe::Paint> {
-        let drop_shadows: Vec<&crate::shapes::shadows::Shadow> =
-            self.drop_shadows().rev().filter(|s| !s.hidden()).collect();
+        let drop_shadows: Vec<&Shadow> = self.drop_shadows_visible().collect();
+
         drop_shadows
             .into_iter()
             .map(|shadow| {
@@ -1215,8 +1227,8 @@ impl Shape {
     }
 
     pub fn inner_shadow_paints(&self) -> Vec<skia_safe::Paint> {
-        let inner_shadows: Vec<&crate::shapes::shadows::Shadow> =
-            self.inner_shadows().rev().filter(|s| !s.hidden()).collect();
+        let inner_shadows: Vec<&Shadow> = self.inner_shadows_visible().collect();
+
         inner_shadows
             .into_iter()
             .map(|shadow| {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/12248

### Summary

This PR refactors a bit the way we retrieve both drop and inner shadows, ensuring they're always returned in the same order and, in this case, filtering always only visible shadows

### Steps to reproduce 

Create several shapes with multiple drop shadows and check they're being rendered in the same order as production

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Check CI passes successfully.
