### PR TITLE
:bug: Fix sidebar overflow

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -1057,11 +1057,12 @@
         (reset! overflow* (> scroll-height client-height))))
 
     [:*
-     [:div {:ref container}
+     [:div {:class (stl/css :sidebar-content-wrapper)}
       (when nitrate?
         [:div {:class (stl/css :orgs-container)}
          [:> sidebar-org-switch* {:team team :profile profile}]])
-      [:div {:class (stl/css-case :sidebar-content true :sidebar-content-nitrate nitrate?)}
+      [:div {:ref container
+             :class (stl/css-case :sidebar-content true :sidebar-content-nitrate nitrate?)}
        [:> sidebar-team-switch* {:team team :profile profile}]
 
        [:> sidebar-search* {:search-term search-term

--- a/frontend/src/app/main/ui/dashboard/sidebar.scss
+++ b/frontend/src/app/main/ui/dashboard/sidebar.scss
@@ -29,11 +29,20 @@
 }
 
 // SIDEBAR CONTENT COMPONENT
+.sidebar-content-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
 .sidebar-content {
   display: grid;
   grid-template-rows: auto auto auto auto 1fr;
   gap: var(--sp-xxl);
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   padding: 0;
   overflow: hidden auto;
 }

--- a/frontend/src/app/main/ui/dashboard/subscription.scss
+++ b/frontend/src/app/main/ui/dashboard/subscription.scss
@@ -224,7 +224,7 @@
   display: flex;
   border-radius: var(--sp-s);
   flex-direction: column;
-  margin: var(--sp-m);
+  margin: var(--sp-m) var(--sp-m) 0;
   background: var(--color-background-quaternary);
   border: $b-1 solid var(--color-accent-primary-muted);
   padding: var(--sp-l);
@@ -254,7 +254,7 @@
 
 .nitrate-current-plan {
   border-radius: var(--sp-s);
-  margin: 0 var(--sp-m) var(--sp-m) var(--sp-m);
+  margin: var(--sp-m);
   background: var(--color-background-tertiary);
   border: $b-1 solid var(--color-background-quaternary);
   padding: var(--sp-m) var(--sp-l);


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26361

### Summary

The sidebar content could overflow and push down the banners (Nitrate, CTA) and the profile section in the dashboard. Now, the sidebar content scrolls correctly, and the overflow-separator only appears when the content actually overflows above the banners.

### Steps to reproduce 

1. Pin enough projects so that the sidebar content reaches or overflows the banners and the profile section.
2. Observe that:
 - The sidebar content scrolls, and the banners/profile section remain fixed at the bottom.
 - The overflow-separator appears only when the content overflows.

<img width="982" height="590" alt="imagen" src="https://github.com/user-attachments/assets/967fe201-01d1-4c85-a694-ee92d7a3016d" />

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
