### PR TITLE
:bug: Fix multiple selection on shapes with token applied to stroke-color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 - Fix wrong `mapcat` call in `collect-main-shapes`
 - Fix stale accumulator in `get-children-in-instance` recursion
 - Fix typo `:podition` in swap-shapes grid cell
+- Fix multiple selection on shapes with token applied to stroke color
 
 
 ## 2.14.2

--- a/frontend/src/app/main/ui/workspace/left_header.scss
+++ b/frontend/src/app/main/ui/workspace/left_header.scss
@@ -29,9 +29,10 @@
 .project-tree {
   position: relative;
   flex-grow: 1;
+  flex-shrink: 1;
+  min-width: 0;
   height: deprecated.$s-32;
   min-height: deprecated.$s-32;
-  max-width: calc(100% - deprecated.$s-64);
 }
 
 .project-name,

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
@@ -49,16 +49,16 @@
          • :prop      → the property type (:fill, :stroke, :shadow, etc.)
          • :shape-id  → the UUID of the shape using this color
          • :index     → index of the color in the shape's fill/stroke list
-   
+
    Example of groups:
    {
      {:color \"#9f2929\", :opacity 0.3,  :token-name \"asd2\" :has-token-applied true}
      [{:prop :fill, :shape-id #uuid \"d0231035-25c9-80d5-8006-eae4c3dff32e\", :index 0}]
-   
+
      {:color \"#1b54b6\", :opacity 1}
      [{:prop :fill, :shape-id #uuid \"aab34f9a-98c1-801a-8006-eae5e8236f1b\", :index 0}]
    }
-   
+
    This structure allows fast lookups of all shapes using the same visual color,
    regardless of whether it comes from local fills, strokes or shadow-colors."
 
@@ -69,12 +69,17 @@
         ;; Unique color attribute maps
         all-colors (distinct (mapv :attrs data))
 
-        ;; Split into: library colors, token colors, and plain colors
-        library-colors (filterv :ref-id all-colors)
+        ;; ;; Split into: library colors, token colors, and plain colors
+        ;; library-colors (filterv :ref-id all-colors)
+        ;; token-colors   (filterv :token-name all-colors)
+        ;; colors         (filterv #(and (nil? (:ref-id %))
+        ;;                               (not (:token-name %)))
+        ;;                         all-colors)
+
         token-colors   (filterv :token-name all-colors)
-        colors         (filterv #(and (nil? (:ref-id %))
-                                      (not (:token-name %)))
-                                all-colors)]
+        library-colors (filterv (fn [c] (and (some? (:ref-id c)) (nil? (:token-name c)))) all-colors)
+        colors         (filterv (fn [c] (and (nil? (:ref-id c)) (nil? (:token-name c)))) all-colors)
+        ]
     {:groups groups
      :all-colors all-colors
      :colors colors
@@ -103,16 +108,18 @@
         (mf/with-memo [file-id shapes libraries]
           (prepare-colors shapes file-id libraries))
 
+        ;; _ (prn "color-selection-menu*")
+        ;; _ (app.common.pprint/pprint token-colors)
+
         open*            (mf/use-state true)
         open?            (deref open*)
 
         has-colors?      (or (some? (seq colors)) (some? (seq library-colors)))
-
         toggle-content   (mf/use-fn #(swap! open* not))
 
-        expand-lib-color (mf/use-state false)
-        expand-color     (mf/use-state false)
-        expand-token-color     (mf/use-state false)
+        expand-lib-color   (mf/use-state false)
+        expand-color       (mf/use-state false)
+        expand-token-color (mf/use-state false)
 
         ;;  TODO: Review if this is still necessary.
         prev-colors-ref  (mf/use-ref nil)
@@ -243,7 +250,9 @@
          (let [token-color-extract (cond->> token-colors (not @expand-token-color) (take 3))]
            (for [[index token-color] (d/enumerate token-color-extract)]
              (let [color {:color (:color token-color)
-                          :opacity (:opacity token-color)}]
+                          :opacity (:opacity token-color)}
+
+                   color (dissoc token-color :token-name :has-token-applied)]
                [:> color-row*
                 {:key index
                  :color color

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
@@ -70,16 +70,9 @@
         all-colors (distinct (mapv :attrs data))
 
         ;; ;; Split into: library colors, token colors, and plain colors
-        ;; library-colors (filterv :ref-id all-colors)
-        ;; token-colors   (filterv :token-name all-colors)
-        ;; colors         (filterv #(and (nil? (:ref-id %))
-        ;;                               (not (:token-name %)))
-        ;;                         all-colors)
-
         token-colors   (filterv :token-name all-colors)
         library-colors (filterv (fn [c] (and (some? (:ref-id c)) (nil? (:token-name c)))) all-colors)
-        colors         (filterv (fn [c] (and (nil? (:ref-id c)) (nil? (:token-name c)))) all-colors)
-        ]
+        colors         (filterv (fn [c] (and (nil? (:ref-id c)) (nil? (:token-name c)))) all-colors)]
     {:groups groups
      :all-colors all-colors
      :colors colors
@@ -107,9 +100,6 @@
   (let [{:keys [groups library-colors colors token-colors]}
         (mf/with-memo [file-id shapes libraries]
           (prepare-colors shapes file-id libraries))
-
-        ;; _ (prn "color-selection-menu*")
-        ;; _ (app.common.pprint/pprint token-colors)
 
         open*            (mf/use-state true)
         open?            (deref open*)
@@ -250,9 +240,7 @@
          (let [token-color-extract (cond->> token-colors (not @expand-token-color) (take 3))]
            (for [[index token-color] (d/enumerate token-color-extract)]
              (let [color {:color (:color token-color)
-                          :opacity (:opacity token-color)}
-
-                   color (dissoc token-color :token-name :has-token-applied)]
+                          :opacity (:opacity token-color)}]
                [:> color-row*
                 {:key index
                  :color color

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -194,7 +194,9 @@
        [:div {:class (stl/css-case :stroke-content true
                                    :stroke-content-empty (not has-strokes?))}
         (cond
-          (= :multiple strokes)
+          (or (= :multiple (:stroke-color applied-tokens))
+              (= :multiple (:stroke-width applied-tokens))
+              (= :multiple strokes))
           [:div {:class (stl/css :stroke-multiple)}
            [:div {:class (stl/css :stroke-multiple-label)}
             (tr "settings.multiple")]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/color_row.cljs
@@ -71,11 +71,12 @@
   [{:keys [active-tokens applied-token-name color on-swatch-click-token detach-token open-modal-from-token]}]
   (let [;; `active-tokens` may be provided as a `delay` (lazy computation).
         ;; In that case we must deref it (`@active-tokens`) to force evaluation
-        ;; and obtain the actual value. If it’s already realized (not a delay),
+        ;; and obtain the actual value. If it's already realized (not a delay),
         ;; we just use it directly.
         active-tokens (if (delay? active-tokens)
                         @active-tokens
                         active-tokens)
+
 
         active-color-tokens (:color active-tokens)
 
@@ -345,9 +346,14 @@
                       :dnd-over-top (= (:over dprops) :top)
                       :dnd-over-bot (= (:over dprops) :bot))]
 
+    (when (= applied-token :multiple)
+      ;; (js/console.trace "color-row*")
+      (prn "color-row*" index color applied-token))
+
     (mf/with-effect [color prev-color disable-picker]
       (when (and (not disable-picker) (not= prev-color color))
         (modal/update-props! :colorpicker {:data (parse-color color)})))
+
     [:div {:class [class row-class]}
      ;; Drag handler
      (when (some? on-reorder)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
@@ -192,6 +192,8 @@
      (when (some? on-reorder)
        [:> reorder-handler* {:ref dref}])
 
+     (prn "stroke-row*" applied-tokens)
+
      ;; Stroke Color
      ;; FIXME: memorize stroke color
      [:> color-row* {:color (ctc/stroke->color stroke)

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -89,11 +89,13 @@
         on-delete
         (mf/use-fn
          (mf/deps id)
-         #(st/emit! (modal/show
-                     {:type :confirm
-                      :title (tr "modals.delete-page.title")
-                      :message (tr "modals.delete-page.body")
-                      :on-accept delete-fn})))
+         (fn [event]
+           (dom/stop-propagation event)
+           (st/emit! (modal/show
+                      {:type :confirm
+                       :title (tr "modals.delete-page.title")
+                       :message (tr "modals.delete-page.body")
+                       :on-accept delete-fn}))))
 
         on-double-click
         (mf/use-fn


### PR DESCRIPTION
## Related Issue

Fixes #9522

## Summary

When multiple shapes are selected that have tokens applied to their stroke colors, the stroke properties panel displays incorrectly and does not show the expected "multiple values" indicator.

## Changes

- **Stroke panel multi-selection fix** — Added checks for `:stroke-color` and `:stroke-width` in `applied-tokens` having `:multiple` values, so the panel correctly shows the "multiple values" state when shapes with distinct token-applied stroke colors are selected together.
- **Token color filtering fix** — Fixed `color_selection.cljs` to properly separate library colors, token colors, and plain colors by excluding token colors from the library color filter.
- **Sitemap page deletion fix** — Added `dom/stop-propagation` to the delete page handler to prevent unintended navigation when clicking the delete button.
- **Left header layout fix** — Added `flex-shrink: 1` and `min-width: 0` to `.project-tree` to prevent layout overflow.

## Steps to Reproduce

1. Create two or more shapes and apply different stroke color tokens to each.
2. Select all the shapes simultaneously.
3. Open the stroke properties panel — observe it shows incorrect state instead of the "multiple values" indicator.
