### PR TITLE
:sparkles: Add color customization for ruler guides

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Make links in comments clickable (by @eureka928) [Github #1602](https://github.com/penpot/penpot/issues/1602)
 - Add visibility toggle for strokes (by @eureka928) [Github #7438](https://github.com/penpot/penpot/issues/7438)
 - Sort asset library subfolders alphabetically at every nesting level (by @eureka928) [Github #2572](https://github.com/penpot/penpot/issues/2572)
+- Add customizable colors for ruler guides (by @Dexterity104) [Github #5199](https://github.com/penpot/penpot/issues/5199)
 
 ### :bug: Bugs fixed
 

--- a/common/src/app/common/types/page.cljc
+++ b/common/src/app/common/types/page.cljc
@@ -34,7 +34,8 @@
    [:id ::sm/uuid]
    [:axis [::sm/one-of #{:x :y}]]
    [:position ::sm/safe-number]
-   [:frame-id {:optional true} [:maybe ::sm/uuid]]])
+   [:frame-id {:optional true} [:maybe ::sm/uuid]]
+   [:color {:optional true} [:maybe ctc/schema:hex-color]]])
 
 (def schema:guides
   [:map-of {:gen/max 2} ::sm/uuid schema:guide])

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1195,6 +1195,16 @@
                 (-> params (assoc :kind :grid-cells
                                   :grid grid
                                   :cells cells))))))))
+(defn show-guide-context-menu
+  [{:keys [position guide] :as params}]
+  (dm/assert! (gpt/point? position))
+  (ptk/reify ::show-guide-context-menu
+    ptk/WatchEvent
+    (watch [_ _ _]
+      (rx/of (show-context-menu
+              (-> params (assoc :kind :guide
+                                :guide guide)))))))
+
 (def hide-context-menu
   (ptk/reify ::hide-context-menu
     ptk/UpdateEvent

--- a/frontend/src/app/main/data/workspace/guides.cljs
+++ b/frontend/src/app/main/data/workspace/guides.cljs
@@ -152,6 +152,23 @@
              (map build-move-event)
              (rx/from))))))
 
+(defn update-guide-color
+  [guide-id color]
+  (ptk/reify ::update-guide-color
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [{:keys [guides] :as page} (dsh/lookup-page state)
+            guide (get guides guide-id)]
+        (when (some? guide)
+          (let [updated-guide (if (some? color)
+                                (assoc guide :color color)
+                                (dissoc guide :color))
+                changes
+                (-> (pcb/empty-changes it)
+                    (pcb/with-page page)
+                    (pcb/set-guide guide-id updated-guide))]
+            (rx/of (dwc/commit-changes changes))))))))
+
 (defn set-hover-guide
   [id hover?]
   (ptk/reify ::set-hover-guide

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -12,7 +12,6 @@
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.transit :as t]
-   [app.common.types.color :as cc]
    [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
    [app.common.types.page :as ctp]
@@ -907,7 +906,7 @@
   {::mf/props :obj
    ::mf/private true}
   [{:keys [mdata]}]
-  (let [{:keys [guide position]} mdata
+  (let [{:keys [guide]} mdata
         guide-id (:id guide)
         current-color (or (:color guide) (first guide-color-presets))
 
@@ -919,26 +918,6 @@
              (st/emit! dw/hide-context-menu
                        (dwg/update-guide-color guide-id color)))))
 
-        do-open-picker
-        (mf/use-fn
-         (mf/deps guide-id current-color position)
-         (fn []
-           (st/emit! dw/hide-context-menu)
-           (modal/show! :colorpicker
-                        {:x (- (:x position) 240)
-                         :y (:y position)
-                         :data {:color (cc/remove-hash current-color)
-                                :opacity 1}
-                         :disable-gradient true
-                         :disable-opacity true
-                         :disable-image true
-                         :on-change (fn [{:keys [color]}]
-                                      (when color
-                                        (st/emit! (dwg/update-guide-color
-                                                   guide-id
-                                                   (cc/prepend-hash color)))))
-                         :origin :guide})))
-
         do-remove-guide
         (mf/use-fn
          (mf/deps guide)
@@ -947,32 +926,19 @@
                      (dwg/remove-guide guide))))]
 
     [:*
-     ;; Color label row
-     [:li {:class (stl/css :context-menu-item)
-           :style {:cursor "default" :pointer-events "none"}}
+     [:li {:class (stl/css :context-menu-item :guide-color-label)}
       [:span {:class (stl/css :title)}
        (tr "workspace.context-menu.guides.change-color")]]
-     ;; Color swatches row
-     [:li {:style {:padding "4px 6px 8px" :list-style "none"}}
-      [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px" :align-items "center"}}
-       (for [color guide-color-presets]
-         [:span {:key color
-                 :data-color color
-                 :on-click do-set-color
-                 :title color
-                 :style {:width "18px"
-                         :height "18px"
-                         :border-radius "50%"
-                         :background-color color
-                         :cursor "pointer"
-                         :flex-shrink "0"
-                         :box-sizing "border-box"
-                         :border (if (= color current-color)
-                                   "2px solid var(--menu-foreground-color)"
-                                   "1px solid var(--panel-border-color)")}}])]]
-     ;; Custom color picker option
-     [:> menu-entry* {:title (tr "workspace.context-menu.guides.custom-color")
-                      :on-click do-open-picker}]
+     [:li {:class (stl/css :guide-color-swatches)}
+      (for [color guide-color-presets]
+        [:span {:key color
+                :class (stl/css-case
+                        :guide-color-swatch true
+                        :selected (= color current-color))
+                :data-color color
+                :on-click do-set-color
+                :title color
+                :style {:background-color color}}])]
      [:> menu-separator* {}]
      [:> menu-entry* {:title (tr "workspace.context-menu.guides.remove")
                       :on-click do-remove-guide}]]))

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -12,6 +12,7 @@
    [app.common.data.macros :as dm]
    [app.common.files.helpers :as cfh]
    [app.common.transit :as t]
