### PR TITLE
:bug: Fix go to viewer with frame selected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 - Token tree should be expanded by default [Taiga #13631](https://tree.taiga.io/project/penpot/issue/13631)
 - Fix opacity incorrectly disabled for visible shapes [Taiga #13906](https://tree.taiga.io/project/penpot/issue/13906)
 - Update onboarding image [Taiga #13864](https://tree.taiga.io/project/penpot/issue/13864)
+- Fix hot update on color-row on texts [Taiga #13923](https://tree.taiga.io/project/penpot/issue/13923)
 
 ## 2.15.0 (Unreleased)
 

--- a/frontend/src/app/main/data/common.cljs
+++ b/frontend/src/app/main/data/common.cljs
@@ -459,6 +459,17 @@
       (let [page-id (or page-id (:current-page-id state))
             file-id (or file-id (:current-file-id state))
             section (or section :interactions)
+            selected (get-in state [:workspace-local :selected])
+            objects  (dsh/lookup-page-objects state file-id page-id)
+            frame-id (or frame-id
+                         (reduce
+                          (fn [_ id]
+                            (let [obj (get objects id)]
+                              (when (and obj
+                                         (= :frame (:type obj)))
+                                (reduced (:id obj)))))
+                          nil
+                          selected))
             params  {:file-id file-id
                      :page-id page-id
                      :section section

--- a/frontend/src/app/main/ui/workspace/right_header.cljs
+++ b/frontend/src/app/main/ui/workspace/right_header.cljs
@@ -111,10 +111,8 @@
 ;; --- Header Component
 
 (mf/defc right-header*
-  [{:keys [file layout page-id]}]
-  (let [file-id           (:id file)
-
-        threads-map       (mf/deref refs/comment-threads)
+  [{:keys [file-id layout page-id]}]
+  (let [threads-map       (mf/deref refs/comment-threads)
 
         zoom              (mf/deref refs/selected-zoom)
         read-only?        (mf/use-ctx ctx/workspace-read-only?)

--- a/frontend/src/app/main/ui/workspace/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar.cljs
@@ -280,7 +280,7 @@
         [:> history-toolbox*]])]))
 
 (mf/defc right-sidebar*
-  [{:keys [layout section file page-id drawing-tool active-tokens] :as props}]
+  [{:keys [layout section file-id page-id drawing-tool active-tokens] :as props}]
   (let [is-comments?     (= drawing-tool :comments)
         is-history?      (contains? layout :document-history)
         is-inspect?      (= section :inspect)
@@ -340,7 +340,7 @@
                 :on-pointer-move on-pointer-move}])
 
        [:> right-header*
-        {:file file
+        {:file-id file-id
          :layout layout
          :page-id page-id}]
 

--- a/frontend/src/app/main/ui/workspace/webgl_unavailable_modal.scss
+++ b/frontend/src/app/main/ui/workspace/webgl_unavailable_modal.scss
@@ -6,15 +6,14 @@
 
 @use "ds/_utils.scss" as *;
 @use "ds/_borders.scss" as *;
-
 @use "refactor/common-refactor.scss" as deprecated;
 
 .modal-overlay {
-  @extend .modal-overlay-base;
+  @extend %modal-overlay-base;
 }
 
 .modal-dialog {
-  @extend .modal-container-base;
+  @extend %modal-container-base;
 
   color: var(--color-foreground-secondary);
   display: grid;


### PR DESCRIPTION
### Related Ticket

This PR fixes [this bug](https://tree.taiga.io/project/penpot/issue/13898)

### Summary

When we have a board selected and we press "go to viewer" button this board must be selected in viewer.

### Steps to reproduce 
1. Create several boards and add something to identify them
2. Select one of theme
3. Press "Go to viewer" button or press "G V"

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
