### PR TITLE
:sparkles: Persist asset search query when switching sidebar tabs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@
 
 - Access Tokens look & feel refinement [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
 - Enhance readability of applied tokens in plugins API [Taiga #13714](https://tree.taiga.io/project/penpot/issue/13714)
+- Persist asset search query and section filter when switching sidebar tabs (by @eureka0928) [Github #2913](https://github.com/penpot/penpot/issues/2913)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -70,16 +70,24 @@
   [v a b]
   (if (= v a) b a))
 
+;; Per-file, session-scoped (in-memory only) so the search term and section
+;; filter survive switching between the Layers and Assets sidebar tabs without
+;; leaking across files or persisting across reloads.
+(defonce ^:private session-filters*
+  (atom {}))
+
 (mf/defc assets-toolbox*
   {::mf/wrap [mf/memo]}
   [{:keys [size file-id]}]
   (let [read-only?     (mf/use-ctx ctx/workspace-read-only?)
         filters*       (mf/use-state
-                        {:term ""
-                         :section "all"
-                         :ordering (dwa/get-current-assets-ordering)
-                         :list-style (dwa/get-current-assets-list-style)
-                         :open-menu false})
+                        (fn []
+                          (-> (or (get @session-filters* file-id)
+                                  {:term ""
+                                   :section "all"})
+                              (assoc :ordering (dwa/get-current-assets-ordering)
+                                     :list-style (dwa/get-current-assets-list-style)
+                                     :open-menu false))))
         filters        (deref filters*)
         term           (:term filters)
         list-style     (:list-style filters)
@@ -161,6 +169,9 @@
            {:name    (tr "workspace.assets.typography")
             :id      "typographies"
             :handler on-section-filter-change}])]
+
+    (mf/with-effect [file-id term section]
+      (swap! session-filters* assoc file-id {:term term :section section}))
 
     [:article  {:class (stl/css :assets-bar)}
      [:div {:class (stl/css :assets-header)}


### PR DESCRIPTION
## Summary

Closes #2913

When users switch between the Layers and Assets sidebar tabs, the asset search query and section filter are lost because `assets-toolbox*` unmounts and its local `use-state` is discarded. This is a frequent papercut for users who toggle between panes while picking assets.

- Introduce a per-file, in-memory `defonce` session atom in `assets.cljs` that holds `{file-id {:term :section}}`
- Initialize `filters*` from that atom on mount, falling back to defaults when no entry exists for the current file
- Sync `:term` and `:section` back to the atom via a small `mf/with-effect`
- `:ordering` and `:list-style` continue to use `storage/user` (localStorage) — those are user preferences, not session state
- Filters are scoped per file, so switching files does not leak a stale search; reloading the browser clears them

## Test plan

- [ ] Type a query in the assets search bar, switch to the Layers tab and back — query is preserved
- [ ] Pick a section filter (e.g. Components), switch tabs and back — filter is preserved
- [ ] Open a different file — assets search starts empty (no leak across files)
- [ ] Reload the browser — search starts empty (session-only)
- [ ] Ordering toggle and list-style toggle still persist across reloads as before