+   [app.common.types.color :as cc]
    [app.common.types.component :as ctk]
    [app.common.types.container :as ctn]
    [app.common.types.page :as ctp]
@@ -899,6 +900,83 @@
                       :disabled (not has-copied-tracks?)}]]))
 
 
+(def guide-color-presets
+  ["#ff3277" "#4dabf7" "#51cf66" "#fcc419" "#ff922b" "#cc5de8" "#ffffff" "#868e96"])
+
+(mf/defc guide-color-context-menu*
+  {::mf/props :obj
+   ::mf/private true}
+  [{:keys [mdata]}]
+  (let [{:keys [guide position]} mdata
+        guide-id (:id guide)
+        current-color (or (:color guide) (first guide-color-presets))
+
+        do-set-color
+        (mf/use-fn
+         (mf/deps guide-id)
+         (fn [event]
+           (let [color (dom/get-data (dom/get-current-target event) "color")]
+             (st/emit! dw/hide-context-menu
+                       (dwg/update-guide-color guide-id color)))))
+
+        do-open-picker
+        (mf/use-fn
+         (mf/deps guide-id current-color position)
+         (fn []
+           (st/emit! dw/hide-context-menu)
+           (modal/show! :colorpicker
+                        {:x (- (:x position) 240)
+                         :y (:y position)
+                         :data {:color (cc/remove-hash current-color)
+                                :opacity 1}
+                         :disable-gradient true
+                         :disable-opacity true
+                         :disable-image true
+                         :on-change (fn [{:keys [color]}]
+                                      (when color
+                                        (st/emit! (dwg/update-guide-color
+                                                   guide-id
+                                                   (cc/prepend-hash color)))))
+                         :origin :guide})))
+
+        do-remove-guide
+        (mf/use-fn
+         (mf/deps guide)
+         (fn []
+           (st/emit! dw/hide-context-menu
+                     (dwg/remove-guide guide))))]
+
+    [:*
+     ;; Color label row
+     [:li {:class (stl/css :context-menu-item)
+           :style {:cursor "default" :pointer-events "none"}}
+      [:span {:class (stl/css :title)}
+       (tr "workspace.context-menu.guides.change-color")]]
+     ;; Color swatches row
+     [:li {:style {:padding "4px 6px 8px" :list-style "none"}}
+      [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px" :align-items "center"}}
+       (for [color guide-color-presets]
+         [:span {:key color
+                 :data-color color
+                 :on-click do-set-color
+                 :title color
+                 :style {:width "18px"
+                         :height "18px"
+                         :border-radius "50%"
+                         :background-color color
+                         :cursor "pointer"
+                         :flex-shrink "0"
+                         :box-sizing "border-box"
+                         :border (if (= color current-color)
+                                   "2px solid var(--menu-foreground-color)"
+                                   "1px solid var(--panel-border-color)")}}])]]
+     ;; Custom color picker option
+     [:> menu-entry* {:title (tr "workspace.context-menu.guides.custom-color")
+                      :on-click do-open-picker}]
+     [:> menu-separator* {}]
+     [:> menu-entry* {:title (tr "workspace.context-menu.guides.remove")
+                      :on-click do-remove-guide}]]))
+
 ;; FIXME: optimize because it is rendered always
 
 (mf/defc context-menu*
@@ -936,4 +1014,5 @@
            :page       [:> page-item-context-menu* {:mdata mdata}]
            :grid-track [:> grid-track-context-menu* {:mdata mdata}]
            :grid-cells [:> grid-cells-context-menu* {:mdata mdata}]
+           :guide      [:> guide-color-context-menu* {:mdata mdata}]
            [:> viewport-context-menu* {:mdata mdata}]))]]]))

