### PR TITLE
:bug: Fix text-editor v2 waitForIdle not having a timeout

### DIFF
--- a/frontend/playwright/ui/pages/WasmWorkspacePage.js
+++ b/frontend/playwright/ui/pages/WasmWorkspacePage.js
@@ -40,6 +40,13 @@ export class WasmWorkspacePage extends WorkspacePage {
     this.canvas = page.getByTestId("canvas-wasm-shapes");
   }
 
+  async waitForIdle(options) {
+    return this.page.evaluate(
+      (options) => new Promise((resolve) => globalThis.requestIdleCallback(resolve, options)),
+      options
+    );
+  }
+
   async waitForFirstRender() {
     await this.pageName.waitFor();
     await this.canvas.waitFor();

--- a/frontend/playwright/ui/pages/WorkspacePage.js
+++ b/frontend/playwright/ui/pages/WorkspacePage.js
@@ -53,19 +53,18 @@ export class WorkspacePage extends BaseWebSocketPage {
       for (let i = 0; i < amount; i++) {
         await this.page.keyboard.press("ArrowLeft");
       }
-      await this.waitForIdle();
+      await this.waitForIdle({ timeout: 100 });
     }
 
     async moveToRight(amount = 0) {
       for (let i = 0; i < amount; i++) {
         await this.page.keyboard.press("ArrowRight");
       }
-      await this.waitForIdle();
+      await this.waitForIdle({ timeout: 100 });
     }
 
     async moveFromStart(offset = 0) {
       await this.page.keyboard.press("Home");
-      await this.waitForIdle();
       await this.moveToRight(offset);
     }
 
@@ -107,8 +106,10 @@ export class WorkspacePage extends BaseWebSocketPage {
       return this.changeNumericInput(this.letterSpacing, newValue);
     }
 
-    async waitForIdle() {
-      await this.page.evaluate(() => new Promise((resolve) => globalThis.requestIdleCallback(resolve)));
+    async waitForIdle(options) {
+      await this.page.evaluate(
+        (options) => new Promise(
+          (resolve) => globalThis.requestIdleCallback(resolve, options)), options);
     }
   };
 

--- a/frontend/playwright/ui/specs/text-editor-v2.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v2.spec.js
@@ -96,7 +96,6 @@ test("Update an already created text shape by prepending text", async ({
   await workspace.clickLeafLayer("Lorem ipsum");
   await workspace.textEditor.startEditing();
   await workspace.textEditor.moveFromStart(0);
-  await page.evaluate(() => new Promise((resolve) => globalThis.requestIdleCallback(resolve)));
   await page.keyboard.type("Dolor sit amet ");
   await workspace.textEditor.stopEditing();
   await workspace.waitForSelectedShapeName("Dolor sit amet Lorem ipsum");


### PR DESCRIPTION
### Summary

Fix some text-editor v2 tests that failed because `requestIdleCallback` didn't have a timeout and it did not triggered properly.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
