### PR TITLE
:tada: Add copy as image to clipboard menu option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### :heart: Community contributions (Thank you!)
 
+- Copy as image to clipboard (by @dfelinto) [Github #8313](https://github.com/penpot/penpot/pull/8313)
+
 ### :sparkles: New features & Enhancements
 
 - Access to design tokens in Penpot Plugins [Taiga #8990](https://tree.taiga.io/project/penpot/us/8990)

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1434,6 +1434,7 @@
 (dm/export dwcp/paste-shapes)
 (dm/export dwcp/paste-data-valid?)
 (dm/export dwcp/copy-link-to-clipboard)
+(dm/export dwcp/copy-as-image)
 
 ;; Drawing
 (dm/export dwd/select-for-drawing)

--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -1078,15 +1078,13 @@
 
          ;; Call exporter to get image URI, then fetch and copy blob.
          (->> (rp/cmd! :export params)
-              (rx/mapcat (fn [{:keys [uri mtype]}]
-                           (->> (http/send! {:method :get
-                                             :uri uri
-                                             :response-type :blob})
-                                (rx/map :body))))
-              (rx/map (fn [blob]
-                        (let [promise (js/Promise. (fn [resolve _] (resolve blob)))]
-                          (clipboard/to-clipboard-promise "image/png" promise)
-                          nil)))
+              (rx/mapcat (fn [{:keys [uri]}]
+                           (http/send! {:method :get
+                                        :uri uri
+                                        :response-type :blob})))
+              (rx/map :body)
+              (rx/tap (fn [blob]
+                        (clipboard/to-clipboard-promise "image/png" (p/resolved blob))))
               (rx/map (fn [_]
                         (ntf/success (tr "workspace.clipboard.image-copied"))))
               (rx/catch (fn [e]

--- a/frontend/src/app/main/data/workspace/clipboard.cljs
+++ b/frontend/src/app/main/data/workspace/clipboard.cljs
@@ -1039,3 +1039,57 @@
     ptk/WatchEvent
     (watch [_ _ _]
       (clipboard/to-clipboard (rt/get-current-href)))))
+
+(defn copy-as-image
+  []
+  (ptk/reify ::copy-as-image
+    ptk/WatchEvent
+    (watch [_ state _]
+      (let [file-id  (:current-file-id state)
+            page-id  (:current-page-id state)
+            selected (first (dsh/lookup-selected state))
+
+            export {:file-id file-id
+                    :page-id page-id
+                    :object-id selected
+                    ;; webp would be preferrable, but PNG is the most supported image MIME type by clipboard APIs.
+                    :type :png
+                    ;; Always use 2 to ensure good enough quality for wireframes.
+                    :scale 2
+                    :suffix ""
+                    :enabled true
+                    :name ""}
+
+            params {:exports [export]
+                    :profile-id (:profile-id state)
+                    :cmd :export-shapes
+                    :wait true}]
+
+        (rx/concat
+         ;; Ensure current state persisted before exporting.
+         (rx/of ::dps/force-persist)
+         (->> (rx/from-atom refs/persistence-state {:emit-current-value? true})
+              (rx/filter #(or (nil? %) (= :saved %)))
+              (rx/first)
+              (rx/timeout 400 (rx/empty)))
+
+         ;; Exporting itself can time its time, better to notify that we are busy.
+         (rx/of (ntf/info (tr "workspace.clipboard.copying")))
+
+         ;; Call exporter to get image URI, then fetch and copy blob.
+         (->> (rp/cmd! :export params)
+              (rx/mapcat (fn [{:keys [uri mtype]}]
+                           (->> (http/send! {:method :get
+                                             :uri uri
+                                             :response-type :blob})
+                                (rx/map :body))))
+              (rx/map (fn [blob]
+                        (let [promise (js/Promise. (fn [resolve _] (resolve blob)))]
+                          (clipboard/to-clipboard-promise "image/png" promise)
+                          nil)))
+              (rx/map (fn [_]
+                        (ntf/success (tr "workspace.clipboard.image-copied"))))
+              (rx/catch (fn [e]
+                          (js/console.error "clipboard blocked:" e)
+                          (ntf/error (tr "workspace.clipboard.image-copy-failed"))
+                          (rx/empty)))))))))

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -150,7 +150,9 @@
   {::mf/props :obj
    ::mf/private true}
   [{:keys [shapes]}]
-  (let [do-copy           #(st/emit! (dw/copy-selected))
+  (let [multiple?         (> (count shapes) 1)
+
+        do-copy           #(st/emit! (dw/copy-selected))
         do-copy-link      #(st/emit! (dw/copy-link-to-clipboard))
 
         do-cut            #(st/emit! (dw/copy-selected)
@@ -177,6 +179,9 @@
 
         handle-copy-text
         (mf/use-callback #(st/emit! (dw/copy-selected-text)))
+
+        handle-copy-as-image
+        (mf/use-callback #(st/emit! (dw/copy-as-image)))
 
         handle-hover-copy-paste
         (mf/use-callback
@@ -222,6 +227,11 @@
       [:> menu-entry* {:title (tr "workspace.shape.menu.copy-svg")
                        :on-click handle-copy-svg}]
 
+      (when (some cfh/frame-shape? shapes)
+        [:> menu-entry* {:title (tr "workspace.shape.menu.copy-as-image")
+                         :disabled multiple?
+                         :on-click handle-copy-as-image}])
+
       [:> menu-separator* {}]
 
       [:> menu-entry* {:title (tr "workspace.shape.menu.copy-text")
@@ -229,7 +239,7 @@
 
       [:> menu-entry* {:title (tr "workspace.shape.menu.copy-props")
                        :shortcut (sc/get-tooltip :copy-props)
-                       :disabled (> (count shapes) 1)
+                       :disabled multiple?
                        :on-click handle-copy-props}]
       [:> menu-entry* {:title (tr "workspace.shape.menu.paste-props")
                        :shortcut (sc/get-tooltip :paste-props)

--- a/frontend/src/app/util/object.cljc
+++ b/frontend/src/app/util/object.cljc
@@ -408,7 +408,6 @@
 
         (= :property curr)
         (let [definition (first params)]
-          (prn definition (meta definition))
           (if (some? definition)
             (let [definition (if (map? definition)
                                (c/merge {:wrap (:wrap tmeta)

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7587,6 +7587,18 @@ msgstr "Paste"
 msgid "workspace.shape.menu.paste-props"
 msgstr "Paste properties"
 
+msgid "workspace.shape.menu.copy-as-image"
+msgstr "Copy as image"
+
+msgid "workspace.clipboard.copying"
+msgstr "Copying image…"
+
+msgid "workspace.clipboard.image-copied"
+msgstr "Image copied to the clipboard"
+
+msgid "workspace.clipboard.image-copy-failed"
+msgstr "Error copying image"
+
 #: src/app/main/ui/workspace/context_menu.cljs:442
 msgid "workspace.shape.menu.path"
 msgstr "Path"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -7535,6 +7535,18 @@ msgstr "Pegar"
 msgid "workspace.shape.menu.paste-props"
 msgstr "Pegar propiedades"
 
+msgid "workspace.shape.menu.copy-as-image"
+msgstr "Copiar como imagen"
+
+msgid "workspace.clipboard.copying"
+msgstr "Copiando imagen…"
+
+msgid "workspace.clipboard.image-copied"
+msgstr "Imagen copiada al portapapeles"
+
+msgid "workspace.clipboard.image-copy-failed"
+msgstr "Error al copiar la imagen"
+
 #: src/app/main/ui/workspace/context_menu.cljs:442
 msgid "workspace.shape.menu.path"
 msgstr "Ruta"


### PR DESCRIPTION
### Related Ticket

Replaces https://github.com/penpot/penpot/pull/8313
