### PR TITLE
:lipstick: Rename i18n keys for tokens errors

### DIFF
--- a/common/src/app/common/files/tokens.cljc
+++ b/common/src/app/common/files/tokens.cljc
@@ -26,7 +26,7 @@
   [{:keys [value]}]
   (when (or (str/empty? value)
             (str/blank? value))
-    (tr "workspace.tokens.empty-input")))
+    (tr "errors.tokens.empty-input")))
 
 (def schema:token-value-generic
   [::sm/text {:error/fn token-value-empty-fn}])
@@ -34,7 +34,7 @@
 (def schema:token-value-numeric
   [:and
    [::sm/text {:error/fn token-value-empty-fn}]
-   [:fn {:error/fn #(tr "workspace.tokens.invalid-value" (:value %))}
+   [:fn {:error/fn #(tr "errors.tokens.invalid-value" (:value %))}
     (fn [value]
       (if (str/numeric? value)
         (let [n (d/parse-double value)]
@@ -44,7 +44,7 @@
 (def schema:token-value-percent
   [:and
    [::sm/text {:error/fn token-value-empty-fn}]
-   [:fn {:error/fn #(tr "workspace.tokens.value-with-percent" (:value %))}
+   [:fn {:error/fn #(tr "errors.tokens.value-with-percent" (:value %))}
     (fn [value]
       (if (d/percent? value)
         (let [v (d/parse-percent value)]
@@ -57,7 +57,7 @@
 (def schema:token-value-opacity
   [:and
    [::sm/text {:error/fn token-value-empty-fn}]
-   [:fn {:error/fn #(tr "workspace.tokens.opacity-range")}
+   [:fn {:error/fn #(tr "errors.tokens.opacity-range")}
     (fn [opacity]
       (if (str/numeric? opacity)
         (let [n (d/parse-percent opacity)]
@@ -71,7 +71,7 @@
 
 (def schema:token-value-font-weight
   [:or
-   [:fn {:error/fn #(tr "workspace.tokens.invalid-font-weight-token-value")}
+   [:fn {:error/fn #(tr "errors.tokens.invalid-font-weight-token-value")}
     cto/valid-font-weight-variant]
    ::sm/text])  ;; Leave references or formulas to be checked by the resolver
 
@@ -181,7 +181,7 @@
      [:value (make-token-value-schema token-type)]
      [:description {:optional true} schema:token-description]])
    [:fn {:error/field :value
-         :error/fn #(tr "workspace.tokens.self-reference")}
+         :error/fn #(tr "errors.tokens.self-reference")}
     (fn [{:keys [name value]}]
       (when (and name value)
         (not (cto/token-value-self-reference? name value))))]])

--- a/frontend/src/app/main/data/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/errors.cljs
@@ -12,109 +12,109 @@
 (def error-codes
   {:error.import/json-parse-error
    {:error/code :error.import/json-parse-error
-    :error/fn #(tr "workspace.tokens.error-parse")}
+    :error/fn #(tr "errors.tokens.error-parse")}
 
    :error.import/no-token-files-found
    {:error/code :error.import/no-token-files-found
-    :error/fn #(tr "workspace.tokens.no-token-files-found")}
+    :error/fn #(tr "errors.tokens.no-token-files-found")}
 
    :error.import/invalid-json-data
    {:error/code :error.import/invalid-json-data
-    :error/fn #(tr "workspace.tokens.invalid-json")}
+    :error/fn #(tr "errors.tokens.invalid-json")}
 
    :error.import/invalid-token-name
    {:error/code :error.import/invalid-token-name
-    :error/fn #(tr "workspace.tokens.invalid-json-token-name")
-    :error/detail #(tr "workspace.tokens.invalid-json-token-name-detail" %)}
+    :error/fn #(tr "errors.tokens.invalid-json-token-name")
+    :error/detail #(tr "errors.tokens.invalid-json-token-name-detail" %)}
 
    :error.import/style-dictionary-reference-errors
    {:error/code :error.import/style-dictionary-reference-errors
-    :error/fn #(str (tr "workspace.tokens.import-error") "\n\n" (first %))
+    :error/fn #(str (tr "errors.tokens.import-error") "\n\n" (first %))
     :error/detail #(str/join "\n\n" (rest %))}
 
    :error.import/style-dictionary-unknown-error
    {:error/code :error.import/style-dictionary-reference-errors
-    :error/fn #(tr "workspace.tokens.import-error")}
+    :error/fn #(tr "errors.tokens.import-error")}
 
    :error.token/empty-input
    {:error/code :error.token/empty-input
-    :error/fn #(tr "workspace.tokens.empty-input")}
+    :error/fn #(tr "errors.tokens.empty-input")}
 
    :error.token/direct-self-reference
    {:error/code :error.token/direct-self-reference
-    :error/fn #(tr "workspace.tokens.self-reference")}
+    :error/fn #(tr "errors.tokens.self-reference")}
 
    :error.token/invalid-color
    {:error/code :error.token/invalid-color
-    :error/fn #(str (tr "workspace.tokens.invalid-color" %))}
+    :error/fn #(str (tr "errors.tokens.invalid-color" %))}
 
    :error.token/number-too-large
    {:error/code :error.token/number-too-large
-    :error/fn #(str (tr "workspace.tokens.number-too-large" %))}
+    :error/fn #(str (tr "errors.tokens.number-too-large" %))}
 
    :error.style-dictionary/missing-reference
    {:error/code :error.style-dictionary/missing-reference
-    :error/fn #(str (tr "workspace.tokens.missing-references") (str/join " " %))}
+    :error/fn #(str (tr "errors.tokens.missing-references") (str/join " " %))}
 
    :error.style-dictionary/invalid-token-value
    {:error/code :error.style-dictionary/invalid-token-value
-    :error/fn #(str (tr "workspace.tokens.invalid-value" %))}
+    :error/fn #(str (tr "errors.tokens.invalid-value" %))}
 
    :error.style-dictionary/value-with-units
    {:error/code :error.style-dictionary/value-with-units
-    :error/fn #(str (tr "workspace.tokens.value-with-units"))}
+    :error/fn #(str (tr "errors.tokens.value-with-units"))}
 
    :error.style-dictionary/value-with-percent
    {:error/code :error.style-dictionary/value-with-percent
-    :error/fn #(str (tr "workspace.tokens.value-with-percent"))}
+    :error/fn #(str (tr "errors.tokens.value-with-percent"))}
 
    :error.style-dictionary/invalid-token-value-opacity
    {:error/code :error.style-dictionary/invalid-token-value-opacity
-    :error/fn #(str/join "\n" [(str (tr "workspace.tokens.invalid-value" %) ".") (tr "workspace.tokens.opacity-range")])}
+    :error/fn #(str/join "\n" [(str (tr "errors.tokens.invalid-value" %) ".") (tr "errors.tokens.opacity-range")])}
 
    :error.style-dictionary/invalid-token-value-stroke-width
    {:error/code :error.style-dictionary/invalid-token-value-stroke-width
-    :error/fn #(str/join "\n" [(str (tr "workspace.tokens.invalid-value" %) ".") (tr "workspace.tokens.stroke-width-range")])}
+    :error/fn #(str/join "\n" [(str (tr "errors.tokens.invalid-value" %) ".") (tr "errors.tokens.stroke-width-range")])}
 
    :error.style-dictionary/invalid-token-value-text-case
    {:error/code :error.style-dictionary/invalid-token-value-text-case
-    :error/fn #(tr "workspace.tokens.invalid-text-case-token-value" %)}
+    :error/fn #(tr "errors.tokens.invalid-text-case-token-value" %)}
 
    :error.style-dictionary/invalid-token-value-text-decoration
    {:error/code :error.style-dictionary/invalid-token-value-text-decoration
-    :error/fn #(tr "workspace.tokens.invalid-text-decoration-token-value" %)}
+    :error/fn #(tr "errors.tokens.invalid-text-decoration-token-value" %)}
 
    :error.style-dictionary/invalid-token-value-font-weight
    {:error/code :error.style-dictionary/invalid-token-value-font-weight
-    :error/fn #(tr "workspace.tokens.invalid-font-weight-token-value" %)}
+    :error/fn #(tr "errors.tokens.invalid-font-weight-token-value" %)}
 
    :error.style-dictionary/invalid-token-value-font-family
    {:error/code :error.style-dictionary/invalid-token-value-font-family
-    :error/fn #(tr "workspace.tokens.invalid-font-family-token-value" %)}
+    :error/fn #(tr "errors.tokens.invalid-font-family-token-value" %)}
 
    :error.style-dictionary/invalid-token-value-typography
    {:error/code :error.style-dictionary/invalid-token-value-typography
-    :error/fn #(tr "workspace.tokens.invalid-token-value-typography" %)}
+    :error/fn #(tr "errors.tokens.invalid-token-value-typography" %)}
 
    :error.style-dictionary/composite-line-height-needs-font-size
    {:error/code :error.style-dictionary/composite-line-height-needs-font-size
-    :error/fn #(tr "workspace.tokens.composite-line-height-needs-font-size" %)}
+    :error/fn #(tr "errors.tokens.composite-line-height-needs-font-size" %)}
 
    :error.style-dictionary/invalid-token-value-shadow-type
    {:error/code :error.style-dictionary/invalid-token-value-shadow-type
-    :error/fn #(tr "workspace.tokens.invalid-shadow-type-token-value" %)}
+    :error/fn #(tr "errors.tokens.invalid-shadow-type-token-value" %)}
 
    :error.style-dictionary/invalid-token-value-shadow-blur
    {:error/code :error.style-dictionary/invalid-token-value-shadow-blur
-    :error/fn #(tr "workspace.tokens.shadow-blur-range")}
+    :error/fn #(tr "errors.tokens.shadow-blur-range")}
 
    :error.style-dictionary/invalid-token-value-shadow-spread
    {:error/code :error.style-dictionary/invalid-token-value-shadow-spread
-    :error/fn #(tr "workspace.tokens.shadow-spread-range")}
+    :error/fn #(tr "errors.tokens.shadow-spread-range")}
 
    :error.style-dictionary/invalid-token-value-shadow
    {:error/code :error.style-dictionary/invalid-token-value-shadow
-    :error/fn #(tr "workspace.tokens.invalid-token-value-shadow" %)}
+    :error/fn #(tr "errors.tokens.invalid-token-value-shadow" %)}
 
    :error/unknown
    {:error/code :error/unknown

--- a/frontend/src/app/main/data/workspace/tokens/warnings.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/warnings.cljs
@@ -12,11 +12,11 @@
 (def warning-codes
   {:warning.style-dictionary/invalid-referenced-token-value-opacity
    {:warning/code :warning.style-dictionary/invalid-referenced-token-value-opacity
-    :warning/fn (fn [value] (str/join "\n" [(str (tr "workspace.tokens.resolved-value" value) ".") (tr "workspace.tokens.opacity-range")]))}
+    :warning/fn (fn [value] (str/join "\n" [(str (tr "workspace.tokens.resolved-value" value) ".") (tr "errors.tokens.opacity-range")]))}
 
    :warning.style-dictionary/invalid-referenced-token-value-stroke-width
    {:warning/code :warning.style-dictionary/invalid-referenced-token-value-stroke-width
-    :warning/fn (fn [value] (str/join "\n" [(str (tr "workspace.tokens.resolved-value" value) ".") (tr "workspace.tokens.stroke-width-range")]))}
+    :warning/fn (fn [value] (str/join "\n" [(str (tr "workspace.tokens.resolved-value" value) ".") (tr "errors.tokens.stroke-width-range")]))}
 
    :warning/unknown
    {:warning/code :warning/unknown

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/shadow.cljs
@@ -296,7 +296,7 @@
       [:string {:max 2048 :error/fn #(tr "errors.field-max-length" 2048)}]]]
 
     [:fn {:error/field [:value :reference]
-          :error/fn #(tr "workspace.tokens.self-reference")}
+          :error/fn #(tr "errors.tokens.self-reference")}
      (fn [{:keys [name value]}]
        (let [reference (get value :reference)]
          (if (and reference name)

--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/typography.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/typography.cljs
@@ -239,7 +239,7 @@
       [:string {:max 2048 :error/fn #(tr "errors.field-max-length" 2048)}]]]
 
     [:fn {:error/field [:value :reference]
-          :error/fn #(tr "workspace.tokens.self-reference")}
+          :error/fn #(tr "errors.tokens.self-reference")}
      (fn [{:keys [name value]}]
        (let [reference (get value :reference)]
          (if (and reference name)
@@ -247,7 +247,7 @@
            true)))]
 
     [:fn {:error/field [:value :line-height]
-          :error/fn #(tr "workspace.tokens.composite-line-height-needs-font-size")}
+          :error/fn #(tr "errors.tokens.composite-line-height-needs-font-size")}
      (fn [{:keys [value]}]
        (let [line-heigh (get value :line-height)
              font-size (get value :font-size)]

--- a/frontend/translations/de.po
+++ b/frontend/translations/de.po
@@ -7530,7 +7530,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "%s Token bearbeiten"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Der Token-Wert darf nicht leer sein"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7538,7 +7538,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "%s Token-Name eingeben"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Fehler beim Importieren. JSON konnte nicht verarbeitet werden."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7602,7 +7602,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "%s importieren"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Fehler beim Import:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7659,57 +7659,57 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Einzelne Token verwenden"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Ungültiger Farbwert: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Ungültiger Wert für die Schriftstärke: Verwenden Sie numerische Werte "
 "(100–950) oder Standardbezeichnungen (dünn, leicht, normal, fett usw.), "
 "optional gefolgt von „kursiv”"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Fehler beim Importieren: Ihre JSON-Datei enthält ungültige Token-Daten."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Fehler beim Importieren: Ihre JSON-Datei enthält ungültige Token-Namen."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "„%s“ ist kein gültiger Namen für ein Token.\n"
 "Token-Namen dürfen nur Buchstaben und Ziffern enthalten, die durch Punkte "
 "getrennt sind und dürfen nicht mit einem Dollarzeichen beginnen."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr ""
 "Ungültiger Schattentyp: Es werden nur „innerShadow” oder „dropShadow” "
 "akzeptiert"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Ungültiger Token-Wert: Es werden nur „none“, „Uppercase“, „Lowercase“ oder "
 "„Capitalize“ akzeptiert"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "Ungültiger Token-Wert: Es werden nur „none“, „underline“ oder "
 "„strike-through“ akzeptiert"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr ""
 "Ungültiger Wert: Der Wert muss auf ein zusammengesetztes Typografie-Token "
 "verweisen."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Ungültiger Token-Wert: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7749,7 +7749,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Mindestgröße"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Fehlende Token-Referenzen: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7789,7 +7789,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "Sie haben derzeit keine Themes."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "In dieser Datei wurden keine Tokens, Sets oder Themen gefunden."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7797,11 +7797,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s aktivierte Sets"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Ungültiger Tokenwert. Der ermittelte Wert ist zu hoch: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr ""
 "Die Deckkraft muss zwischen 0 und 100 % oder zwischen 0 und 1 liegen (z. B. "
 "50 % oder 0,5)."
@@ -7846,7 +7846,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Set auswählen."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Der Token referenziert sich selbst"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -7887,7 +7887,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Weichzeichnen"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "Wert muss größer oder gleich 0 sein."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -7925,7 +7925,7 @@ msgid "workspace.tokens.size"
 msgstr "Größe"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Die Rahmenbreite muss größer oder gleich 0 sein."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8036,11 +8036,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Der Wert ist nicht gültig"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Ungültiger Wert: % ist nicht zulässig."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Ungültiger Wert: Einheiten sind hier nicht zulässig."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -8222,7 +8222,7 @@ msgid "workspace.tokens.color"
 msgstr "Color"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr "Line Height depends on Font Size. Add a Font Size to get the resolved value."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:57
@@ -8274,7 +8274,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "Edit %s token"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Token value cannot be empty"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -8282,7 +8282,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Enter %s token name"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Import Error: Could not parse JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -8346,7 +8346,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Import %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Import Error:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -8397,58 +8397,58 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Use individual tokens"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Invalid color value: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "Invalid token value: you can only reference a font-family token"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Invalid font weight value: use numeric values (100-950) or standard names "
 "(thin, light, regular, bold, etc.) optionally followed by 'Italic'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Import Error: Invalid token data in JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Import Error: Invalid token name in JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" is not a valid token name.\n"
 "Token names should only contain letters and digits separated by . "
 "characters and must not start with a $ sign."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr "Invalid shadow type: only 'innerShadow' or 'dropShadow' are accepted"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Invalid token value: only none, Uppercase, Lowercase or Capitalize are "
 "accepted"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr "Invalid token value: only none, underline and strike-through are accepted"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "Invalid value: must reference a composite shadow token."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "Invalid value: must reference a composite typography token."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Invalid token value: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -8492,7 +8492,7 @@ msgid "workspace.tokens.missing-reference"
 msgstr "Missing reference"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Missing token references: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -8542,7 +8542,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "You currently have no themes."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "No tokens, sets, or themes were found in this file."
 
 #: src/app/main/ui/workspace/tokens/remapping_modal.cljs:95
@@ -8554,11 +8554,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s active sets"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Invalid token value. The resolved value is too large: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "Opacity must be between 0 and 100% or 0 and 1 (e.g. 50% or 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -8634,7 +8634,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Select set."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Token has self reference"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8671,7 +8671,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Blur"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "Shadow blur must be greater than or equal to 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -8692,7 +8692,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "Spread"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "Shadow spread must be greater than or equal to 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8722,7 +8722,7 @@ msgid "workspace.tokens.size"
 msgstr "Size"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Stroke width must be greater than or equal to 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8837,11 +8837,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "The value is not valid"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Invalid value: % is not allowed."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Invalid value: Units are not allowed."
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -8030,7 +8030,7 @@ msgid "workspace.tokens.choose-folder"
 msgstr "Elige carpeta"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "El Line Height depende del Font Size. Añade un Font Size para obtener el "
 "valor computado."
@@ -8084,7 +8084,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "Editar token de %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "El valor del token no puede estar vacío"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -8092,7 +8092,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Introduce un nombre para el token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Error al importar: No se pudo procesar el JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -8152,7 +8152,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Importar %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Error al importar:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -8207,55 +8207,55 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Usa tokens individuales"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Valor de color inválido: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "Valor de token no válido: solo puedes referenciar tokens tipo font-family"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Valor de peso de fuente inválido: usa valores numéricos (100-950) o nombres "
 "estándar (thin, light, regular, bold, etc.) opcionalmente seguidos de "
 "'Italic'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Error al importar: Datos de token no válidos en JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Error al importar: Nombre de token no válido en JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" no es un nombre de token válido.\n"
 "Los nombres de token solo pueden contener letras y dígitos separados por "
 "caracteres . y no pueden empezar con un signo $."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr "Tipo de sombra no válida: solo se aceptan 'innerShadow' o 'dropShadow'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "Valor de token no válido: solo none, underline y strike-through son "
 "aceptados"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "Valor no válido: debe hacer referencia a un token de sombra compuesto."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "Valor no válido: debe hacer referencia a un token tipográfico compuesto."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Valor de token no válido: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -8287,7 +8287,7 @@ msgid "workspace.tokens.missing-reference"
 msgstr "Referencia no encontrada"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Referencias de tokens no encontradas: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -8343,11 +8343,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s sets activos"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Valor de token no valido. El valor resuelto es muy grande: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "La opacidad debe estar entre 0 y 100% o 0 y 1 (p.e. 50% o 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -8403,7 +8403,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Selecciona set"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "El token tiene una autoreferencia"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8442,7 +8442,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Blur"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "El desenfoque (blur) de la sombra debe ser mayor o igual a 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -8463,7 +8463,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "Spread"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "La extensión (spread) de la sombra debe ser mayor o igual a 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8489,7 +8489,7 @@ msgid "workspace.tokens.shadow-y"
 msgstr "Y"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Stroke width debe ser mayor o igual a 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8587,7 +8587,7 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "El valor no es válido"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Valor no válido: No se permiten unidades."
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs

--- a/frontend/translations/fr.po
+++ b/frontend/translations/fr.po
@@ -7706,7 +7706,7 @@ msgid "workspace.tokens.color"
 msgstr "Couleur"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "L'interlignage dépend de la taille de la police. Ajoutez une taille de "
 "police pour obtenir la valeur déduite."
@@ -7756,7 +7756,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "Modifier le token"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "La valeur du token doit être renseignée"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7764,7 +7764,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Entrez le nom du token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Erreur d'importation : Impossible d'interpréter le fichier JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7818,7 +7818,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Importer %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Erreur d'importation :"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7877,19 +7877,19 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Utiliser des tokens individuels"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Couleur non valide : %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Erreur d'importation : données du token non valides dans le fichier JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Erreur lors de l'importation : nom du token non valide au format JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "« %s » n'est pas un nom de token valide.\n"
 "Les noms des tokens ne doivent pas comporter de lettres et de chiffres "
@@ -7897,25 +7897,25 @@ msgstr ""
 "« $ »."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Valeur du token non valide : seules les valeurs Aucune, Majuscules, "
 "Minuscules ou Première lettre en capitale sont acceptées"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "Valeur du token non valide : seules les valeurs none, underline et "
 "strike-through sont acceptées"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr ""
 "Valeur non valide : elle doit faire référence à un token de typographie "
 "composite."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Valeur du token non valide : %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7951,7 +7951,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Taille min."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Références du token manquantes : "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7991,7 +7991,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "Vous n'avez actuellement aucun thème."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "Aucun token, collection ou thème n'ont été trouvés dans ce fichier."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7999,11 +7999,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s collections actives"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Valeur du token non valide. La valeur est trop grande : %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr ""
 "L'opacité doit être comprise entre 0 % et 100 % ou entre 0 et 1 (ex : 50 % "
 "ou 0.5)."
@@ -8044,7 +8044,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Sélectionner la collection."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Le token s'auto-référence"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8079,7 +8079,7 @@ msgid "workspace.tokens.size"
 msgstr "Taille"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "La largueur du tracé doit être plus grand ou égal à 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:41, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:169
@@ -8167,11 +8167,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "La valeur n'est pas valide"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Valeur non valide : % n'est pas autorisé."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Valeur non valide : les unités ne sont pas autorisées."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/he.po
+++ b/frontend/translations/he.po
@@ -7516,7 +7516,7 @@ msgid "workspace.tokens.color"
 msgstr "צבע"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr "גובה השורה תלוי בגודל הגופן. יש להוסיף גודל גופן כדי לקבל את הערך הפתור."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:57
@@ -7564,7 +7564,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "עריכת אסימון %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "ערך האסימון לא יכול להישאר ריק"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7572,7 +7572,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "נא למלא את שם האסימון %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "שגיאת ייבוא: לא ניתן לפענח JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7634,7 +7634,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "ייבוא %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "שגיאת ייבוא:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7685,57 +7685,57 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "להשתמש באסימונים עצמאיים"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "ערך צבע שגוי: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "ערך אסימון שגוי: אפשר להפנות לאסימון font-family (משפחת גופנים) בלבד"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "ערך משקל גופן שגוי: יש להשתמש בערכים מספריים (100-‏950) או שמות תקניים "
 "(thin,‏ light,‏ regular,‏ bold ועוד), אפשר גם לצרף בסוף ‚Italic’ (נטוי) "
 "במקרה הצורך"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "שגיאת ייבוא: נתוני אסימון שגויים ב־JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "שגיאת ייבוא: שם אסימון שגוי ב־JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "„%s” אינו שם תקף לאסימון.\n"
 "שמות האסימונים יכולים להכיל אותיות וספרות מופרדים בתווי . ואסור שיתחילו "
 "בדולר ($)."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr "סוג הצללה שגוי: רק ‚innerShadow’ או ‚dropShadow’ מורשים"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr "ערך אסימון שגוי: רק none,‏ Uppercase,‏ Lowercase או Capitalize מורשים"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr "ערך אסימון שגוי: מותר רק none,‏ underline ו־strike-through"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "ערך שגוי: יש להפנות לאסימון הצללה מורכבת."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "ערך שגוי: חייב להפנות לאסימון טיפוגרפיה מרוכב."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "ערך אסימון שגוי: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7775,7 +7775,7 @@ msgid "workspace.tokens.min-size"
 msgstr "גודל מזערי"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "חסרות הפניות אסימונים: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7815,7 +7815,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "אין לך ערכות עיצוב עדיין."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "לא נמצאו אסימונים, סדרות או ערכות עיצוב בקובץ הזה."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7823,11 +7823,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s סדרות פעילות"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "ערך אסימון שגוי. הערך הפתור גדול מדי: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "שקיפות צריכה להיות בין 0 ל־100% או 0 ו־1 (כלומר 50% או 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -7874,7 +7874,7 @@ msgid "workspace.tokens.select-set"
 msgstr "בחירה ערכה."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "לאסימון יש הפניה עצמית"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -7911,7 +7911,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "טשטוש"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "טשטוש הצל חייב להיות גדול או שווה ל־0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -7932,7 +7932,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "התפרסות"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "התפרסות ההצללה חייב להיות גדולה או שווה ל־0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -7953,7 +7953,7 @@ msgid "workspace.tokens.size"
 msgstr "גודל"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "עובי הקו חייב להיות גדול או שווה ל־0."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:154
@@ -8046,11 +8046,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "הערך לא תקף"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "ערך שגוי: אסור %."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "ערך שגוי: אסור יחידות."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/hi.po
+++ b/frontend/translations/hi.po
@@ -7651,7 +7651,7 @@ msgid "workspace.tokens.color"
 msgstr "रंग"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "पंक्ति की ऊँचाई फ़ॉन्ट आकार पर निर्भर करती है। हल किया गया मान प्राप्त करने "
 "के लिए फ़ॉन्ट आकार जोड़ें।"
@@ -7701,7 +7701,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "%s token संपादित करें"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "टोकन मान रिक्त नहीं हो सकता"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7709,7 +7709,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "%s टोकन नाम दर्ज करें"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "आयात त्रुटि: JSON को पार्स नहीं किया जा सका।"
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7773,7 +7773,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "%s आयात करें"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "आयात त्रुटि:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7824,60 +7824,60 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "व्यक्तिगत टोकन का प्रयोग करें"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "अमान्य रंग मान: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "Invalid token value: आप केवल फ़ॉन्ट-परिवार token का संदर्भ ले सकते हैं"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "अमान्य फ़ॉन्ट भार मान: संख्यात्मक मान (100-950) या मानक नाम (पतला, हल्का, "
 "नियमित, बोल्ड, आदि) का उपयोग करें, वैकल्पिक रूप से उसके बाद 'इटैलिक' लिखें"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "आयात त्रुटि: JSON में अमान्य टोकन डेटा।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "आयात त्रुटि: JSON में अमान्य टोकन नाम।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" एक मान्य टोकन नाम नहीं है।\n"
 "टोकन नामों में केवल अक्षर और अंक होने चाहिए, जो डॉट (.) से अलग किए गए हों, "
 "और $ चिह्न से शुरू नहीं होने चाहिए।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr "अमान्य छाया प्रकार: केवल 'innerShadow' या 'dropShadow' स्वीकार किए जाते हैं"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "अमान्य token मान: केवल कोई नहीं, अपरकेस, लोअरकेस या कैपिटलाइज़ स्वीकार किए "
 "जाते हैं"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "अमान्य token मान: केवल कोई नहीं, रेखांकित और स्ट्राइक-थ्रू स्वीकार किए जाते "
 "हैं"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "अमान्य मूल्य: एक समग्र छाया टोकन का संदर्भ देना चाहिए।।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "अमान्य मान: एक संयुक्त टाइपोग्राफी token का संदर्भ होना चाहिए।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "अमान्य टोकन मान: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7917,7 +7917,7 @@ msgid "workspace.tokens.min-size"
 msgstr "न्यूनतम. आकार"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "गुम टोकन संदर्भ: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7957,7 +7957,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "आपके पास वर्तमान में कोई थीम नहीं है।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "इस फ़ाइल में कोई टोकन, सेट या थीम नहीं मिला।"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7965,11 +7965,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s सक्रिय सेट"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "अमान्य टोकन मान. हल किया गया मान बहुत बड़ा है: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "अपारदर्शिता 0 और 100% या 0 और 1 (जैसे 50% या 0.5) के बीच होनी चाहिए।"
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -8016,7 +8016,7 @@ msgid "workspace.tokens.select-set"
 msgstr "सेट का चयन करें।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "टोकन में स्व-संदर्भ होता है"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8057,7 +8057,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "धुंधला"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "छाया धुंधलापन 0 से अधिक या उसके बराबर होना चाहिए।"
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -8078,7 +8078,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "फैलाना"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "छाया प्रसार 0 से अधिक या उसके बराबर होना चाहिए।"
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8099,7 +8099,7 @@ msgid "workspace.tokens.size"
 msgstr "आकार"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "स्ट्रोक की चौड़ाई 0 से बड़ी या उसके बराबर होनी चाहिए।"
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8200,11 +8200,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "मान मान्य नहीं है"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "अमान्य मान: % की अनुमति नहीं है।"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "अमान्य मान: इकाइयाँ अनुमति नहीं हैं।"
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/id.po
+++ b/frontend/translations/id.po
@@ -6620,7 +6620,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Masukkan nama token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Kesalahan Pengimporan: Tidak dapat mengurai JSON."
 
 #: src/app/main/ui/workspace/tokens/management/context_menu.cljs:240
@@ -6642,7 +6642,7 @@ msgid "workspace.tokens.grouping-set-alert"
 msgstr "Pengelompokan Set Token belum didukung."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Kesalahan Pengimporan:"
 
 #: src/app/main/ui/workspace/tokens/sidebar.cljs:414, src/app/main/ui/workspace/tokens/sidebar.cljs:415
@@ -6651,15 +6651,15 @@ msgid "workspace.tokens.import-tooltip"
 msgstr "Mengimpor berkas JSON akan menimpa semua token, set, dan tema Anda saat ini"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Nilai warna tidak valid: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Kesalahan pengimporan: Data token tidak valid dalam JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Nilai token tidak valid: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -6691,7 +6691,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Ukuran minimal"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Referensi token hilang: "
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:135
@@ -6731,11 +6731,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s set aktif"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Nilai token tidak valid. Nilai terurai terlalu besar: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "Opasitas harus antara 0 dan 100% atau 0 dan 1 (mis. 50% atau 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -6774,7 +6774,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Pilih set."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Token memiliki referensi diri"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60

--- a/frontend/translations/it.po
+++ b/frontend/translations/it.po
@@ -7840,7 +7840,7 @@ msgid "workspace.tokens.color"
 msgstr "Colore"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "L'interlinea dipende dalla dimensione del carattere. Aggiungi una "
 "dimensione carattere per ottenere il valore risolto."
@@ -7890,7 +7890,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "Modifica token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Il valore del token non può essere vuoto"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7898,7 +7898,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Inserisci il nome del token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Errore di importazione: Impossibile analizzare il JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7962,7 +7962,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Importa %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Errore di importazione:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -8019,65 +8019,65 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Utilizza token individuali"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Valore colore invalido: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr ""
 "Valore del token non valido: puoi fare riferimento solo a un token "
 "font-family"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Valore del peso del font non valido: usa valori numerici (100-950) o nomi "
 "standard (thin, light, regular, bold, ecc.) eventualmente seguiti da "
 "'Italic'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Errore di importazione: Dati del token non validi nel JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Errore di importazione: nome token non valido nel JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" non è un nome token valido\n"
 "I nomi dei token devono contenere solo lettere e cifre, separate dal "
 "carattere . e non devono iniziare con il simbolo $."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr ""
 "Tipologia ombra non valida: sono consentite solo 'innerShadow' o "
 "'dropShadow'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Valore del token non valido: sono accettati solo none, Uppercase, Lowercase "
 "o Capitalize"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "Valore del token non valido: sono accettati solo none, underline e "
 "strike-through"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "Valore non valido: deve fare riferimento a un token ombra composito."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "Valore non valido: deve fare riferimento a un token tipografico composito."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Valore token non valido: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -8117,7 +8117,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Dimensione min"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Riferimenti al token mancanti: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -8169,7 +8169,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "Al momento non hai temi."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "Nessun token, set o tema trovato in questo file."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -8177,11 +8177,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "% set attivi"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Valore token non valido. Il valore risolto è troppo grande: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr ""
 "L'opacità deve essere compresa tra 0 e 100% o tra 0 e 1 (ad esempio 50% o "
 "0.5)."
@@ -8231,7 +8231,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Seleziona set."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Il token ha un riferimento a se stesso"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8270,7 +8270,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Sfocatura"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "La sfocatura dell'ombra deve essere maggiore o uguale a 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -8291,7 +8291,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "Diffusione"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "La diffusione dell'ombra deve essere maggiore o uguale a 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8321,7 +8321,7 @@ msgid "workspace.tokens.size"
 msgstr "Dimensione"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "La larghezza della traccia deve essere maggiore o uguale a 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8432,11 +8432,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Il valore non è valido"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Valore non valido: % non è consentito."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Valore non valido: le unità non sono consentite."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/lv.po
+++ b/frontend/translations/lv.po
@@ -7378,7 +7378,7 @@ msgid "workspace.tokens.edit-themes"
 msgstr "Labot izskatus"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Tekstvienības vērtība nevar būt tukša"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7386,7 +7386,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Jāievada %s tekstvienības nosaukums"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Ievietošanas kļūda: nevarēja apstrādāt JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7432,7 +7432,7 @@ msgid "workspace.tokens.grouping-set-alert"
 msgstr "Tekstvienību apkopošana vēl netiek nodrošināta."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Ievietošanas kļūda:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:241
@@ -7473,26 +7473,26 @@ msgstr ""
 "redzētu izmaiņas"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Nederīga krāsas vērtība: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Ievietošanas kļūda: JSON satur nederīgus tekstvienību datus."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Ievietošanas kļūda: nederīgs tekstvienības nosaukums JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" nav derīgs tekstvienības nosaukums.\n"
 "Tekstvienību nosaukumos var būt tikai burti un cipari, kas atdalīti ar "
 "rakstzīmi \".\", un tie nedrīkst sākties ar zīmi \"$\"."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Nederīga tekstvienības vērtība: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7524,7 +7524,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Mazākais lielums"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Trūkst tekstvienību atsauces: "
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:135
@@ -7564,11 +7564,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s spēkā esošas kopas"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Nederīga tekstvienības vērtība. Aprēķinātā vērtība ir pārāk liela: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "Necaurspīdīgumam ir jābūt starp 0 un 100 % vai 0 un 1 (piem., 50% jeb 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -7607,7 +7607,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Atlasīt kopu."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Tekstvienībai ir atsauce uz sevi"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -7655,7 +7655,7 @@ msgid "workspace.tokens.size"
 msgstr "Izmērs"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Vilkuma platumam ir jābūt vienādam vai lielākam par 0."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:154
@@ -7729,7 +7729,7 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Vērtība nav derīga"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Nederīga vērtība: mērvienības nav atļautas."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/nl.po
+++ b/frontend/translations/nl.po
@@ -7854,7 +7854,7 @@ msgid "workspace.tokens.color"
 msgstr "Kleur"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "Regelafstand is afhankelijk van de lettergrootte. Voeg een lettergrootte "
 "toe om de opgeloste waarde te verkrijgen."
@@ -7904,7 +7904,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "%s token bewerken"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "De tokenwaarde mag niet leeg zijn"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7912,7 +7912,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Voer de tokennaam %s in"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Fout bij importeren: Kan JSON niet verwerken."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7976,7 +7976,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Importeren: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Fout bij importeren:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -8033,63 +8033,63 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Individuele tokens gebruiken"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Ongeldige kleurwaarde: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "Ongeldige tokenwaarde: je kunt alleen verwijzen naar een font-family-token"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Ongeldige gewichtswaarde lettertype: gebruik numerieke waarden (100-950) of "
 "standaardtermen (thin, light, regular, bold, etc.) optioneel gevolgd door "
 "'Italic'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Fout bij importeren: Ongeldige tokengegevens in JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Importfout: Ongeldige tokennaam in JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" is geen geldige tokennaam.\n"
 "Tokennamen mogen alleen letters en cijfers bevatten, gescheiden door . "
 "tekens en mogen niet beginnen met een $-teken."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr ""
 "Ongeldig schaduwtype: alleen 'innerShadow' of 'dropShadow' worden "
 "geaccepteerd"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Ongeldige tokenwaarde: alleen none, Uppercase, Lowercase of Capitalize zijn "
 "toegestaan"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "Ongeldige tokenwaarde: alleen none, underline en strike-through zijn "
 "toegestaan"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "Ongeldige waarde: moet verwijzen naar een samengesteld schaduwtoken."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "Ongeldige waarde: moet verwijzen naar een samengesteld typografietoken."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Ongeldige tokenwaarde: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -8129,7 +8129,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Min. grootte"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Ontbrekende tokenverwijzingen: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -8181,7 +8181,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "Je hebt momenteel geen thema's."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "Er zijn geen tokens, verzamelingen of thema's gevonden in dit bestand."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -8189,11 +8189,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s actieve verzamelingen"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Ongeldige tokenwaarde. De opgeloste waarde is te groot: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "De dekking moet tussen 0 en 100% of 0 en 1 zijn (bijv. 50% of 0,5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -8245,7 +8245,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Verzameling kiezen."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Token bevat cirkelverwijzing"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8286,7 +8286,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Vervanging"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "Schaduwonscherpte moet groter zijn dan of gelijk zijn aan 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -8307,7 +8307,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "Spreiding"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "Schaduwspreiding moet groter zijn dan of gelijk zijn aan 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8337,7 +8337,7 @@ msgid "workspace.tokens.size"
 msgstr "Grootte"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "De dikte van de streek moet groter zijn dan of gelijk zijn aan 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8448,11 +8448,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "De waarde is niet geldig"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Ongeldige waarde: % is niet toegestaan."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Ongeldige waarde: Eenheden zijn niet toegestaan."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/ro.po
+++ b/frontend/translations/ro.po
@@ -7492,7 +7492,7 @@ msgid "workspace.tokens.color"
 msgstr "Culoare"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "Înălțimea liniei depinde de dimensiunea fontului. Adaugă o dimensiune "
 "pentru font pentru a primi valoarea rezultată."
@@ -7542,7 +7542,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "Editează token %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Valoarea token-ului nu poate fi goală"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7550,7 +7550,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Introdu numele token-ului %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Eroare la import: Nu s-a putut interpreta JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7610,7 +7610,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Importă %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Eroare import:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7667,49 +7667,49 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Folosește token-uri individuale"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Valoare culoare invalidă: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Valoare greutate font invalidă: folosește valori numerice (100-950) sau "
 "nume standardizate (thin, light, regular, bold, etc.) opțional urmate de "
 "'italic'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Eroare import: Date token invalide în fișierul JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Eroare import: Nume token invalid în fișierul JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" nu este nu nume valid pentru token.\n"
 "Numele token-urilor trebuie să conțină doar litere și cifre separate de "
 "caracterul . și nu trebuie să înceapă cu un semn $."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Valoare token invalidă: doar none, Uppercase, Lowercase sau Capitalize sunt "
 "acceptate"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr "Valoare token invalidă: doar none, underline și strike-trough sunt acceptate"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr ""
 "Valoare invalidă: trebuie să facă referință la un token de tipografie "
 "compozită."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Valoare token invalidă: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7749,7 +7749,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Dimensiune minimă"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Referințe token lipsă: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7789,7 +7789,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "În prezent nu ai teme."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "Nu s-au găsit token-uri, seturi sau teme în acest fișier."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7797,11 +7797,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s seturi active"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Valoare token invalidă. Valoarea rezultată este prea mare: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "Opacitatea trebuie să fie între 0 și 100% sau 0 și 1 (ex: 50% sau 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -7844,7 +7844,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Selectează setul."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Token-ul își face referință singur"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -7881,7 +7881,7 @@ msgid "workspace.tokens.size"
 msgstr "Dimensiune"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Lățimea conturului trebuie să fie mai mare sau egală cu 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -7973,11 +7973,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Valoarea este invalidă"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Valoare invalidă: % nu este permis."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Valoare invalidă: Unitățile nu sunt permise."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/sv.po
+++ b/frontend/translations/sv.po
@@ -7567,7 +7567,7 @@ msgid "workspace.tokens.color"
 msgstr "Färg"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "Radhöjden beror på teckenstorleken. Lägg till en teckenstorlek för att få "
 "det uträknade värdet."
@@ -7617,7 +7617,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "Redigera %s token"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Token-värdet kan inte vara tomt"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7625,7 +7625,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Ange %s tokennamn"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Importeringsfel: Kunde inte tolka JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7689,7 +7689,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "Importera %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Importeringsfel:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7746,58 +7746,58 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Använd individuella tokens"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Ogiltigt färgvärde: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "Ogiltigt token-värde: du kan bara referera till en teckensnittsfamiljs-token"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Ogiltigt värde för typsnittsvikt: använd numeriska värden (100–950) eller "
 "standardnamn (smal, lätt, normal, fet, etc.) eventuellt följt av 'Kursiv'"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Importeringsfel: Ogiltig token-data i JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Importeringsfel: Ogiltigt token-namn i JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" är inte ett giltigt token-namn.\n"
 "Token-namn ska endast innehålla bokstäver och siffror separerade med . "
 "tecken och får inte börja med ett $-tecken."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr "Ogiltig skuggningstyp: endast 'innerShadow' eller 'dropShadow' accepteras"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Ogiltigt token-värde: endast ingen, versaler, gemener eller versalisera "
 "accepteras"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr "Ogiltigt token-värde: endast ingen, understruken och genomstruken accepteras"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "Ogiltigt värde: måste referera till en sammansatt skuggnings-token."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "Ogiltigt värde: måste referera till en sammansatt typografi-token."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Ogiltigt token-värde: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7837,7 +7837,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Min. storlek"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Saknade token-referenser: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7877,7 +7877,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "Du har för närvarande inga teman."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "Inga tokens, uppsättningar eller teman hittades i den här filen."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7885,11 +7885,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s aktiva uppsättningar"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Ogiltigt token-värde. Det uträknade värdet är för stort: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr ""
 "Opaciteten måste vara mellan 0 och 100 % eller 0 och 1 (t.ex. 50 % eller "
 "0,5)."
@@ -7938,7 +7938,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Välj uppsättning."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Token har självreferens"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -7977,7 +7977,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Oskärpa"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "Skuggningsoskärpan måste vara större än eller lika med 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -7998,7 +7998,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "Spridning"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "Skuggningsspridning måste vara större än eller lika med 0."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8019,7 +8019,7 @@ msgid "workspace.tokens.size"
 msgstr "Storlek"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Streckbredden måste vara större än eller lika med 0."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8120,11 +8120,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Värdet är inte giltigt"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Ogiltigt värde: % är inte tillåtet."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Ogiltigt värde: Enheter är ej tillåtna."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/tr.po
+++ b/frontend/translations/tr.po
@@ -7814,7 +7814,7 @@ msgid "workspace.tokens.color"
 msgstr "Renk"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:101, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:251
-msgid "workspace.tokens.composite-line-height-needs-font-size"
+msgid "errors.tokens.composite-line-height-needs-font-size"
 msgstr ""
 "Satır yüksekliği yazı tipi boyutuna bağlıdır. Çözülen değeri elde etmek "
 "için bir yazı tipi boyutu ekleyin."
@@ -7864,7 +7864,7 @@ msgid "workspace.tokens.edit-token"
 msgstr "%s tokenini düzenle"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Token değeri boş olamaz"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7872,7 +7872,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "%s token adını gir"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "İçe Aktarma Hatası: JSON ayrıştırılamadı."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7936,7 +7936,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "%s içe aktar"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "İçe Aktarma Hatası:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -7993,61 +7993,61 @@ msgid "workspace.tokens.individual-tokens"
 msgstr "Bireysel tokenler kullan"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Geçersiz renk değeri: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:93
-msgid "workspace.tokens.invalid-font-family-token-value"
+msgid "errors.tokens.invalid-font-family-token-value"
 msgstr "Geçersiz token değeri: yalnızca font-family tokenine referans verebilirsiniz"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr ""
 "Geçersiz yazı tipi kalınlığı değeri: sayısal değerler (100-950) veya "
 "standart adlar (ince, hafif, normal, kalın vb.) kullanın, isteğe bağlı "
 "olarak ardından 'İtalik' ekleyin"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "İçe Aktarma Hatası: JSON'da geçersiz token verisi."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "İçe Aktarma Hatası: JSON'da geçersiz token adı."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" geçerli bir token adı değil.\n"
 "Token adları yalnızca . karakterleriyle ayrılan harfler ve rakamlar "
 "içermeli ve $ işaretiyle başlamamalıdır."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:105
-msgid "workspace.tokens.invalid-shadow-type-token-value"
+msgid "errors.tokens.invalid-shadow-type-token-value"
 msgstr "Geçersiz gölge türü: yalnızca 'innerShadow' veya 'dropShadow' kabul edilir"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr ""
 "Geçersiz token değeri: yalnızca none, Uppercase, Lowercase veya Capitalize "
 "kabul edilir"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr ""
 "Geçersiz token değeri: yalnızca none, underline ve strike-through kabul "
 "edilir"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:117
-msgid "workspace.tokens.invalid-token-value-shadow"
+msgid "errors.tokens.invalid-token-value-shadow"
 msgstr "Geçersiz değer: bileşik gölge tokenine referans vermelidir."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:97
-msgid "workspace.tokens.invalid-token-value-typography"
+msgid "errors.tokens.invalid-token-value-typography"
 msgstr "Geçersiz değer: bileşik tipografi tokenine referans vermelidir."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Geçersiz token değeri: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -8087,7 +8087,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Asgari boyut"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Eksik token referansları: "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -8139,7 +8139,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "Şu anda hiç temanız yok."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "Bu dosyada token, küme veya tema bulunamadı."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -8147,11 +8147,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s etkin küme"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Geçersiz token değeri. Çözülen değer çok büyük: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "Opaklık 0 ile %100 veya 0 ile 1 arasında olmalıdır (örneğin %50 veya 0.5)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -8203,7 +8203,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Küme seç."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Tokenin kendine referansı var"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -8244,7 +8244,7 @@ msgid "workspace.tokens.shadow-blur"
 msgstr "Bulanıklık"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:109
-msgid "workspace.tokens.shadow-blur-range"
+msgid "errors.tokens.shadow-blur-range"
 msgstr "Gölge bulanıklığı 0 veya 0'dan büyük olmalıdır."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:987, src/app/main/ui/workspace/tokens/management/create/form.cljs:988
@@ -8265,7 +8265,7 @@ msgid "workspace.tokens.shadow-spread"
 msgstr "Yayılım"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:113
-msgid "workspace.tokens.shadow-spread-range"
+msgid "errors.tokens.shadow-spread-range"
 msgstr "Gölge yayılımı 0 veya 0'dan büyük olmalıdır."
 
 #: src/app/main/ui/workspace/tokens/management/create/form.cljs:1215
@@ -8295,7 +8295,7 @@ msgid "workspace.tokens.size"
 msgstr "Boyut"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Çerçeve genişliği 0'dan büyük veya 0 olmalıdır."
 
 #: src/app/main/ui/workspace/tokens/management/forms/form_container.cljs:40, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:161
@@ -8406,11 +8406,11 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Değer geçerli değil"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:69
-msgid "workspace.tokens.value-with-percent"
+msgid "errors.tokens.value-with-percent"
 msgstr "Geçersiz değer: % izin verilmiyor."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Geçersiz değer: Birimlere izin verilmiyor."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/ukr_UA.po
+++ b/frontend/translations/ukr_UA.po
@@ -7106,7 +7106,7 @@ msgid "workspace.tokens.edit-themes"
 msgstr "Редагувати теми"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:41
-msgid "workspace.tokens.empty-input"
+msgid "errors.tokens.empty-input"
 msgstr "Значення токену не може бути порожнім"
 
 #: src/app/main/ui/workspace/tokens/management/forms/generic_form.cljs:241
@@ -7114,7 +7114,7 @@ msgid "workspace.tokens.enter-token-name"
 msgstr "Вкажіть %s ім'я токену"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "Помилка імпорту: Неможливо обробити JSON."
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -7160,7 +7160,7 @@ msgid "workspace.tokens.grouping-set-alert"
 msgstr "Групування наборів токенів поки не підтримується."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "Помилка імпорту:"
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:241
@@ -7197,26 +7197,26 @@ msgstr ""
 "області перегляду"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "Помилкове значення кольору: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "Помилка імпорту: Помилкові дани токену в JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "Помилка імпорту: Помилкове імʼя токену в JSON."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "\"%s\" це не дійсне імʼя токену.\n"
 "Імена токену можуть містити в собі літери та цифри, розділені крапкою та не "
 "повинні починатись з $."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "Помилкове значення токену: %s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7248,7 +7248,7 @@ msgid "workspace.tokens.min-size"
 msgstr "Мін. розмір"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "Відсутні посилання на токен: "
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:135
@@ -7288,11 +7288,11 @@ msgid "workspace.tokens.num-active-sets"
 msgstr "%s активних наборів"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:53
-msgid "workspace.tokens.number-too-large"
+msgid "errors.tokens.number-too-large"
 msgstr "Помилкове значення токену. Отримане значення завелике: %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/warnings.cljs:15
-msgid "workspace.tokens.opacity-range"
+msgid "errors.tokens.opacity-range"
 msgstr "Непрозорість має бути між 0 та 100% або ж між 0 та 1 (де 0.5 - 50%)."
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:121
@@ -7331,7 +7331,7 @@ msgid "workspace.tokens.select-set"
 msgstr "Обрати набір."
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Токен має самопосилання"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60
@@ -7366,7 +7366,7 @@ msgid "workspace.tokens.size"
 msgstr "Розмір"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:77, src/app/main/data/workspace/tokens/warnings.cljs:19
-msgid "workspace.tokens.stroke-width-range"
+msgid "errors.tokens.stroke-width-range"
 msgstr "Ширина обведення має бути більшим ніж 0 або дорівнювати 0."
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:154
@@ -7430,7 +7430,7 @@ msgid "workspace.tokens.value-not-valid"
 msgstr "Значення не є дійсним"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:65
-msgid "workspace.tokens.value-with-units"
+msgid "errors.tokens.value-with-units"
 msgstr "Помилкове значення: Одиниці не дозволені."
 
 #: src/app/main/ui/workspace/sidebar.cljs:159, src/app/main/ui/workspace/sidebar.cljs:166

--- a/frontend/translations/zh_CN.po
+++ b/frontend/translations/zh_CN.po
@@ -6903,7 +6903,7 @@ msgid "workspace.tokens.edit-themes"
 msgstr "编辑主题"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:15
-msgid "workspace.tokens.error-parse"
+msgid "errors.tokens.error-parse"
 msgstr "导入错误：不能解析 JSON。"
 
 #: src/app/main/ui/workspace/tokens/export/modal.cljs:49
@@ -6940,7 +6940,7 @@ msgid "workspace.tokens.import-button-prefix"
 msgstr "导入 %s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:32, src/app/main/data/workspace/tokens/errors.cljs:37
-msgid "workspace.tokens.import-error"
+msgid "errors.tokens.import-error"
 msgstr "导入错误："
 
 #: src/app/main/ui/workspace/tokens/import/modal.cljs:273
@@ -6973,37 +6973,37 @@ msgid "workspace.tokens.inactive-set-description"
 msgstr "此设置未启用。请更改主题或启用此设置以在视口中查看更改"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:49
-msgid "workspace.tokens.invalid-color"
+msgid "errors.tokens.invalid-color"
 msgstr "无效的颜色值：%s"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:89
-msgid "workspace.tokens.invalid-font-weight-token-value"
+msgid "errors.tokens.invalid-font-weight-token-value"
 msgstr "字体粗细值无效：使用数值（100-950）或标准名称（细、亮、常规、粗体等），后跟可选的“斜体”"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:23
-msgid "workspace.tokens.invalid-json"
+msgid "errors.tokens.invalid-json"
 msgstr "导入错误：JSON 中存在无效的令牌数据。"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:27
-msgid "workspace.tokens.invalid-json-token-name"
+msgid "errors.tokens.invalid-json-token-name"
 msgstr "导入错误；JSON中存在无效的令牌名。"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:28
-msgid "workspace.tokens.invalid-json-token-name-detail"
+msgid "errors.tokens.invalid-json-token-name-detail"
 msgstr ""
 "“%s” 不是有效的 token 名称。\n"
 "token 名称只能包含字母和数字，并以 . 字符分隔，并且不能以 $ 符号开头。"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:81
-msgid "workspace.tokens.invalid-text-case-token-value"
+msgid "errors.tokens.invalid-text-case-token-value"
 msgstr "无效的token值：仅接受无、大写、小写或大写"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:85
-msgid "workspace.tokens.invalid-text-decoration-token-value"
+msgid "errors.tokens.invalid-text-decoration-token-value"
 msgstr "无效的token值：仅接受无、下划线和删除线"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:61, src/app/main/data/workspace/tokens/errors.cljs:73, src/app/main/data/workspace/tokens/errors.cljs:77
-msgid "workspace.tokens.invalid-value"
+msgid "errors.tokens.invalid-value"
 msgstr "无效的令牌值：%s"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:205
@@ -7035,7 +7035,7 @@ msgid "workspace.tokens.min-size"
 msgstr "最小尺寸"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:57
-msgid "workspace.tokens.missing-references"
+msgid "errors.tokens.missing-references"
 msgstr "缺少token引用： "
 
 #: src/app/main/ui/workspace/tokens/management/token_pill.cljs:124
@@ -7075,7 +7075,7 @@ msgid "workspace.tokens.no-themes-currently"
 msgstr "您目前没有主题。"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:19
-msgid "workspace.tokens.no-token-files-found"
+msgid "errors.tokens.no-token-files-found"
 msgstr "在此文件中未找到任何标记、集合或主题。"
 
 #: src/app/main/ui/workspace/tokens/themes/create_modal.cljs:134
@@ -7118,7 +7118,7 @@ msgid "workspace.tokens.select-set"
 msgstr "选择集。"
 
 #: src/app/main/data/workspace/tokens/errors.cljs:45, src/app/main/ui/workspace/tokens/management/forms/shadow.cljs:299, src/app/main/ui/workspace/tokens/management/forms/typography.cljs:243
-msgid "workspace.tokens.self-reference"
+msgid "errors.tokens.self-reference"
 msgstr "Token存在自我引用"
 
 #: src/app/main/ui/workspace/tokens/sets/lists.cljs:60


### PR DESCRIPTION
### Summary

Rename i18n message keys for tokens errors to include the `error-` prefix. This way it makes the intention clearer for the translators.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->



Fixes #9649
