### PR TITLE
:bug: Remove stray println debug logs from dashboard team invitations

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -924,7 +924,6 @@
         on-error
         (fn [form]
           (let [{:keys [type code] :as error} (ex-data form)]
-            (println form)
             (cond
               (and (= :validation type)
                    (= :profile-is-muted code))
@@ -986,7 +985,6 @@
                  new-direction (if (= current-field :status)
                                  (if (= current-direction :asc) :desc :asc)
                                  :asc)]
-             (println @invitations)
              (swap! sort-state assoc :field :status :direction new-direction)
              (swap! invitations #(let [sorted (sort-by (juxt :expired :email) %)]
                                    (if (= new-direction :desc)


### PR DESCRIPTION
### Related Ticket

Github bug report: stray println debug logs left in dashboard team invitations panel.

### Summary

Two leftover `println` calls in [frontend/src/app/main/ui/dashboard/team.cljs](frontend/src/app/main/ui/dashboard/team.cljs) were emitting diagnostics to the browser console:

* The invitations `on-error` handler dumped the rejected exception's `ex-data` on every failed invitation action (muted profile, quota reached, bounced address, and so on).
* The `on-order-by-status` handler dumped the full invitations list every time the *Status* column header was clicked to re-sort.

Both prints have been dropped. No behavior change beyond a quiet console, mirroring the cleanup already done in PRs #9243 and #9258.

### Steps to reproduce

1. Open Penpot in the browser with the developer console visible.
2. Go to *Dashboard → Team settings → Invitations*.
3. Trigger any failure path on an invitation action (for example, send an invite to an address that resolves to `:profile-is-muted` or `:max-quote-reached`) and confirm no `ex-data` payload is logged.
4. Click the *Status* column header to re-sort the invitation list and confirm the invitations vector is no longer logged.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
