### PR TITLE
:bug: Fix :hide typo dropping LDAP not-initialized error hint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix `login-with-ldap` silently dropping its error message on the `ldap-not-initialized` restriction (typo `:hide` → `:hint`); the message `"ldap auth provider is not initialized"` now actually surfaces in logs and error responses instead of being discarded into an unread key
 - Fix `PENPOT_OIDC_USER_INFO_SOURCE` flag being silently ignored (`userinfo` / `token`) in the OIDC callback, causing "incomplete user info" failures during registration [Github #9108](https://github.com/penpot/penpot/issues/9108)
 - Fix `get-view-only-bundle` crashing when a share-link viewer encounters a team member whose email lacks `@` (NullPointerException in `obfuscate-email`) or whose domain has no `.` (previously produced a dangling-dot `****@****.`); now the viewer-side obfuscation is nil-safe and omits the trailing dot when the domain has no TLD
 - Remove `corepack` from the MCP local launcher so it runs on Node.js 25+, where corepack is no longer bundled [Github #8877](https://github.com/penpot/penpot/issues/8877)

--- a/backend/src/app/rpc/commands/ldap.clj
+++ b/backend/src/app/rpc/commands/ldap.clj
@@ -42,7 +42,7 @@
   (when-not provider
     (ex/raise :type :restriction
               :code :ldap-not-initialized
-              :hide "ldap auth provider is not initialized"))
+              :hint "ldap auth provider is not initialized"))
 
   (let [info (ldap/authenticate provider params)]
     (when-not info


### PR DESCRIPTION
## Summary

- `login-with-ldap` raised a `:restriction` exception with the error message stored under `:hide` instead of `:hint`; `ex/raise` (`common/src/app/common/exceptions.cljc:33-34`) only reads `:hint` when building the ExceptionInfo message, and downstream error formatters (`exceptions.cljc:250`, `312`, and `get-hint`) also only read `:hint` — so the string `"ldap auth provider is not initialized"` was silently dropped and operators saw only the generic `"restriction"` fallback in logs
- The `:hide` key is not consumed anywhere in the codebase (`grep -rn ":hide \"" backend/src --include="*.clj"` returns exactly 1 match — this buggy line. `:hint` has 447 sibling occurrences)
- One-character fix: `:hide` → `:hint`. No behaviour change for successful LDAP logins or for other `ex/raise` sites; only the diagnostic message for the specific `ldap-not-initialized` restriction now makes it into logs / error responses
- Add a CHANGES.md entry under the 2.17.0 Unreleased `:bug: Bugs fixed` section

## Related Issues

N/A — code review. The typo has been present since commit `14d1cb90bd` (2022-06-30, *"Refactor auth code"*) when the LDAP command was carved into its own rpc namespace. Preserved through five subsequent commits without being caught. No upstream PR touches `ldap-not-initialized` (verified via `search/issues?q="ldap-not-initialized"+is:pr` → 0 hits).

## Before / After

Server log line when an operator without the `login-with-ldap` feature flag sees a login attempt:

| | Before | After |
|---|---|---|
| ExceptionInfo message | `"restriction"` (generic fallback) | `"ldap auth provider is not initialized"` |
| Structured error data | `{:type :restriction, :code :ldap-not-initialized, :hide "ldap auth provider is not initialized"}` — message stored in an unread key | `{:type :restriction, :code :ldap-not-initialized, :hint "ldap auth provider is not initialized"}` — message in the canonical location |
| `get-hint` result | `nil` | `"ldap auth provider is not initialized"` |

## Checklist

- [x] Code follows project style guidelines (matches every other `ex/raise` call site in the codebase — 447 sibling `:hint` usages)
- [x] Self-review completed
- [x] Changelog entry added in CHANGES.md



Fixes #9533
