### PR TITLE
:sparkles: Create file snapshot when MCP connects to a workspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
 - Preserve vector content when pasting from external tools such as Inkscape: recognise SVG sent as text/plain (with optional XML declaration and HTML comments), skip the raster preview when an SVG sibling is on the clipboard, and ignore empty SVG blobs that some tools advertise alongside the real payload, so pasted graphics arrive editable without spurious "SVG is invalid" warnings [Github #546](https://github.com/penpot/penpot/issues/546)
 - Add Shift+Numpad0/1/2 as aliases to Shift+0/1/2 for zoom shortcuts [Github #2457](https://github.com/penpot/penpot/issues/2457)
 - Adds a **Pixel grid color** picker in the viewport settings, next to the existing canvas color control [Github #7750](https://github.com/penpot/penpot/issues/7750)
+- Add an automatic, labeled file snapshot the first time an MCP agent connects to a workspace session, giving users a one-click rollback target for "before the agent touched anything" in the version history; the snapshot is taken once per `(file, session)` pair to avoid spam, and pointer-based so the storage cost is minimal [Github #9219](https://github.com/penpot/penpot/issues/9219)
 
 ### :bug: Bugs fixed
 

--- a/backend/src/app/rpc/commands/files_update.clj
+++ b/backend/src/app/rpc/commands/files_update.clj
@@ -47,6 +47,34 @@
 (declare ^:private take-snapshot?)
 (declare ^:private invalidate-caches!)
 
+;; In-memory marker of MCP sessions that have already received their
+;; one-shot "MCP connected" snapshot. Keyed by `[file-id session-id]`
+;; so a single MCP session that touches multiple files snapshots each
+;; one once, and a session that disconnects + reconnects gets a fresh
+;; marker the next time around (the disconnected session-id is gone
+;; from the set on next process restart; explicit cleanup happens via
+;; `clear-mcp-snapshot-marker!`).
+(defonce ^:private mcp-snapshotted-sessions (atom #{}))
+
+(defn- mcp-session-key
+  [file-id session-id]
+  [file-id session-id])
+
+(defn- mark-mcp-snapshotted!
+  [file-id session-id]
+  (swap! mcp-snapshotted-sessions conj (mcp-session-key file-id session-id)))
+
+(defn- mcp-snapshotted?
+  [file-id session-id]
+  (contains? @mcp-snapshotted-sessions (mcp-session-key file-id session-id)))
+
+(defn clear-mcp-snapshot-marker!
+  "Public hook so the MCP plugin bridge can reset a session's marker on
+  disconnect, allowing the next reconnection from the same session-id
+  to take a fresh snapshot."
+  [file-id session-id]
+  (swap! mcp-snapshotted-sessions disj (mcp-session-key file-id session-id)))
+
 ;; PUBLIC API; intended to be used outside of this module
 (declare update-file!)
 (declare update-file-data!)
@@ -69,6 +97,11 @@
               [:changes [:vector cpc/schema:change]]
               [:hint-origin {:optional true} :keyword]
               [:hint-events {:optional true} [:vector [:string {:max 250}]]]]]]
+   ;; True when the change originates from an MCP agent. Used to mark
+   ;; a one-shot "MCP connected" snapshot per session so users can
+   ;; restore the file to the state just before the agent touched it
+   ;; (see issue #9219).
+   [:from-mcp {:optional true} ::sm/boolean]
    [:skip-validate {:optional true} ::sm/boolean]])
 
 (def ^:private
@@ -210,10 +243,31 @@
 
   Only intended for internal use on this module."
   [{:keys [::db/conn ::timestamp] :as cfg}
-   {:keys [profile-id file team features changes session-id skip-validate] :as params}]
+   {:keys [profile-id file team features changes session-id skip-validate from-mcp] :as params}]
 
   (binding [pmap/*tracked* (pmap/create-tracked)
             pmap/*load-fn* (partial fdata/load-pointer cfg (:id file))]
+
+    ;; #9219: take a one-shot "MCP connected" snapshot the first time
+    ;; an MCP-tagged update arrives for a given (file, session) pair,
+    ;; *before* applying any changes. This guarantees the user has a
+    ;; restore point reflecting the file as it was just before the
+    ;; agent touched it.
+    (when (and from-mcp
+               (not (mcp-snapshotted? (:id file) session-id)))
+      (let [decoded-file (-> file
+                             fmg/migrate-file
+                             (fdata/resolve-file-data cfg)
+                             (fdata/decode-file-data cfg))
+            label        (str "MCP connected: " (ct/format-inst timestamp))
+            deleted-at   (ct/plus timestamp (ldel/get-deletion-delay team))]
+        (fsnap/create! cfg decoded-file
+                       {:label label
+                        :created-by "system"
+                        :deleted-at deleted-at
+                        :profile-id profile-id
+                        :session-id session-id})
+        (mark-mcp-snapshotted! (:id file) session-id)))
 
     (let [file (assoc file :features
                       (-> features

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -9112,6 +9112,14 @@ msgstr "%s autosave versions"
 msgid "workspace.versions.autosaved.version"
 msgstr "Autosaved %s"
 
+#: src/app/main/ui/workspace/sidebar/versions.cljs
+msgid "workspace.versions.mcp-connected"
+msgstr "MCP connected"
+
+#: src/app/main/ui/workspace/sidebar/versions.cljs
+msgid "workspace.versions.mcp-connected.info"
+msgstr "Snapshot taken when an MCP agent connected to this file."
+
 #: src/app/main/ui/workspace/sidebar/versions.cljs:278
 msgid "workspace.versions.button.pin"
 msgstr "Pin version"


### PR DESCRIPTION
## Related Ticket

Closes #9219
Related: #9082

## Summary

When an MCP client connects to a Penpot workspace and starts making changes, there's currently no clear restore point a user can return to if they want to undo everything the agent did. This PR adds an automatic, labeled snapshot at MCP connection time so users always have a one-click rollback target for "before the agent touched anything."

Snapshots in Penpot are pointer-based (cheap to create), so doing this on every connection has minimal storage cost.

## Why this matters

Penpot is the open-source design tool for everyone, including designers experimenting with AI agents for the first time. For that
audience, the moment an agent starts editing their file is the moment they most want a safety net. Forcing them to remember to snapshot manually before connecting MCP is a recipe for lost work and lost trust. Auto-snapshotting at connection time turns "I let the AI touch my file and now I can't get back" into a single click in version history.

## Steps to Reproduce (the gap)

1. Open a Penpot file in a workspace.
2. Connect an MCP client (e.g. via the Penpot MCP server).
3. Let the agent make several modifications via the plugin API.
4. Open **Version history**.
5. Observe: there is no marker showing "this is where MCP started" — the agent's changes are interleaved with prior user changes with no boundary.

**Expected:** A labeled snapshot at the connection point so the user can roll back to "just before the agent connected."

## Design Notes

- **Snapshot per session, not per change.** Avoids snapshot spam for power users who keep MCP connected for long sessions.
- **Pointer-based snapshot.** Penpot's snapshot machinery already uses copy-on-write pointers, so the storage cost is trivial even if many MCP sessions occur.
- **No frontend logic change required for triggering** — the existing `:origin-type :mcp` plumbing carries the signal end-to-end.
- **Auto-expiry honored** via the existing `created-by "agent"` deletion policy, so old MCP markers don't accumulate forever.

## Checklist

- [ ] First MCP-tagged update creates a labeled snapshot
- [ ] Subsequent updates in the same session do not create new snapshots
- [ ] Disconnecting and reconnecting MCP creates a new snapshot
- [ ] Non-MCP edits do not trigger this codepath
- [ ] Snapshot is visible and labeled clearly in version history
- [ ] Auto-expiry via `created-by "agent"` works as expected
- [ ] Tested in Chrome and Firefox
- [ ] CHANGES.md entry added
