### PR TITLE
:bug: Fix LDAP schema typo bind-passwor -> bind-password

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix LDAP provider params schema typo (`bind-passwor` → `bind-password`) introduced during the `clojure.spec` → `malli` migration; the schema slot now matches the runtime key actually read by `prepare-params` (`:password (:bind-password cfg)`) and `try-connectivity` (`(:bind-password cfg)`), so a wrong type for the password no longer slips through unvalidated
 - Fix `PENPOT_OIDC_USER_INFO_SOURCE` flag being silently ignored (`userinfo` / `token`) in the OIDC callback, causing "incomplete user info" failures during registration [Github #9108](https://github.com/penpot/penpot/issues/9108)
 - Fix `get-view-only-bundle` crashing when a share-link viewer encounters a team member whose email lacks `@` (NullPointerException in `obfuscate-email`) or whose domain has no `.` (previously produced a dangling-dot `****@****.`); now the viewer-side obfuscation is nil-safe and omits the trailing dot when the domain has no TLD
 - Remove `corepack` from the MCP local launcher so it runs on Node.js 25+, where corepack is no longer bundled [Github #8877](https://github.com/penpot/penpot/issues/8877)

--- a/backend/src/app/auth/ldap.clj
+++ b/backend/src/app/auth/ldap.clj
@@ -111,7 +111,7 @@
    [:host {:optional true} :string]
    [:port {:optional true} ::sm/int]
    [:bind-dn {:optional true} :string]
-   [:bind-passwor {:optional true} :string]
+   [:bind-password {:optional true} :string]
    [:query {:optional true} :string]
    [:base-dn {:optional true} :string]
    [:attrs-email {:optional true} :string]


### PR DESCRIPTION
## Summary

The malli schema for the LDAP provider params in `backend/src/app/auth/ldap.clj` declared the bind-password slot as `:bind-passwor` (missing trailing `d`). The runtime code in the same file uses `:bind-password` everywhere (`prepare-params` line 21, `try-connectivity` line 89), so the schema slot is targeting the wrong key.

The typo was introduced by commit `88fb5e7ab` (2024-10-29, ":recycle: Update integrant to latest version") which carried the `clojure.spec` → `malli` migration. The deleted spec block correctly defined `(s/def ::bind-password ::us/string)` — the typo was a copy-paste slip during the manual rewrite.

## Effects of the typo

1. **Wrong-type slips through unvalidated.** Malli `[:map ...]` is open by default, so the genuine `:bind-password` key is silently accepted as an unknown extra. `check-params` cannot enforce that the password is actually a string; an operator who accidentally sets it to a number gets a runtime nil instead of an early validation error.
2. **Schema misleads readers.** Anyone reading the schema (or tooling generating config docs from it) sees `:bind-passwor` as the way to set the password. Setting that key passes validation but is never read by the runtime — LDAP bind silently fails.

## Fix

One-character change: `:bind-passwor` → `:bind-password` in `schema:params` at line 114.

After the fix, the schema slot validates the actual runtime key. No runtime behaviour change for any deployment that already had a working `:bind-password` (which is every working deployment, since the runtime always reads the correct key); the only change is that wrong-type passwords now fail at boot-time validation instead of at first LDAP bind attempt.

## Related Issues

N/A — code review. The typo has been present since `88fb5e7ab` (2024-10-29) and has not been fixed in any subsequent commit. No upstream PR or issue mentions it (verified via `search/issues?q="bind-passwor"+is:pr` → 0 hits).

## Testing

- [x] Verified the typo against the pre-migration `clojure.spec` block in commit `88fb5e7ab` — the OLD form had `::bind-password` correctly; the NEW form regressed
- [x] Verified the runtime callsites: `(:bind-password cfg)` in `prepare-params` (line 21) and `try-connectivity` (line 89). Neither was updated to read the typo'd key, confirming the schema slot was the regression
- [x] No new tests required — the schema change is a literal key rename and the existing `try-connectivity` integration path is unchanged

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changelog entry added in CHANGES.md



Fixes #9531
