### PR TITLE
:bug: Use page name for multi-export downloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - Add CSS linter [Taiga #13790](https://tree.taiga.io/project/penpot/us/13790)
 - Save and restore selection state in undo/redo (by @eureka928) [Github #6007](https://github.com/penpot/penpot/issues/6007)
 - Add per-group add button for typographies (by @eureka928) [Github #5275](https://github.com/penpot/penpot/issues/5275)
+- Use page name for multi-export ZIP/PDF downloads (by @Dexterity104) [Github #8773](https://github.com/penpot/penpot/issues/8773)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/data/exports/assets.cljs
+++ b/frontend/src/app/main/data/exports/assets.cljs
@@ -65,6 +65,9 @@
                        (dsh/lookup-shapes state selected)
                        (reverse (dsh/filter-shapes state #(pos? (count (:exports %))))))
 
+            page      (dsh/lookup-page state)
+            page-name (:name page)
+
             exports  (for [shape  shapes
                            export (:exports shape)]
                        (-> export
@@ -76,10 +79,12 @@
                            (assoc :name (:name shape))))]
 
         (rx/of (modal/show :export-shapes
-                           {:exports (vec exports) :origin origin}))))))
+                           {:exports (vec exports)
+                            :origin origin
+                            :name page-name}))))))
 
 (defn show-viewer-export-dialog
-  [{:keys [shapes page-id file-id share-id exports]}]
+  [{:keys [shapes page-id file-id share-id exports name]}]
   (ptk/reify ::show-viewer-export-dialog
     ptk/WatchEvent
     (watch [_ _ _]
@@ -93,27 +98,32 @@
                           (assoc :shape (dissoc shape :exports))
                           (assoc :name (:name shape))
                           (cond-> share-id (assoc :share-id share-id))))]
