### PR TITLE
:tada: Add new page separators feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@
 - Edit ruler guide position by double-clicking the guide pill (by @eureka0928) [Github #2311](https://github.com/penpot/penpot/issues/2311)
 - Add a search bar to filter colors in the color palette toolbar (by @eureka0928) [Github #7653](https://github.com/penpot/penpot/issues/7653)
 - Allow customising the OIDC login button label (by @wdeveloper16) [Github #7027](https://github.com/penpot/penpot/issues/7027)
+- Add page separators in Workspace [Taiga #13611](https://tree.taiga.io/project/penpot/us/13611?milestone=262806)
+
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/data/workspace/pages.cljs
+++ b/frontend/src/app/main/data/workspace/pages.cljs
@@ -328,11 +328,24 @@
   (ptk/reify ::rename-page
     ptk/WatchEvent
     (watch [it state _]
-      (let [page    (dsh/lookup-page state id)
-            changes (-> (pcb/empty-changes it)
-                        (pcb/with-page page)
-                        (pcb/mod-page page {:name name}))]
-        (rx/of (dch/commit-changes changes))))))
+      (let [page             (dsh/lookup-page state id)
+            changes          (-> (pcb/empty-changes it)
+                                 (pcb/with-page page)
+                                 (pcb/mod-page page {:name name}))
+            pages            (-> (dsh/lookup-file-data state) :pages)
+            index            (d/index-of pages id)
+            prev-id          (when (and (some? index) (pos? index))
+                               (nth pages (dec index) nil))
+            next-id          (when (some? index)
+                               (nth pages (inc index) nil))
+            fallback-page-id (or prev-id next-id)
+            separator?       (= "---" (str/trim name))]
+        (rx/concat
+         (rx/of (dch/commit-changes changes))
+         (when (and separator?
+                    (= id (:current-page-id state))
+                    (some? fallback-page-id))
+           (rx/of (dcm/go-to-workspace :page-id fallback-page-id))))))))
 
 (defn- delete-page-components
   [changes page]

--- a/frontend/src/app/main/ui/ds/buttons/icon_button.cljs
+++ b/frontend/src/app/main/ui/ds/buttons/icon_button.cljs
@@ -19,6 +19,7 @@
    [:tooltip-class {:optional true} [:maybe :string]]
    [:type {:optional true} [:maybe [:enum "button" "submit" "reset"]]]
    [:icon-class {:optional true} :string]
+   [:icon-size {:optional true} [:maybe [:enum "s" "m" "l"]]]
    [:icon
     [:and :string [:fn #(contains? icon-list %)]]]
    [:aria-label :string]
@@ -30,7 +31,7 @@
 (mf/defc icon-button*
   {::mf/schema schema:icon-button
    ::mf/memo true}
-  [{:keys [class icon icon-class variant aria-label children tooltip-placement tooltip-class type] :rest props}]
+  [{:keys [class icon icon-class icon-size variant aria-label children tooltip-placement tooltip-class type] :rest props}]
   (let [variant
         (d/nilv variant "primary")
 
@@ -60,5 +61,5 @@
                   :placement tooltip-placement
                   :id tooltip-id}
      [:> :button props
-      [:> icon* {:icon-id icon :aria-hidden true :class icon-class}]
+      [:> icon* {:icon-id icon :aria-hidden true :class icon-class :size icon-size}]
       children]]))

--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.cljs
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.cljs
@@ -322,22 +322,16 @@
 (mf/defc icon*
   {::mf/schema schema:icon}
   [{:keys [icon-id size class] :rest props}]
-  (let [props   (mf/spread-props props
-                                 {:class [class (stl/css :icon)]
-                                  :width icon-size-m
-                                  :height icon-size-m})
-
-        size-px (cond (= size "l") icon-size-l
+  (let [size-px (cond (= size "l") icon-size-l
                       (= size "s") icon-size-s
                       :else        icon-size-m)
 
-        offset  (if (or (= size "s") (= size "m"))
-                  (/ (- icon-size-m size-px) 2)
-                  0)]
+        props   (mf/spread-props props
+                                 {:class [class (stl/css :icon)]
+                                  :width size-px
+                                  :height size-px})]
 
     [:> :svg props
      [:use {:href (dm/str "#icon-" icon-id)
             :width size-px
-            :height size-px
-            :x offset
-            :y offset}]]))
+            :height size-px}]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.types.page :as ctp]
    [app.main.data.common :as dcm]
    [app.main.data.helpers :as dsh]
    [app.main.data.modal :as modal]
@@ -50,8 +51,10 @@
   each object change)"
   [page-id]
   (l/derived (fn [fdata]
-               (-> (dsh/get-page fdata page-id)
-                   (dissoc :objects)))
+               (let [page (dsh/get-page fdata page-id)]
+                 (-> page
+                     (assoc :empty? (ctp/is-empty? page))
+                     (dissoc :objects))))
              refs/workspace-data
              =))
 
