### PR TITLE
:sparkles: Add search bar to color palette

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 - Persist asset search query and section filter when switching sidebar tabs (by @eureka0928) [Github #2913](https://github.com/penpot/penpot/issues/2913)
 - Add delete and duplicate buttons to typography dialog (by @eureka0928) [Github #5270](https://github.com/penpot/penpot/issues/5270)
 - Edit ruler guide position by double-clicking the guide pill (by @eureka0928) [Github #2311](https://github.com/penpot/penpot/issues/2311)
-
+- Add a search bar to filter colors in the color palette toolbar (by @eureka0928) [Github #7653](https://github.com/penpot/penpot/issues/7653)
 
 ### :bug: Bugs fixed
 
@@ -76,9 +76,6 @@
 
 - Access Tokens look & feel refinement [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
 - Enhance readability of applied tokens in plugins API [Taiga #13714](https://tree.taiga.io/project/penpot/issue/13714)
-- Persist asset search query and section filter when switching sidebar tabs (by @eureka0928) [Github #2913](https://github.com/penpot/penpot/issues/2913)
-- Add delete and duplicate buttons to typography dialog (by @eureka0928) [Github #5270](https://github.com/penpot/penpot/issues/5270)
-- Add a search bar to filter colors in the color palette toolbar (by @eureka0928) [Github #7653](https://github.com/penpot/penpot/issues/7653)
 
 ### :bug: Bugs fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,9 @@
 
 - Access Tokens look & feel refinement [Taiga #13114](https://tree.taiga.io/project/penpot/us/13114)
 - Enhance readability of applied tokens in plugins API [Taiga #13714](https://tree.taiga.io/project/penpot/issue/13714)
+- Persist asset search query and section filter when switching sidebar tabs (by @eureka0928) [Github #2913](https://github.com/penpot/penpot/issues/2913)
+- Add delete and duplicate buttons to typography dialog (by @eureka0928) [Github #5270](https://github.com/penpot/penpot/issues/5270)
+- Add a search bar to filter colors in the color palette toolbar (by @eureka0928) [Github #7653](https://github.com/penpot/penpot/issues/7653)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/workspace/color_palette.cljs
+++ b/frontend/src/app/main/ui/workspace/color_palette.cljs
@@ -15,6 +15,7 @@
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.color-bullet :as cb]
+   [app.main.ui.components.search-bar :refer [search-bar*]]
    [app.main.ui.context :as ctx]
    [app.main.ui.ds.utilities.swatch :refer [swatch*]]
    [app.main.ui.icons :as deprecated-icon]
@@ -23,6 +24,7 @@
    [app.util.i18n :refer [tr]]
    [app.util.keyboard :as kbd]
    [app.util.object :as obj]
+   [app.util.strings :refer [matches-search]]
    [okulary.core :as l]
    [potok.v2.core :as ptk]
    [rumext.v2 :as mf]))
@@ -59,21 +61,36 @@
   {::mf/wrap [mf/memo]}
   [{:keys [colors size width selected]}]
   (let [state        (mf/use-state #(do {:show-menu false}))
+        search-term* (mf/use-state "")
+        search-term  (deref search-term*)
+
+        filtered-colors
+        (mf/with-memo [colors search-term]
+          (if (empty? search-term)
+            colors
+            (filterv #(matches-search (or (uc/get-color-name %) "") search-term)
+                     colors)))
+
+        on-search-change
+        (mf/use-fn #(reset! search-term* %))
+
         offset-step  (cond
                        (<= size 64) 40
                        (<= size 80) 72
                        :else 72)
+        ;; Reserve room for the search bar (matches `.palette-search` width in scss)
+        search-width   160
         buttons-size (cond
-                       (<= size 64) 164
-                       :else 132)
+                       (<= size 64) (+ 164 search-width)
+                       :else (+ 132 search-width))
         width          (- width buttons-size)
         visible        (int (/ width offset-step))
-        show-arrows?   (> (count colors) visible)
+        show-arrows?   (> (count filtered-colors) visible)
         visible        (if show-arrows?
                          (int (/ (- width 48) offset-step))
                          visible)
         offset         (:offset @state 0)
-        max-offset     (- (count colors)
+        max-offset     (- (count filtered-colors)
                           visible)
         container      (mf/use-ref nil)
         bullet-size  (cond
@@ -121,7 +138,7 @@
             width (obj/get dom "clientWidth")]
         (swap! state assoc :width width)))
 
-    (mf/with-effect [width colors]
+    (mf/with-effect [width filtered-colors]
       (when (not= 0 (:offset @state))
         (swap! state assoc :offset 0)))
 
@@ -131,6 +148,11 @@
            :style #js {"--bullet-size" (dm/str bullet-size "px")
                        "--color-cell-width" (dm/str color-cell-width "px")}}
 
+     [:div {:class (stl/css :palette-search)}
+      [:> search-bar* {:on-change on-search-change
+                       :value search-term
+                       :placeholder (tr "workspace.assets.search")}]]
+
      (when show-arrows?
        [:button {:class (stl/css :left-arrow)
                  :disabled (= offset 0)
@@ -138,18 +160,20 @@
      [:div {:class (stl/css :color-palette-content)
             :ref container
             :on-wheel on-scroll}
-      (if (empty? colors)
+      (if (empty? filtered-colors)
         [:div {:class  (stl/css :color-palette-empty)
                :style {:position "absolute"
                        :left "50%"
                        :top "50%"
                        :transform "translate(-50%, -50%)"}}
-         (tr "workspace.libraries.colors.empty-palette")]
+         (if (empty? search-term)
+           (tr "workspace.libraries.colors.empty-palette")
+           (tr "workspace.assets.not-found"))]
         [:div {:class  (stl/css :color-palette-inside)
                :style {:position "relative"
                        :max-width (str width "px")
                        :right (str (* offset-step offset) "px")}}
-         (for [[idx item] (map-indexed vector colors)]
+         (for [[idx item] (map-indexed vector filtered-colors)]
            [:> palette-item* {:color item :key idx :size size :selected selected}])])]
 
      (when show-arrows?

--- a/frontend/src/app/main/ui/workspace/color_palette.cljs
+++ b/frontend/src/app/main/ui/workspace/color_palette.cljs
@@ -17,6 +17,8 @@
    [app.main.ui.components.color-bullet :as cb]
    [app.main.ui.components.search-bar :refer [search-bar*]]
    [app.main.ui.context :as ctx]
+   [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.foundations.assets.icon :as i]
    [app.main.ui.ds.utilities.swatch :refer [swatch*]]
    [app.main.ui.icons :as deprecated-icon]
    [app.util.color :as uc]
@@ -63,6 +65,9 @@
   (let [state        (mf/use-state #(do {:show-menu false}))
         search-term* (mf/use-state "")
         search-term  (deref search-term*)
+        search-open* (mf/use-state false)
+        search-open? (deref search-open*)
+        has-colors?  (seq colors)
 
         filtered-colors
         (mf/with-memo [colors search-term]
@@ -74,12 +79,27 @@
         on-search-change
         (mf/use-fn #(reset! search-term* %))
 
+        on-toggle-search
+        (mf/use-fn
+         (fn [_]
+           (when @search-open*
+             (reset! search-term* ""))
+           (swap! search-open* not)))
+
+        on-search-clear
+        (mf/use-fn
+         (fn [_]
+           (reset! search-term* "")
+           (reset! search-open* false)))
+
         offset-step  (cond
                        (<= size 64) 40
                        (<= size 80) 72
                        :else 72)
-        ;; Reserve room for the search bar (matches `.palette-search` width in scss)
-        search-width   160
+        ;; Reserve room for the search bar, icon button, or nothing
+        search-width   (cond (not has-colors?) 0
+                             search-open? 192
+                             :else 32)
         buttons-size (cond
                        (<= size 64) (+ 164 search-width)
                        :else (+ 132 search-width))
@@ -142,16 +162,30 @@
       (when (not= 0 (:offset @state))
         (swap! state assoc :offset 0)))
 
+    (mf/with-effect [has-colors?]
+      (when-not has-colors?
+        (reset! search-open* false)
+        (reset! search-term* "")))
+
     [:div {:class (stl/css-case
                    :color-palette true
                    :no-text (< size 64))
            :style #js {"--bullet-size" (dm/str bullet-size "px")
                        "--color-cell-width" (dm/str color-cell-width "px")}}
 
-     [:div {:class (stl/css :palette-search)}
-      [:> search-bar* {:on-change on-search-change
-                       :value search-term
-                       :placeholder (tr "workspace.assets.search")}]]
+     (when has-colors?
+       [:div {:class (stl/css-case :palette-search search-open?
+                                   :palette-search-collapsed (not search-open?))}
+        (when search-open?
+          [:> search-bar* {:on-change on-search-change
+                           :on-clear on-search-clear
+                           :value search-term
+                           :placeholder (tr "workspace.assets.search")
+                           :auto-focus true}])
+        [:> icon-button* {:variant "ghost"
+                          :icon i/search
+                          :on-click on-toggle-search
+                          :aria-label (tr "workspace.assets.search")}]])
 
      (when show-arrows?
        [:button {:class (stl/css :left-arrow)

--- a/frontend/src/app/main/ui/workspace/color_palette.scss
+++ b/frontend/src/app/main/ui/workspace/color_palette.scss
@@ -11,6 +11,14 @@
   display: flex;
 }
 
+.palette-search {
+  display: flex;
+  align-items: center;
+  width: deprecated.$s-160;
+  min-width: deprecated.$s-160;
+  padding-inline: deprecated.$s-4;
+}
+
 .left-arrow,
 .right-arrow {
   @include deprecated.buttonStyle;

--- a/frontend/src/app/main/ui/workspace/color_palette.scss
+++ b/frontend/src/app/main/ui/workspace/color_palette.scss
@@ -11,12 +11,22 @@
   display: flex;
 }
 
-.palette-search {
+.palette-search,
+.palette-search-collapsed {
   display: flex;
   align-items: center;
-  width: deprecated.$s-160;
-  min-width: deprecated.$s-160;
   padding-inline: deprecated.$s-4;
+}
+
+.palette-search {
+  gap: deprecated.$s-4;
+  width: deprecated.$s-192;
+  min-width: deprecated.$s-192;
+}
+
+.palette-search-collapsed {
+  width: deprecated.$s-32;
+  min-width: deprecated.$s-32;
 }
 
 .left-arrow,


### PR DESCRIPTION
## Summary

Closes #7653

Adds a search bar to the bottom workspace color palette toolbar so users can quickly filter a large palette by color name. The visible swatch list, arrow visibility, and scroll offset all react to the filtered result.

- New local \`search-term*\` atom inside \`palette*\`; a \`mf/with-memo\` produces \`filtered-colors\` via \`matches-search\` on each color's \`get-color-name\`
- Arrow navigation, \`visible\` count, \`max-offset\` and the \`with-effect\` that resets offset now all key off \`filtered-colors\` instead of raw \`colors\`, so the scroll snaps back to the start whenever the filter changes
- Reserves room in the layout math for the new search bar (160px) so the existing swatch grid doesn't overflow
- Empty state: keeps the original "empty palette" message when no library is loaded, shows \`workspace.assets.not-found\` when the current filter has no matches
- Uses the existing \`search-bar*\` component, no new i18n keys, no new icons
- \`.palette-search\` scss rule added; width matches the \`search-width\` constant used in the layout math

## Test plan

- [ ] Load a library with at least one named color → search bar is visible in the palette toolbar
- [ ] Type a partial color name → only matching swatches remain; scroll jumps back to the start
- [ ] Type a non-matching term → "Not found" message is shown inside the palette area
- [ ] Click the clear (×) button inside the search bar → full palette restored
- [ ] Switch palette swatch size (32/64/80) → layout still fits the search bar, no overflow
- [ ] Open a file with no library colors → original "empty palette" message is shown, search bar still renders

https://github.com/user-attachments/assets/a9c0d9e5-c15e-46e5-bfe1-8877c4967ded