### PR TITLE
:bug: Fix MCP integrations copy button to match displayed URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,5 @@
 # CHANGELOG
 
-
 ## 2.15.0 (Unreleased)
 
 ### :sparkles: New features & Enhancements
@@ -11,6 +10,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix MCP integrations URL copy action to match the URL displayed in settings [Github #9238](https://github.com/penpot/penpot/issues/9238)
 - Fix Plugin API token methods rejecting JS array of strings [Github #9162](https://github.com/penpot/penpot/issues/9162)
 - Harden Nginx responses with standard security headers and hide upstream `X-Powered-By` headers
 - Fix keep-alive interval leak in PluginBridge (by @opcode81) [Github #9435](https://github.com/penpot/penpot/pull/9435)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 - Fix release notes modal appearing behind the dashboard sidebar (by @RenzoMXD) [Github #8296](https://github.com/penpot/penpot/issues/8296)
 - Fix incorrect handling of version restore operation [Github #9041](https://github.com/penpot/penpot/pull/9041)
+- Fix MCP integrations URL copy action to match the URL displayed in settings [Github #9238](https://github.com/penpot/penpot/issues/9238)
 
 
 ## 2.14.4

--- a/frontend/src/app/main/ui/settings/integrations.cljs
+++ b/frontend/src/app/main/ui/settings/integrations.cljs
@@ -410,6 +410,8 @@
         profile (mf/deref refs/profile)
 
         mcp-key      (some #(when (= (:type %) "mcp") %) tokens)
+        mcp-token    (:token mcp-key "")
+        mcp-url      (dm/str cf/mcp-server-url "?userToken=" mcp-token)
         mcp-enabled? (true? (-> profile :props :mcp-enabled))
 
         expires-at  (:expires-at mcp-key)
@@ -457,9 +459,10 @@
 
         on-copy-to-clipboard
         (mf/use-fn
+         (mf/deps mcp-url)
          (fn [event]
            (dom/prevent-default event)
-           (clipboard/to-clipboard cf/mcp-server-url)
+           (clipboard/to-clipboard mcp-url)
            (st/emit! (ntf/show {:level :info
                                 :type :toast
                                 :content (tr "integrations.notification.success.copied-link")
@@ -550,7 +553,7 @@
                   :class (stl/css :color-secondary)}
         (tr "integrations.mcp-server.mcp-keys.info")]
 
-       [:> input-copy* {:value (dm/str cf/mcp-server-url "?userToken=")
+       [:> input-copy* {:value mcp-url
                         :on-copy-to-clipboard on-copy-to-clipboard}]
 
        [:> text* {:as "div"


### PR DESCRIPTION
### Related Ticket

Closes  #9238

### Summary
In **Settings → Integrations → MCP Server**, the URL shown in the input includes `?userToken=` (for example `https://design.penpot.app/mcp/stream?userToken=`), but when clicking **Copy to clipboard**, Penpot copies a different URL without the query param (`https://design.penpot.app/mcp/stream`).
This creates confusion because users think they copied the exact server URL displayed in the UI.

### Steps to reproduce 
1. Go to **Settings → Integrations**.
2. Open the **MCP Server** section.
3. In the info block, check the URL shown in the input (it includes `?userToken=`).
4. Click **Copy to clipboard**.
5. Paste into any text editor.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

