### PR TITLE
:recycle: Revert ESC keypress closes plugins

### DIFF
--- a/frontend/src/app/main/data/workspace/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/shortcuts.cljs
@@ -6,12 +6,10 @@
 
 (ns app.main.data.workspace.shortcuts
   (:require
-   [app.common.data.macros :as dm]
    [app.main.data.common :as dcm]
    [app.main.data.event :as ev]
    [app.main.data.exports.assets :as de]
    [app.main.data.modal :as modal]
-   [app.main.data.plugins :as dpl]
    [app.main.data.preview :as dp]
    [app.main.data.profile :as du]
    [app.main.data.shortcuts :as ds]
@@ -32,7 +30,6 @@
    [app.main.store :as st]
    [app.main.ui.hooks.resize :as r]
    [app.util.dom :as dom]
-   [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -50,17 +47,6 @@
         read-only? (deref refs/workspace-read-only?)]
     (when (and can-edit? (not read-only?))
       (run! st/emit! events))))
-
-(def esc-pressed
-  (ptk/reify ::esc-pressed
-    ptk/WatchEvent
-    (watch [_ state _]
-      (rx/of
-       :interrupt
-       (let [selection (dm/get-in state [:workspace-local :selected])]
-         (if (empty? selection)
-           (dpl/close-current-plugin)
-           (dw/deselect-all true)))))))
 
 ;; Shortcuts format https://github.com/ccampbell/mousetrap
 
@@ -149,7 +135,7 @@
    :escape               {:tooltip (ds/esc)
                           :command "escape"
                           :subsections [:edit]
-                          :fn #(st/emit! esc-pressed)}
+                          :fn #(st/emit! :interrupt (dw/deselect-all true))}
 
    :find             {:tooltip (ds/meta "F") :command (ds/c-mod "f") :subsections [:edit]
                       :fn #(st/emit! (dw/open-layers-search :find))}


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->
https://tree.taiga.io/project/penpot/issue/14052

### Summary
Currently, pressing ESC in the context of the canvas, deselects the shape and, if any plugin is open, it closes it. This causes a problem with some plugins, specially the MCP, that gets disconnected.

Reverted this behaviour so closing a plugin must be done manually.

### Steps to reproduce 

Open a plugin
Create a shape and select it
Press ESC

Current: shape is deselected and plugin closed
Expected: only shape is deselected

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
