### PR TITLE
:sparkles: Show detailed messages on file import errors

### DIFF
--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -295,7 +295,9 @@
 
        import-error?
        [:div {:class (stl/css :error-message)}
-        (tr "labels.error")]
+        (if (some? (:error entry))
+          (tr (:error entry))
+          (tr "labels.error"))]
 
        (and (not import-success?) (some? progress))
        [:div {:class (stl/css :progress-message)} (parse-progress-message progress)])
@@ -491,7 +493,12 @@
           [:ul {:class (stl/css :import-error-list)}
            (for [entry entries]
              (when (contains? #{:import-error :analyze-error} (:status entry))
-               [:li {:class (stl/css :import-error-list-enry)} (:name entry)]))]
+               [:li {:class (stl/css :import-error-list-enry)
+                     :key (dm/str (or (:file-id entry) (:uri entry) (:name entry)))}
+                [:div (:name entry)]
+                (when-let [err (:error entry)]
+                  [:div {:class (stl/css :import-error-detail)}
+                   (tr err)])]))]
           [:div (tr "dashboard.import.import-error.message2")]]
 
          (for [entry entries]

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -266,7 +266,7 @@
 }
 
 .import-error-detail {
-  @include deprecated.bodySmallTypography;
+  @include deprecated.body-small-typography;
 
   margin-top: var(--sp-xs);
   color: var(--modal-text-foreground-color);

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -149,8 +149,14 @@
   .progress-message {
     display: flex;
     align-items: center;
-    height: deprecated.$s-32;
+    min-height: deprecated.$s-32;
     color: var(--modal-text-foreground-color);
+  }
+
+  .error-message {
+    align-items: flex-start;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
   .linked-library {
@@ -257,4 +263,13 @@
 
 .import-error-list-enry {
   padding: var(--sp-xs) 0;
+}
+
+.import-error-detail {
+  @include deprecated.bodySmallTypography;
+
+  margin-top: var(--sp-xs);
+  color: var(--modal-text-foreground-color);
+  white-space: pre-wrap;
+  word-break: break-word;
 }

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -156,7 +156,7 @@
   .error-message {
     align-items: flex-start;
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 
   .linked-library {
@@ -271,5 +271,5 @@
   margin-top: var(--sp-xs);
   color: var(--modal-text-foreground-color);
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }

--- a/frontend/src/app/worker/import.cljs
+++ b/frontend/src/app/worker/import.cljs
@@ -23,6 +23,22 @@
 
 (log/set-level! :warn)
 
+(defn- import-cause-message
+  "Prefer the server `:hint` (full text, e.g. SSE error payload), then `:explain`
+   when present; avoid the generic `stream exception` wrapper when a payload exists."
+  [cause default-msg]
+  (let [data    (ex-data cause)
+        hint    (some-> data :hint str/trim)
+        explain (some-> data :explain str/trim)]
+    (cond
+      (not (str/blank? hint)) hint
+      (not (str/blank? explain)) explain
+      :else
+      (let [msg (some-> (ex-message cause) str/trim)]
+        (if (or (str/blank? msg) (= msg "stream exception"))
+          default-msg
+          msg)))))
+
 ;; Upload changes batches size
 (def ^:const change-batch-size 100)
 
@@ -122,7 +138,7 @@
                           :error (tr "dashboard.import.analyze-error")}))))
 
          (rx/catch (fn [cause]
-                     (let [error (or (ex-message cause) (tr "dashboard.import.analyze-error"))]
+                     (let [error (import-cause-message cause (tr "dashboard.import.analyze-error"))]
                        (rx/of (assoc file :error error :status :error))))))))
 
 (defmethod impl/handler :analyze-import
@@ -178,7 +194,7 @@
                                 :project-id project-id
                                 :cause cause)
                      (rx/of {:status :error
-                             :error (ex-message cause)
+                             :error (import-cause-message cause (tr "labels.error"))
                              :file-id (:file-id data)})))))))
 
      (->> (rx/from binfile-v3)
@@ -212,8 +228,9 @@
                                 :project-id project-id
                                 ::log/sync? true
                                 :cause cause)
-                     (->> (rx/from entries)
-                          (rx/map (fn [entry]
-                                    {:status :error
-                                     :error (ex-message cause)
-                                     :file-id (:file-id entry)}))))))))))))
+                     (let [err (import-cause-message cause (tr "labels.error"))]
+                       (->> (rx/from entries)
+                            (rx/map (fn [entry]
+                                      {:status :error
+                                       :error err
+                                       :file-id (:file-id entry)})))))))))))))


### PR DESCRIPTION
### Related Ticket

Closes #8212
### Summary
Import/analyze failures often showed a generic error. For SSE failures, the worker stored ex-message, which is the wrapper "stream exception", while the real message lives in ex-data (:hint, and sometimes :explain). The dashboard UI also ignored (:error entry) for :import-error rows.


### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