@@ -62,29 +65,32 @@
 (mf/defc page-item
   {::mf/wrap-props false}
   [{:keys [page index deletable? selected? editing? hovering? current-page-id]}]
-  (let [input-ref    (mf/use-ref)
-        id           (:id page)
-        delete-fn    (mf/use-fn (mf/deps id) #(st/emit! (dw/delete-page id)))
-        navigate-fn  (mf/use-fn (mf/deps id) #(st/emit! :interrupt (dcm/go-to-workspace :page-id id)))
-        read-only?   (mf/use-ctx ctx/workspace-read-only?)
+  (let [input-ref     (mf/use-ref)
+        id            (:id page)
+        name          (:name page "")
+        is-separator? (and (= "---" (str/trim name)) (:empty? page))
+        delete-fn     (mf/use-fn (mf/deps id) #(st/emit! (dw/delete-page id)))
+        navigate-fn   (mf/use-fn (mf/deps id) #(st/emit! :interrupt (dcm/go-to-workspace :page-id id)))
+        read-only?    (mf/use-ctx ctx/workspace-read-only?)
 
         on-click
         (mf/use-fn
-         (mf/deps id current-page-id)
+         (mf/deps id current-page-id is-separator?)
          (fn []
-           ;; For the wasm renderer, apply a blur effect to the viewport canvas
-           ;; when we navigate to a different page.
-           (if (and (features/active-feature? @st/state "render-wasm/v1")
-                    (not= id current-page-id))
-             (do
-               (wasm.api/capture-canvas-pixels)
-               (wasm.api/apply-canvas-blur)
-               ;; NOTE: it seems we need two RAF so the blur is actually applied and visible
-               ;;       in the canvas :(
-               (timers/raf
-                (fn []
-                  (timers/raf navigate-fn))))
-             (navigate-fn))))
+           (when-not is-separator?
+             ;; For the wasm renderer, apply a blur effect to the viewport canvas
+             ;; when we navigate to a different page.
+             (if (and (features/active-feature? @st/state "render-wasm/v1")
+                      (not= id current-page-id))
+               (do
+                 (wasm.api/capture-canvas-pixels)
+                 (wasm.api/apply-canvas-blur)
+                 ;; NOTE: it seems we need two RAF so the blur is actually applied and visible
+                 ;;       in the canvas :(
+                 (timers/raf
+                  (fn []
+                    (timers/raf navigate-fn))))
+               (navigate-fn)))))
 
         on-delete
         (mf/use-fn
@@ -106,11 +112,14 @@
 
         on-blur
         (mf/use-fn
+         (mf/deps id is-separator?)
          (fn [event]
-           (let [name   (str/trim (dom/get-target-val event))]
-             (when-not (str/empty? name)
-               (st/emit! (dw/rename-page id name)))
-             (st/emit! (dw/stop-rename-page-item)))))
+           (let [new-name (str/trim (dom/get-target-val event))]
+             (if (str/empty? new-name)
+               (when is-separator?
+                 (st/emit! (dw/delete-page id)))
+               (st/emit! (dw/rename-page id new-name))))
+           (st/emit! (dw/stop-rename-page-item))))
 
         on-key-down
         (mf/use-fn
@@ -166,40 +175,46 @@
            (dom/select-text! edit-input))
          nil)))
 
-    [:li {:class (stl/css-case
-                  :page-element true
-                  :selected selected?
-                  :dnd-over-top (= (:over dprops) :top)
-                  :dnd-over-bot (= (:over dprops) :bot))
-          :ref dref}
-     [:div {:class (stl/css-case
-                    :element-list-body true
-                    :hover hovering?
-                    :selected selected?)
-            :data-testid (dm/str "page-" id)
-            :tab-index "0"
-            :on-click on-click
-            :on-double-click on-double-click
-            :on-context-menu on-context-menu}
-      [:div {:class (stl/css :page-icon)}
-       deprecated-icon/document]
-
-      (if editing?
-        [:*
-         [:input {:class  (stl/css :element-name)
-                  :type "text"
-                  :ref input-ref
-                  :on-blur on-blur
-                  :on-key-down on-key-down
-                  :auto-focus true
-                  :default-value (:name page "")}]]
-        [:*
-         [:span {:class (stl/css :page-name) :title (:name page) :data-testid "page-name"}
-          (:name page)]
-         [:div {:class  (stl/css :page-actions)}
-          (when (and deletable? (not read-only?))
-            [:button {:on-click on-delete}
-             deprecated-icon/delete])]])]]))
+    (let [selected? (and selected? (not is-separator?))]
+      [:li {:class (stl/css-case
+                    :page-element true
+                    :separator is-separator?
+                    :selected selected?
+                    :dnd-over-top (= (:over dprops) :top)
+                    :dnd-over-bot (= (:over dprops) :bot))
+            :ref dref}
+       [:div {:class (stl/css-case
+                      :element-list-body true
+                      :separator-body is-separator?
+                      :hover (and hovering? (not is-separator?))
+                      :selected selected?)
+              :data-testid (dm/str "page-" id)
+              :tab-index "0"
+              :on-click on-click
+              :on-double-click on-double-click
+              :on-context-menu on-context-menu}
+        (if (and is-separator? (not editing?))
+          [:div {:class (stl/css :page-separator)
+                 :data-testid "page-separator"}]
+          [:*
+           (when-not is-separator?
+             [:div {:class (stl/css :page-icon)}
+              deprecated-icon/document])
+           (if editing?
+             [:input {:class        (stl/css :element-name)
+                      :type         "text"
+                      :ref          input-ref
+                      :on-blur      on-blur
+                      :on-key-down  on-key-down
+                      :auto-focus   true
+                      :default-value name}]
+             [:*
+              [:span {:class (stl/css :page-name) :title name :data-testid "page-name"}
+               name]
+              [:div {:class (stl/css :page-actions)}
+               (when (and deletable? (not read-only?))
+                 [:button {:on-click on-delete}
+                  deprecated-icon/delete])]])])]])))
 
 ;; --- Page Item Wrapper
 

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -20,9 +20,8 @@
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.context :as ctx]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
-   [app.main.ui.ds.foundations.assets.icon :as i]
+   [app.main.ui.ds.foundations.assets.icon :as i :refer [icon*]]
    [app.main.ui.hooks :as hooks]
