### PR TITLE
:sparkles: Add search bar to prototype interaction destination dropdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@
 - Allow customising the OIDC login button label (by @wdeveloper16) [Github #7027](https://github.com/penpot/penpot/issues/7027)
 - Add page separators in Workspace [Taiga #13611](https://tree.taiga.io/project/penpot/us/13611?milestone=262806)
 - Add Shift+Numpad0/1/2 as aliases to Shift+0/1/2 for zoom shortcuts [Github #2457](https://github.com/penpot/penpot/issues/2457)
+- Add search bar to prototype interaction destination dropdown (by @moorsecopers99) [Github #8618](https://github.com/penpot/penpot/issues/8618)
 
 ### :bug: Bugs fixed
 

--- a/frontend/src/app/main/ui/components/select.cljs
+++ b/frontend/src/app/main/ui/components/select.cljs
@@ -15,7 +15,6 @@
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [app.util.keyboard :as kbd]
-   [app.util.timers :as ts]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -66,13 +65,17 @@
 
         is-open?      (get state :is-open?)
 
-        search*       (mf/use-state "")
+        ;; nil = the user is not actively searching (input shows the current
+        ;; selection's label); a string = the user has typed (input shows that
+        ;; string and options are filtered).
+        search*       (mf/use-state nil)
         search        (deref search*)
+        searching?    (and searchable? (some? search))
         search-input-ref (mf/use-ref nil)
 
         visible-options
         (mf/with-memo [options search searchable?]
-          (if (and searchable? (not (str/blank? search)))
+          (if (and searchable? (some? search) (not (str/blank? search)))
             (let [needle (str/lower search)]
               (into [] (filter (fn [item]
                                  (and (map? item)
@@ -94,7 +97,7 @@
 
         handle-key-up
         (mf/use-fn
-         (mf/deps disabled visible-options current-value)
+         (mf/deps disabled visible-options current-value searchable?)
          (fn [e]
            (when-not disabled
              (let [options (into [] (remove :disabled) visible-options)
@@ -105,20 +108,26 @@
                (cond
                  (or (kbd/left-arrow? e)
                      (kbd/up-arrow? e))
-                 (let [value (rotate-option-backward options index length)]
-                   (swap! state* assoc :current-value value)
-                   (when (fn? on-change)
-                     (on-change value)))
+                 (when (pos? length)
+                   (let [value (rotate-option-backward options index length)]
+                     (swap! state* assoc :current-value value)
+                     (when (fn? on-change)
+                       (on-change value))))
 
                  (or (kbd/right-arrow? e)
                      (kbd/down-arrow? e))
-                 (let [value (rotate-option-forward options index)]
-                   (swap! state* assoc :current-value value)
-                   (when (fn? on-change)
-                     (on-change value)))
+                 (when (pos? length)
+                   (let [value (rotate-option-forward options index)]
+                     (swap! state* assoc :current-value value)
+                     (when (fn? on-change)
+                       (on-change value))))
 
-                 (or (kbd/enter? e)
-                     (kbd/space? e))
+                 (kbd/enter? e)
+                 (swap! state* assoc :is-open? false)
+
+                 ;; In searchable mode the input owns Space — let the user
+                 ;; type spaces in the filter without closing the dropdown.
+                 (and (not searchable?) (kbd/space? e))
                  (swap! state* assoc :is-open? false)
 
                  (kbd/tab? e)
@@ -126,12 +135,31 @@
                         :is-open? true
                         :current-value (-> options first :value)))))))
 
-        open-dropdown
+        handle-search-change
+        (mf/use-fn
+         (fn [e]
+           (let [v (dom/get-target-val e)]
+             (reset! search* v)
+             (swap! state* assoc :is-open? true))))
+
+        handle-search-focus
         (mf/use-fn
          (mf/deps disabled)
-         (fn []
+         (fn [_]
            (when-not disabled
              (swap! state* assoc :is-open? true))))
+
+        open-dropdown
+        (mf/use-fn
+         (mf/deps disabled searchable?)
+         (fn []
+           (when-not disabled
+             (swap! state* assoc :is-open? true)
+             ;; In searchable mode the input is the focus target — pull focus
+             ;; in case the click landed on the wrapper or the dropdown arrow.
+             (when searchable?
+               (when-let [el (mf/ref-val search-input-ref)]
+                 (dom/focus! el))))))
 
         close-dropdown
         (mf/use-fn #(swap! state* assoc :is-open? false))
@@ -178,12 +206,7 @@
 
     (mf/with-effect [is-open?]
       (when (and searchable? (not is-open?))
-        (reset! search* "")))
-
-    (mf/with-effect [is-open?]
-      (when (and searchable? is-open?)
-        (ts/schedule 0 #(when-let [el (mf/ref-val search-input-ref)]
-                          (dom/focus! el)))))
+        (reset! search* nil)))
 
     (mf/with-effect [is-open?]
       (let [dropdown-element (mf/ref-val node-ref)]
@@ -194,11 +217,12 @@
 
     (let [selected-option (first (filter #(= (:value %) default-value) options))
           current-icon (:icon selected-option)
-          current-icon-ref (deprecated-icon/key->icon current-icon)]
+          current-icon-ref (deprecated-icon/key->icon current-icon)
+          input-value (if searching? search (or current-label ""))]
       [:div {:id (dm/str current-id)
              :on-click open-dropdown
              :on-key-up handle-key-up
-             :tab-index "0"
+             :tab-index (if searchable? "-1" "0")
              :role "combobox"
              :class (dm/str (stl/css-case :custom-select true
                                           :disabled disabled
@@ -206,23 +230,26 @@
                             " " class)}
        (when (and current-icon current-icon-ref)
          [:span {:class (stl/css :current-icon)} current-icon-ref])
-       [:span {:class (stl/css :current-label)} current-label]
+       (if searchable?
+         [:input {:ref search-input-ref
+                  :type "text"
+                  :class (stl/css :current-label-input)
+                  :value input-value
+                  :placeholder (or search-placeholder current-label)
+                  :disabled disabled
+                  :role "searchbox"
+                  :aria-autocomplete "list"
+                  :aria-label (or search-placeholder current-label)
+                  :on-focus handle-search-focus
+                  :on-click handle-search-focus
+                  :on-change handle-search-change}]
+         [:span {:class (stl/css :current-label)} current-label])
        [:span {:class (stl/css :dropdown-button)} deprecated-icon/arrow]
        [:& dropdown {:show is-open? :on-close close-dropdown}
         [:ul {:ref node-ref
               :data-direction (d/nilv data-direction dropdown-direction)
               :class (dm/str dropdown-class " " (stl/css :custom-select-dropdown))}
-         (when searchable?
-           [:li {:class (stl/css :custom-select-search)
-                 :role "presentation"
-                 :on-click dom/stop-propagation}
-            [:input {:ref search-input-ref
-                     :type "text"
-                     :class (stl/css :custom-select-search-input)
-                     :placeholder (or search-placeholder (tr "labels.search"))
-                     :value search
-                     :on-change #(reset! search* (dom/get-target-val %))}]])
-         (when (and searchable? (seq search) (empty? visible-options))
+         (when (and searchable? searching? (not (str/blank? search)) (empty? visible-options))
            [:li {:class (stl/css :custom-select-no-matches)
                  :role "presentation"}
             (tr "labels.no-matches")])

--- a/frontend/src/app/main/ui/components/select.cljs
+++ b/frontend/src/app/main/ui/components/select.cljs
@@ -13,7 +13,10 @@
    [app.main.ui.components.dropdown :refer [dropdown]]
    [app.main.ui.icons :as deprecated-icon]
    [app.util.dom :as dom]
+   [app.util.i18n :refer [tr]]
    [app.util.keyboard :as kbd]
+   [app.util.timers :as ts]
+   [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
 (defn- as-key-value
@@ -47,7 +50,7 @@
   (:value (nth options (rotate-index-backward index length))))
 
 (mf/defc select
-  [{:keys [default-value options class dropdown-class is-open? on-change on-pointer-enter-option on-pointer-leave-option disabled data-direction]}]
+  [{:keys [default-value options class dropdown-class is-open? on-change on-pointer-enter-option on-pointer-leave-option disabled data-direction searchable? search-placeholder]}]
   (let [label-index   (mf/with-memo [options]
                         (into {} (map as-key-value) options))
 
@@ -63,6 +66,21 @@
 
         is-open?      (get state :is-open?)
 
+        search*       (mf/use-state "")
+        search        (deref search*)
+        search-input-ref (mf/use-ref nil)
+
+        visible-options
+        (mf/with-memo [options search searchable?]
+          (if (and searchable? (not (str/blank? search)))
+            (let [needle (str/lower search)]
+              (into [] (filter (fn [item]
+                                 (and (map? item)
+                                      (when-let [label (:label item)]
+                                        (str/includes? (str/lower (dm/str label)) needle)))))
+                    options))
+            options))
+
         node-ref      (mf/use-ref nil)
 
         dropdown-direction*
@@ -76,10 +94,10 @@
 
         handle-key-up
         (mf/use-fn
-         (mf/deps disabled options current-value)
+         (mf/deps disabled visible-options current-value)
          (fn [e]
            (when-not disabled
-             (let [options (into [] (remove :disabled) options)
+             (let [options (into [] (remove :disabled) visible-options)
                    length  (count options)
                    index   (d/index-of-pred options #(= (:value %) current-value))
                    index   (d/nilv index 0)]
@@ -159,6 +177,15 @@
         (mf/set-ref-val! dropdown-direction-change* 0)))
 
     (mf/with-effect [is-open?]
+      (when (and searchable? (not is-open?))
+        (reset! search* "")))
+
+    (mf/with-effect [is-open?]
+      (when (and searchable? is-open?)
+        (ts/schedule 0 #(when-let [el (mf/ref-val search-input-ref)]
+                          (dom/focus! el)))))
+
+    (mf/with-effect [is-open?]
       (let [dropdown-element (mf/ref-val node-ref)]
         (when (and (= 0 (mf/ref-val dropdown-direction-change*)) dropdown-element)
           (let [is-outside? (dom/is-element-outside? dropdown-element)]
@@ -185,7 +212,21 @@
         [:ul {:ref node-ref
               :data-direction (d/nilv data-direction dropdown-direction)
               :class (dm/str dropdown-class " " (stl/css :custom-select-dropdown))}
-         (for [[index item] (d/enumerate options)]
+         (when searchable?
+           [:li {:class (stl/css :custom-select-search)
+                 :role "presentation"
+                 :on-click dom/stop-propagation}
+            [:input {:ref search-input-ref
+                     :type "text"
+                     :class (stl/css :custom-select-search-input)
+                     :placeholder (or search-placeholder (tr "labels.search"))
+                     :value search
+                     :on-change #(reset! search* (dom/get-target-val %))}]])
+         (when (and searchable? (seq search) (empty? visible-options))
+           [:li {:class (stl/css :custom-select-no-matches)
+                 :role "presentation"}
+            (tr "labels.no-matches")])
+         (for [[index item] (d/enumerate visible-options)]
            (if (= :separator item)
              [:li {:id (dm/str current-id "-" index)
                    :key (dm/str current-id "-" index)

--- a/frontend/src/app/main/ui/components/select.scss
+++ b/frontend/src/app/main/ui/components/select.scss
@@ -91,38 +91,36 @@
   }
 }
 
-.custom-select-search {
-  position: sticky;
-  inset-block-start: 0;
-  z-index: 1;
-  padding: deprecated.$s-4 deprecated.$s-4 deprecated.$s-6 deprecated.$s-4;
-  background-color: var(--menu-background-color);
-  border-block-end: deprecated.$s-1 solid var(--dropdown-separator-color);
-}
-
-.custom-select-search-input {
-  @include deprecated.bodySmallTypography;
+.current-label-input {
+  @include deprecated.text-ellipsis;
 
   width: 100%;
-  height: deprecated.$s-28;
-  padding: 0 deprecated.$s-8;
-  border: deprecated.$s-1 solid var(--input-border-color, transparent);
-  border-radius: deprecated.$br-6;
-  background-color: var(--input-background-color, var(--menu-background-color-hover));
-  color: var(--menu-foreground-color);
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
   outline: none;
+  cursor: pointer;
 
   &::placeholder {
-    color: var(--menu-foreground-color-disabled);
+    color: inherit;
+    opacity: 1;
   }
 
   &:focus {
-    border-color: var(--input-border-color-focus, var(--menu-background-focus));
+    cursor: text;
+  }
+
+  &:disabled {
+    cursor: default;
   }
 }
 
 .custom-select-no-matches {
-  @include deprecated.bodySmallTypography;
+  @include deprecated.body-small-typography;
 
   padding: deprecated.$s-8 deprecated.$s-12;
   color: var(--menu-foreground-color-disabled);

--- a/frontend/src/app/main/ui/components/select.scss
+++ b/frontend/src/app/main/ui/components/select.scss
@@ -91,6 +91,45 @@
   }
 }
 
+.custom-select-search {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: 1;
+  padding: deprecated.$s-4 deprecated.$s-4 deprecated.$s-6 deprecated.$s-4;
+  background-color: var(--menu-background-color);
+  border-block-end: deprecated.$s-1 solid var(--dropdown-separator-color);
+}
+
+.custom-select-search-input {
+  @include deprecated.bodySmallTypography;
+
+  width: 100%;
+  height: deprecated.$s-28;
+  padding: 0 deprecated.$s-8;
+  border: deprecated.$s-1 solid var(--input-border-color, transparent);
+  border-radius: deprecated.$br-6;
+  background-color: var(--input-background-color, var(--menu-background-color-hover));
+  color: var(--menu-foreground-color);
+  outline: none;
+
+  &::placeholder {
+    color: var(--menu-foreground-color-disabled);
+  }
+
+  &:focus {
+    border-color: var(--input-border-color-focus, var(--menu-background-focus));
+  }
+}
+
+.custom-select-no-matches {
+  @include deprecated.bodySmallTypography;
+
+  padding: deprecated.$s-8 deprecated.$s-12;
+  color: var(--menu-foreground-color-disabled);
+  text-align: center;
+  pointer-events: none;
+}
+
 .custom-select-dropdown[data-direction="up"] {
   bottom: deprecated.$s-32;
   top: auto;

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs
@@ -450,7 +450,9 @@
            [:div {:class (stl/css :interaction-row-select)}
             [:& select {:default-value (str (:destination interaction))
                         :options destination-options
-                        :on-change change-destination}]]])
+                        :on-change change-destination
+                        :searchable? true
+                        :search-placeholder (tr "workspace.options.interaction-destination")}]]])
 
         ;; Preserve scroll
         (when (ctsi/has-preserve-scroll interaction)

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2868,6 +2868,10 @@ msgstr "No pending invitations."
 msgid "labels.no-invitations-gather-people"
 msgstr "Gather your people and build great things together."
 
+#: src/app/main/ui/components/select.cljs
+msgid "labels.no-matches"
+msgstr "No matches"
+
 #: src/app/main/ui/static.cljs
 #, unused
 msgid "labels.not-found.desc-message"


### PR DESCRIPTION
### Related Ticket

Closes [#8618](https://github.com/penpot/penpot/issues/8618)

### Summary

On pages with a large number of boards (40+), the **Destination** dropdown used by the prototype *Navigate to* interaction becomes hard to scan. This PR adds live, keyboard-driven filtering to that dropdown without introducing a new component or disturbing any other callsite.

- Extend the shared `app.main.ui.components.select` component with an optional `searchable?` flag (and an optional `search-placeholder`). Default behavior is unchanged for every existing callsite.
- When `searchable?` is on, the dropdown renders a sticky text input at the top that filters options by `:label` (case-insensitive `cuerdas.core/includes?`). Filtering operates on the already-computed options vector, so it stays O(n) per keystroke and touches no page data.
- Arrow-key navigation now walks the filtered list instead of the full one, so up/down/Enter always match what the user sees.
- Search state is reset whenever the dropdown closes, which matches the issue's requirement that the filter not leak across reopenings.
- A new `labels.no-matches` i18n key ("No matches") renders when the filter empties the list.
- Opted in only on the Interaction **Destination** select (`interactions.cljs`); Trigger, Action, Relative to, Animation and Easing dropdowns are untouched.

### Steps to reproduce

1. Open a file that contains many boards (e.g. import the *Design Tokens Starter Kit* template, or create ≥ 10 boards on a page).
2. Select any shape → **Design** tab → **Interactions** → **+** → expand the new interaction.
3. Set *Action* to **Navigate to**.
4. Open the **Destination** dropdown:
   - A search input appears at the top and is autofocused.
   - Typing filters the listed boards case-insensitively.
   - Arrow keys walk only the filtered boards; Enter closes the dropdown.
   - Typing a string with no matches shows a **"No matches"** row.
   - Close the dropdown without selecting, then reopen it — the search field is empty again (filter does not persist).
5. Verify other selects in the same panel (Trigger, Action, Relative to, Animation, Easing) are unchanged — no search field.
6. Verify any other `select` callsite in the app (e.g. dashboard sorting, color profile selectors) still behaves exactly as before.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

### Screenshots

https://github.com/user-attachments/assets/b17e4056-44f9-4bcf-ba67-4f0c6f3ec786