-        (rx/of (modal/show :export-shapes {:exports (vec exports) :origin "viewer"})))))) #_TODO
+        (rx/of (modal/show :export-shapes {:exports (vec exports)
+                                           :origin "viewer"
+                                           :name name})))))) #_TODO
 
 (defn show-workspace-export-frames-dialog
   [frames]
   (ptk/reify ::show-workspace-export-frames-dialog
     ptk/WatchEvent
     (watch [_ state _]
-      (let [file-id  (:current-file-id state)
-            page-id  (:current-page-id state)
-            exports  (mapv (fn [frame]
-                             {:enabled true
-                              :page-id page-id
-                              :file-id file-id
-                              :object-id (:id frame)
-                              :shape frame
-                              :name (:name frame)})
-                           frames)]
+      (let [file-id   (:current-file-id state)
+            page-id   (:current-page-id state)
+            page      (dsh/lookup-page state)
+            page-name (:name page)
+            exports   (mapv (fn [frame]
+                              {:enabled true
+                               :page-id page-id
+                               :file-id file-id
+                               :object-id (:id frame)
+                               :shape frame
+                               :name (:name frame)})
+                            frames)]
 
         (rx/of (modal/show :export-frames
                            {:exports exports
-                            :origin "workspace:menu"}))))))
+                            :origin "workspace:menu"
+                            :name page-name}))))))
 
 (defn- initialize-export-status
   [exports cmd resource]
@@ -197,7 +207,7 @@
                              (rx/throw cause)))))))))))
 
 (defn request-multiple-export
-  [{:keys [exports cmd]
+  [{:keys [exports cmd name]
     :or {cmd :export-shapes}
     :as params}]
   (ptk/reify ::request-multiple-export
@@ -206,14 +216,17 @@
       (let [resource-id (volatile! nil)
             profile-id  (:profile-id state)
             ws-conn     (:ws-conn state)
-            params      {:exports exports
-                         :cmd cmd
-                         :profile-id profile-id
-                         :force-multiple true
-                         :is-wasm
-                         (and
-                          (features/active-feature? state "render-wasm/v1")
-                          (contains? cf/flags :wasm-export))}
+            params      (cond->
+                          {:exports exports
+                           :cmd cmd
+                           :profile-id profile-id
+                           :force-multiple true
+                           :is-wasm
+                           (and
+                            (features/active-feature? state "render-wasm/v1")
+                            (contains? cf/flags :wasm-export))}
+                          (some? name)
+                          (assoc :name name))
 
             progress-stream
             (->> (ws/get-rcv-stream ws-conn)

--- a/frontend/src/app/main/data/exports/assets.cljs
+++ b/frontend/src/app/main/data/exports/assets.cljs
@@ -217,14 +217,14 @@
             profile-id  (:profile-id state)
             ws-conn     (:ws-conn state)
             params      (cond->
-                          {:exports exports
-                           :cmd cmd
-                           :profile-id profile-id
-                           :force-multiple true
-                           :is-wasm
-                           (and
-                            (features/active-feature? state "render-wasm/v1")
-                            (contains? cf/flags :wasm-export))}
+                         {:exports exports
+                          :cmd cmd
+                          :profile-id profile-id
+                          :force-multiple true
+                          :is-wasm
+                          (and
+                           (features/active-feature? state "render-wasm/v1")
+                           (contains? cf/flags :wasm-export))}
                           (some? name)
                           (assoc :name name))
 

--- a/frontend/src/app/main/ui/exports/assets.cljs
+++ b/frontend/src/app/main/ui/exports/assets.cljs
@@ -36,7 +36,7 @@
 
 (mf/defc export-multiple-dialog*
   {::mf/private true}
-  [{:keys [exports title cmd no-selection origin]}]
+  [{:keys [exports title cmd no-selection origin name]}]
   (let [lstate          (mf/deref refs/export)
         in-progress?    (:in-progress lstate)
         exports         (mf/use-state exports)
@@ -59,7 +59,7 @@
         (fn [event]
           (dom/prevent-default event)
           (st/emit! (modal/hide)
-                    (de/request-multiple-export {:exports enabled-exports :cmd cmd})
+                    (de/request-multiple-export {:exports enabled-exports :cmd cmd :name name})
                     (de/export-shapes-event enabled-exports origin)))
 
         on-toggle-enabled
@@ -185,25 +185,27 @@
 (mf/defc export-shapes-dialog
   {::mf/register modal/components
    ::mf/register-as :export-shapes}
-  [{:keys [exports origin]}]
+  [{:keys [exports origin name]}]
   (let [title (tr "dashboard.export-shapes.title")]
     [:> export-multiple-dialog*
      {:exports exports
       :title title
       :cmd :export-shapes
       :no-selection shapes-no-selection
-      :origin origin}]))
+      :origin origin
+      :name name}]))
 
 (mf/defc export-frames
   {::mf/register modal/components
    ::mf/register-as :export-frames}
-  [{:keys [exports origin]}]
+  [{:keys [exports origin name]}]
   (let [title (tr "dashboard.export-frames.title")]
     [:> export-multiple-dialog*
      {:exports exports
       :title title
       :cmd :export-frames
-      :origin origin}]))
+      :origin origin
+      :name name}]))
 
 ;; FIXME: deprecated, should be refactored in two components and use
 ;; the generic progress reporter

--- a/frontend/src/app/main/ui/inspect/exports.cljs
+++ b/frontend/src/app/main/ui/inspect/exports.cljs
@@ -47,7 +47,7 @@
           (if (= :multiple type)
             (st/emit! (de/show-viewer-export-dialog {:shapes shapes
                                                      :exports @exports
-                                                     :filename filename
+                                                     :name filename
                                                      :page-id page-id
                                                      :file-id file-id
                                                      :share-id share-id}))


### PR DESCRIPTION
### Related Ticket

[Github #8773](https://github.com/penpot/penpot/issues/8773)

### Summary

- Multi-export (export shapes dialog) and export frames now send the current **page** name as the exporter's top-level `name`, so the downloaded ZIP or combined PDF is named after the page instead of the first board.
- Viewer inspect: the existing computed label for multi-shape export is passed through as `name` so the modal path matches workspace behavior.
- No exporter changes; behavior uses the already-documented optional `name` parameter.

### Steps to reproduce 

**Before:** On a page named e.g. "Landing" with boards "Hero", "Footer" (with export settings), **File -> Export** with nothing selected produced a bundle named like the first board.

**After:** The same flow produces a bundle whose base name matches the page.

**Verify**

1. Open a file, rename the page to something distinct from board names.
2. Add export settings on two or more boards; deselect everything.
3. **File -> Export**, confirm export -> check the downloaded ZIP name.
4. Optional: **Export boards as PDF** -> PDF name should follow the page as well.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.