### PR TITLE
:fire: Remove redundant mf/props metadata from modern components

### DIFF
--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -541,8 +541,7 @@
             [:div {:class (stl/css :comments-mentions-email)} email]]))])))
 
 (mf/defc mentions-button*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   (let [mentions-s        (mf/use-ctx mentions-context)
         display-mentions* (mf/use-state false)
@@ -647,8 +646,7 @@
            [:span {:class (stl/css :replies-unread)} (str unread-replies " " (tr "labels.replies.new"))]))])]])
 
 (mf/defc comment-form-buttons*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-submit on-cancel is-disabled]}]
   (let [handle-cancel
         (mf/use-fn
@@ -684,8 +682,7 @@
   (> (count content) 750))
 
 (mf/defc comment-reply-form*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-submit]}]
   (let [content       (mf/use-state "")
 

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -48,8 +48,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc dashboard-content*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [team projects project section search-term profile default-project]}]
   (let [container       (mf/use-ref)
         content-width   (mf/use-state 0)

--- a/frontend/src/app/main/ui/dashboard/comments.cljs
+++ b/frontend/src/app/main/ui/dashboard/comments.cljs
@@ -25,7 +25,6 @@
   (deprecated-icon/icon-xref :comments (stl/css :comments-icon)))
 
 (mf/defc comments-icon*
-  {::mf/props :obj}
   [{:keys [profile on-show-comments]}]
 
   (let [threads-map (mf/deref refs/comment-threads)

--- a/frontend/src/app/main/ui/dashboard/deleted.cljs
+++ b/frontend/src/app/main/ui/dashboard/deleted.cljs
@@ -54,8 +54,7 @@
                 :on-accept accept-fn}))))
 
 (mf/defc header*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   [:header {:class (stl/css :dashboard-header) :data-testid "dashboard-header"}
    [:div#dashboard-deleted-title {:class (stl/css :dashboard-title)}

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -31,8 +31,7 @@
   (deprecated-icon/icon-xref :menu (stl/css :menu-icon)))
 
 (mf/defc header*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [project create-fn can-edit]}]
   (let [project-id (:id project)
 
@@ -133,7 +132,6 @@
                            :on-import on-import}])]]))
 
 (mf/defc files-section*
-  {::mf/props :obj}
   [{:keys [project team]}]
   (let [files            (mf/deref refs/files)
         project-id       (get project :id)

--- a/frontend/src/app/main/ui/dashboard/fonts.cljs
+++ b/frontend/src/app/main/ui/dashboard/fonts.cljs
@@ -54,8 +54,7 @@
        (str/blank? (:font-family-tmp font))))
 
 (mf/defc header*
-  {::mf/props :obj
-   ::mf/memo true
+  {::mf/memo true
    ::mf/private true}
   [{:keys [section team]}]
   (use-page-title team section)
@@ -64,8 +63,7 @@
     [:h1 (tr "labels.fonts")]]])
 
 (mf/defc font-variant-display-name*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [variant]}]
   [:*
    [:span (cm/font-weight->name (:font-weight variant))]
@@ -73,8 +71,7 @@
      [:span " " (str/capital (:font-style variant))])])
 
 (mf/defc uploaded-fonts*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [team installed-fonts]}]
   (let [fonts*     (mf/use-state {})
         fonts      (deref fonts*)
@@ -438,7 +435,6 @@
             :on-edit on-edit}]]))]))
 
 (mf/defc installed-fonts*
-  {::mf/props :obj}
   [{:keys [fonts can-edit]}]
   (let [sterm (mf/use-state "")
 
@@ -491,7 +487,6 @@
   (l/derived :fonts st/state))
 
 (mf/defc fonts-page*
-  {::mf/props :obj}
   [{:keys [team]}]
   (let [fonts       (mf/deref ref:fonts)
         permissions (:permissions team)
@@ -505,7 +500,6 @@
        {:team team :fonts fonts :can-edit can-edit}]]]))
 
 (mf/defc font-providers-page*
-  {::mf/props :obj}
   [{:keys [team]}]
   [:*
    [:> header* {:team team :section :providers}]

--- a/frontend/src/app/main/ui/dashboard/grid.cljs
+++ b/frontend/src/app/main/ui/dashboard/grid.cljs
@@ -84,8 +84,7 @@
        (rx/mapcat (partial persist-thumbnail file-id revn))))
 
 (mf/defc grid-item-thumbnail*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [can-edit file can-restore]}]
   (let [file-id      (get file :id)
         revn         (get file :revn)
@@ -131,7 +130,6 @@
   (deprecated-icon/icon-xref :menu (stl/css :menu-icon)))
 
 (mf/defc grid-item-library*
-  {::mf/props :obj}
   [{:keys [file can-restore]}]
   (mf/with-effect [file]
     (when file
@@ -466,7 +464,6 @@
                             :can-restore can-restore}]])]]]]]))
 
 (mf/defc grid*
-  {::mf/props :obj}
   [{:keys [files project origin limit create-fn can-edit selected-files can-restore]}]
   (let [dragging?  (mf/use-state false)
         project-id (get project :id)

--- a/frontend/src/app/main/ui/dashboard/import.cljs
+++ b/frontend/src/app/main/ui/dashboard/import.cljs
@@ -192,8 +192,7 @@
             (swap! state update-entry-status message))))))
 
 (mf/defc import-entry*
-  {::mf/props :obj
-   ::mf/memo true
+  {::mf/memo true
    ::mf/private true}
   [{:keys [entries entry edition can-be-deleted on-edit on-change on-delete]}]
   (let [status          (:status entry)

--- a/frontend/src/app/main/ui/dashboard/libraries.cljs
+++ b/frontend/src/app/main/ui/dashboard/libraries.cljs
@@ -27,7 +27,6 @@
              st/state))
 
 (mf/defc libraries-page*
-  {::mf/props :obj}
   [{:keys [team default-project]}]
   (let [files
         (mf/deref refs/shared-files)

--- a/frontend/src/app/main/ui/dashboard/pin_button.cljs
+++ b/frontend/src/app/main/ui/dashboard/pin_button.cljs
@@ -18,7 +18,6 @@
   (deprecated-icon/icon-xref :pin (stl/css :icon)))
 
 (mf/defc pin-button*
-  {::mf/props :obj}
   [{:keys [aria-label is-pinned class] :as props}]
   (let [aria-label (or aria-label (tr "dashboard.pin-unpin"))
         class (dm/str (or class "") " " (stl/css-case :button true :button-active is-pinned))

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -48,7 +48,6 @@
 
 (mf/defc header*
   {::mf/wrap [mf/memo]
-   ::mf/props :obj
    ::mf/private true}
   [{:keys [can-edit]}]
   (let [on-click (mf/use-fn #(st/emit! (dd/create-project)))]
@@ -62,8 +61,7 @@
         (tr "dashboard.new-project")])]))
 
 (mf/defc team-hero*
-  {::mf/wrap [mf/memo]
-   ::mf/props :obj}
+  {::mf/wrap [mf/memo]}
   [{:keys [team on-close]}]
   (let [on-nav-members-click (mf/use-fn #(st/emit! (dcm/go-to-dashboard-members)))
 
@@ -102,8 +100,7 @@
       close-icon]]))
 
 (mf/defc project-item*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [project is-first team files can-edit]}]
   (let [project-id (get project :id)
         team-id    (get team :id)
@@ -313,7 +310,6 @@
   (l/derived :recent-files st/state))
 
 (mf/defc projects-section*
-  {::mf/props :obj}
   [{:keys [team projects profile]}]
 
   (let [team-id         (get team :id)

--- a/frontend/src/app/main/ui/dashboard/search.cljs
+++ b/frontend/src/app/main/ui/dashboard/search.cljs
@@ -32,7 +32,6 @@
              st/state))
 
 (mf/defc search-page*
-  {::mf/props :obj}
   [{:keys [team search-term]}]
   (let [search-term (d/nilv search-term "")
 

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -967,8 +967,7 @@
       [:div {:class (stl/css-case :separator true :overflow-separator overflow?)}]]]))
 
 (mf/defc help-learning-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-close on-click]}]
   (let [handle-click-url
         (mf/use-fn
@@ -1012,8 +1011,7 @@
         (tr "labels.give-feedback")])]))
 
 (mf/defc community-contributions-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-close]}]
   (let [handle-click-url
         (mf/use-fn
@@ -1043,8 +1041,7 @@
       (tr "labels.community")]]))
 
 (mf/defc about-penpot-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-close]}]
   (let [version cf/version
         show-release-notes
@@ -1276,8 +1273,7 @@
          nil))]))
 
 (mf/defc sidebar*
-  {::mf/props :obj
-   ::mf/wrap [mf/memo]}
+  {::mf/wrap [mf/memo]}
   [{:keys [team profile] :as props}]
   [:nav {:class (stl/css :dashboard-sidebar) :data-testid "dashboard-sidebar"}
    [:> sidebar-content* props]

--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -118,7 +118,6 @@
           :is-highlighted false}]))))
 
 (mf/defc nitrate-sidebar*
-  {::mf/props :obj}
   [{:keys [profile teams]}]
   (let [nitrate? (dnt/is-valid-license? profile)
         orgs (mf/with-memo [teams]

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -364,8 +364,7 @@
     (st/emit! (dtm/update-member-role params))))
 
 (mf/defc team-member*
-  {::mf/wrap [mf/memo]
-   ::mf/props :obj}
+  {::mf/wrap [mf/memo]}
   [{:keys [team member total-members profile]}]
 
   (let [member-id     (:id member)
@@ -493,8 +492,7 @@
                            :on-leave on-leave'}]]]))
 
 (mf/defc team-members*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [team profile]}]
   (let [members (get team :members)
 
@@ -533,7 +531,6 @@
           :total-members total-members}])]]))
 
 (mf/defc team-members-page*
-  {::mf/props :obj}
   [{:keys [team profile]}]
   (mf/with-effect [team]
     (dom/set-html-title
@@ -562,7 +559,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (mf/defc invitation-role-selector*
-  {::mf/props :obj}
   [{:keys [can-invite role status on-change]}]
   (let [show?   (mf/use-state false)
         label   (cond
@@ -608,8 +604,7 @@
         (tr "labels.viewer")]]]]))
 
 (mf/defc invitation-actions*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [invitation team-id]}]
   (let [email   (:email invitation)
         on-error
@@ -658,8 +653,7 @@
 
 (mf/defc invitation-row*
   {::mf/wrap [mf/memo]
-   ::mf/private true
-   ::mf/props :obj}
+   ::mf/private true}
   [{:keys [invitation can-invite team-id selected on-select-change]}]
 
   (let [expired? (:expired invitation)
@@ -725,8 +719,7 @@
           :team-id team-id}])]]))
 
 (mf/defc empty-invitation-table*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [can-invite team]}]
   (let
    [route                (mf/deref refs/route)
@@ -793,8 +786,7 @@
          (tr "labels.resend"))]]]]])
 
 (mf/defc invitation-section*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [team]}]
   (let [permissions (get team :permissions)
         invitations (mf/use-state (get team :invitations))
@@ -978,7 +970,6 @@
             :on-select-change on-select-change}])])]))
 
 (mf/defc team-invitations-page*
-  {::mf/props :obj}
   [{:keys [team profile]}]
 
   (mf/with-effect [team]
@@ -1132,7 +1123,6 @@
                     (tr "modals.create-webhook.submit-label"))}]]]]]]))
 
 (mf/defc webhooks-hero*
-  {::mf/props :obj}
   []
   [:div {:class (stl/css :webhooks-hero-container)}
    [:h2 {:class (stl/css :hero-title)}
@@ -1144,8 +1134,7 @@
     (tr "dashboard.webhooks.create")]])
 
 (mf/defc webhook-actions*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-edit on-delete can-edit]}]
   (let [show?   (mf/use-state false)
         on-show (mf/use-fn #(reset! show? true))
@@ -1168,7 +1157,6 @@
 
 (mf/defc webhook-item*
   {::mf/wrap [mf/memo]
-   ::mf/props :obj
    ::mf/private true}
   [{:keys [webhook permissions]}]
   (let [error-code (:error-code webhook)
@@ -1234,8 +1222,7 @@
         :can-edit can-edit}]]]))
 
 (mf/defc webhooks-list*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [webhooks permissions]}]
   [:div {:class (stl/css :table-rows :webhook-table)}
    (for [webhook webhooks]
@@ -1245,7 +1232,6 @@
        :permissions permissions}])])
 
 (mf/defc webhooks-page*
-  {::mf/props :obj}
   [{:keys [team]}]
   (let [webhooks (:webhooks team)]
 
@@ -1277,7 +1263,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (mf/defc team-settings-page*
-  {::mf/props :obj}
   [{:keys [team]}]
   (let [finput      (mf/use-ref)
 

--- a/frontend/src/app/main/ui/dashboard/templates.cljs
+++ b/frontend/src/app/main/ui/dashboard/templates.cljs
@@ -64,8 +64,7 @@
        :on-finish-import on-finish}))))
 
 (mf/defc title*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [on-click is-collapsed]}]
   (let [on-key-down
         (mf/use-fn
@@ -171,7 +170,6 @@
          [:div {:class (stl/css :template-link-text)} (tr "dashboard.libraries-and-templates.explore")]]]]]]))
 
 (mf/defc templates-section*
-  {::mf/props :obj}
   [{:keys [default-project-id profile project-id team-id]}]
   (let [templates   (mf/deref builtin-templates)
         templates   (mf/with-memo [templates]

--- a/frontend/src/app/main/ui/exports/files.cljs
+++ b/frontend/src/app/main/ui/exports/files.cljs
@@ -45,8 +45,7 @@
      :files files}))
 
 (mf/defc export-entry*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [file]}]
   [:div {:class (stl/css-case
                  :file-entry true

--- a/frontend/src/app/main/ui/modal.cljs
+++ b/frontend/src/app/main/ui/modal.cljs
@@ -46,8 +46,7 @@
       (st/emit! (modal/hide)))))
 
 (mf/defc modal-wrapper*
-  {::mf/props :obj
-   ::mf/wrap [mf/memo]}
+  {::mf/wrap [mf/memo]}
   [{:keys [data]}]
   (let [wrapper-ref    (mf/use-ref nil)
         components     (mf/deref modal/components)
@@ -82,7 +81,6 @@
   (l/derived ::modal/modal st/state))
 
 (mf/defc modal-container*
-  {::mf/props :obj}
   []
   (let [container (hooks/use-portal-container :modal)]
     (when-let [modal (mf/deref ref:modal)]

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -25,7 +25,6 @@
    [rumext.v2 :as mf]))
 
 (mf/defc plan-card*
-  {::mf/props :obj}
   [{:keys [card-title
            card-title-icon
            price-value price-period

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -41,7 +41,6 @@
 (def TimeoutError rxjs/TimeoutError)
 
 (mf/defc error-container*
-  {::mf/props :obj}
   [{:keys [children]}]
   (let [profile-id  (:profile-id @st/state)
         on-nav-root (mf/use-fn #(st/emit! (rt/nav-root)))]
@@ -186,7 +185,6 @@
           [:& recovery-sent-page {:email @user-email}]])]]]))
 
 (mf/defc request-dialog*
-  {::mf/props :obj}
   [{:keys [title content button-text on-button-click cancel-text on-close]}]
   (let [on-click (or on-button-click on-close)]
     [:div {:class (stl/css :overlay)}
@@ -532,7 +530,6 @@
    children])
 
 (mf/defc exception-page*
-  {::mf/props :obj}
   [{:keys [data route] :as props}]
 
   (let [type        (:type data)

--- a/frontend/src/app/main/ui/viewer.cljs
+++ b/frontend/src/app/main/ui/viewer.cljs
@@ -278,7 +278,6 @@
                           :zoom zoom}])]])
 
 (mf/defc viewer-content*
-  {::mf/props :obj}
   [{:keys [data page-id share-id section index interactions-mode share]}]
   (let [{:keys [file users project permissions]} data
         allowed (or

--- a/frontend/src/app/main/ui/viewer/comments.cljs
+++ b/frontend/src/app/main/ui/viewer/comments.cljs
@@ -235,7 +235,6 @@
            :zoom zoom}])]]]))
 
 (mf/defc comments-sidebar*
-  {::mf/props :obj}
   [{:keys [profiles frame page]}]
   (let [profile     (mf/deref refs/profile)
         local       (mf/deref refs/comments-local)

--- a/frontend/src/app/main/ui/viewer/interactions.cljs
+++ b/frontend/src/app/main/ui/viewer/interactions.cljs
@@ -219,8 +219,7 @@
                       :fixed? fixed?}]))
 
 (mf/defc flows-menu*
-  {::mf/wrap [mf/memo]
-   ::mf/props :obj}
+  {::mf/wrap [mf/memo]}
   [{:keys [page index]}]
   (let [flows            (not-empty (:flows page))
         frames           (:frames page)
@@ -268,7 +267,6 @@
               [:span {:class (stl/css :icon)} deprecated-icon/tick])])]]])))
 
 (mf/defc interactions-menu*
-  {::mf/props :obj}
   [{:keys [interactions-mode]}]
   (let [show-dropdown?  (mf/use-state false)
         toggle-dropdown (mf/use-fn #(swap! show-dropdown? not))

--- a/frontend/src/app/main/ui/workspace/context_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/context_menu.cljs
@@ -54,8 +54,7 @@
   (dom/stop-propagation event))
 
 (mf/defc menu-entry*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [title shortcut on-click on-pointer-enter on-pointer-leave
            on-unmount children is-selected icon disabled value]}]
   (let [submenu-ref (mf/use-ref nil)
@@ -142,14 +141,12 @@
           children])])))
 
 (mf/defc menu-separator*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   [:li {:class (stl/css :separator)}])
 
 (mf/defc context-menu-edit*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [multiple?         (> (count shapes) 1)
 
@@ -251,8 +248,7 @@
      [:> menu-separator* {}]]))
 
 (mf/defc context-menu-layer-position*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [do-bring-forward  (mf/use-fn #(st/emit! (dw/vertical-order-selected :up)))
         do-bring-to-front (mf/use-fn #(st/emit! (dw/vertical-order-selected :top)))
@@ -298,8 +294,7 @@
      [:> menu-separator* {}]]))
 
 (mf/defc context-menu-flip*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   (let [do-flip-vertical #(st/emit! (dw/flip-vertical-selected))
         do-flip-horizontal #(st/emit! (dw/flip-horizontal-selected))]
@@ -314,8 +309,7 @@
      [:> menu-separator* {}]]))
 
 (mf/defc context-menu-thumbnail*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [single?    (= (count shapes) 1)
         has-frame? (some cfh/frame-shape? shapes)
@@ -331,8 +325,7 @@
        [:> menu-separator* {}]])))
 
 (mf/defc context-menu-rename*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [do-rename #(st/emit! (dw/start-rename-selected))]
     (when (= (count shapes) 1)
@@ -343,8 +336,7 @@
                         :on-click do-rename}]])))
 
 (mf/defc context-menu-group*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [multiple?       (> (count shapes) 1)
         single?         (= (count shapes) 1)
@@ -397,8 +389,7 @@
         [:> menu-separator* {}]])]))
 
 (mf/defc context-focus-mode-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   (let [focus (mf/deref refs/workspace-focus-selected)
         do-toggle-focus-mode #(st/emit! (dw/toggle-focus-mode))]
@@ -410,8 +401,7 @@
                      :on-click do-toggle-focus-mode}]))
 
 (mf/defc context-menu-path*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes objects disable-flatten disable-booleans]}]
   (let [multiple?            (> (count shapes) 1)
         single?              (= (count shapes) 1)
@@ -488,8 +478,7 @@
                             :on-click do-transform-to-path}]])])]))
 
 (mf/defc context-menu-layer-options*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [ids (mapv :id shapes)
         do-show-shape #(st/emit! (dw/update-shape-flags ids {:hidden false}))
@@ -514,8 +503,7 @@
                         :on-click do-lock-shape}])]))
 
 (mf/defc context-menu-prototype*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [flows           (mf/deref refs/workspace-page-flows)
         options-mode    (mf/deref refs/options-mode-global)
@@ -536,8 +524,7 @@
                          :on-click do-add-flow}]))))
 
 (mf/defc context-menu-layout*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [shapes]}]
   (let [single?      (= (count shapes) 1)
         objects      (deref refs/workspace-page-objects)
@@ -647,8 +634,7 @@
                          :on-click do-combine-as-variants}]])]))
 
 (mf/defc context-menu-delete*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   []
   (let [do-delete #(st/emit! (dw/delete-selected))]
     [:*
@@ -690,8 +676,7 @@
        [:> context-menu-delete* props]])))
 
 (mf/defc page-item-context-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [mdata]}]
   (let [page (:page mdata)
         deletable? (:deletable? mdata)
@@ -718,7 +703,6 @@
                       :on-click do-duplicate}]]))
 
 (mf/defc viewport-context-menu*
-  {::mf/props :obj}
   []
   (let [focus      (mf/deref refs/workspace-focus-selected)
         read-only? (mf/use-ctx ctx/workspace-read-only?)
@@ -741,8 +725,7 @@
                         :on-click do-toggle-focus-mode}])]))
 
 (mf/defc grid-track-context-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [mdata]}]
   (let [{:keys [type index grid-id]} mdata
         do-delete-track
@@ -791,8 +774,7 @@
        [:> menu-entry* {:title (tr "workspace.context-menu.grid-track.row.delete-shapes") :on-click do-delete-track-shapes}]])))
 
 (mf/defc grid-cells-context-menu*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [mdata]}]
   (let [{:keys [grid cells]} mdata
 

--- a/frontend/src/app/main/ui/workspace/libraries.cljs
+++ b/frontend/src/app/main/ui/workspace/libraries.cljs
@@ -112,8 +112,7 @@
      "\u00A0")))
 
 (mf/defc library-description*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [summary]}]
   (let [components-count (get summary :components)
         graphics-count   (get summary :graphics)
@@ -138,8 +137,7 @@
         (tr "workspace.libraries.typography" (c typography-count))])]))
 
 (mf/defc sample-library-entry*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [library importing]}]
   (let [id         (:id library)
         importing? (deref importing)
@@ -190,8 +188,7 @@
     (not (ctob/empty-lib? tokens-lib))))
 
 (mf/defc libraries-tab*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [is-shared linked-libraries shared-libraries]}]
   (let [file-id        (mf/use-ctx ctx/current-file-id)
         search-term*   (mf/use-state "")
@@ -488,8 +485,7 @@
                         :typographies typographies}]))
 
 (mf/defc updates-tab*
-  {::mf/props :obj
-   ::mf/private true}
+  {::mf/private true}
   [{:keys [file-id libraries]}]
   ;; FIXME: naming
   (let [summary?*  (mf/use-state true)

--- a/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets.cljs
@@ -29,7 +29,6 @@
 
 (mf/defc assets-libraries*
   {::mf/wrap [mf/memo]
-   ::mf/props :obj
    ::mf/private true}
   [{:keys [filters]}]
   (let [file-id   (mf/use-ctx ctx/current-file-id)

--- a/frontend/src/app/main/ui/workspace/tokens/settings/menu.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/settings/menu.cljs
@@ -26,7 +26,6 @@
    [rumext.v2 :as mf]))
 
 (mf/defc token-settings*
-  {::mf/wrap-props false}
   []
   (let [file-data (deref refs/workspace-data)
         base-font-size* (mf/use-state #(ctf/get-base-font-size file-data))

--- a/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/gradients.cljs
@@ -448,7 +448,6 @@
                    :fill "var(--app-white)"}]))]))
 
 (mf/defc gradient-handlers-impl*
-  {::mf/props :obj}
   [{:keys [zoom stops gradient editing shape]}]
   (let [transform         (gsh/transform-matrix shape)
         transform-inverse (gsh/inverse-transform-matrix shape)
@@ -517,8 +516,7 @@
       :on-change-width on-change-width}]))
 
 (mf/defc gradient-handlers*
-  {::mf/wrap [mf/memo]
-   ::mf/props :obj}
+  {::mf/wrap [mf/memo]}
   [{:keys [id zoom]}]
   (let [shape-ref    (mf/use-memo (mf/deps id) #(refs/object-by-id id))
         shape        (mf/deref shape-ref)


### PR DESCRIPTION
### Summary

The `::mf/props` and `::mf/wrap-props` metadata keys are no-ops on modern components (those defined with `mf/defc` and the `*` suffix) since the `*` suffix already triggers the props behavior these keys attempt to configure. 

This cleanup removes the redundant metadata from modern components across all UI directories.

### How to Test

No tests required, all covered by the linter and compiler




Fixes #9648
