### PR TITLE
:bug: Fix typo in restore-deleted-team-files reduce accumulator

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -1284,7 +1284,7 @@
                         (update :files conj id)
                         (update :projects conj project-id))))
 
-                {:files #{} :projectes #{}}
+                {:files #{} :projects #{}}
                 (db/plan conn [sql:resolve-editable-files team-id
                                (db/create-array conn "uuid" ids)]))]
 


### PR DESCRIPTION
### Related Ticket

Closes #9240 

### Summary

The reduce accumulator in `restore-deleted-team-files` was declared as `{:files #{} :projectes #{}}`, but the reducer body writes to the `:projects` key. The misspelled `:projectes` key stayed empty for the entire reduction, while `:projects` was built from `nil` via `conj`, producing a list with possible duplicates instead of the intended deduplicated set.

The functional impact was mild because `restore-projects` runs `WHERE id = ANY(?::uuid[])` and Postgres deduplicates on the SQL side, but the original intent (a set) was not what got built, and the mismatch was confusing to read.

This patch renames the key so the accumulator and the reducer agree.

### Steps to reproduce

1. Open `backend/src/app/rpc/commands/files.clj` at the `restore-deleted-team-files` definition.
2. Confirm the reduce accumulator now reads `{:files #{} :projects #{}}` and matches the keys updated inside the reducer body.
3. Restore deleted team files and verify that project restoration still works as before.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.