### PR TITLE
:bug: Fix swapped analytics event names on MCP tab-switch dialog

### DIFF
--- a/frontend/src/app/main/data/workspace/mcp.cljs
+++ b/frontend/src/app/main/data/workspace/mcp.cljs
@@ -185,11 +185,11 @@
                     {:content (tr "notifications.mcp.active-in-another-tab")
                      :cancel {:label (tr "labels.dismiss")
                               :callback #(st/emit! (ntf/hide)
-                                                   (ev/event {::ev/name "confirm-mcp-tab-switch"
+                                                   (ev/event {::ev/name "dismiss-mcp-tab-switch"
                                                               ::ev/origin "workspace-notification"}))}
                      :accept {:label (tr "labels.switch")
                               :callback #(st/emit! (connect-mcp)
-                                                   (ev/event {::ev/name "dismiss-mcp-tab-switch"
+                                                   (ev/event {::ev/name "confirm-mcp-tab-switch"
                                                               ::ev/origin "workspace-notification"}))}})))
           (rx/of (ntf/hide)))))))
 


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/9496

### Summary

The "MCP is active in another tab" dialog records its analytics event names backwards. The Dismiss button (which rejects the switch) emits `confirm-mcp-tab-switch`, while the Switch button (which actually performs the switch via `connect-mcp`) emits `dismiss-mcp-tab-switch`. As a result, every metric derived from these events is inverted, so adoption dashboards report the opposite of what users actually did.

The names are swapped in `frontend/src/app/main/data/workspace/mcp.cljs` so each button reports the action it represents.

### Steps to reproduce

1. Open Penpot in two tabs of the same browser session.
2. Enable MCP in tab A and connect an AI client so the tab claims the MCP session.
3. In tab B, wait for the "MCP is active in another tab" dialog to appear.
4. Open DevTools in tab B, switch to the Network panel, and filter for analytics event requests.
5. Click **Dismiss**: before the fix, the request payload contains `name: "confirm-mcp-tab-switch"`; after the fix, it contains `name: "dismiss-mcp-tab-switch"`.
6. Trigger the dialog again and click **Switch**: before the fix, the payload contains `name: "dismiss-mcp-tab-switch"`; after the fix, it contains `name: "confirm-mcp-tab-switch"`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
