### PR TITLE
:bug: Fix obfuscate-email crashing on malformed email or dotless domain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix `get-view-only-bundle` crashing when a share-link viewer encounters a team member whose email lacks `@` (NullPointerException in `obfuscate-email`) or whose domain has no `.` (previously produced a dangling-dot `****@****.`); now the viewer-side obfuscation is nil-safe and omits the trailing dot when the domain has no TLD
 - Fix Copy as SVG: emit a single valid SVG document when multiple shapes are selected, and publish `image/svg+xml` to the clipboard so the paste target works in Inkscape and other SVG-native tools [Github #838](https://github.com/penpot/penpot/issues/838)
 - Reset profile submenu state when the account menu closes (by @eureka0928) [Github #8947](https://github.com/penpot/penpot/issues/8947)
 - Add export panel to inspect styles tab [Taiga #13582](https://tree.taiga.io/project/penpot/issue/13582)

--- a/backend/src/app/rpc/commands/viewer.clj
+++ b/backend/src/app/rpc/commands/viewer.clj
@@ -28,19 +28,25 @@
       (update :pages-index select-keys allowed)))
 
 (defn obfuscate-email
+  "Obfuscate the `email` for share-link members so the viewer only sees a
+   partially redacted address. Accepts any string shape (including nil,
+   missing `@`, or a domain with no `.`) and falls back to a fully-masked
+   result rather than throwing — the function is called while building the
+   view-only bundle for anonymous viewers, so an NPE here would abort the
+   entire share-link response."
   [email]
   (let [[name domain]
-        (str/split email "@" 2)
+        (str/split (or email "") "@" 2)
 
         [_ rest]
-        (str/split domain "." 2)
+        (str/split (or domain "") "." 2)
 
         name
         (if (> (count name) 3)
           (str (subs name 0 1) (apply str (take (dec (count name)) (repeat "*"))))
           "****")]
 
-    (str name "@****." rest)))
+    (str name "@****" (when rest (str "." rest)))))
 
 (defn anonymize-member
   [member]

--- a/backend/test/backend_tests/rpc_viewer_test.clj
+++ b/backend/test/backend_tests/rpc_viewer_test.clj
@@ -9,12 +9,35 @@
    [app.common.uuid :as uuid]
    [app.db :as db]
    [app.rpc :as-alias rpc]
+   [app.rpc.commands.viewer :as viewer]
    [backend-tests.helpers :as th]
    [clojure.test :as t]
    [datoteka.fs :as fs]))
 
 (t/use-fixtures :once th/state-init)
 (t/use-fixtures :each th/database-reset)
+
+(t/deftest obfuscate-email-happy-path
+  (t/is (= "a****@****.com" (viewer/obfuscate-email "alice@example.com")))
+  (t/is (= "a****@****.example.com" (viewer/obfuscate-email "alice@sub.example.com")))
+  (t/is (= "****@****.com" (viewer/obfuscate-email "bob@bar.com"))))
+
+(t/deftest obfuscate-email-handles-domain-without-dot
+  ;; `localhost`-style domains have no `.`; the previous implementation produced
+  ;; a dangling-dot output like "a****@****." — now the trailing `.` is only
+  ;; emitted when there actually is a TLD segment to append.
+  (t/is (= "a****@****" (viewer/obfuscate-email "alice@localhost")))
+  (t/is (= "****@****" (viewer/obfuscate-email "x@y"))))
+
+(t/deftest obfuscate-email-handles-malformed-input
+  ;; These shapes must not throw — `obfuscate-email` runs while building the
+  ;; view-only bundle for share-link viewers and an NPE here aborts the whole
+  ;; RPC response. The previous implementation called `clojure.string/split`
+  ;; on `nil` for the `no-@` case, raising NullPointerException.
+  (t/is (= "****@****" (viewer/obfuscate-email nil)))
+  (t/is (= "****@****" (viewer/obfuscate-email "")))
+  (t/is (= "r***@****" (viewer/obfuscate-email "root")))       ; no `@`, count > 3
+  (t/is (= "****@****" (viewer/obfuscate-email "bob"))))       ; no `@`, count <= 3
 
 (t/deftest retrieve-bundle
   (let [prof     (th/create-profile* 1 {:is-active true})


### PR DESCRIPTION
## Summary

- `obfuscate-email` in `backend/src/app/rpc/commands/viewer.clj` split the raw email on `@` and then the domain on `.`. Two shapes triggered failures in the share-link viewer bundle:
  - Stored email with no `@` (legacy data, LDAP-sourced UIDs, fixtures that bypassed `::sm/email`) → destructuring bound `domain` to `nil`, the next `(str/split nil "." 2)` raised `NullPointerException`, and the whole `get-view-only-bundle` RPC response aborted
  - Single-label domain (`alice@localhost`, internal-server addresses) → `(str/split "localhost" "." 2)` returned `["localhost"]`, `rest` ended up `nil`, and the final format produced `"****@****."` with a dangling dot
- Guard both split calls with `(or x "")` so the chain is nil-safe at every level, and emit the trailing `.<tld>` segment only when `rest` is actually present
- Add three `deftest` groups in `backend/test/backend_tests/rpc_viewer_test.clj` covering the happy path (`alice@example.com`, `alice@sub.example.com`, short names), dotless domains (`alice@localhost`, `x@y`), and malformed inputs (nil, empty string, `"root"`, `"bob"`)
- Add a CHANGES.md entry under the 2.17.0 Unreleased `:bug: Bugs fixed` section

## Related Issues

N/A — code review. The function was added by `ae718c332` (*"Fix incorrect data returned on viewer subapp bundle"*) and has been untouched since; no upstream PR or issue references `obfuscate-email` (verified via `search/issues?q=obfuscate-email+is:pr` → 0 hits).

## Before / After

| Input | Before | After |
|---|---|---|
| `"alice@example.com"` | `"a****@****.com"` | `"a****@****.com"` (unchanged) |
| `"alice@sub.example.com"` | `"a****@****.example.com"` | `"a****@****.example.com"` (unchanged) |
| `"alice@localhost"` | `"****@****."` (dangling dot) | `"a****@****"` |
| `"root"` (no `@`) | **NPE crash — aborts RPC** | `"r***@****"` |
| `nil` / `""` | **NPE crash — aborts RPC** | `"****@****"` |

## Testing

- Added `obfuscate-email-happy-path`, `obfuscate-email-handles-domain-without-dot`, and `obfuscate-email-handles-malformed-input` `deftest` groups
- Manually simulated Clojure `str/split` + destructure + `str` nil-coercion semantics against nine input shapes — all match the expected output
- Existing `retrieve-bundle` integration test is unchanged; the helper runs through it indirectly via `anonymize-member` on normal emails

## Checklist

- [x] Code follows project style guidelines (threading, `let` binding, gitmoji commit)
- [x] Self-review completed
- [x] Tests added
- [x] Changelog entry added in CHANGES.md



Fixes #9530
