### PR TITLE
:bug: Fix empty warning on login

### DIFF
--- a/frontend/src/app/main/ui/auth/login.cljs
+++ b/frontend/src/app/main/ui/auth/login.cljs
@@ -36,8 +36,8 @@
 (mf/defc demo-warning*
   []
   [:> context-notification*
-   {:level :warning
-    :content (tr "auth.demo-warning")}])
+   {:level :warning}
+   (tr "auth.demo-warning")])
 
 (defn create-demo-profile
   []


### PR DESCRIPTION
### Related Ticket

No issue created

### Summary

This issue fixes this empty warningn
<img width="1205" height="1153" alt="image" src="https://github.com/user-attachments/assets/ec213e5f-3958-4cd2-9d5b-e85946bca867" />

This warning is only happening on hourly. 

In order to see this warning you must activate this flag. `enable-demo-warning`

### Steps to reproduce 
Enter on hourly enviroment and go to login. 

Expected message
<img width="1205" height="1153" alt="image" src="https://github.com/user-attachments/assets/e72a6a90-fcc1-4f0f-8e4c-dfd2dc7ba130" />

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