-   [app.main.ui.icons :as deprecated-icon]
    [app.main.ui.notifications.badge :refer [badge-notification]]
    [app.render-wasm.api :as wasm.api]
    [app.util.dom :as dom]
@@ -199,7 +198,7 @@
           [:*
            (when-not is-separator?
              [:div {:class (stl/css :page-icon)}
-              deprecated-icon/document])
+              [:> icon* {:icon-id i/document}]])
            (if editing?
              [:input {:class        (stl/css :element-name)
                       :type         "text"
@@ -213,8 +212,10 @@
                name]
               [:div {:class (stl/css :page-actions)}
                (when (and deletable? (not read-only?))
-                 [:button {:on-click on-delete}
-                  deprecated-icon/delete])]])])]])))
+                 [:> icon-button* {:variant "ghost"
+                                   :aria-label (tr "modals.delete-page.title")
+                                   :on-click on-delete
+                                   :icon i/delete}])]])])]])))
 
 ;; --- Page Item Wrapper
 

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -198,7 +198,7 @@
           [:*
            (when-not is-separator?
              [:div {:class (stl/css :page-icon)}
-              [:> icon* {:icon-id i/document}]])
+              [:> icon* {:icon-id i/document :size "s"}]])
            (if editing?
              [:input {:class        (stl/css :element-name)
                       :type         "text"
@@ -215,6 +215,7 @@
                  [:> icon-button* {:variant "ghost"
                                    :aria-label (tr "modals.delete-page.title")
                                    :on-click on-delete
+                                   :icon-size "s"
                                    :icon i/delete}])]])])]])))
 
 ;; --- Page Item Wrapper

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
@@ -150,6 +150,17 @@
       border: deprecated.$s-1 solid var(--input-border-color-focus);
       color: var(--layer-row-foreground-color);
     }
