### PR TITLE
:fire: Remove stray prn debug log in stroke-row* render

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs
@@ -205,8 +205,6 @@
      (when (some? on-reorder)
        [:> reorder-handler* {:ref dref}])
 
-     (prn "stroke-row*" applied-tokens)
-
      ;; Stroke Color
      ;; FIXME: memorize stroke color
      [:div {:class (stl/css :stroke-color-actions)}


### PR DESCRIPTION
### Related Ticket

N/A

### Summary

A leftover `(prn "stroke-row*" applied-tokens)` call at [stroke_row.cljs:208](frontend/src/app/main/ui/workspace/sidebar/options/rows/stroke_row.cljs#L208) was firing on every render of a stroke row, spamming the browser console whenever the workspace stroke options were visible. The call has been removed so the render path stays quiet. Mirrors the cleanup done previously for `color-row*` and `frame-preview`.

### Steps to reproduce

1. Open any file in the workspace and select a shape that has a stroke.
2. Open the browser devtools console.
3. Observe repeated `stroke-row*` lines being printed on every re-render of the stroke options.
4. After the fix, no such log lines should appear.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
