### PR TITLE
:bug: Stop swallowing unrelated exceptions in get-profile RPC

### DIFF
--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -31,7 +31,9 @@
    [app.tokens :as tokens]
    [app.util.services :as sv]
    [app.worker :as wrk]
-   [cuerdas.core :as str]))
+   [cuerdas.core :as str])
+  (:import
+   clojure.lang.ExceptionInfo))
 
 (declare check-profile-existence!)
 (declare decode-row)
@@ -102,16 +104,20 @@
   ;; We need to return the anonymous profile object in two cases, when
   ;; no profile-id is in session, and when db call raises not found. In all other
   ;; cases we need to reraise the exception.
-  (try
-    (let [profile (-> (get-profile pool profile-id)
-                      (strip-private-attrs)
-                      (update :props filter-props))]
-      (if (contains? cf/flags :nitrate)
-        (nitrate/add-nitrate-licence-to-profile cfg profile)
-        profile))
+  (if (nil? profile-id)
+    {:id uuid/zero :fullname "Anonymous User"}
+    (try
+      (let [profile (-> (get-profile pool profile-id)
+                        (strip-private-attrs)
+                        (update :props filter-props))]
+        (if (contains? cf/flags :nitrate)
+          (nitrate/add-nitrate-licence-to-profile cfg profile)
+          profile))
 
-    (catch Throwable _
-      {:id uuid/zero :fullname "Anonymous User"})))
+      (catch ExceptionInfo cause
+        (if (= :not-found (:type (ex-data cause)))
+          {:id uuid/zero :fullname "Anonymous User"}
+          (throw cause))))))
 
 (defn get-profile
   "Get profile by id. Throws not-found exception if no profile found."


### PR DESCRIPTION
### Related Ticket

Closes #9276 

### Summary

The `::get-profile` RPC was wrapping its body in `(catch Throwable _ ...)` and returning `{:id uuid/zero :fullname "Anonymous User"}` for every failure. Database outages, `OutOfMemoryError`, and any other runtime exception were silently downgrading logged in users to anonymous, which masked real incidents and caused downstream code that compares the response against the session `profile-id` to disagree with itself.

The comment above the block already described the intended behavior: return the anonymous profile only when no `profile-id` is present in session, or when the database call raises `:type :not-found`. The implementation now matches that contract.

* The nil `profile-id` precondition is checked before entering the `try`, so the documented "no profile in session" case no longer
  relies on an exception path.
* The `catch` is narrowed from `Throwable` to `ExceptionInfo`, and inside the handler the fallback only runs when `(:type (ex-data
  cause))` is `:not-found`. Anything else is rethrown.
* `clojure.lang.ExceptionInfo` is added to the namespace `:import`, matching the pattern already used in `app.rpc.climit`.

### Steps to reproduce

1. Read the comment block above the `try` in `get-profile` at `backend/src/app/rpc/commands/profile.clj`. Confirm the contract:
   anonymous profile only when there is no `profile-id` in session, or when the database call raises not found.
2. Trigger an unrelated failure inside `get-profile`, for example by dropping the database connection mid call so the JDBC layer raises a `SQLException`, or by temporarily monkey patching `get-profile` to throw `IllegalStateException`.
3. Issue a `::get-profile` request from a logged in client.

Before the fix, the response was the anonymous profile object regardless of the underlying failure. After the fix, only the two documented cases return the anonymous profile, and every other throwable propagates to the caller as a 5xx error.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and verify the fix.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
