### PR TITLE
:sparkles: Add Alt+click to expand a layer subtree in the Layers sidebar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### :sparkles: New features & Enhancements
 
+- Add `Alt+click` on a layer's disclosure arrow to recursively expand the entire subtree rooted at that layer in the Layers sidebar; symmetric with the existing `Shift+click` collapse-all gesture, and removes the O(siblings × depth) click cost of unfolding a deep subtree one level at a time [Github #7736](https://github.com/penpot/penpot/issues/7736)
 - Show alpha percentage next to library color values to distinguish colors that differ only in opacity (by @rockchris099) [Github #6328](https://github.com/penpot/penpot/issues/6328)
 - Add "Clear artboard guides" option to right-click context menu for frames (by @eureka0928) [Github #6987](https://github.com/penpot/penpot/issues/6987)
 - Add loader feedback while importing and exporting files [Github #9020](https://github.com/penpot/penpot/issues/9020)

--- a/frontend/src/app/main/data/workspace/collapse.cljs
+++ b/frontend/src/app/main/data/workspace/collapse.cljs
@@ -49,3 +49,19 @@
     (update [_ state]
       (update state :workspace-local dissoc :expanded))))
 
+(defn expand-subtree
+  "Recursively expand the layer subtree rooted at `id`, marking the shape
+   and all of its descendants as expanded in the Layers sidebar.
+
+   Closes the gap with `collapse-all`: there was no symmetric way to
+   open every nested level of a single subtree, so unfolding a deep
+   shape required clicking each disclosure indicator one by one
+   (O(siblings × depth) clicks)."
+  [id objects]
+  (ptk/reify ::expand-subtree
+    ptk/UpdateEvent
+    (update [_ state]
+      (let [ids        (cfh/get-children-ids-with-self objects id)
+            expansions (into {} (map (fn [descendant-id] [descendant-id true])) ids)]
+        (update-in state [:workspace-local :expanded] merge expansions)))))
+

--- a/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layer_item.cljs
@@ -275,11 +275,19 @@
 
         toggle-collapse
         (mf/use-fn
-         (mf/deps is-expanded)
+         (mf/deps is-expanded id objects)
          (fn [event]
            (dom/stop-propagation event)
-           (if (and is-expanded (kbd/shift? event))
+           (cond
+             ;; Shift+click while expanded collapses every layer in the sidebar
+             (and is-expanded (kbd/shift? event))
              (st/emit! (dwc/collapse-all))
+
+             ;; Alt+click while collapsed expands the entire subtree rooted at this id
+             (and (not is-expanded) (kbd/alt? event))
+             (st/emit! (dwc/expand-subtree id objects))
+
+             :else
              (st/emit! (dwc/toggle-collapse id)))))
 
         toggle-blocking


### PR DESCRIPTION

## Summary

Closes #7736.

The Layers sidebar offers no way to expand every nested level of a
single subtree at once. Unfolding a deep layer requires clicking each
disclosure indicator one level at a time — `O(siblings × depth)`
clicks for a tree of depth `d` with `s` siblings at each level.

The existing keyboard gesture set is asymmetric:

| Gesture                              | Today                              |
| ------------------------------------ | ---------------------------------- |
| Click on a disclosure indicator      | Toggle this single layer           |
| Shift+click while expanded           | `collapse-all` — every layer folds |
| *(none)*                             | *No expand-equivalent*             |

The issue author explicitly notes that re-using `Shift+click` for an
expand variant would be ambiguous ("for a layer of middle depth it is
unclear whether it should fold all (up to the topmost parent) or
expand all (only the current subtree)"). `Alt+click` avoids that
overload and matches the cross-platform "do this recursively"
convention used by Finder, several file managers, and many IDEs.

## Fix

- `app.main.data.workspace.collapse`: add `expand-subtree` event.
  Uses `cfh/get-children-ids-with-self` to gather the shape's id
  plus every descendant id, then merges `{descendant-id true}`
  entries into `[:workspace-local :expanded]` in one update.
  Unrelated branches are left untouched (`merge`, not `assoc`),
  matching the per-key shape used by `toggle-collapse` and
  `expand-collapse`.
- `app.main.ui.workspace.sidebar.layer-item`: extend the
  `toggle-collapse` callback with a third branch:

      - Shift+click while expanded → `collapse-all` (existing)
      - Alt+click while collapsed   → `expand-subtree id objects` (new)
      - Otherwise                   → `toggle-collapse id` (existing)

  The callback's `mf/deps` vector is extended with `id` and
  `objects` so the closure refreshes when the shape tree changes.

CHANGES.md entry added under the 2.17.0 New features & Enhancements
section.

## Reproduction

1. Build a layer tree several levels deep (e.g. group → group →
   group → leaves).
2. Collapse the top-level group (single click on its disclosure
   arrow).
3. **Before:** to see the leaves again you must click each
   disclosure arrow at every level — one click per node along the
   path.
4. **After:** `Alt+click` once on the top-level group's disclosure
   arrow expands the entire subtree at every nested level.

## Closes

Closes #7736.
