### PR TITLE
:recycle: Remove unreachable try/catch in hex->hsl

### DIFF
--- a/common/src/app/common/colors.cljc
+++ b/common/src/app/common/colors.cljc
@@ -332,10 +332,7 @@
       (conj opacity)))
 
 (defn hex->hsl [hex]
-  (try
-    (-> hex hex->rgb rgb->hsl)
-    (catch #?(:clj Throwable :cljs :default) _e
-      [0 0 0])))
+  (-> hex hex->rgb rgb->hsl))
 
 (defn hex->hsla
   [data opacity]


### PR DESCRIPTION
### Related Ticket

Closes #9244 

### Summary

The `hex->hsl` helper in `common/src/app/common/colors.cljc` wrapped its body in a `try`/`catch` returning `[0 0 0]` on failure, but the catch clause was unreachable:

* `hex->rgb` already swallows its own exceptions and always returns either a `[r g b]` vector of integers or `[0 0 0]`.
* `rgb->hsl` performs only arithmetic on numbers, and the `(= max min)` branch short-circuits the only divisions that could otherwise hit zero.

With both callees safe, the wrapper became dead error handling. Reduced the function to a plain composition.

### Steps to reproduce

1. Open `common/src/app/common/colors.cljc`.
2. Compare `hex->hsl` against the call chain `hex->rgb` and `rgb->hsl`; confirm no value forwarded between them can throw.
3. After the change, verify that `(hex->hsl "#ff8800")` and `(hex->hsl "not-a-hex")` still return sensible vectors (the second falls back via `hex->rgb`'s own catch to `[0 0 0]`).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.