### PR TITLE
:lipstick: Fix styles between grid layout inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 ### :bug: Bugs fixed
 
 - Add export panel to inspect styles tab [Taiga #13582](https://tree.taiga.io/project/penpot/issue/13582)
+- Fix styles between grid layout inputs [Taiga #13526](https://tree.taiga.io/project/penpot/issue/13526)
 
 ## 2.15.0 (Unreleased)
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.scss
@@ -188,6 +188,7 @@
   align-items: flex-start;
   position: relative;
   gap: var(--sp-xs);
+  margin-block-end: var(--sp-s);
 }
 
 .locate-button {
@@ -424,6 +425,7 @@
     var(--grid-exception-input-width) /* second input block */
     var(--sp-xxxl); /* action button */
   gap: var(--sp-xs);
+  margin-block-end: var(--sp-xs);
 }
 
 .grid-first-row {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13526

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Fixes #9656
