### PR TITLE
:bug: Fix MCP "active in another tab" notification not clearing

### DIFF
--- a/frontend/src/app/main/data/workspace/mcp.cljs
+++ b/frontend/src/app/main/data/workspace/mcp.cljs
@@ -85,7 +85,7 @@
           (update state :mcp assoc :connected-tab id)
 
           (and (= "disconnected" (:connection-status data))
-               (= id (:connection-status mcp-state)))
+               (= id (:connected-tab mcp-state)))
           (update state :mcp dissoc :connected-tab)
 
           :else


### PR DESCRIPTION
### Related Ticket

No open ticket. Regression from #8856 ("Fix MCP active tab switching").

### Summary

In `handle-pong` at [frontend/src/app/main/data/workspace/mcp.cljs:88](frontend/src/app/main/data/workspace/mcp.cljs#L88), the "disconnected" branch compared the broadcaster's session UUID (`id`) against `(:connection-status mcp-state)`, which holds a status string (`"connected"`, `"disconnected"`, or `nil`). Two unrelated value types meant the equality check could never succeed, so `:connected-tab` was never cleared and the "MCP is active in another tab" notification stayed up indefinitely.

The field that actually stores the connected tab's session UUID is `:connected-tab`, set both by `connect-mcp` (line 148) and by the matching `"connected"` branch one line above (line 85). Switching the comparison to `(:connected-tab mcp-state)` restores the symmetry between the connect and disconnect branches and makes the notification clear automatically once the previously connected tab announces it is no longer connected.

### Steps to reproduce

1. Enable MCP in Settings, Integrations, MCP Server, generate a key, and connect a client (Cursor, Claude Desktop, or similar).
2. Open the same workspace in a second browser tab. The second tab shows the "MCP is active in another tab" notification.
3. In the first tab, disconnect MCP via the menu.
4. Before the fix: the notification persists in the second tab until "Switch" is clicked manually. After the fix: the notification dismisses on its own as soon as the `disconnected` pong is received.

<img width="1135" height="188" alt="Screenshot 2026-05-05 093817" src="https://github.com/user-attachments/assets/6da3a9cb-e98e-444d-a2a5-5dadeaa8abec" />


### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. (State-only change; reproduction above covers it.)
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable. (No cross-tab BroadcastChannel harness exists in the repo.)
- [ ] Refactor any modified SCSS files following the refactor guide. (No SCSS touched.)
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