+    &.separator-body {
+      height: auto;
+      min-height: deprecated.$s-32;
+      padding: 0;
+    }
+    .page-separator {
+      width: 100%;
+      height: deprecated.$s-1;
+      margin: deprecated.$s-8;
+      background-color: var(--color-background-quaternary);
+    }
   }
 
   &:active,
@@ -248,6 +259,16 @@
 
       .page-icon svg {
         stroke: var(--layer-row-foreground-color-hidden);
+      }
+    }
+  }
+  &.separator {
+    &:hover,
+    &.hover {
+      .element-list-body {
+        color: var(--layer-row-foreground-color);
+        background-color: transparent;
+        box-shadow: none;
       }
     }
   }

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
@@ -100,8 +100,6 @@
       svg {
         @extend %button-icon-small;
 
-        height: deprecated.$s-12;
-        width: deprecated.$s-12;
         color: transparent;
         fill: none;
         stroke: var(--icon-foreground);
@@ -110,6 +108,8 @@
 
     .page-actions {
       height: deprecated.$s-32;
+      display: flex;
+      align-items: center;
 
       button {
         @include deprecated.buttonStyle;
@@ -122,8 +122,6 @@
         svg {
           @extend %button-icon-small;
 
-          height: deprecated.$s-12;
-          width: deprecated.$s-12;
           color: transparent;
           fill: none;
           stroke: var(--icon-foreground);

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
@@ -5,6 +5,7 @@
 // Copyright (c) KALEIDOS INC
 
 @use "refactor/common-refactor.scss" as deprecated;
+@use "ds/_borders.scss" as *;
 
 .sitemap {
   position: relative;
@@ -150,17 +151,6 @@
       border: deprecated.$s-1 solid var(--input-border-color-focus);
       color: var(--layer-row-foreground-color);
     }
-    &.separator-body {
-      height: auto;
-      min-height: deprecated.$s-32;
-      padding: 0;
-    }
-    .page-separator {
-      width: 100%;
-      height: deprecated.$s-1;
-      margin: deprecated.$s-8;
-      background-color: var(--color-background-quaternary);
-    }
   }
 
   &:active,
@@ -262,16 +252,26 @@
       }
     }
   }
