### PR TITLE
:bug: Normalize token set names in themes

### DIFF
--- a/common/src/app/common/types/tokens_lib.cljc
+++ b/common/src/app/common/types/tokens_lib.cljc
@@ -723,7 +723,8 @@
         (update :is-source d/nilv false)
         (update :external-id #(or % (str new-id)))
         (update :modified-at #(or % (ct/now)))
-        (update :sets #(into #{} (filter some?) %))
+        (update :sets #(into #{} (comp (filter some?)
+                                       (map normalize-set-name)) %))
         (check-token-theme-attrs)
         (map->TokenTheme))))
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13849

### Summary

To fix the issue, we made that the token set names are automatically normalized when created. But this needs to be done also in token themes, that references sets by name.

### Steps to reproduce 

- Open the file in the issue
- Edit one theme and check if the number of active sets in the themes list matches the actual sets in the theme.
- Activate one theme and see that changes are applied into the file.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
