### PR TITLE
:sparkles: Add loader feedback while importing and exporting files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 - Show alpha percentage next to library color values to distinguish colors that differ only in opacity (by @rockchris099) [Github #6328](https://github.com/penpot/penpot/issues/6328)
 - Add "Clear artboard guides" option to right-click context menu for frames (by @eureka0928) [Github #6987](https://github.com/penpot/penpot/issues/6987)
+- Add loader feedback while importing and exporting files [Github #9020](https://github.com/penpot/penpot/issues/9020)
 - Allow duplicating color and typography styles (by @MkDev11) [Github #2912](https://github.com/penpot/penpot/issues/2912)
 - Add woff2 support on user uploaded fonts (by @Nivl) [Github #8248](https://github.com/penpot/penpot/pull/8248)
 - Import Tokens from linked library (by @dfelinto) [Github #8391](https://github.com/penpot/penpot/pull/8391)

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -507,14 +507,15 @@
 
        (when (some? template)
          [:> import-entry* {:entry (assoc template :status status)
-                            :can-be-deleted false}])]
+                            :can-be-deleted false}])
 
-      [:div {:class (stl/css :modal-footer)}
        (when (= :import-progress status)
-         [:div {:class (stl/css :footer-status)
+         [:div {:class (stl/css :status-message)
                 :role "status"
                 :aria-live "polite"}
-          (tr "labels.importing-files")])
+          (tr "labels.uploading-file")])]
+
+      [:div {:class (stl/css :modal-footer)}
        [:div {:class (stl/css :action-buttons)}
         (when (= :analyze status)
           [:input {:class (stl/css :cancel-button)
@@ -530,8 +531,10 @@
                    :on-click on-continue}])
 
         (when (or (= :import-success status)
-                  (= :import-error status))
+                  (= :import-error status)
+                  (= :import-progress status))
           [:input {:class (stl/css :accept-btn)
                    :type "button"
                    :value (tr "labels.accept")
+                   :disabled (= :import-progress status)
                    :on-click on-accept}])]]]]))

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -508,6 +508,13 @@
                             :can-be-deleted false}])]
 
       [:div {:class (stl/css :modal-footer)}
+       (when (= :import-progress status)
+         [:div {:class (stl/css :footer-status)
+                :role "status"
+                :aria-live "polite"}
+          [:> loader* {:width 16 :title (tr "labels.importing-files")}]
+          [:span {:class (stl/css :footer-status-label)}
+           (tr "labels.importing-files")]])
        [:div {:class (stl/css :action-buttons)}
         (when (= :analyze status)
           [:input {:class (stl/css :cancel-button)
@@ -523,10 +530,8 @@
                    :on-click on-continue}])
 
         (when (or (= :import-success status)
-                  (= :import-error status)
-                  (= :import-progress status))
+                  (= :import-error status))
           [:input {:class (stl/css :accept-btn)
                    :type "button"
                    :value (tr "labels.accept")
-                   :disabled (= :import-progress status)
                    :on-click on-accept}])]]]]))

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -195,13 +195,14 @@
   {::mf/props :obj
    ::mf/memo true
    ::mf/private true}
