### PR TITLE
:bug: Fix dates to avoid show them in english when browser is in auto

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 - Fix id prop on switch component [Taiga #13534](https://tree.taiga.io/project/penpot/issue/13534)
 - Update copy on penpot update message [Taiga #12924](https://tree.taiga.io/project/penpot/issue/12924)
 - Fix scroll on library modal [Taiga #13639](https://tree.taiga.io/project/penpot/issue/13639)
+- Fix dates to avoid show them in english when browser is in auto [Taiga #13786](https://tree.taiga.io/project/penpot/issue/13786)
 
 ## 2.15.0 (Unreleased)
 

--- a/frontend/src/app/util/i18n.cljs
+++ b/frontend/src/app/util/i18n.cljs
@@ -213,6 +213,9 @@
              (when (not= pv cv)
                (ct/set-default-locale cv))))
 
+;; Initialize date-fns locale on startup, the watch above only fires on changes
+(ct/set-default-locale *current-locale*)
+
 ;; We set the real translation function in the common i18n namespace,
 ;; so that when common code calls (tr ...) it uses this function.
 (set! app.common.i18n/tr tr)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13786

### Steps to reproduce 

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.
- [X] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
