### PR TITLE
:bug: Fix layer hierarchy to match old and new SCSS

### DIFF
--- a/frontend/resources/styles/common/refactor/basic-rules.scss
+++ b/frontend/resources/styles/common/refactor/basic-rules.scss
@@ -800,7 +800,7 @@
   position: absolute;
   padding: $s-4;
   border-radius: $br-8;
-  z-index: $z-index-10;
+  z-index: $z-index-dropdown;
   color: var(--title-foreground-color-hover);
   background-color: var(--menu-background-color);
   border: $s-2 solid var(--panel-border-color);

--- a/frontend/resources/styles/common/refactor/z-index.scss
+++ b/frontend/resources/styles/common/refactor/z-index.scss
@@ -11,5 +11,5 @@ $z-index-4: 4; // context menu
 $z-index-5: 5; // modal
 $z-index-10: 10;
 $z-index-20: 20;
-$z-index-modal: 30; // When refactor finish we can reduce this number,
-$z-index-alert: 40; // When refactor finish we can reduce this number,
+$z-index-modal: 300;
+$z-index-dropdown: 400;

--- a/frontend/src/app/main/ui/components/context_menu_a11y.scss
+++ b/frontend/src/app/main/ui/components/context_menu_a11y.scss
@@ -5,12 +5,13 @@
 // Copyright (c) KALEIDOS INC
 
 @use "refactor/common-refactor.scss" as deprecated;
+@use "ds/z-index.scss" as *;
 
 .context-menu {
   position: relative;
   visibility: hidden;
   opacity: deprecated.$op-0;
-  z-index: deprecated.$z-index-4;
+  z-index: var(--z-index-dropdown);
 
   &.is-open {
     position: relative;

--- a/frontend/src/app/main/ui/dashboard/deleted.scss
+++ b/frontend/src/app/main/ui/dashboard/deleted.scss
@@ -6,11 +6,11 @@
 
 @use "refactor/common-refactor.scss" as deprecated;
 @use "common/refactor/common-dashboard";
-@use "../ds/typography.scss" as t;
-@use "../ds/_borders.scss" as *;
-@use "../ds/spacing.scss" as *;
-@use "../ds/_sizes.scss" as *;
-@use "../ds/z-index.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/spacing.scss" as *;
+@use "ds/z-index.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
 
 .dashboard-container {
   flex: 1 0 0;
@@ -51,7 +51,7 @@
   padding: var(--sp-xxl) var(--sp-xxl) var(--sp-s) var(--sp-xxl);
   position: sticky;
   top: 0;
-  z-index: $z-index-100;
+  z-index: var(--z-index-panels);
 }
 
 .nav-inside {

--- a/frontend/src/app/main/ui/dashboard/files.scss
+++ b/frontend/src/app/main/ui/dashboard/files.scss
@@ -6,6 +6,8 @@
 
 @use "refactor/common-refactor.scss" as deprecated;
 @use "common/refactor/common-dashboard";
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
 
 .dashboard-container {
   flex: 1 0 0;
@@ -13,6 +15,7 @@
   overflow-y: auto;
   width: 100%;
   border-top: deprecated.$s-1 solid var(--color-background-quaternary);
+  padding-block-end: var(--sp-xxxl);
 
   &.dashboard-projects {
     user-select: none;

--- a/frontend/src/app/main/ui/dashboard/grid.scss
+++ b/frontend/src/app/main/ui/dashboard/grid.scss
@@ -17,7 +17,7 @@ $thumbnail-default-height: deprecated.$s-168; // Default width
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 0 deprecated.$s-16;
+  padding: 0 var(--sp-l) deprecated.$s-16;
 }
 
 .grid-row {

--- a/frontend/src/app/main/ui/dashboard/projects.scss
+++ b/frontend/src/app/main/ui/dashboard/projects.scss
@@ -19,16 +19,15 @@
   margin-inline-end: var(--sp-l);
   border-block-start: $b-1 solid var(--panel-border-color);
   overflow-y: auto;
-  padding-block-end: var(--sp-xxxl);
 }
 
 .dashboard-projects {
   user-select: none;
-  block-size: calc(100vh - px2rem(64));
+  block-size: calc(100vh - px2rem(80));
 }
 
 .with-team-hero {
-  block-size: calc(100vh - px2rem(280));
+  block-size: calc(100vh - px2rem(360));
 }
 
 .dashboard-shared {

--- a/frontend/src/app/main/ui/dashboard/templates.scss
+++ b/frontend/src/app/main/ui/dashboard/templates.scss
@@ -4,10 +4,11 @@
 //
 // Copyright (c) KALEIDOS INC
 
-@use "ds/_borders.scss" as *;
-@use "ds/_utils.scss" as *;
-@use "ds/_sizes.scss" as *;
 @use "ds/typography.scss" as t;
+@use "ds/z-index.scss" as *;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
 
 .dashboard-templates-section {
   background-color: var(--color-background-tertiary);
@@ -26,6 +27,8 @@
   transition: bottom 300ms;
   width: calc(100% - $sz-12);
   pointer-events: none;
+  z-index: var(--z-index-set);
+
   &.collapsed {
     inset-block-end: calc(-1 * px2rem(228));
     background-color: transparent;


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/8296

Taiga [#13962](https://tree.taiga.io/project/penpot/issue/13962) - This is a follow-up of Github https://github.com/penpot/penpot/pull/8937

### Summary

In the previous PR we changed the `z-index` of the toolbar, but we did not consider the `z-index` of the modal, so it appeared behind the toolbar. This happens because the z-indexes for the old and the new SCSS styleguides do not match. This fixes the hierarchy of the elements.