-  [{:keys [entries entry edition can-be-deleted on-edit on-change on-delete]}]
+  [{:keys [entries entry edition can-be-deleted importing? on-edit on-change on-delete]}]
   (let [status          (:status entry)
         ;; FIXME: rename to format
         format          (:type entry)
 
         loading?        (or (= :analyze status)
-                            (= :import-progress status))
+                            (= :import-progress status)
+                            (and importing? (= :import-ready status)))
         analyze-error?  (= :analyze-error status)
         import-success? (= :import-success status)
         import-error?   (= :import-error status)
@@ -498,6 +499,7 @@
                               :key (dm/str (:uri entry) "/" (:file-id entry))
                               :entry entry
                               :entries entries
+                              :importing? (= :import-progress status)
                               :on-edit on-edit
                               :on-change on-entry-change
                               :on-delete on-entry-delete
@@ -512,9 +514,7 @@
          [:div {:class (stl/css :footer-status)
                 :role "status"
                 :aria-live "polite"}
-          [:> loader* {:width 16 :title (tr "labels.importing-files")}]
-          [:span {:class (stl/css :footer-status-label)}
-           (tr "labels.importing-files")]])
+          (tr "labels.importing-files")])
        [:div {:class (stl/css :action-buttons)}
         (when (= :analyze status)
           [:input {:class (stl/css :cancel-button)

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -44,15 +44,10 @@
 }
 
 .footer-status {
-  display: flex;
-  align-items: center;
-  gap: deprecated.$s-8;
-  color: var(--modal-text-foreground-color);
-  margin-block-end: deprecated.$s-16;
-}
-
-.footer-status-label {
   @include deprecated.bodySmallTypography;
+
+  color: var(--modal-title-foreground-color);
+  margin-block-end: deprecated.$s-16;
 }
 
 .action-buttons {

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -43,6 +43,18 @@
   min-height: 40px;
 }
 
+.footer-status {
+  display: flex;
+  align-items: center;
+  gap: deprecated.$s-8;
+  color: var(--modal-text-foreground-color);
+  margin-block-end: deprecated.$s-16;
+}
+
+.footer-status-label {
+  @include deprecated.bodySmallTypography;
+}
+
 .action-buttons {
   @extend %modal-action-btns;
 }

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -44,7 +44,7 @@
 }
 
 .status-message {
-  @include deprecated.bodySmallTypography;
+  @include deprecated.body-small-typography;
 
   color: var(--modal-title-foreground-color);
   font-style: italic;

--- a/frontend/src/app/main/ui/dashboard/import.scss
+++ b/frontend/src/app/main/ui/dashboard/import.scss
@@ -43,11 +43,11 @@
   min-height: 40px;
 }
 
-.footer-status {
+.status-message {
   @include deprecated.bodySmallTypography;
 
   color: var(--modal-title-foreground-color);
-  margin-block-end: deprecated.$s-16;
+  font-style: italic;
 }
 
 .action-buttons {

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -185,9 +185,7 @@
               [:div {:class (stl/css :footer-status)
                      :role "status"
                      :aria-live "polite"}
-               [:> loader* {:width 16 :title (tr "labels.exporting-files")}]
-               [:span {:class (stl/css :footer-status-label)}
-                (tr "labels.exporting-files")]])
+               (tr "labels.exporting-files")])
             [:div {:class (stl/css :action-buttons)}
              [:input {:class (stl/css :accept-btn)
                       :type "button"

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -174,15 +174,23 @@
                     :on-click on-accept}]]]]
 
         (= status :exporting)
-        [:*
-         [:div {:class (stl/css :modal-content)}
-          (for [file (:files state)]
-            [:> export-entry* {:file file :key (dm/str (:id file))}])]
+        (let [in-progress? (->> state :files (some :loading))]
+          [:*
+           [:div {:class (stl/css :modal-content)}
+            (for [file (:files state)]
+              [:> export-entry* {:file file :key (dm/str (:id file))}])]
 
-         [:div {:class (stl/css :modal-footer)}
-          [:div {:class (stl/css :action-buttons)}
-           [:input {:class (stl/css :accept-btn)
-                    :type "button"
-                    :value (tr "labels.close")
-                    :disabled (->> state :files (some :loading))
-                    :on-click on-cancel}]]]])]]))
+           [:div {:class (stl/css :modal-footer)}
+            (when in-progress?
+              [:div {:class (stl/css :footer-status)
+                     :role "status"
+                     :aria-live "polite"}
+               [:> loader* {:width 16 :title (tr "labels.exporting-files")}]
+               [:span {:class (stl/css :footer-status-label)}
+                (tr "labels.exporting-files")]])
+            [:div {:class (stl/css :action-buttons)}
+             [:input {:class (stl/css :accept-btn)
+                      :type "button"
+                      :value (tr "labels.close")
+                      :disabled in-progress?
+                      :on-click on-cancel}]]]]))]]))

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -178,14 +178,15 @@
           [:*
            [:div {:class (stl/css :modal-content)}
             (for [file (:files state)]
-              [:> export-entry* {:file file :key (dm/str (:id file))}])]
+              [:> export-entry* {:file file :key (dm/str (:id file))}])
 
