### PR TITLE
:bug: Fix MCP media uploads and SVG data URI image parsing

### DIFF
--- a/frontend/src/app/plugins/api.cljs
+++ b/frontend/src/app/plugins/api.cljs
@@ -284,7 +284,23 @@
                  {:file-id file-id
                   :local? false
                   :name name
-                  :blobs [(js/Blob. #js [data] #js {:type mime-type})]
+                  :blobs [(js/Blob.
+                           #js [(cond
+                                  (instance? js/Uint8Array data)
+                                  data
+
+                                  (instance? js/ArrayBuffer data)
+                                  (js/Uint8Array. data)
+
+                                  (array? data)
+                                  (js/Uint8Array.from data)
+
+                                  (and (some? data) (= (type data) js/Object))
+                                  (js/Uint8Array.from (js/Object.values data))
+
+                                  :else
+                                  data)]
+                           #js {:type mime-type})]
                   :on-image identity
                   :on-svg identity})
                 (rx/take 1)

--- a/frontend/src/app/util/webapi.cljs
+++ b/frontend/src/app/util/webapi.cljs
@@ -97,17 +97,22 @@
 
 (defn data-uri->blob
   [data-uri]
-  (let [[mtype b64-data] (str/split data-uri ";base64," 2)
-        mtype   (subs mtype (inc (str/index-of mtype ":")))
-        decoded (.atob js/window b64-data)
-        size    (.-length ^js decoded)
-        content (js/Uint8Array. size)]
-
-    (loop [i 0]
-      (when (< i size)
-        (aset content i (.charCodeAt ^js decoded i))
-        (recur (inc i))))
-
+  (let [[meta data] (str/split data-uri "," 2)
+        mtype-end   (or (str/index-of meta ";") (count meta))
+        mtype       (subs meta (inc (str/index-of meta ":")) mtype-end)
+        base64?     (str/includes? meta ";base64")
+        content     (if base64?
+                      (let [decoded (.atob js/window data)
+                            size    (.-length ^js decoded)
+                            bytes   (js/Uint8Array. size)]
+                        (loop [i 0]
+                          (when (< i size)
+                            (aset bytes i (.charCodeAt ^js decoded i))
+                            (recur (inc i))))
+                        bytes)
+                      ;; Data URIs can be plain/URL-encoded (e.g. ;utf8,<svg...>).
+                      ;; Encode into UTF-8 bytes before creating the Blob.
+                      (.encode (js/TextEncoder.) (js/decodeURIComponent data)))]
     (create-blob content mtype)))
 
 (defn get-current-selected-text

--- a/frontend/src/app/util/webapi.cljs
+++ b/frontend/src/app/util/webapi.cljs
@@ -102,7 +102,7 @@
         mtype       (subs meta (inc (str/index-of meta ":")) mtype-end)
         base64?     (str/includes? meta ";base64")
         content     (if base64?
-                      (let [decoded (.atob js/window data)
+                      (let [decoded (.atob js/globalThis data)
                             size    (.-length ^js decoded)
                             bytes   (js/Uint8Array. size)]
                         (loop [i 0]
@@ -112,7 +112,7 @@
                         bytes)
                       ;; Data URIs can be plain/URL-encoded (e.g. ;utf8,<svg...>).
                       ;; Encode into UTF-8 bytes before creating the Blob.
-                      (.encode (js/TextEncoder.) (js/decodeURIComponent data)))]
+                      (.encode (js/TextEncoder.) (.decodeURIComponent js/globalThis data)))]
     (create-blob content mtype)))
 
 (defn get-current-selected-text

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -32,6 +32,7 @@
    [frontend-tests.tokens.workspace-tokens-remap-test]
    [frontend-tests.ui.ds-controls-numeric-input-test]
    [frontend-tests.util-object-test]
+   [frontend-tests.util-webapi-test]
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]
    [frontend-tests.worker-snap-test]))
@@ -77,6 +78,7 @@
    'frontend-tests.tokens.workspace-tokens-remap-test
    'frontend-tests.ui.ds-controls-numeric-input-test
    'frontend-tests.util-object-test
+   'frontend-tests.util-webapi-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
    'frontend-tests.worker-snap-test))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -32,9 +32,9 @@
    [frontend-tests.tokens.workspace-tokens-remap-test]
    [frontend-tests.ui.ds-controls-numeric-input-test]
    [frontend-tests.util-object-test]
-   [frontend-tests.util-webapi-test]
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]
+   [frontend-tests.util-webapi-test]
    [frontend-tests.worker-snap-test]))
 
 (enable-console-print!)
@@ -78,7 +78,7 @@
    'frontend-tests.tokens.workspace-tokens-remap-test
    'frontend-tests.ui.ds-controls-numeric-input-test
    'frontend-tests.util-object-test
-   'frontend-tests.util-webapi-test
    'frontend-tests.util-range-tree-test
    'frontend-tests.util-simple-math-test
+   'frontend-tests.util-webapi-test
    'frontend-tests.worker-snap-test))

--- a/frontend/test/frontend_tests/util_webapi_test.cljs
+++ b/frontend/test/frontend_tests/util_webapi_test.cljs
@@ -1,0 +1,34 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util-webapi-test
+  (:require
+   [app.util.webapi :as wapi]
+   [cljs.test :as t :include-macros true]))
+
+(t/deftest data-uri->blob-supports-base64
+  (t/async done
+    (let [blob (wapi/data-uri->blob "data:text/plain;base64,SGVsbG8=")]
+      (-> (.text blob)
+          (.then (fn [text]
+                   (t/is (= "text/plain" (.-type blob)))
+                   (t/is (= "Hello" text))
+                   (done)))
+          (.catch (fn [err]
+                    (t/is false (str "unexpected error: " err))
+                    (done)))))))
+
+(t/deftest data-uri->blob-supports-utf8-data
+  (t/async done
+    (let [blob (wapi/data-uri->blob "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E")]
+      (-> (.text blob)
+          (.then (fn [text]
+                   (t/is (= "image/svg+xml" (.-type blob)))
+                   (t/is (= "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>" text))
+                   (done)))
+          (.catch (fn [err]
+                    (t/is false (str "unexpected error: " err))
+                    (done)))))))


### PR DESCRIPTION
### Related Ticket

Closes #9164

### What and why:
Fixes issue where image-bearing SVG imports could lose embedded image content when href uses data:image/svg+xml;utf8,....
Hardens plugin API media upload path used by MCP by normalizing byte-like input before Blob creation.

### Testing notes:

- Added frontend-tests.util-webapi-test with coverage for base64 and utf8/url-encoded data URIs.
- Registered the new test namespace in frontend_tests/runner.cljs.
- Local full pnpm run test may fail on Windows shell due to ../render-wasm/build invocation; run in the project’s expected Unix-like dev environment/container.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