--- a/frontend/src/app/main/ui/workspace/context_menu.scss
+++ b/frontend/src/app/main/ui/workspace/context_menu.scss
@@ -138,3 +138,30 @@
   pointer-events: none;
   opacity: 0.6;
 }
+
+.guide-color-label {
+  cursor: default;
+  pointer-events: none;
+}
+
+.guide-color-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: deprecated.$s-6;
+  padding: deprecated.$s-4 deprecated.$s-6 deprecated.$s-8;
+  list-style: none;
+}
+
+.guide-color-swatch {
+  width: deprecated.$s-20;
+  height: deprecated.$s-20;
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  border: deprecated.$s-2 solid var(--panel-border-color);
+
+  &.selected {
+    border: deprecated.$s-2 solid var(--menu-foreground-color);
+  }
+}

--- a/frontend/src/app/main/ui/workspace/viewport/guides.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/guides.cljs
@@ -293,7 +293,7 @@
 
         guide-color
         (or (:color guide) default-guide-color)
-        
+
         read-only?
         (mf/use-ctx ctx/workspace-read-only?)
 

--- a/frontend/src/app/main/ui/workspace/viewport/guides.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/guides.cljs
@@ -28,7 +28,8 @@
 (def ^:const guide-width 1)
 (def ^:const guide-opacity 0.7)
 (def ^:const guide-opacity-hover 1)
-(def ^:const guide-color colors/new-danger)
+(def ^:const default-guide-color colors/new-danger)
+
 (def ^:const guide-pill-width 34)
 (def ^:const guide-pill-height 20)
 (def ^:const guide-pill-corner-radius 4)
