### PR TITLE
:bug: Fix tooltip shown on tab change

### DIFF
--- a/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
+++ b/frontend/src/app/main/ui/ds/tooltip/tooltip.cljs
@@ -198,6 +198,14 @@
                                (reset! active-tooltip {:id tooltip-id :trigger trigger-el})
                                (reset! visible* true)))))))
 
+        on-show-focus
+        (mf/use-fn
+         (mf/deps on-show)
+         (fn [event]
+           (let [related (dom/get-related-target event)]
+             (when (some? related)
+               (on-show event)))))
+
         on-hide
         (mf/use-fn
          (mf/deps tooltip-id)
@@ -234,7 +242,7 @@
         (mf/spread-props props
                          {:on-mouse-enter on-show
                           :on-mouse-leave on-hide
-                          :on-focus on-show
+                          :on-focus on-show-focus
                           :on-blur on-hide
                           :ref internal-trigger-ref
                           :on-key-down handle-key-down
@@ -243,17 +251,6 @@
                           :aria-label (if (string? content)
                                         content
                                         aria-label)})]
-
-    (mf/use-effect
-     (mf/deps tooltip-id)
-     (fn []
-       (let [handle-visibility-change
-             (fn []
-               (when (.-hidden js/document)
-                 (on-hide)))]
-         (js/document.addEventListener "visibilitychange" handle-visibility-change)
-         ;; cleanup
-         #(js/document.removeEventListener "visibilitychange" handle-visibility-change))))
 
     (mf/use-effect
      (mf/deps visible placement offset)


### PR DESCRIPTION
### Related Ticket

This PR fixes this issue https://tree.taiga.io/project/penpot/issue/13627

This line has been already added to the changelog. This is the second attempt to fix this issue. 

### Summary


### Steps to reproduce 

Hover over any button that has a tooltip to confirm it works correctly. (I.E. Add interaction)
<img width="422" height="234" alt="Screenshot from 2026-03-23 12-12-12" src="https://github.com/user-attachments/assets/9e5dc382-de83-4b18-aa14-69fc902f5935" />

Click the button to trigger its action. IMPORTANT

Switch to another browser tab.

Return to the original tab.

Expected behavior: No tooltip is visible since the mouse is not over the button.

Actual behavior: The tooltip appears even though the mouse cursor is not near the button.

Root cause: After clicking a button, it retains focus. When switching tabs, the browser fires a focus event on that element upon returning, which was incorrectly triggering the tooltip's show handler.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Fixes #9539
