### PR TITLE
:sparkles: Make links in comments clickable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Fix warnings for unsupported token $type (by @Dexterity104) [Github #8790](https://github.com/penpot/penpot/issues/8790)
 - Add per-group add button for typographies (by @eureka928) [Github #5275](https://github.com/penpot/penpot/issues/5275)
 - Use page name for multi-export ZIP/PDF downloads (by @Dexterity104) [Github #8773](https://github.com/penpot/penpot/issues/8773)
+- Make links in comments clickable (by @eureka928) [Github #1602](https://github.com/penpot/penpot/issues/1602)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -55,10 +55,9 @@
     (let [text (:content element)
           parts (str/split text r-url-split)
           urls (re-seq r-url-split text)]
-      (->> (d/interleave-all
-            (map #(hash-map :type :text :content %) parts)
-            (map #(hash-map :type :url :content %) urls))
-           (remove #(and (= (:type %) :text) (str/empty? (:content %))))))
+      (d/interleave-all
+       (map #(hash-map :type :text :content %) parts)
+       (map #(hash-map :type :url :content %) urls)))
     [element]))
 
 (defn- parse-comment

--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -198,6 +198,7 @@
              (doseq [{:keys [type content data]} (parse-comment value)]
                (case type
                  :text     (dom/append-child! node (create-text-node content))
+                 :url      (dom/append-child! node (create-text-node content))
                  :mention  (dom/append-child! node (create-mention-node (:id data) content))
                  nil)))))
 

--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -45,20 +45,35 @@
 (def mentions-context (mf/create-context nil))
 (def r-mentions-split #"@\[[^\]]*\]\([^\)]*\)")
 (def r-mentions #"@\[([^\]]*)\]\(([^\)]*)\)")
+(def r-url-split #"https?://[^\s\)\]]+[^\s\)\]\.,;:!?]")
 (def zero-width-space \u200B)
 
-(defn- parse-comment
-  "Parse a comment into its elements (texts and mentions)"
-  [comment]
-  (d/interleave-all
-   (->> (str/split comment r-mentions-split)
-        (map #(hash-map :type :text :content %)))
+(defn- parse-urls
+  "Split a text element into text and url sub-elements"
+  [element]
+  (if (= (:type element) :text)
+    (let [text (:content element)
+          parts (str/split text r-url-split)
+          urls (re-seq r-url-split text)]
+      (->> (d/interleave-all
+            (map #(hash-map :type :text :content %) parts)
+            (map #(hash-map :type :url :content %) urls))
+           (remove #(and (= (:type %) :text) (str/empty? (:content %))))))
+    [element]))
 
-   (->> (re-seq r-mentions comment)
-        (map (fn [[_ user id]]
-               {:type :mention
-                :content user
-                :data {:id id}})))))
+(defn- parse-comment
+  "Parse a comment into its elements (texts, mentions and urls)"
+  [comment]
+  (->> (d/interleave-all
+        (->> (str/split comment r-mentions-split)
+             (map #(hash-map :type :text :content %)))
+
+        (->> (re-seq r-mentions comment)
+             (map (fn [[_ user id]]
+                    {:type :mention
+                     :content user
+                     :data {:id id}}))))
+       (mapcat parse-urls)))
 
 (defn- parse-nodes
   "Parse the nodes to format a comment"
@@ -146,7 +161,13 @@
   [{:keys [content]}]
   (let [comment-elements (mf/use-memo (mf/deps content) #(parse-comment content))]
     (for [[idx {:keys [type content]}] (d/enumerate comment-elements)]
-      (case type
+      (if (= type :url)
+        [:a {:key idx
+             :href content
+             :target "_blank"
+             :rel "noopener noreferrer"
+             :class (stl/css :comment-link)}
+         content]
         [:span
          {:key idx
           :class (stl/css-case

--- a/frontend/src/app/main/ui/comments.scss
+++ b/frontend/src/app/main/ui/comments.scss
@@ -418,6 +418,12 @@
   color: var(--color-accent-primary);
 }
 
+.comment-link {
+  color: var(--color-accent-primary);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .comments-mentions-empty {
   font-size: deprecated.$fs-12;
   color: var(--color-foreground-secondary);


### PR DESCRIPTION
### Related Ticket

Closes https://github.com/penpot/penpot/issues/1602
https://tree.taiga.io/project/penpot/issue/2930

### Summary

URLs pasted in comments are now detected and rendered as clickable links that open in a new tab. This extends the existing mention parsing pipeline to also handle URL patterns.

**How it works:**
- Added `r-url-split` regex to match `http://` and `https://` URLs
- Added `parse-urls` function that splits text elements into text and URL sub-elements
- `parse-comment` pipes through `parse-urls` via `mapcat` after mention parsing
- `comment-content*` renders `:url` type elements as `<a>` with `target="_blank"` and `rel="noopener noreferrer"`
- Trailing punctuation (`.` `,` `;` `:` `!` `?`) is excluded from URLs

### Steps to reproduce

1. Open any file in the workspace
2. Add a comment containing a URL, e.g. `Check https://example.com for details`
3. Verify the URL is rendered as a clickable, underlined link
4. Click the link — it should open in a new tab
5. Test with mixed content: `Hey @someone see https://example.com and https://test.org!`
6. Verify mentions and URLs are both correctly rendered
7. Test trailing punctuation: `Visit https://example.com.` — the period should not be part of the link

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.