### PR TITLE
:bug: Fix missing labels.open i18n key surfacing raw key as aria-label

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,7 @@
 - Fix tooltip appearing two times when nested elements [Github #9031](https://github.com/penpot/penpot/issues/9031)
 - Fix broken update library notification link in the UI [Github #9070](https://github.com/penpot/penpot/issues/9070)
 - Fix plugin API `ShapeBase.component()` returning the outermost component instead of the immediate component in case of nested component instances [Github #9183](https://github.com/penpot/penpot/issues/9183)
+- Fix missing `labels.open` translation that surfaced the raw key as the typography font open-button `aria-label`, breaking screen-reader output (by @MilosM348)
 
 ## 2.15.0 (Unreleased)
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -2945,6 +2945,10 @@ msgstr "Old password"
 msgid "labels.only-yours"
 msgstr "Only yours"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:698
+msgid "labels.open"
+msgstr "Open"
+
 #: src/app/main/ui/comments.cljs:911, src/app/main/ui/comments.cljs:976, src/app/main/ui/workspace/palette.cljs:199, src/app/main/ui/workspace/sidebar/options/menus/blur.cljs:107, src/app/main/ui/workspace/sidebar/options/menus/component.cljs:906, src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:155, src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:213, src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs:294, src/app/main/ui/workspace/sidebar/options/menus/interactions.cljs:402, src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs:1031, src/app/main/ui/workspace/sidebar/options/menus/text.cljs:316, src/app/main/ui/workspace/sidebar/options/menus/text.cljs:345, src/app/main/ui/workspace/sidebar/options/rows/shadow_row.cljs:146
 msgid "labels.options"
 msgstr "Options"


### PR DESCRIPTION
```
## Summary

`frontend/src/app/main/ui/workspace/sidebar/options/menus/typography.cljs:698` references the i18n key `labels.open` as the `aria-label` of the typography font open-button:

```
[:> icon-button* {:variant "action"
                  :aria-label (tr "labels.open")
                  :on-click on-open
                  :icon i/menu}]
```

But `labels.open` was never added to `frontend/translations/en.po`. Penpot's `tr` function (in `frontend/src/app/util/i18n.cljs:173-184`) falls back to the literal key string when a translation is missing, so at runtime the button's `aria-label` becomes the string `"labels.open"` rather than `"Open"`. Screen readers announce that as "labels dot open", which is an accessibility regression for users on the typography sidebar.

## Verification

I parsed the current `en.po` through the same `gettext-parser` library that `frontend/scripts/_helpers.js` uses to bundle translations:

```js
import gt from 'gettext-parser';
const data = gt.po.parse(content, 'utf-8');
console.log(data.translations[''].['labels.open']);  // → undefined (before)
console.log(data.translations[''].['labels.open']);  // → ['Open'] (after)
```

Total parsed key count went from 2259 → 2260. No other entries were touched.

## Fix

Adds the missing `labels.open` entry to `en.po`, slotted alphabetically between `labels.only-yours` and `labels.options`, with the source-reference comment pointing at the single callsite. The English msgstr matches the verb form of every other `labels.*` action key (e.g. `labels.close` → "Close", `labels.add` → "Add", `labels.cancel` → "Cancel"):

```