### PR TITLE
:bug: Fix hidden on multiple selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - Fix dates to avoid show them in english when browser is in auto [Taiga #13786](https://tree.taiga.io/project/penpot/issue/13786)
 - Fix focus radio button [Taiga #13841](https://tree.taiga.io/project/penpot/issue/13841)
 - Token tree should be expanded by default [Taiga #13631](https://tree.taiga.io/project/penpot/issue/13631)
+- Fix opacity incorrectly disabled for visible shapes [Taiga #13906](https://tree.taiga.io/project/penpot/issue/13906)
 
 ## 2.15.0 (Unreleased)
 

--- a/frontend/src/app/main/ui/ds/controls/radio_buttons.cljs
+++ b/frontend/src/app/main/ui/ds/controls/radio_buttons.cljs
@@ -24,7 +24,7 @@
     [:and :string [:fn #(contains? icon-list %)]]]
    [:label :string]
    [:value [:or :keyword :string]]
-   [:disabled {:optional true} :boolean]])
+   [:disabled {:optional true} [:maybe :boolean]]])
 
 (def ^:private schema:radio-buttons
   [:map
@@ -35,8 +35,8 @@
    [:name {:optional true} :string]
    [:selected {:optional true}
     [:maybe [:or :keyword :string]]]
-   [:allow-empty {:optional true} :boolean]
-   [:disabled {:optional true} :boolean]
+   [:allow-empty {:optional true} [:maybe :boolean]]
+   [:disabled {:optional true} [:maybe :boolean]]
    [:options [:vector {:min 1} schema:radio-button]]
    [:on-change {:optional true} fn?]])
 
@@ -85,7 +85,8 @@
      (for [[idx {:keys [id class value label icon disabled]}] (d/enumerate options)]
        (let [value-str (d/name value)
              selected-str (when selected (d/name selected))
-             checked? (= selected-str value-str)]
+             checked? (= selected-str value-str)
+             disabled (d/nilv disabled false)]
          [:label {:key idx
                   :html-for id
                   :data-label true

--- a/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/shapes/multiple.cljs
@@ -255,6 +255,9 @@
                                   (cond
                                     (= attr-group :measure) (select-measure-keys shape)
                                     :else (select-keys shape editable-attrs)))
+                    shape-values (cond-> shape-values
+                                   (= attr-group :layer)
+                                   (update :hidden #(if (nil? %) false %)))
                     new-token-acc (merge-token-values token-acc editable-attrs applied-tokens)]
                 [(conj ids id)
                  (merge-attrs values shape-values)


### PR DESCRIPTION
### Related Ticket

This PR fixes this PR https://tree.taiga.io/project/penpot/issue/13906

### Summary

When selecting two shapes opacity input is disabled.

### Steps to reproduce 

Steps on issue. 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Fixes #9658
