### PR TITLE
:bug: Fix .component() returning outermost component for nested instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,7 @@
 - Fix internal error on layer prev/next sibling selection (by @jsdevninja) [Github #9003](https://github.com/penpot/penpot/issues/9003)
 - Fix tooltip appearing two times when nested elements [Github #9031](https://github.com/penpot/penpot/issues/9031)
 - Fix broken update library notification link in the UI [Github #9070](https://github.com/penpot/penpot/issues/9070)
+- Fix plugin API `ShapeBase.component()` returning the outermost component instead of the immediate component in case of nested component instances [Github #9183](https://github.com/penpot/penpot/issues/9183)
 
 
 ## 2.15.0 (Unreleased)

--- a/frontend/src/app/plugins/shape.cljs
+++ b/frontend/src/app/plugins/shape.cljs
@@ -1186,8 +1186,8 @@
              (let [objects (u/locate-objects file-id page-id)
                    shape (u/locate-shape file-id page-id id)]
                (when (ctn/in-any-component? objects shape)
-                 (let [[root component] (u/locate-component objects shape)]
-                   (lib-component-proxy plugin-id (:component-file root) (:id component))))))
+                 (when-let [[head component] (u/locate-head-component objects shape)]
+                   (lib-component-proxy plugin-id (:component-file head) (:id component))))))
 
            :detach
            (fn []

--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -100,6 +100,17 @@
         root            (ctn/get-instance-root objects shape)]
     [root (ctf/resolve-component root file libraries {:include-deleted? true})]))
 
+(defn locate-head-component
+  "Like locate-component but resolves via the nearest component head
+  instead of the outermost instance root."
+  [objects shape]
+  (let [state           (deref st/state)
+        file            (dsh/lookup-file state)
+        libraries       (dsh/lookup-libraries state)
+        head            (ctn/get-head-shape objects shape)]
+    (when head
+      [head (ctf/resolve-component head file libraries {:include-deleted? true})])))
+
 (defn proxy->file
   [proxy]
   (let [id (obj/get proxy "$id")]


### PR DESCRIPTION
Note: This PR was created by AI as part of the Penpot self-improvement initiative.

## Relevant Issues

* #9183 

## Problem

The plugin API method `shape.component()` returned the wrong component for nested component instances. For example, selecting a button that is an instance of a `btn` component nested inside a `related-card` component instance would return `related-card` instead of `btn`.

## Root Cause

The `:component` property in `shape.cljs` used `locate-component`, which internally calls `ctn/get-instance-root` to walk to the **outermost** instance root before resolving the component. For nested components, this skips the nearest component and returns the ancestor.

## Fix

- Added `locate-head-component` in `utils.cljs`, which uses `ctn/get-head-shape` to find the **nearest** component head instead of the outermost root.
- Updated the `:component` property in `shape.cljs` to use this new function.

## Verification

With a `btn` instance selected inside a `related-card` instance:

| Method | Before | After |
|---|---|---|
| `component()` | `related-card` ❌ | `btn` ✅ |
| `componentHead()` | `btn` ✅ | `btn` ✅ |

Fixes penpot/penpot#9183