-  &.separator {
-    &:hover,
-    &.hover {
-      .element-list-body {
-        color: var(--layer-row-foreground-color);
-        background-color: transparent;
-        box-shadow: none;
-      }
-    }
-  }
+}
+
+.element-list-body.separator-body {
+  height: auto;
+  min-height: var(--sp-xxxl);
+  padding: 0;
+}
+
+.page-separator {
+  width: 100%;
+  height: $b-1;
+  margin: var(--sp-s);
+  background-color: var(--color-background-quaternary);
+}
+
+.page-element.separator:hover .element-list-body,
+.page-element.separator.hover .element-list-body {
+  color: var(--layer-row-foreground-color);
+  background-color: transparent;
+  box-shadow: none;
 }
 
 .title-spacing-sitemap {


### PR DESCRIPTION
# Page Separators in Workspace Sitemap

## Overview

This feature adds visual separator support to the left-panel page list (sitemap) in the Penpot workspace. A separator is a regular page whose trimmed name equals `---` **and** whose canvas is empty. When both conditions are met, the page is rendered as a full-width horizontal rule instead of a normal page row.

[Related Taiga US
](https://tree.taiga.io/project/penpot/us/13611?milestone=262806)
### Problem solved

Large files with many pages have no way to visually group them without introducing structural concepts (folders, sections) that would require schema changes and migration. Separators offer a zero-migration, convention-based solution: users create a normal page, name it `---`, and the UI instantly renders it as a divider. The separator can be reordered, renamed back to a real name, or deleted like any other page.

---

## Scope of Changes

| File | Type |
|------|------|
| `frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs` | Modified |
| `frontend/src/app/main/ui/workspace/sidebar/sitemap.scss` | Modified |
| `frontend/src/app/main/data/workspace/pages.cljs` | Modified |

No files were created or deleted.

---

## Detailed Code Changes

### 1. `frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs`

#### A. New require — `app.common.types.page`

**Why:** `ctp/is-empty?` is needed to determine whether a page has no canvas objects, which is the second condition for separator detection.

```clojure
;; Before
(:require
 [app.common.data :as d]
 [app.common.data.macros :as dm]
 [app.main.data.common :as dcm]
 ...)

;; After
(:require
 [app.common.data :as d]
 [app.common.data.macros :as dm]
 [app.common.types.page :as ctp]   ; <-- added
 [app.main.data.common :as dcm]
 ...)
```

---

#### B. `make-page-ref` — derive `:empty?` per page

**Why:** The derived ref strips `:objects` to avoid re-renders on every canvas change. Without storing emptiness *before* stripping objects, the component would have no way to know if the page is empty.

```clojure
;; Before
(defn- make-page-ref [page-id]
  (l/derived (fn [fdata]
               (-> (dsh/get-page fdata page-id)
                   (dissoc :objects)))
             refs/workspace-data =))

;; After
(defn- make-page-ref [page-id]
  (l/derived (fn [fdata]
               (let [page (dsh/get-page fdata page-id)]
                 (-> page
                     (assoc :empty? (ctp/is-empty? page))  ; computed before stripping
                     (dissoc :objects))))
             refs/workspace-data =))
```

---

#### C. `page-item` — separator detection

Added at the top of the component's `let` binding, before any hooks.

```clojure
;; Added
name          (:name page "")
is-separator? (and (= "---" (str/trim name)) (:empty? page))
```

**Why two conditions:** A non-empty page renamed to `---` must remain a normal page to prevent hiding existing canvas content from the user.

---

#### D. `on-click` — navigation disabled for separators

```clojure
;; Before
(mf/use-fn
 (mf/deps id current-page-id)
 (fn []
   (if (and ...)
     (do ...)
     (navigate-fn))))

;; After
(mf/use-fn
 (mf/deps id current-page-id is-separator?)
 (fn []
   (when-not is-separator?      ; <-- guard added
     (if (and ...)
       (do ...)
       (navigate-fn)))))
```

**Why:** Separators are visual markers, not navigation targets. Clicking them should have no effect.

---

#### E. `on-blur` — delete separator on empty rename

```clojure
;; Before
(mf/use-fn
 (fn [event]
   (let [name (str/trim (dom/get-target-val event))]
     (when-not (str/empty? name)
       (st/emit! (dw/rename-page id name)))
     (st/emit! (dw/stop-rename-page-item)))))

;; After
(mf/use-fn
 (mf/deps id is-separator?)
 (fn [event]
   (let [new-name (str/trim (dom/get-target-val event))]
     (if (str/empty? new-name)
       (when is-separator?
         (st/emit! (dw/delete-page id)))   ; delete separator if input cleared
       (st/emit! (dw/rename-page id new-name))))
   (st/emit! (dw/stop-rename-page-item))))
```

**Why:** Clearing the name of a normal page does nothing (existing behaviour preserved). Clearing the name of a separator is an intentional removal gesture — the separator is deleted. This is an explicit asymmetry by design.

---

#### F. Render — separator-aware JSX

The render section wraps the existing `[:li]` in an inner `let` that shadows `selected?`, then branches on `is-separator?` for CSS classes and inner content.

**`[:li]` class changes:**

```clojure
;; Before
[:li {:class (stl/css-case
              :page-element true
              :selected selected?
              :dnd-over-top ...
              :dnd-over-bot ...)}

;; After
(let [selected? (and selected? (not is-separator?))]   ; suppress selection for separators
  [:li {:class (stl/css-case
                :page-element true
                :separator is-separator?               ; new
                :selected selected?
                :dnd-over-top ...
                :dnd-over-bot ...)}
```

**`[:div.element-list-body]` class changes:**

```clojure
;; Before
[:div {:class (stl/css-case
               :element-list-body true
               :hover hovering?
               :selected selected?)}

;; After
[:div {:class (stl/css-case
               :element-list-body true
               :separator-body is-separator?                   ; new
               :hover (and hovering? (not is-separator?))     ; suppressed for separators
               :selected selected?)}
```

**Body content branching:**

```clojure
;; After — separator shows a divider div; normal page shows icon + name/input
(if (and is-separator? (not editing?))
  [:div {:class (stl/css :page-separator)
         :data-testid "page-separator"}]
  [:*
   (when-not is-separator?
     [:div {:class (stl/css :page-icon)}
      deprecated-icon/document])
   (if editing?
     [:input {:class        (stl/css :element-name)
              :type         "text"
              :ref          input-ref
              :on-blur      on-blur
              :on-key-down  on-key-down
              :auto-focus   true
              :default-value name}]
     [:*
      [:span {:class (stl/css :page-name) :title name :data-testid "page-name"}
       name]
      [:div {:class (stl/css :page-actions)}
       (when (and deletable? (not read-only?))
         [:button {:on-click on-delete}
          deprecated-icon/delete])]])])
```

**Why this branching structure:** When a separator is in editing mode (double-clicked), it still shows the input so the user can rename or clear it. The icon is hidden in both modes for separators since it is irrelevant to a visual divider.

---

### 2. `frontend/src/app/main/ui/workspace/sidebar/sitemap.scss`

#### A. Separator body modifier inside `.element-list-body`

```scss
&.separator-body {
  height: auto;
  min-height: deprecated.$s-32;
  padding: 0;
}

.page-separator {
  width: 100%;
  height: deprecated.$s-1;
  margin: deprecated.$s-8;
  background-color: var(--color-background-quaternary);
}
```

**Why:** The normal body has a fixed `height: deprecated.$s-32` and horizontal padding. A separator only needs a 1 px line centred vertically, so padding is removed and height becomes flexible.

---

#### B. Separator hover override inside `.page-element`

```scss
&.separator {
  &:hover,
  &.hover {
    .element-list-body {
      color: var(--layer-row-foreground-color);
      background-color: transparent;
      box-shadow: none;
    }
  }
}
```

**Why:** The generic `:hover` rule adds a background highlight and box-shadow to all page rows. For separators this would visually suggest interactivity that does not exist (no click navigation). Overriding to transparent/none keeps them as passive dividers.

---

### 3. `frontend/src/app/main/data/workspace/pages.cljs`

#### A. `rename-page` — separator-aware fallback navigation

```clojure
;; Before
(defn rename-page [id name]
  (ptk/reify ::rename-page
    ptk/WatchEvent
    (watch [it state _]
      (let [page    (dsh/lookup-page state id)
            changes (-> (pcb/empty-changes it)
                        (pcb/with-page page)
                        (pcb/mod-page page {:name name}))]
        (rx/of (dch/commit-changes changes))))))

;; After
(defn rename-page [id name]
  (ptk/reify ::rename-page
    ptk/WatchEvent
    (watch [it state _]
      (let [page             (dsh/lookup-page state id)
            changes          (-> (pcb/empty-changes it)
                                 (pcb/with-page page)
                                 (pcb/mod-page page {:name name}))
            pages            (-> (dsh/lookup-file-data state) :pages)
            index            (d/index-of pages id)
            prev-id          (when (and (some? index) (pos? index))
                               (nth pages (dec index) nil))
            next-id          (when (some? index)
                               (nth pages (inc index) nil))
            fallback-page-id (or prev-id next-id)
            separator?       (= "---" (str/trim name))]
        (rx/concat
         (rx/of (dch/commit-changes changes))
         (when (and separator?
                    (= id (:current-page-id state))
                    (some? fallback-page-id))
           (rx/of (dcm/go-to-workspace :page-id fallback-page-id))))))))
```

**Why:** If the user renames the currently active page to `---`, the workspace canvas would be displaying a separator — an empty page with no content. To avoid this, the event immediately navigates to the previous page (preferred) or the next page (fallback). This keeps the canvas always showing a real, navigable page.

---

## Architectural or Structural Impact

### Data model
No schema changes. Separators are standard pages identified purely by naming convention (`---`) combined with an emptiness check. No migration is required.

### State management
- `make-page-ref` now derives `:empty?` per page inside the selector, computed before `:objects` is stripped. This means re-renders of `page-item` are triggered when `empty?` changes (e.g. when objects are added to or removed from a page named `---`).
- `selected?` is suppressed at render time for separators via an inner `let` shadow. The upstream state is not modified.
- `rename-page` emits a secondary navigation event when the renamed page becomes a separator and was the currently active page.

### Potential side effects
- `ctp/is-empty?` semantics determine separator detection. If the definition of "empty" changes (e.g. it starts counting guides or grids), separator detection changes accordingly.
- A page containing only non-object elements (e.g. if such a concept is introduced in the future) might unexpectedly become a separator if renamed to `---`.
- The `when` inside `rx/concat` in `rename-page` returns `nil` when the condition is false. `rx/concat` with a `nil` argument is safe in this codebase (it is treated as a no-op observable).

---

## Technical Decisions

### No new entity type for separators
Separators are not a distinct page kind in the data model. They are detected at render time from name + emptiness.

- **Trade-off:** Zero backend changes, zero migration, immediate rollout.
- **Cost:** Behaviour is coupled to a string convention (`"---"`) and `ctp/is-empty?`. A future rename of the convention would require a data migration or a compatibility shim.

### Separator only on empty pages
A non-empty page named `---` remains a normal page row.

- **Trade-off:** Protects users who have content on a page and accidentally rename it to `---`.
- **Cost:** Slight surprise if a user expects the name alone to be sufficient.

### Hover and selection suppressed in CSS, not in data
The selected and hover states are neutralised at the CSS class level (`(and selected? (not is-separator?))`) rather than by filtering separators out of the pages list or marking them in the store.

- **Trade-off:** Simple and local change; no upstream state pollution.
- **Cost:** The `current-page-id` in the store could theoretically still point to a separator page (e.g. if navigation logic elsewhere fails). In that case the UI would show no selected row.

---

## Testing & Validation

Validated manually against the following scenarios:

| Scenario | Expected | Result |
|---|---|---|
| Create page → rename to `---` | Renders as divider row | ✓ |
| Rename `---` page back to any name | Returns to normal row | ✓ |
| Click separator | No navigation | ✓ |
| Double-click separator | Input mode with `---` prefilled | ✓ |
| Clear input on separator and blur | Separator deleted | ✓ |
| Clear input on normal page and blur | Nothing happens (existing behaviour) | ✓ |
| Rename active page to `---` | Workspace navigates to previous/next page | ✓ |
| Non-empty page renamed to `---` | Remains a normal page row | ✓ |
| Separator has no hover highlight | Background stays transparent | ✓ |
| Separator cannot be selected | No selected highlight | ✓ |
| Separator can be reordered via drag-and-drop | Works (no change to sort logic) | ✓ |
| Separator can be deleted via delete button | Confirmation modal, then deleted | ✓ |

### Known limitations
- The `---` convention is not localised or user-configurable.
- No automated frontend tests cover the separator lifecycle.

---

## Future Considerations

- **Explicit `page-kind` metadata:** Introduce a `:kind` field (`:normal` / `:separator`) on page records to decouple the feature from naming convention. This would require a data migration.
- **Automated tests:** Add frontend unit/integration tests for:
  - Separator creation and render.
  - Rename transitions (normal → separator → normal).
  - Delete-on-empty-blur behaviour.
  - Non-empty guard (page stays normal when non-empty and named `---`).
  - Navigation fallback when active page is renamed to separator.
- **Design token review:** `var(--color-background-quaternary)` is used for the separator line colour. Verify this token remains semantically appropriate if the design system evolves.
- **Accessibility:** Separators are currently rendered as a plain `<div>` with no ARIA role. A `role="separator"` attribute could improve screen-reader experience.