### PR TITLE
:bug: Fix plugin parse-point returning plain map instead of Point record

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,7 @@
 - Fix copy to be more specific [Taiga #13990](https://tree.taiga.io/project/penpot/issue/13990)
 - Allow deleting the profile avatar after uploading [Github #9067](https://github.com/penpot/penpot/issues/9067)
 - Fix incorrect rendering when exporting text as SVG, PNG and JPG (by @edwin-rivera-dev) [Github #8516](https://github.com/penpot/penpot/issues/8516)
+- Fix plugin `addInteraction` silently rejecting `open-overlay` actions with `manualPositionLocation` [Github #8409](https://github.com/penpot/penpot/issues/8409)
 
 
 ## 2.16.0 (Unreleased)

--- a/frontend/src/app/plugins/parser.cljs
+++ b/frontend/src/app/plugins/parser.cljs
@@ -7,6 +7,7 @@
 (ns app.plugins.parser
   (:require
    [app.common.data :as d]
+   [app.common.geom.point :as gpt]
    [app.common.json :as json]
    [app.common.types.path :as path]
    [app.common.uuid :as uuid]
@@ -26,10 +27,16 @@
   (if (string? color) (-> color str/lower) color))
 
 (defn parse-point
+  "Parses a point-like JS object into a `gpt/point` record.
+
+  The schema for shape interactions (`schema:open-overlay-interaction`,
+  `::gpt/point`) requires a Point record — returning a plain map caused
+  plugin `addInteraction` calls with an `open-overlay` action and a
+  `manualPositionLocation` to be silently rejected. See issue #8409."
   [^js point]
   (when point
-    {:x (obj/get point "x")
-     :y (obj/get point "y")}))
+    (gpt/point (obj/get point "x")
+               (obj/get point "y"))))
 
 (defn parse-shape-type
   [type]

--- a/frontend/test/frontend_tests/plugins/parser_test.cljs
+++ b/frontend/test/frontend_tests/plugins/parser_test.cljs
@@ -1,0 +1,33 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.plugins.parser-test
+  (:require
+   [app.common.geom.point :as gpt]
+   [app.plugins.parser :as parser]
+   [cljs.test :as t :include-macros true]))
+
+(t/deftest test-parse-point-returns-gpt-point-record
+  ;; Regression test for issue #8409.
+  ;;
+  ;; The plugin parser used to return a plain map `{:x … :y …}`, but the
+  ;; shape-interaction schema expects `::gpt/point` (a Point record).
+  ;; Plugin `addInteraction` calls with an `open-overlay` action and
+  ;; `manualPositionLocation` were silently rejected by validation.
+  (t/testing "parse-point returns nil for nil input"
+    (t/is (nil? (parser/parse-point nil))))
+
+  (t/testing "parse-point returns a gpt/point record for valid input"
+    (let [result (parser/parse-point #js {:x 10 :y 20})]
+      (t/is (gpt/point? result))
+      (t/is (= 10 (:x result)))
+      (t/is (= 20 (:y result)))))
+
+  (t/testing "parse-point passes gpt/point? for a zero point"
+    (let [result (parser/parse-point #js {:x 0 :y 0})]
+      (t/is (gpt/point? result))
+      (t/is (= 0 (:x result)))
+      (t/is (= 0 (:y result))))))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -20,6 +20,7 @@
    [frontend-tests.logic.pasting-in-containers-test]
    [frontend-tests.main-errors-test]
    [frontend-tests.plugins.context-shapes-test]
+   [frontend-tests.plugins.parser-test]
    [frontend-tests.svg-fills-test]
    [frontend-tests.tokens.import-export-test]
    [frontend-tests.tokens.logic.token-actions-test]
@@ -63,6 +64,7 @@
    'frontend-tests.logic.groups-test
    'frontend-tests.logic.pasting-in-containers-test
    'frontend-tests.plugins.context-shapes-test
+   'frontend-tests.plugins.parser-test
    'frontend-tests.svg-fills-test
    'frontend-tests.tokens.import-export-test
    'frontend-tests.tokens.logic.token-actions-test


### PR DESCRIPTION
## Related Ticket

Fixes #8409

## Summary

Plugin `addInteraction` calls with `type: 'open-overlay'` and a `manualPositionLocation` were silently rejected by schema validation. Only a console warning was produced — the interaction never got added.

Reproducer from the issue:

```js
shape.addInteraction('click', {
  type: 'open-overlay',
  destination: destinationBoard,
  position: 'center',
  manualPositionLocation: { x: 0, y: 0 }
});
// Console: [PENPOT PLUGIN] Value not valid: {...}. Code: :addInteraction
```


## Root cause

`parse-point` in `frontend/src/app/plugins/parser.cljs` built a plain map `{:x … :y …}`, but `schema:open-overlay-interaction` in
`common/src/app/common/types/shape/interactions.cljc` requires `:overlay-position` to be `::gpt/point` — a schema whose predicate is `(instance? Point v)`. A plain map fails that predicate, so `sm/validate ctsi/schema:interaction` on the assembled interaction rejected the whole call.

## Fix

Change `parse-point` to return a `gpt/point` record via `gpt/point`. All three call sites of `parse-point` (`parser.cljs` open-overlay
branch, `plugins/page.cljs`, `plugins/comments.cljs`) keep working - Point records expose `:x`/`:y` destructuring like plain maps do.

## Tests

Added `frontend/test/frontend_tests/plugins/parser_test.cljs` with three cases:

- `nil` input returns `nil`
- `{:x 10 :y 20}` parses into a `gpt/point?` record with correct values
- zero-point edge case still returns a `gpt/point?` record

Full test suite run locally: **255 tests / 906 assertions / 0 failures / 0 errors**.