### PR TITLE
:bug: Fix plugin library.connectLibrary breaking Promise contract on permission failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix plugin API `library.connectLibrary()` returning a non-Promise (or throwing synchronously) when the plugin lacks `library:write` permission — the method now always returns a `Promise` and rejects with a structured error message, matching the contract used by every other Promise-returning plugin method (`restore`, `remove`, `pin`, `saveVersion`, `findVersions`, …)
 - Fix `PENPOT_OIDC_USER_INFO_SOURCE` flag being silently ignored (`userinfo` / `token`) in the OIDC callback, causing "incomplete user info" failures during registration [Github #9108](https://github.com/penpot/penpot/issues/9108)
 - Fix `get-view-only-bundle` crashing when a share-link viewer encounters a team member whose email lacks `@` (NullPointerException in `obfuscate-email`) or whose domain has no `.` (previously produced a dangling-dot `****@****.`); now the viewer-side obfuscation is nil-safe and omits the trailing dot when the domain has no TLD
 - Remove `corepack` from the MCP local launcher so it runs on Node.js 25+, where corepack is no longer bundled [Github #8877](https://github.com/penpot/penpot/issues/8877)

--- a/frontend/src/app/plugins/library.cljs
+++ b/frontend/src/app/plugins/library.cljs
@@ -1108,23 +1108,20 @@
 
     :connectLibrary
     (fn [library-id]
-      (cond
-        (not (r/check-permission plugin-id "library:write"))
-        (u/not-valid plugin-id :connectLibrary "Plugin doesn't have 'library:write' permission")
+      (js/Promise.
+       (fn [resolve reject]
+         (cond
+           (not (r/check-permission plugin-id "library:write"))
+           (u/reject-not-valid reject :connectLibrary "Plugin doesn't have 'library:write' permission")
 
-        :else
-        (js/Promise.
-         (fn [resolve reject]
-           (cond
-             (not (string? library-id))
-             (do (u/not-valid plugin-id :connectLibrary library-id)
-                 (reject nil))
+           (not (string? library-id))
+           (u/reject-not-valid reject :connectLibrary library-id)
 
-             :else
-             (let [file-id (:current-file-id @st/state)
-                   library-id (uuid/parse library-id)]
-               (->> st/stream
-                    (rx/filter (ptk/type? ::dwl/attach-library-finished))
-                    (rx/take 1)
-                    (rx/subs! #(resolve (library-proxy plugin-id library-id)) reject))
-               (st/emit! (dwl/link-file-to-library file-id library-id))))))))))
+           :else
+           (let [file-id (:current-file-id @st/state)
+                 library-id (uuid/parse library-id)]
+             (->> st/stream
+                  (rx/filter (ptk/type? ::dwl/attach-library-finished))
+                  (rx/take 1)
+                  (rx/subs! #(resolve (library-proxy plugin-id library-id)) reject))
+             (st/emit! (dwl/link-file-to-library file-id library-id)))))))))


### PR DESCRIPTION
## Summary

- `library.connectLibrary()` declared its `library:write` permission check **outside** the `js/Promise.` wrapper, so a plugin without permission got back `nil` (or a thrown exception with `throwValidationErrors`) instead of a rejected Promise — breaking the `await / .catch()` contract that every other Promise-returning plugin method follows
- Additionally, the inner `(not (string? library-id))` validation branch used `(reject nil)`, so a plugin passing a non-string got a rejected Promise but with no error message
- Move the permission check inside the `js/Promise.` constructor and replace both validation errors with `u/reject-not-valid` — matching the pattern used by `restore`, `remove`, `pin`, `saveVersion`, `findVersions`, and `export` in `frontend/src/app/plugins/file.cljs` (and every other Promise-returning plugin method)
- No new imports, no behaviour change for the happy path, no change to the public method signature
- Add a CHANGES.md entry under the 2.17.0 Unreleased `:bug: Bugs fixed` section

## Related Issues

N/A — code review. No upstream PR references `connectLibrary` (verified via `search/issues?q=connectLibrary+is:pr` → 0 hits).

## Before / After

```js
// Plugin code (developer-facing)
try {
  const lib = await context.library.connectLibrary("some-uuid");
  lib.someProperty;  // use the returned library proxy
} catch (err) {
  console.error("could not connect library:", err);
}
```


Fixes #9646
