### PR TITLE
:lipstick: Fix typos in comments and docstrings

### DIFF
--- a/backend/src/app/binfile/common.clj
+++ b/backend/src/app/binfile/common.clj
@@ -315,8 +315,8 @@
 (defn get-file
   "Get file, resolve all features and apply migrations.
 
-  Usefull when you have plan to apply massive or not cirurgical
-  operations on file, because it removes the ovehead of lazy fetching
+  Useful when you have plan to apply massive or not surgical
+  operations on file, because it removes the overhead of lazy fetching
   and decoding."
   [cfg file-id & {:as opts}]
   (db/run! cfg get-file* file-id opts))

--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -280,7 +280,7 @@
   (sm/explainer schema:config))
 
 (defn read-config
-  "Reads the configuration from enviroment variables and decodes all
+  "Reads the configuration from environment variables and decodes all
   known values."
   [& {:keys [prefix default] :or {prefix "penpot"}}]
   (->> (read-env prefix)

--- a/backend/src/app/http/sse.clj
+++ b/backend/src/app/http/sse.clj
@@ -21,7 +21,7 @@
 
 (defn- write!
   [^OutputStream output ^bytes data]
-  (l/trc :hint "writting data" :data data :length (alength data))
+  (l/trc :hint "writing data" :data data :length (alength data))
   (.write output data)
   (.flush output))
 

--- a/backend/src/app/rpc/cond.clj
+++ b/backend/src/app/rpc/cond.clj
@@ -19,7 +19,7 @@
     of the object. This function can be applied to the object returned by the
     `get-object` but also to the RPC return value (in case you don't provide
     the return value calculated key under `::key` metadata prop.
-  - `::reuse-key?` enables reusing the key calculated on first time; usefull
+  - `::reuse-key?` enables reusing the key calculated on first time; useful
     when the target object is not retrieved on the RPC (typical on retrieving
     dependent objects).
   "

--- a/common/src/app/common/files/indices.cljc
+++ b/common/src/app/common/files/indices.cljc
@@ -13,7 +13,7 @@
 
 (defn- generate-index
   "An optimized algorithm for calculate parents index that walk from top
-  to down starting from a provided shape-id. Usefull when you want to
+  to down starting from a provided shape-id. Useful when you want to
   create an index for the whole objects or subpart of the tree."
   [index objects shape-id parents]
   (let [shape   (get objects shape-id)

--- a/common/src/app/common/files/shapes_builder.cljc
+++ b/common/src/app/common/files/shapes_builder.cljc
@@ -543,7 +543,7 @@
           (update :svg-attrs dissoc :fill)
           (assoc-in [:fills 0 :fill-color] (clr/parse color-style)))
 
-      ;; Only create an opacity if the color is setted. Othewise can create problems down the line
+      ;; Only create an opacity if the color is set. Otherwise can create problems down the line
       (and (or (clr/color-string? color-attr) (clr/color-string? color-style))
            (dm/get-in shape [:svg-attrs :fillOpacity]))
       (-> (update :svg-attrs dissoc :fillOpacity)

--- a/common/src/app/common/geom/shapes/flex_layout/bounds.cljc
+++ b/common/src/app/common/geom/shapes/flex_layout/bounds.cljc
@@ -12,7 +12,7 @@
    [app.common.geom.shapes.points :as gpo]
    [app.common.types.shape.layout :as ctl]))
 
-;; Setted in app.common.geom.shapes.common-layout
+;; Set in app.common.geom.shapes.common-layout
 ;; We do it this way because circular dependencies
 (def -child-min-width nil)
 

--- a/common/src/app/common/geom/shapes/flex_layout/layout_data.cljc
+++ b/common/src/app/common/geom/shapes/flex_layout/layout_data.cljc
@@ -14,7 +14,7 @@
 
 (def conjv (fnil conj []))
 
-;; Setted in app.common.geom.shapes.min-size-layout
+;; Set in app.common.geom.shapes.min-size-layout
 ;; We do it this way because circular dependencies
 (def -child-min-width nil)
 

--- a/common/src/app/common/geom/shapes/grid_layout/layout_data.cljc
+++ b/common/src/app/common/geom/shapes/grid_layout/layout_data.cljc
@@ -39,7 +39,7 @@
 ;;
 ;;   5. If any track still has an infinite growth limit set its growth limit to its base size.
 
-;; - Distribute extra space accross spaned tracks
+;; - Distribute extra space across spanned tracks
 ;; - Maximize tracks
 ;;
 ;; - Expand flexible tracks
@@ -55,7 +55,7 @@
    [app.common.math :as mth]
    [app.common.types.shape.layout :as ctl]))
 
-;; Setted in app.common.geom.shapes.common-layout
+;; Set in app.common.geom.shapes.common-layout
 ;; We do it this way because circular dependencies
 (def -child-min-width nil)
 
@@ -449,7 +449,7 @@
          column-tracks (set-auto-base-size column-tracks children shape-cells bounds objects :column)
          row-tracks    (set-auto-base-size row-tracks children shape-cells bounds objects :row)
 
-         ;; Adjust multi-spaned cells with no flex columns
+         ;; Adjust multi-spanned cells with no flex columns
          column-tracks (set-auto-multi-span parent column-tracks children-map shape-cells bounds objects :column)
          row-tracks (set-auto-multi-span parent row-tracks children-map shape-cells bounds objects :row)
 

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -1840,7 +1840,7 @@
 
                 ;; On texts, when we want to omit the touched attrs, both text (the actual letters)
                 ;; and attrs (bold, font, etc) are in the same attr :content.
-                ;; If only one of them is touched, we want to adress this case and
+                ;; If only one of them is touched, we want to address this case and
                 ;; only update the untouched one
                 text-content-change?
                 (and omit-touched?
@@ -2163,7 +2163,7 @@
 
               ;; On texts, both text (the actual letters)
               ;; and attrs (bold, font, etc) are in the same attr :content.
-              ;; If only one of them is touched, we want to adress this case and
+              ;; If only one of them is touched, we want to address this case and
               ;; only update the untouched one
               text-change?
               (and (not skip-operations?)

--- a/common/src/app/common/types/container.cljc
+++ b/common/src/app/common/types/container.cljc
@@ -259,7 +259,7 @@
    (some? (find-component-main objects shape only-direct-child?))))
 
 (defn in-any-component?
-  "Check if the shape is part of any component (main or copy), wether it's
+  "Check if the shape is part of any component (main or copy), whether it's
    head or not."
   [objects shape]
   (or (ctk/in-component-copy? shape)

--- a/common/src/app/common/types/shape/layout.cljc
+++ b/common/src/app/common/types/shape/layout.cljc
@@ -1074,7 +1074,7 @@
           (maybe-remove?)))))
 
 (defn check-deassigned-cells
-  "Clean the cells whith shapes that are no longer in the layout"
+  "Clean the cells with shapes that are no longer in the layout"
   [parent objects]
 
   (let [child-set (set (:shapes parent))

--- a/frontend/src/app/main.cljs
+++ b/frontend/src/app/main.cljs
@@ -110,10 +110,10 @@
 
 (defn ^:export init
   [options]
-  ;; WORKAROUND: we set this really not usefull property for signal a
-  ;; sideffect and prevent GCC remove it. We need it because we need
+  ;; WORKAROUND: we set this really not useful property for signal a
+  ;; side effect and prevent GCC remove it. We need it because we need
   ;; to populate the Date prototype with transit related properties
-  ;; before SES hardning is applied on loading MCP plugin
+  ;; before SES hardening is applied on loading MCP plugin
   (unchecked-set js/globalThis "penpotStartDate"
                  (-> (ct/now)
                      (t/encode-str)

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -359,7 +359,7 @@
                    (rx/of (du/fetch-access-tokens))))
 
                 ;; Once the essential data is fetched, lets proceed to
-                ;; fetch teh file bunldle
+                ;; fetch the file bundle
                 (rx/of (initialize-file team-id file-id)))
 
                (->> stream

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -696,7 +696,7 @@
       (let [page-id          (:current-page-id state)
             file-id          (:current-file-id state)
 
-            ;; FIXME: revisit, innefficient access
+            ;; FIXME: revisit, inefficient access
             objects          (dsh/lookup-page-objects state page-id)
 
             libraries        (dsh/lookup-libraries state)

--- a/frontend/src/app/main/data/workspace/tokens/application.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/application.cljs
@@ -732,7 +732,7 @@
 
 (defn apply-spacing-token-separated
   "Handles edge-case for spacing token when applying token via toggle button.
-  Splits out `shape-ids` into seperate default actions:
+  Splits out `shape-ids` into separate default actions:
   - Layouts take the `default` update function
   - Shapes inside layout will only take margin"
   [{:keys [token shapes attr]}]

--- a/frontend/src/app/main/ui/context.cljs
+++ b/frontend/src/app/main/ui/context.cljs
@@ -35,7 +35,7 @@
 
 (def sidebar
   "A context that intends to store the current sidebar position,
-  usefull for components that behaves distinctly if they are showed in
+  useful for components that behaves distinctly if they are showed in
   right sidebar or left sidebar.
 
   Possible values: `:right:` and `:left`."

--- a/frontend/src/app/main/ui/shapes/filters.cljs
+++ b/frontend/src/app/main/ui/shapes/filters.cljs
@@ -137,7 +137,7 @@
   (if (or (mth/close? 0.01 (:width selrect))
           (mth/close? 0.01 (:height selrect)))
 
-    ;; We cannot use "objectBoundingbox" if the shape doesn't have width/heigth
+    ;; We cannot use "objectBoundingbox" if the shape doesn't have width/height
     ;; From the SVG spec (https://www.w3.org/TR/SVG11/coords.html#ObjectBoundingBox
     ;; Keyword objectBoundingBox should not be used when the geometry of the applicable element
     ;; has no width or no height, such as the case of a horizontal or vertical line, even when


### PR DESCRIPTION
### Related Ticket

No ticket filed. Continues the cosmetic typo cleanup started in #9204, #9241, and #9250.

### Summary

Spelling corrections in comments, docstrings, and one log-message string spread across the common, frontend, and backend namespaces. Behavior is unchanged.

Notable corrections:

* `setted` to `set`, `Othewise` to `Otherwise`
* `heigth` to `height`, `seperate` to `separate`, `adress` to `address`
* `whith` to `with`, `wether` to `whether`, `usefull` to `useful`
* `innefficient` to `inefficient`, `enviroment` to `environment`
* `cirurgical` to `surgical`, `ovehead` to `overhead`
* `accross` to `across`, `spaned` to `spanned`
* `sideffect` to `side effect`, `hardning` to `hardening`
* `teh file bunldle` to `the file bundle`, `writting` to `writing`

Files touched:

* common: `files/shapes_builder.cljc`, `files/indices.cljc`, `types/shape/layout.cljc`, `types/container.cljc`, `logic/libraries.cljc`, `geom/shapes/flex_layout/layout_data.cljc`, `geom/shapes/flex_layout/bounds.cljc`, `geom/shapes/grid_layout/layout_data.cljc`
* frontend: `main.cljs`, `ui/context.cljs`, `ui/shapes/filters.cljs`, `data/workspace.cljs`, `data/workspace/libraries.cljs`, `data/workspace/tokens/application.cljs`
* backend: `config.clj`, `binfile/common.clj`, `rpc/cond.clj`, `http/sse.clj`

### Steps to reproduce

Not applicable. Comment, docstring, and log-string text only; runtime behavior is unaffected.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
