### PR TITLE
:sparkles: Update issue templates to include the issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
-name: New Render Bug Report
-about: Create a report about the bugs you have found in the new render
+name: Bug report
+about: Create a report to help us improve
 title: ''
-labels: new render
-assignees: claragvinola
+labels: ''
+assignees: ''
 type: Bug
 
 ---
@@ -11,7 +11,7 @@ type: Bug
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**Steps to Reproduce**
+**To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -21,8 +21,8 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots or screen recordings**
-If applicable, add screenshots or screen recording to help illustrate your problem.
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+type: Feature
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Added the type "bug" to the "New render bug report" and the "Bug report" templates and the type "feature" to the "Feature request template".

This will allow us to use the issue Type instead of labels to identify what kind of issue is being created