### PR TITLE
:bug: Fix put onboarding modals of top of libraries & templates panel

### DIFF
--- a/frontend/src/app/main/ui/dashboard/templates.scss
+++ b/frontend/src/app/main/ui/dashboard/templates.scss
@@ -27,7 +27,7 @@
   transition: bottom 300ms;
   width: calc(100% - $sz-12);
   pointer-events: none;
-  z-index: var(--z-index-set);
+  z-index: var(--z-index-panels);
 
   &.collapsed {
     inset-block-end: calc(-1 * px2rem(228));


### PR DESCRIPTION
### Summary

The onboarding modals need to be on top of the libraries & templates panel.