### PR TITLE
:sparkles: Add getVariants() method to LibraryComponent plugin API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@
 - Add a search bar to filter board size presets (by @eureka0928) [Github #4658](https://github.com/penpot/penpot/issues/4658)
 - Allow customising the OIDC login button label (by @wdeveloper16) [Github #7027](https://github.com/penpot/penpot/issues/7027)
 - Add page separators in Workspace [Taiga #13611](https://tree.taiga.io/project/penpot/us/13611?milestone=262806)
+- Add `getVariants()` method to plugin API `LibraryComponent` interface [Github #9185](https://github.com/penpot/penpot/issues/9185)
 - Preserve vector content when pasting SVG from external tools such as Inkscape (by @RenzoMXD) [Github #9182](https://github.com/penpot/penpot/pull/9182)
 - Add Shift+Numpad0/1/2 as aliases to Shift+0/1/2 for zoom shortcuts (by @RenzoMXD) [Github #9063](https://github.com/penpot/penpot/pull/9063)
 - Add pixel grid color picker in viewport settings (by @Yakehira) [Github #7750](https://github.com/penpot/penpot/issues/7750)

--- a/frontend/src/app/plugins/library.cljs
+++ b/frontend/src/app/plugins/library.cljs
@@ -852,6 +852,12 @@
       (let [component (u/locate-library-component file-id id)]
         (ctk/is-variant? component)))
 
+    :getVariants
+    (fn []
+      (let [component (u/locate-library-component file-id id)]
+        (when (ctk/is-variant? component)
+          (variant-proxy plugin-id file-id (:variant-id component)))))
+
     :variants
     {:enumerable false
      :get

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.5.0 (Unreleased)
 
+- **plugin-types**: Added `getVariants()` method to `LibraryComponent` interface [Github #9185](https://github.com/penpot/penpot/issues/9185)
+- **plugin-runtime**: Added `getVariants()` implementation to `LibraryComponentProxy` [Github #9185](https://github.com/penpot/penpot/issues/9185)
 - **plugins-runtime**: Added `version` field that returns the current version
 - **plugin-types**: Added a flags subcontexts with the flag `naturalChildrenOrdering`
 - **plugin-types**: Fix penpot.openPage() to navigate in same tab by default

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -2677,6 +2677,13 @@ export interface LibraryComponent extends LibraryElement {
   isVariant(): boolean;
 
   /**
+   * Returns the Variants object for this component, if this component is a VariantComponent.
+   * The Variants object provides access to variant properties and values.
+   * @return The Variants object if this component is a VariantComponent, null otherwise
+   */
+  getVariants(): Variants | null;
+
+  /**
    * Creates a new Variant from this standard Component. It creates a VariantContainer, transform this Component into a VariantComponent, duplicates it, and creates a
    * set of properties based on the component name and path.
    * Similar to doing it with the contextual menu or the shortcut on the Penpot interface


### PR DESCRIPTION
## Summary

Add a `getVariants()` method to the `LibraryComponent` plugin API interface, allowing plugin developers to easily retrieve the `Variants` object for a component that is a variant.

Closes penpot/penpot#9185

## Problem

Previously, there was no direct way to get the `Variants` object from a `LibraryComponent` instance where `isVariant()` returns true. Developers had to either:
- Use type narrowing via `isVariantComponent()` to access the `variants` property on `LibraryVariantComponent`
- Manually traverse ancestors of `mainInstance()` and check with `isVariantContainer()`

## Solution

Added `getVariants(): Variants | null` to `LibraryComponent`:
- Returns the `Variants` object if the component is a variant
- Returns `null` otherwise

## Changes

- **`plugins/libs/plugin-types/index.d.ts`**: Added `getVariants()` method declaration to the `LibraryComponent` interface
- **`frontend/src/app/plugins/library.cljs`**: Added `:getVariants` implementation to `lib-component-proxy`, reusing the same logic as the existing (non-enumerable) `:variants` property
- **`plugins/CHANGELOG.md`**: Added changelog entries
- **`CHANGES.md`**: Added changelog entry