### PR TITLE
:bug: Remove stray println debug calls in main menu and register

### DIFF
--- a/frontend/src/app/main/ui/auth/register.cljs
+++ b/frontend/src/app/main/ui/auth/register.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.data.macros :as dm]
+   [app.common.logging :as log]
    [app.common.schema :as sm]
    [app.config :as cf]
    [app.main.data.auth :as da]
@@ -104,7 +105,7 @@
 
                (do
                  (when-let [explain (get edata :explain)]
-                   (println explain))
+                   (log/error :hint "register error" :explain explain))
                  (st/emit! (ntf/error (tr "errors.generic"))))))))
 
         on-success

--- a/frontend/src/app/main/ui/workspace/main_menu.cljs
+++ b/frontend/src/app/main/ui/workspace/main_menu.cljs
@@ -128,7 +128,6 @@
            (let [version (:main cf/version)]
              (st/emit! (ptk/event ::ev/event {::ev/name "show-release-notes"
                                               :version version}))
-             (println version)
              (if (and (kbd/alt? event) (kbd/mod? event))
                (st/emit! (modal/show {:type :onboarding}))
                (st/emit! (modal/show {:type :release-notes


### PR DESCRIPTION
### Related Ticket

N/A

### Summary

Two leftover `println` calls were firing in production code paths and leaking diagnostic data to the browser console.

* `frontend/src/app/main/ui/workspace/main_menu.cljs` printed the release notes version on every menu open. The version is already captured by the preceding analytics event, so the call has been deleted.
* `frontend/src/app/main/ui/auth/register.cljs` printed the schema explanation on the generic registration error branch. The call has been routed through `app.common.logging` as `log/error`.

### Steps to reproduce

1. Open Penpot in a browser with the developer console visible.
2. Workspace path: open any file, open the main menu, then click *Help & info → Release notes*. The console should stay clean (previously the version string was printed).
3. Auth path: trigger a registration failure that lands in the generic error branch with `:explain` data attached. The console should stay clean of raw `println` output; structured `log/error` output is emitted instead.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
