### PR TITLE
:sparkles: Add Tab/Shift+Tab navigation to rename layers sequentially

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -56,7 +56,8 @@
            filtered? expanded? dnd-over? dnd-over-top? dnd-over-bot? hide-toggle?
            ;; Callbacks
            on-select-shape on-context-menu on-pointer-enter on-pointer-leave on-zoom-to-selected
-           on-toggle-collapse on-enable-drag on-disable-drag on-toggle-visibility on-toggle-blocking]}]
+           on-toggle-collapse on-enable-drag on-disable-drag on-toggle-visibility on-toggle-blocking
+           on-tab-press]}]
 
   (let [id                    (:id item)
         name                  (:name item)
@@ -159,7 +160,8 @@
                         :variant-properties variant-properties
                         :variant-error variant-error
                         :component-id (:id component)
-                        :is-hidden hidden?}]]
+                        :is-hidden hidden?
+                        :on-tab-press on-tab-press}]]
       (when (not read-only?)
         [:div {:class (stl/css-case
                        :element-actions true
@@ -373,6 +375,23 @@
         enable-drag      (mf/use-fn #(reset! drag-disabled* false))
         disable-drag     (mf/use-fn #(reset! drag-disabled* true))
 
+        on-tab-press
+        (mf/use-fn
+         (mf/deps id objects)
+         (fn [shift?]
+           (let [shape     (get objects id)
+                 parent    (get objects (:parent-id shape))
+                 siblings  (:shapes parent)
+                 pos       (d/index-of siblings id)]
+             (when (some? pos)
+               (let [;; Layers render in reverse: Tab (visually down) = dec index,
+                     ;; Shift+Tab (visually up) = inc index
+                     target-id (if shift?
+                                 (get siblings (inc pos))
+                                 (get siblings (dec pos)))]
+                 (when (some? target-id)
+                   (st/emit! (dw/start-rename-shape target-id))))))))
+
         ;; Lazy loading of child elements via IntersectionObserver
         children-count*  (mf/use-state 0)
         children-count   (deref children-count*)
@@ -477,6 +496,7 @@
       :on-disable-drag disable-drag
       :on-toggle-visibility toggle-visibility
       :on-toggle-blocking toggle-blocking
+      :on-tab-press on-tab-press
       :style style}
 
      (when (and render-children?

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_name.cljs
@@ -31,9 +31,16 @@
   [{:keys [shape-id shape-name is-shape-touched disabled-double-click
            on-start-edit on-stop-edit depth parent-size is-selected
            type-comp type-frame component-id is-hidden is-blocked
-           variant-id variant-name variant-properties variant-error]} external-ref]
+           variant-id variant-name variant-properties variant-error
+           on-tab-press]} external-ref]
   (let [edition*         (mf/use-state false)
         edition?         (deref edition*)
+
+        ;; Mutable ref to track editing state inside mf/use-fn callbacks.
+        ;; mf/use-state wraps React useState, so @edition* inside memoized
+        ;; callbacks captures a stale State object. A ref is a stable mutable
+        ;; container that always reflects the latest value.
+        editing-ref      (mf/use-ref false)
 
         local-ref        (mf/use-ref)
         ref              (d/nilv external-ref local-ref)
@@ -57,6 +64,7 @@
            (when (and (not is-blocked)
                       (not disabled-double-click))
              (on-start-edit)
+             (mf/set-ref-val! editing-ref true)
              (reset! edition* true)
              (st/emit! (dw/start-rename-shape shape-id)))))
 
@@ -64,26 +72,42 @@
         (mf/use-fn
          (mf/deps shape-id on-stop-edit component-id variant-id variant-name variant-properties)
          (fn []
-           (let [name-input     (mf/ref-val ref)
-                 name           (str/trim (dom/get-value name-input))]
-             (on-stop-edit)
-             (reset! edition* false)
-             (st/emit! (dw/rename-shape-or-variant shape-id name)))))
+           (when (mf/ref-val editing-ref)
+             (let [name-input (mf/ref-val ref)
+                   name       (str/trim (dom/get-value name-input))]
+               (on-stop-edit)
+               (mf/set-ref-val! editing-ref false)
+               (reset! edition* false)
+               (st/emit! (dw/rename-shape-or-variant shape-id name))))))
 
         cancel-edit
         (mf/use-fn
          (mf/deps shape-id on-stop-edit)
          (fn []
            (on-stop-edit)
+           (mf/set-ref-val! editing-ref false)
            (reset! edition* false)
            (st/emit! (dw/end-rename-shape shape-id nil))))
 
         on-key-down
         (mf/use-fn
-         (mf/deps accept-edit cancel-edit)
+         (mf/deps accept-edit cancel-edit on-tab-press shape-id on-stop-edit)
          (fn [event]
            (when (kbd/enter? event) (accept-edit))
-           (when (kbd/esc? event) (cancel-edit))))
+           (when (kbd/esc? event) (cancel-edit))
+           (when (kbd/tab? event)
+             (dom/prevent-default event)
+             (dom/stop-propagation event)
+             (when (mf/ref-val editing-ref)
+               (let [shift?    (kbd/shift? event)
+                     name-input (mf/ref-val ref)
+                     name       (str/trim (dom/get-value name-input))]
+                 (on-stop-edit)
+                 (mf/set-ref-val! editing-ref false)
+                 (reset! edition* false)
+                 (st/emit! (dw/end-rename-shape shape-id name))
+                 (when (fn? on-tab-press)
+                   (on-tab-press shift?)))))))
 
         parent-size (dm/str (- parent-size space-for-icons) "px")]
 


### PR DESCRIPTION
### Related Ticket
#2569

### Summary

When renaming layers, you currently have to double-click each layer name one by one. This adds Tab / Shift+Tab support so you can move through sibling layers without leaving the keyboard.

Pressing Tab while editing a layer name saves the current name and opens the next layer below for editing. Shift+Tab does the same but moves upward. At the first or last sibling, it simply saves and stops.

Two files changed:
- `layer_name.cljs` — handles Tab key in `on-key-down`, saves the name via `end-rename-shape`, then delegates navigation to a callback from the parent.
- `layer_item.cljs` — provides the `on-tab-press` callback that finds the sibling in the parent's `:shapes` vector and emits `start-rename-shape` for the target.

One thing worth noting: `mf/use-state` wraps React's `useState`, so dereffing it inside `mf/use-fn` callbacks gives stale values. Added an `editing-ref` (`mf/use-ref`) to reliably track editing state inside memoized closures. This also prevents `accept-edit` from double-firing on blur after Tab already handled the save.

### Steps to reproduce

1. Open a workspace with a frame containing several shapes
2. Double-click any layer name in the layers panel to start editing
3. Press **Tab** — the current name should save and the next layer below should enter edit mode
4. Press **Shift+Tab** — same thing but moves to the layer above
5. At the top or bottom sibling, pressing Shift+Tab or Tab just saves without moving
6. Press **Enter** to save, **Escape** to cancel — both should still work as before
7. Click away from the input — should still save as before

[test.webm](https://github.com/user-attachments/assets/7e8a0715-91f3-4a3b-8778-5c451b40ad9f)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
