### PR TITLE
:bug: Fall back to execCommand copy when navigator.clipboard is unavailable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,7 @@
 - Fix crash in share-link viewer when a team member's email is missing `@` or has no domain TLD (by @boskodev790) [Github #9120](https://github.com/penpot/penpot/pull/9120)
 - Fix crash when pasting a component with variants from an external shared library into a file that uses that library (by @FairyPigDev) [Github #8144](https://github.com/penpot/penpot/issues/8144)
 - Remove `corepack` from the MCP local launcher so it runs on Node.js 25+, where corepack is no longer bundled (by @TheAifam5) [Github #8877](https://github.com/penpot/penpot/issues/8877)
+- Fix Internal Error crash when clicking the Copy button on a newly-created Access Token while accessing a self-hosted Penpot over plain HTTP from a LAN IP — `navigator.clipboard` is `undefined` outside secure contexts, so the synchronous `.writeText` call threw and bubbled up to the React error boundary; the clipboard helpers now fall back to `document.execCommand('copy')` and always return a Promise so callers can handle write failures uniformly (by @jeffrey701) [Github #8496](https://github.com/penpot/penpot/issues/8496)
 - Fix Copy as SVG to produce a valid document for multi-shape selections and use `image/svg+xml` MIME type (by @RenzoMXD) [Github #9066](https://github.com/penpot/penpot/pull/9066)
 - Reset profile submenu state when the account menu closes (by @eureka0928) [Github #8947](https://github.com/penpot/penpot/issues/8947)
 - Preserve OpenType variant name table for custom fonts in the dashboard (by @rutherfordcraze) [Github #8924](https://github.com/penpot/penpot/issues/8924)

--- a/frontend/src/app/util/clipboard.cljs
+++ b/frontend/src/app/util/clipboard.cljs
@@ -70,12 +70,72 @@
   ([event options]
    (from-data-transfer (.-dataTransfer ^js event) options)))
 
+(defn clipboard-write-text-supported?
+  "True when `clipboard` is a non-nil object exposing the async writeText API.
+  In non-secure browsing contexts (e.g. self-hosted Penpot served over plain
+  HTTP from a LAN IP) `navigator.clipboard` is `undefined`, in which case this
+  returns false and callers should fall back to `legacy-write-text!`."
+  [clipboard]
+  (boolean (and (some? clipboard)
+                (some? (unchecked-get clipboard "writeText")))))
+
+(defn clipboard-write-supported?
+  "True when `clipboard` is a non-nil object exposing the rich `write` API
+  used for `ClipboardItem` payloads. Browsers gate this behind a secure
+  context; there is no document.execCommand fallback for arbitrary blobs."
+  [clipboard]
+  (boolean (and (some? clipboard)
+                (some? (unchecked-get clipboard "write")))))
+
+(defn- legacy-write-text!
+  "Insecure-context fallback that copies `text` via document.execCommand.
+  Returns true on success, false when the browser refused the copy command
+  (which can happen in iframes without `allow=\"clipboard-write\"`).
+  Mounts the textarea off-screen via fixed-position with zero opacity so the
+  page does not scroll while the textarea is briefly focused."
+  [text]
+  (let [doc      js/document
+        textarea (.createElement doc "textarea")]
+    (set! (.-value textarea) text)
+    (set! (.-readOnly textarea) true)
+    (set! (.. textarea -style -position) "fixed")
+    (set! (.. textarea -style -top) "0")
+    (set! (.. textarea -style -left) "0")
+    (set! (.. textarea -style -opacity) "0")
+    (set! (.. textarea -style -pointerEvents) "none")
+    (.appendChild (.-body doc) textarea)
+    (try
+      (.focus textarea)
+      (.select textarea)
+      (boolean (.execCommand doc "copy"))
+      (catch :default _ false)
+      (finally
+        (.removeChild (.-body doc) textarea)))))
+
 ;; FIXME: rename to `write-text`
 (defn to-clipboard
+  "Write `data` (string) to the system clipboard. Uses the async Clipboard
+  API in secure contexts; falls back to `document.execCommand('copy')` when
+  `navigator.clipboard` is unavailable (e.g. self-hosted Penpot served over
+  plain HTTP from a LAN IP, which is not a secure context).
+  Always returns a Promise so callers can handle write failures uniformly."
   [data]
   (assert (string? data) "`data` should be string")
   (let [clipboard (unchecked-get js/navigator "clipboard")]
-    (.writeText ^js clipboard data)))
+    (cond
+      (clipboard-write-text-supported? clipboard)
+      (.writeText ^js clipboard data)
+
+      (legacy-write-text! data)
+      (js/Promise.resolve)
+
+      :else
+      (js/Promise.reject
+       (js/Error.
+        (str "Clipboard write failed: navigator.clipboard.writeText is "
+             "unavailable and document.execCommand('copy') was rejected by "
+             "the browser. This typically requires a secure context (HTTPS "
+             "or localhost)."))))))
 
 (defn- create-clipboard-item
   [mimetype promise]
@@ -84,18 +144,28 @@
 
 ;; FIXME: this API is very confuse
 (defn to-clipboard-promise
+  "Write a single ClipboardItem holding a Promise that resolves to the
+  payload for `mimetype`. Returns a Promise that rejects with a clear
+  error when the rich Clipboard API is unavailable (no legacy fallback
+  exists for arbitrary blob payloads)."
   [mimetype promise]
-  (let [clipboard (unchecked-get js/navigator "clipboard")
-        data (create-clipboard-item mimetype promise)]
-    (.write ^js clipboard #js [data])))
+  (let [clipboard (unchecked-get js/navigator "clipboard")]
+    (if (clipboard-write-supported? clipboard)
+      (let [data (create-clipboard-item mimetype promise)]
+        (.write ^js clipboard #js [data]))
+      (js/Promise.reject
+       (js/Error.
+        (str "Clipboard rich-write is unavailable: navigator.clipboard.write "
+             "requires a secure context (HTTPS or localhost)."))))))
 
 (defn to-clipboard-multi
   "Write multiple MIME representations as a single ClipboardItem.
   `items` is a map of mime-type (string) -> string payload.
-  Falls back to `writeText` when the async Clipboard API is unavailable."
+  Falls back to writing the `text/plain` payload (or, if absent, the first
+  value) via `to-clipboard` when the async Clipboard API is unavailable."
   [items]
   (let [clipboard (unchecked-get js/navigator "clipboard")]
-    (if (and clipboard (unchecked-get clipboard "write"))
+    (if (clipboard-write-supported? clipboard)
       (let [obj (reduce-kv
                  (fn [acc mime payload]
                    (let [blob (js/Blob. #js [payload] #js {:type mime})]
@@ -106,4 +176,4 @@
         (.write ^js clipboard #js [item]))
       (when-let [text (or (get items "text/plain")
                           (first (vals items)))]
-        (.writeText ^js clipboard text)))))
+        (to-clipboard text)))))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -31,6 +31,7 @@
    [frontend-tests.tokens.token-errors-test]
    [frontend-tests.tokens.workspace-tokens-remap-test]
    [frontend-tests.ui.ds-controls-numeric-input-test]
+   [frontend-tests.util-clipboard-test]
    [frontend-tests.util-object-test]
    [frontend-tests.util-range-tree-test]
    [frontend-tests.util-simple-math-test]

--- a/frontend/test/frontend_tests/util_clipboard_test.cljs
+++ b/frontend/test/frontend_tests/util_clipboard_test.cljs
@@ -1,0 +1,70 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.util-clipboard-test
+  "Unit tests for the navigator.clipboard availability predicates introduced
+  in the secure-context fallback for [Github #8496]."
+  (:require
+   [app.util.clipboard :as clipboard]
+   [cljs.test :as t :include-macros true]))
+
+(t/deftest clipboard-write-text-supported?-test
+  (t/testing "Returns false when navigator.clipboard is undefined"
+    (t/is (false? (clipboard/clipboard-write-text-supported? nil)))
+    (t/is (false? (clipboard/clipboard-write-text-supported? js/undefined))))
+
+  (t/testing "Returns false when clipboard exists but lacks writeText"
+    ;; Browsers gate even the bare `navigator.clipboard` object behind a
+    ;; secure context in some environments; an empty object should not be
+    ;; treated as supporting the async API.
+    (t/is (false? (clipboard/clipboard-write-text-supported? (js-obj))))
+    (t/is (false? (clipboard/clipboard-write-text-supported?
+                   (js-obj "read" (fn [] nil))))))
+
+  (t/testing "Returns true when clipboard exposes writeText"
+    (t/is (true? (clipboard/clipboard-write-text-supported?
+                  (js-obj "writeText" (fn [_] (js/Promise.resolve)))))))
+
+  (t/testing "Returns true even when writeText is co-located with other APIs"
+    (t/is (true? (clipboard/clipboard-write-text-supported?
+                  (js-obj "writeText" (fn [_] (js/Promise.resolve))
+                          "write"     (fn [_] (js/Promise.resolve))
+                          "read"      (fn []  (js/Promise.resolve []))))))))
+
+(t/deftest clipboard-write-supported?-test
+  (t/testing "Returns false when navigator.clipboard is undefined"
+    (t/is (false? (clipboard/clipboard-write-supported? nil)))
+    (t/is (false? (clipboard/clipboard-write-supported? js/undefined))))
+
+  (t/testing "Returns false when clipboard exists but lacks write"
+    ;; A clipboard object that only supports the older writeText API does
+    ;; not support rich (ClipboardItem) writes; callers must reject rather
+    ;; than fall through to a non-existent .write call.
+    (t/is (false? (clipboard/clipboard-write-supported? (js-obj))))
+    (t/is (false? (clipboard/clipboard-write-supported?
+                   (js-obj "writeText" (fn [_] (js/Promise.resolve)))))))
+
+  (t/testing "Returns true when clipboard exposes write"
+    (t/is (true? (clipboard/clipboard-write-supported?
+                  (js-obj "write" (fn [_] (js/Promise.resolve)))))))
+
+  (t/testing "Returns true even when write is co-located with other APIs"
+    (t/is (true? (clipboard/clipboard-write-supported?
+                  (js-obj "writeText" (fn [_] (js/Promise.resolve))
+                          "write"     (fn [_] (js/Promise.resolve))))))))
+
+(t/deftest predicates-are-independent
+  (t/testing "writeText support does not imply rich write support"
+    (let [text-only (js-obj "writeText" (fn [_] (js/Promise.resolve)))]
+      (t/is (true?  (clipboard/clipboard-write-text-supported? text-only)))
+      (t/is (false? (clipboard/clipboard-write-supported?      text-only)))))
+
+  (t/testing "Rich write support does not imply writeText support"
+    ;; Defensive: spec-wise both ship together, but predicates should treat
+    ;; the surface independently so a partial polyfill does not crash.
+    (let [write-only (js-obj "write" (fn [_] (js/Promise.resolve)))]
+      (t/is (false? (clipboard/clipboard-write-text-supported? write-only)))
+      (t/is (true?  (clipboard/clipboard-write-supported?      write-only))))))


### PR DESCRIPTION
## Summary

When self-hosting Penpot over plain HTTP from a LAN IP (e.g.
`http://192.168.1.83:3100`), clicking the **Copy** button on the Access
Token modal crashed the UI with "Internal Error" and the underlying
exception:

> `can't access property "writeText", navigator.clipboard is undefined`

Browsers gate `navigator.clipboard` to **secure contexts** (HTTPS or
`localhost`), so on LAN HTTP the property is `undefined`. The
synchronous `(.writeText ^js clipboard data)` call in
`app.util.clipboard/to-clipboard` then threw a `TypeError`, which the
React error boundary surfaced as a full-page crash. Reported and
root-caused by @NerdBase-by-Stark in #8496.

## Fix

`frontend/src/app/util/clipboard.cljs` now:

- Exposes two pure availability predicates (`clipboard-write-text-supported?`,
  `clipboard-write-supported?`) so callers and tests can reason about the
  Clipboard API surface without poking `js/navigator` directly.
- Falls back to a private `legacy-write-text!` that uses
  `document.execCommand('copy')` via a temporary off-screen textarea when
  `navigator.clipboard.writeText` is missing. This works in non-secure
  contexts and is the standard pre-async-Clipboard polyfill.
- `to-clipboard` now always returns a Promise (resolved on success,
  rejected with a descriptive `Error` if both the async and legacy paths
  fail), so the synchronous-throw path that bubbled up to the React error
  boundary is gone.
- `to-clipboard-promise` now rejects with a clear error message when
  `navigator.clipboard.write` is unavailable, instead of synchronously
  throwing on `.write` of `undefined`. There is no good
  `document.execCommand` fallback for arbitrary `ClipboardItem` blobs.
- `to-clipboard-multi`'s existing fallback was buggy: when
  `navigator.clipboard` was missing the guard fell through and called
  `.writeText` on the same nil/undefined `clipboard`. It now routes the
  text fallback through `to-clipboard`, which has the legacy execCommand
  path.

## Tests

`frontend/test/frontend_tests/util_clipboard_test.cljs` — unit tests for
the two predicates covering: undefined/nil clipboard, empty object,
clipboard with only `writeText`, clipboard with only `write`, and
clipboard with both. Predicates are intentionally independent so a
partial polyfill exposing one method but not the other does not crash.

Tests are registered in `frontend/test/frontend_tests/runner.cljs`.

## Reproduction

1. Self-host Penpot via Docker with `enable-access-tokens`.
2. Access from a LAN IP (e.g. `http://192.168.1.83:3100`) — **not**
   `localhost`.
3. **Settings → Access Tokens →** create a token → click **Copy**.
4. Before this PR: full "Internal Error" crash page.
5. After this PR: copy succeeds via the `execCommand` fallback; the
   existing success notification fires.

## Closes

#8496
