### PR TITLE
:bug: Fix typography style creation with tokenized line-height

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,7 +76,7 @@
 - Fix copy to be more specific [Taiga #13990](https://tree.taiga.io/project/penpot/issue/13990)
 - Allow deleting the profile avatar after uploading [Github #9067](https://github.com/penpot/penpot/issues/9067)
 - Fix incorrect rendering when exporting text as SVG, PNG and JPG (by @edwin-rivera-dev) [Github #8516](https://github.com/penpot/penpot/issues/8516)
-
+- Fix typography style creation with tokenized line-height (by @juan-flores077) [Github #8479](https://github.com/penpot/penpot/issues/8479)
 
 ## 2.16.0 (Unreleased)
 

--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -935,6 +935,12 @@
                             (d/concat-vec txt/text-font-attrs
                                           txt/text-spacing-attrs
                                           txt/text-transform-attrs)))
+             values    (cond-> values
+                         (number? (:line-height values))
+                         (update :line-height str)
+
+                         (number? (:letter-spacing values))
+                         (update :letter-spacing str))
 
              typ-id    (uuid/next)
              typ       (-> (if multiple?


### PR DESCRIPTION
### Related Ticket

Fixes #8479

### Summary

Fix frontend assertion error when creating a typography style from a text element whose line-height is set via a design token. The fix normalizes/serializes the line-height value before validation so the typography creation flow accepts tokenized values (e.g. 1.5).

### Steps to reproduce

1. Create a typography design token and set `line-height` (multiplier/px/%).
2. Apply the token to a text element.
3. Try to create a new typography style from the selected text.
4. Observe an assertion error / “check error” preventing style creation.

### Verification / test plan

- Repeat the steps above and confirm the typography style is created successfully.
- Confirm creating typography styles still works for non-token line-height values.
- Quick regression: try tokenized `line-height` values for multiplier (e.g. 1.5), px (e.g. 24), and % (e.g. 120%).

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

### Videos
#### Before

https://github.com/user-attachments/assets/30f2d8e8-cf94-42fb-aeed-60df206f9857



#### After

https://github.com/user-attachments/assets/4be27d97-f065-4f40-b790-e5519b9cf714