-           [:div {:class (stl/css :modal-footer)}
             (when in-progress?
-              [:div {:class (stl/css :footer-status)
+              [:div {:class (stl/css :status-message)
                      :role "status"
                      :aria-live "polite"}
-               (tr "labels.exporting-files")])
+               (tr "labels.downloading-file")])]
+
+           [:div {:class (stl/css :modal-footer)}
             [:div {:class (stl/css :action-buttons)}
              [:input {:class (stl/css :accept-btn)
                       :type "button"

--- a/frontend/src/app/main/ui/exports/files.scss
+++ b/frontend/src/app/main/ui/exports/files.scss
@@ -183,11 +183,11 @@
   }
 }
 
-.footer-status {
+.status-message {
   @include deprecated.bodySmallTypography;
 
   color: var(--modal-title-foreground-color);
-  margin-block-end: deprecated.$s-16;
+  font-style: italic;
 }
 
 .action-buttons {

--- a/frontend/src/app/main/ui/exports/files.scss
+++ b/frontend/src/app/main/ui/exports/files.scss
@@ -184,15 +184,10 @@
 }
 
 .footer-status {
-  display: flex;
-  align-items: center;
-  gap: deprecated.$s-8;
-  color: var(--modal-text-foreground-color);
-  margin-block-end: deprecated.$s-16;
-}
-
-.footer-status-label {
   @include deprecated.bodySmallTypography;
+
+  color: var(--modal-title-foreground-color);
+  margin-block-end: deprecated.$s-16;
 }
 
 .action-buttons {

--- a/frontend/src/app/main/ui/exports/files.scss
+++ b/frontend/src/app/main/ui/exports/files.scss
@@ -184,7 +184,7 @@
 }
 
 .status-message {
-  @include deprecated.bodySmallTypography;
+  @include deprecated.body-small-typography;
 
   color: var(--modal-title-foreground-color);
   font-style: italic;

--- a/frontend/src/app/main/ui/exports/files.scss
+++ b/frontend/src/app/main/ui/exports/files.scss
@@ -183,6 +183,18 @@
   }
 }
 
+.footer-status {
+  display: flex;
+  align-items: center;
+  gap: deprecated.$s-8;
+  color: var(--modal-text-foreground-color);
+  margin-block-end: deprecated.$s-16;
+}
+
+.footer-status-label {
+  @include deprecated.bodySmallTypography;
+}
+
 .action-buttons {
   @extend %modal-action-btns;
 }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2805,12 +2805,12 @@ msgid "labels.loading"
 msgstr "Loading…"
 
 #: src/app/main/ui/dashboard/import.cljs
-msgid "labels.importing-files"
-msgstr "Importing files…"
+msgid "labels.uploading-file"
+msgstr "Uploading file…"
 
 #: src/app/main/ui/exports/files.cljs
-msgid "labels.exporting-files"
-msgstr "Exporting files…"
+msgid "labels.downloading-file"
+msgstr "Downloading file…"
 
 #: src/app/main/ui/workspace/sidebar/versions.cljs:210
 msgid "labels.lock"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2804,6 +2804,14 @@ msgstr "Libraries & Templates"
 msgid "labels.loading"
 msgstr "Loading…"
 
+#: src/app/main/ui/dashboard/import.cljs
+msgid "labels.importing-files"
+msgstr "Importing files…"
+
+#: src/app/main/ui/exports/files.cljs
+msgid "labels.exporting-files"
+msgstr "Exporting files…"
+
 #: src/app/main/ui/workspace/sidebar/versions.cljs:210
 msgid "labels.lock"
 msgstr "Lock"


### PR DESCRIPTION
### Related Ticket

Closes https://github.com/penpot/penpot/issues/9020

### Summary

Adds clearer in-progress feedback to the file **import** and **export** dialogs, as requested in the issue. While an operation is running, the dialog footer now shows the existing `loader*` component (pencil animation backed by `loader.svg`) next to a status label, and the action button is hidden/disabled so the operation cannot be retriggered.

- **Import dialog** (`ui/dashboard/import.cljs`): during `:import-progress`, the footer shows a loader + **"Importing files…"**. The disabled "Accept" button that previously showed during this phase was removed (it reappears on `:import-success` / `:import-error`).
- **Export dialog** (`ui/exports/files.cljs`): during `:exporting`, the footer shows a loader + **"Exporting files…"** while any file is still being packaged. The "Close" button stays disabled until every file has finished, then the loader disappears.
- Both status elements use `role="status"` and `aria-live="polite"` so the state is announced to assistive tech — the feedback is text + icon, not color-only.
- New i18n keys: `labels.importing-files`, `labels.exporting-files`.
- Co-located SCSS gets a small `.footer-status` / `.footer-status-label` rule in both `import.scss` and `exports/files.scss`.

### Steps to reproduce

**Import**
1. Dashboard → open a project → project "⋯" menu → **Import files**.
2. Pick a `.penpot` file (larger file makes the state more visible).
3. When analysis finishes, click **Continue**.
4. The footer immediately shows the pencil loader + **"Importing files…"**; no clickable action button is present.
5. On success the loader disappears and **Accept** + success notification appear. On error, the loader disappears and the error notification + Accept appear.

<img width="878" height="527" alt="Image" src="https://github.com/user-attachments/assets/8ba0d407-9bc5-4391-97cf-37c992e261fe" />

**Export**
1. Dashboard → right-click a file card → **Download Penpot file (.penpot)** (or select multiple files → Export Penpot files).
2. Pick an export type and click **Continue** (auto-starts when there are no libraries).
3. While files are being packaged the footer shows the loader + **"Exporting files…"**, and **Close** is disabled.
4. When all files finish downloading, the loader disappears and **Close** becomes enabled.

<img width="785" height="588" alt="Image" src="https://github.com/user-attachments/assets/c489586b-ad15-4b7d-ba79-5679726a4190" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.