### PR TITLE
:wrench: Remove VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "files.exclude": {
-    "**/.clj-kondo": true,
-    "**/.cpcache": true,
-    "**/.lsp": true,
-    "**/.shadow-cljs": true,
-    "**/node_modules": true
-  }
-}


### PR DESCRIPTION
Having this committed in the repo prevent us to customize our project settings to suit our own set up (extensions, etc.)