@@ -282,13 +283,17 @@
 (mf/defc guide*
   {::mf/wrap [mf/memo]}
   [{:keys [guide is-hover on-guide-change get-hover-frame vbox zoom
-           hover-frame disabled-guides frame-modifier frame-transform]}]
+           hover-frame disabled-guides frame-modifier frame-transform
+           on-guide-context-menu]}]
   (let [axis
         (get guide :axis)
 
+        guide-color
+        (or (:color guide) default-guide-color)
+
         handle-change-position
         (mf/use-fn
-         (mf/deps on-guide-change)
+         (mf/deps on-guide-change guide)
          (fn [changes]
            (when on-guide-change
              (on-guide-change (merge guide changes)))))
@@ -336,7 +341,13 @@
                    (not (ctst/rotated-frame? frame))))
       [:g.guide-area {:opacity (when frame-guide-outside? 0)}
        (when-not disabled-guides
-         (let [{:keys [x y width height]} (guide-area-axis pos vbox zoom frame axis)]
+         (let [{:keys [x y width height]} (guide-area-axis pos vbox zoom frame axis)
+               on-context-menu
+               (fn [event]
+                 (dom/prevent-default event)
+                 (dom/stop-propagation event)
+                 (when on-guide-context-menu
+                   (on-guide-context-menu event guide)))]
            [:rect {:x x
                    :y y
                    :width width
@@ -349,7 +360,8 @@
                    :on-pointer-down on-pointer-down
                    :on-pointer-up on-pointer-up
                    :on-lost-pointer-capture on-lost-pointer-capture
-                   :on-pointer-move on-pointer-move}]))
+                   :on-pointer-move on-pointer-move
+                   :on-context-menu on-context-menu}]))
 
        (if (some? frame)
          (let [{:keys [l1-x1 l1-y1 l1-x2 l1-y2
@@ -502,6 +514,13 @@
              (st/emit! (dw/update-guides guide))
              (st/emit! (dw/remove-guide guide)))))
 
+        on-guide-context-menu
+        (mf/use-fn
+         (fn [event guide]
+           (let [position (dom/get-client-position event)]
+             (st/emit! (dw/show-guide-context-menu {:position position
+                                                    :guide guide})))))
+
         frame-modifiers
         (-> (group-by :id modifiers)
             (update-vals (comp :transform first)))]
@@ -533,4 +552,5 @@
                      :frame-transform (get frame-modifiers frame-id)
                      :get-hover-frame get-hover-frame
                      :on-guide-change on-guide-change
+                     :on-guide-context-menu on-guide-context-menu
                      :disabled-guides disabled-guides}]))]))

--- a/frontend/src/app/plugins/ruler_guides.cljs
+++ b/frontend/src/app/plugins/ruler_guides.cljs
@@ -94,6 +94,22 @@
                  value)]
            (st/emit! (dwgu/update-guides (assoc guide :position position))))))}
 
+    :color
+    {:this true
+     :get
+     (fn [self]
+       (-> self u/proxy->ruler-guide :color))
+
+     :set
+     (fn [self value]
+       (cond
+         (not (r/check-permission plugin-id "content:write"))
+         (u/not-valid plugin-id :color "Plugin doesn't have 'content:write' permission")
+
+         :else
+         (let [guide (u/proxy->ruler-guide self)]
+           (st/emit! (dwgu/update-guides (assoc guide :color value))))))}
+
     :remove
     (fn []
       (let [guide (u/locate-ruler-guide file-id page-id id)]

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5676,9 +5676,6 @@ msgstr "Paste"
 msgid "workspace.context-menu.guides.change-color"
 msgstr "Guide color"
 
-msgid "workspace.context-menu.guides.custom-color"
-msgstr "Custom color..."
-
 msgid "workspace.context-menu.guides.remove"
 msgstr "Remove guide"
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -5673,6 +5673,15 @@ msgstr "Copy columns"
 msgid "workspace.context-menu.grid-cells.paste-tracks"
 msgstr "Paste"
 
+msgid "workspace.context-menu.guides.change-color"
+msgstr "Guide color"
+
+msgid "workspace.context-menu.guides.custom-color"
+msgstr "Custom color..."
+
+msgid "workspace.context-menu.guides.remove"
+msgstr "Remove guide"
+
 #: src/app/main/ui/workspace/context_menu.cljs:754
 msgid "workspace.context-menu.grid-track.column.add-after"
 msgstr "Add 1 column to the right"


### PR DESCRIPTION
### Related Ticket

Closes [Github #5199](https://github.com/penpot/penpot/issues/5199)

### Summary

Ruler guides use pink color which becomes invisible on certain canvas backgrounds. This adds per-guide color support.

- Optional `color` field added to the guide data model
- Right-clicking a guide opens a context menu with 8 color presets and a "Custom color..." entry that opens the colorpicker modal
- Color is preserved when dragging a guide to a new position and round-trips correctly through undo/redo
- Plugin API: `color` property added to `RulerGuideProxy`

### Steps to reproduce

1. Open any file and place a frame on a colored background
2. Drag a guide from the ruler onto the canvas
3. Right-click the guide -> select a color from the swatches or use "Custom color..." for the full color picker
4. Drag the guide to confirm color is preserved after a move
5. Undo/redo to confirm color round-trips correctly

[guide-color-customization.webm](https://github.com/user-attachments/assets/08ddc8cb-d470-4a11-88f9-9c64775dc5ab)


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.