### PR TITLE
:fire: Remove stray debug log in exporter upload-resource

### DIFF
--- a/exporter/src/app/handlers/resources.cljs
+++ b/exporter/src/app/handlers/resources.cljs
@@ -68,7 +68,6 @@
   [auth-token resource]
   (->> (fsp/readFile (:path resource))
        (p/fmap (fn [buffer]
-                 (js/console.log buffer)
                  (new js/Blob #js [buffer] #js {:type (:mtype resource)})))
        (p/mcat (fn [blob]
                  (let [fdata  (new http/FormData)


### PR DESCRIPTION
### Related Ticket

Closes #9270

### Summary

`exporter/src/app/handlers/resources.cljs:67-72` was logging the entire upload `Buffer` to stdout for every uploaded resource. `buffer` here is the raw bytes of an exported asset (any image, font, or asset that the exporter pipes back to the backend), so on a moderately-sized export with embedded images this prints multiple megabytes of unstructured noise per export.

```clojure
(defn upload-resource
  [auth-token resource]
  (->> (fsp/readFile (:path resource))
       (p/fmap (fn [buffer]
                 (js/console.log buffer)               ;; <-- removed
                 (new js/Blob #js [buffer] #js {:type (:mtype resource)})))
       …))
```

`git blame` shows the line was introduced by commit `34e84ee3c8 :bug: Fix incorrect resource lifetime handling on exporter` (2025-12-10) — the surrounding fix is intentional, but this one `console.log` is a leftover debug print that survived the commit.

This is the same pattern as the recently-merged `f530a0ba2 :fire: Remove stray debug log in color-row component (#9243)`.

### Steps to reproduce

1. Run the exporter (`./manage.sh run-devenv` then start the exporter, or any production stack running `penpotapp/exporter`).
2. Trigger any export that uploads a resource through the exporter, e.g. *Export → SVG / PDF / PNG* on a file with images or fonts.
3. Watch stdout of the exporter container.

**Before:** one `<Buffer 89 50 4e 47 …>` hex dump per uploaded asset, per export.

**After:** no buffer dumps; the structured logger output is unchanged.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide. _(N/A — no SCSS changes)_
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
