### PR TITLE
:bug: Fix crash on variant switch of nested component subinstance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix file crash when switching the variant of a nested component subinstance [Github #9259](https://github.com/penpot/penpot/issues/9259)
 - Fix Alt/Option to draw shapes from center point (by @offreal) [Github #8361](https://github.com/penpot/penpot/pull/8361)
 - Add token name on broken token pill on sidebar [Taiga #13527](https://tree.taiga.io/project/penpot/issue/13527)
 - Fix tooltip activated when tab change [Taiga #13627](https://tree.taiga.io/project/penpot/issue/13627)

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2119,7 +2119,14 @@
                             (contains? #{:auto-height :auto-width} (:grow-type current-shape)))]
 
     (loop [attrs       updatable-attrs
-           roperations [{:type :set-touched :touched (:touched previous-shape)}]
+           ;; Preserve any :swap-slot-* groups from current-shape: they are structural
+           ;; metadata (set by generate-new-shape-for-swap when the destination is a
+           ;; subinstance head) that must survive the touched copy from previous-shape,
+           ;; otherwise the file fails referential integrity validation (#missing-slot).
+           roperations [{:type :set-touched
+                         :touched (into (or (:touched previous-shape) #{})
+                                        (filter ctk/swap-slot?)
+                                        (:touched current-shape))}]
            uoperations (list {:type :set-touched :touched (:touched current-shape)})]
       (if-let [attr (first attrs)]
         (let [sync-group


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

Corresponding chat: https://claude.ai/share/d18f7ce8-5e76-4c7f-8321-ec52e329247b

@hirunatan I know that this task is now assigned to you, but we decided to look into this issue as a good candidate for testing #9300. If you have already determined how best to fix the issue, feel free to close this. 
In any case, please take a brief look at the chat (link above) to follow the agent's process.

## Summary

Fixes [#9259](https://github.com/penpot/penpot/issues/9259).

Switching a variant on a component instance that is a **subinstance head** —
i.e. the instance is itself nested inside another component copy — causes the
file to crash. The local change goes through, but ~1s later the backend
rejects the resulting `update-file` with HTTP 400, type `:validation`, code
`:referential-integrity`, and the workspace falls into the **Internal Error**
page.

### Reproduction

1. Open the project attached to the issue
2. Select the *read more* button (a `btn` instance nested inside a `Board`
   that is itself a child of a `related-card` copy)
3. Change the *type* variant property from `primary` to `secondary`

→ Workspace crashes.

### Root cause

The validator `check-required-swap-slot` in `common/src/app/common/files/validate.cljc`
reports `:missing-slot — "Shape has been swapped, should have swap slot"` for
the swapped instance. Subinstance heads whose `:shape-ref` no longer matches
the near-main shape must carry a `:swap-slot-<uuid>` touched group.

`generate-new-shape-for-swap` does the right thing: it detects the
subinstance-head case and emits a `change-touched` op that adds the
`:swap-slot-<uuid>` group to the new shape's `:touched`. So the swap-slot
*does* reach the change set initially.

But when `keep-touched?` is true, `component-swap` then calls
`generate-keep-touched`, which for the swapped shape itself ends up in
`update-attrs-on-switch`. That function seeds its redo op with:

```clojure
roperations [{:type :set-touched :touched (:touched previous-shape)}]
```

This **overwrites** the entire `:touched` set with the previous shape's
touched (e.g. `#{:geometry-group}`), silently clobbering the
`:swap-slot-<uuid>` group set a step earlier. The backend then rejects the
update.

I confirmed the chain end-to-end by intercepting `dch/commit-changes` and
inspecting the redo ops for the `btn` id — the `:set-touched` carrying the
swap-slot is followed immediately by another `:set-touched` carrying only
`#{:geometry-group}`.

### Fix

In `update-attrs-on-switch`, when seeding the redo `:set-touched` op with
`previous-shape`'s touched, also union in any `:swap-slot-*` groups already
present on `current-shape`. The swap-slot is structural metadata (set
upstream by `generate-new-shape-for-swap`), not a user override, so it must
survive the touched copy from the previous shape.

```clojure
roperations [{:type :set-touched
              :touched (into (or (:touched previous-shape) #{})
                             (filter ctk/swap-slot?)
                             (:touched current-shape))}]
```

When `current-shape` has no swap-slot (the common case) the filter yields
nothing and the behaviour is identical to before — so this is a no-op
outside the bug scenario.

### Verification

Tested live in the dev workspace on the project from the issue:

- Switching `primary` → `secondary` no longer crashes; the variant changes
  and the resulting shape carries both `:geometry-group` (from
  `previous-shape`) and `:swap-slot-2f31177d-…c67b38fbdfe9` (preserved from
  `current-shape`).
- Switching back (`secondary` → `primary`) works.
- Switching other property positions (`form`, `state`) works.
- The existing `variants_switch_test.cljc` suite still applies; CI will run it.

### Files changed

- `common/src/app/common/logic/libraries.cljc` — preserve `:swap-slot-*` groups
  in `update-attrs-on-switch`
- `CHANGES.md` — entry under `2.16.0 (Unreleased)` › `:bug:`