### PR TITLE
:sparkles: Sort asset subfolders alphabetically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - Use page name for multi-export ZIP/PDF downloads (by @Dexterity104) [Github #8773](https://github.com/penpot/penpot/issues/8773)
 - Make links in comments clickable (by @eureka928) [Github #1602](https://github.com/penpot/penpot/issues/1602)
 - Add visibility toggle for strokes (by @eureka928) [Github #7438](https://github.com/penpot/penpot/issues/7438)
+- Sort asset library subfolders alphabetically at every nesting level (by @eureka928) [Github #2572](https://github.com/penpot/penpot/issues/2572)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs
@@ -86,6 +86,17 @@
                           :on-click on-context-menu
                           :icon i/menu}]]])))
 
+(defn- sort-groups
+  "Recursively sort subgroup keys alphabetically at every nesting level."
+  [groups reverse-sort?]
+  (let [cmp (if reverse-sort? #(compare %2 %1) compare)
+        sort-tree (fn sort-tree [m]
+                    (into (sorted-map-by cmp)
+                          (map (fn [[k v]]
+                                 [k (if (map? v) (sort-tree v) v)]))
+                          m))]
+    (sort-tree groups)))
+
 (defn group-assets
   "Convert a list of assets in a nested structure like this:
 
@@ -97,19 +108,17 @@
   "
   [assets reverse-sort?]
   (when-not (empty? assets)
-    (reduce (fn [groups {:keys [path] :as asset}]
-              (let [path (cpn/split-path (or path ""))]
-                (update-in groups
-                           (conj path "")
-                           (fn [group]
-                             (if group
-                               (conj group asset)
-                               [asset])))))
-            (sorted-map-by (fn [key1 key2]
-                             (if reverse-sort?
-                               (compare key2 key1)
-                               (compare key1 key2))))
-            assets)))
+    (-> (reduce (fn [groups {:keys [path] :as asset}]
+                  (let [path (cpn/split-path (or path ""))]
+                    (update-in groups
+                               (conj path "")
+                               (fn [group]
+                                 (if group
+                                   (conj group asset)
+                                   [asset])))))
+                {}
+                assets)
+        (sort-groups reverse-sort?))))
 
 (def ^:private schema:group-form
   [:map {:title "GroupForm"}


### PR DESCRIPTION
## Summary
- Fixes asset library **subfolders** (nested groups) not appearing in alphabetical order, while top-level groups and items already did
- Adds a recursive post-process (`sort-groups`) that rebuilds every nesting level as a `sorted-map-by` so subfolders sort correctly at any depth
- Respects the existing `reverse-sort?` flag at every level

Closes #2572

## Root cause
`group-assets` initialized `reduce` with a `sorted-map-by` — but `update-in` creates intermediate maps as plain `PersistentArrayMap` when descending into new path keys. So only the **top** level of the tree was sorted; every nested subgroup was in hash-map iteration order.

## Changes
- `frontend/src/app/main/ui/workspace/sidebar/assets/groups.cljs` — new `sort-groups` helper + `group-assets` threads the reduce result through it
- `CHANGES.md` — changelog entry

## Test plan
- [ ] Open a library with nested component/color/typography subfolders (e.g. `Main/Z-Thing`, `Main/A-Thing`)
- [ ] Verify subfolders now render alphabetically at every nesting depth (Components, Colors, Typographies tabs)
- [ ] Verify top-level groups still sort correctly
- [ ] Verify the reverse-sort toggle still reverses order at every level
- [ ] Verify flat assets (no group path) still appear at the top of their parent