### PR TITLE
:bug: Fix plugin schema-error formatter losing field name

### DIFF
--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -276,13 +276,68 @@
   (let [s (set values)]
     (if (= (count s) 1) (first s) "mixed")))
 
+(defn- error-path-segment->str
+  "Stringify one segment of a schema-explain path.
+
+  Keywords lose the leading colon, ints are kept verbatim (so tuple positions
+  read as ``\"applyToken.0\"`` rather than crashing through ``name``), and
+  anything else falls through ``str``."
+  [seg]
+  (cond
+    (keyword? seg) (name seg)
+    (string? seg)  seg
+    :else          (str seg)))
+
+(defn- error-path->label
+  "Render the dotted field path that the user sees in the error message.
+
+  Empty paths fall back to ``\"value\"`` so the formatted message never reads
+  ``\"Field  is invalid: …\"`` when the schema rejects the whole input."
+  [path]
+  (if (seq path)
+    (str/join "." (map error-path-segment->str path))
+    "value"))
+
+(defn collect-schema-error-leaves
+  "Walk the nested error map produced by ``csm/interpret-schema-problem`` and
+  emit a sequence of ``[field-path message]`` pairs, one per leaf.
+
+  Each leaf is the ``{:message <string>}`` map that the reducer assoc-ins under
+  the offending field path. Returning the *full* path (rather than just the
+  innermost key, as the prior implementation did) keeps the eventual user
+  message anchored to the property the plugin actually called — for example
+  ``applyToken.1`` instead of the unhelpful ``message``."
+  ([m] (collect-schema-error-leaves [] m))
+  ([path m]
+   (cond
+     (and (map? m)
+          (contains? m :message)
+          (== 1 (count m)))
+     [[path (:message m)]]
+
+     (map? m)
+     (mapcat (fn [[k v]] (collect-schema-error-leaves (conj path k) v)) m)
+
+     :else
+     [])))
+
 (defn error-messages
+  "Render an ``::sm/explain`` map into a list of human-readable plugin errors.
+
+  The previous implementation iterated entries of the inner ``{:message …}``
+  map and destructured each value, which silently produced a literal
+  ``\"Field message is invalid: \"`` string for any single-level schema failure
+  (issue #9290). The walker now collects every leaf with its full field path so
+  the formatted line names the offending property and the message body is the
+  schema's own explanation."
   [explain]
   (->> (:errors explain)
        (reduce csm/interpret-schema-problem {})
-       (mapcat (comp seq val))
-       (map (fn [[field {:keys [message]}]]
-              (tr "plugins.validation.message" (name field) message)))
+       (collect-schema-error-leaves)
+       (map (fn [[path message]]
+              (tr "plugins.validation.message"
+                  (error-path->label path)
+                  (or message ""))))
        (str/join ". ")))
 
 (defn handle-error

--- a/frontend/test/frontend_tests/plugins/utils_test.cljs
+++ b/frontend/test/frontend_tests/plugins/utils_test.cljs
@@ -1,0 +1,109 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns frontend-tests.plugins.utils-test
+  "Regression coverage for the schema-explain walker that backs the
+   ``[PENPOT PLUGIN] Value not valid: …`` console error.
+
+   Pre-fix the walker collapsed every leaf to its inner ``:message`` key,
+   producing the literal string ``\"Field message is invalid: \"`` for any
+   single-level schema failure (issue #9290 — ``applyToken`` on color /
+   dimension / opacity tokens). The replacement function is pure and exercised
+   here against the *post-reduce* shape returned by
+   ``app.common.schema.messages/interpret-schema-problem``."
+  (:require
+   [app.plugins.utils :as pu]
+   [cljs.test :as t :include-macros true]))
+
+(defn- as-leaves
+  "Convert the lazy seq ``collect-schema-error-leaves`` returns into a stable
+   set of vectors so test assertions are order-independent."
+  [m]
+  (->> (pu/collect-schema-error-leaves m)
+       (map vec)
+       set))
+
+;; ---------------------------------------------------------------------------
+;; Single-level field paths — the regression case behind issue #9290
+;; ---------------------------------------------------------------------------
+
+(t/deftest test-collect-leaves-single-level-keyword-path
+  ;; What ``interpret-schema-problem`` produces for an ``error/field`` named
+  ;; ``:applyToken`` is ``{:applyToken {:message "..."}}``. The pre-fix walker
+  ;; turned this into ``[:message "..."]`` pairs and lost the field name; the
+  ;; replacement keeps the full path.
+  (let [errors {:applyToken {:message "Not a valid token attribute"}}]
+    (t/is (= #{[[:applyToken] "Not a valid token attribute"]}
+             (as-leaves errors)))))
+
+(t/deftest test-collect-leaves-single-level-numeric-tuple-position
+  ;; Tuple-shaped schemas (e.g. the ``applyToken`` arity validator) report
+  ;; ``in [<index>]`` for the offending positional argument. The walker must
+  ;; survive integer path segments — calling ``name`` on them used to crash.
+  (let [errors {1 {:message "Expected a set of token attributes"}}]
+    (t/is (= #{[[1] "Expected a set of token attributes"]}
+             (as-leaves errors)))))
+
+(t/deftest test-collect-leaves-single-level-string-path
+  (let [errors {"width" {:message "Out of range"}}]
+    (t/is (= #{[["width"] "Out of range"]}
+             (as-leaves errors)))))
+
+;; ---------------------------------------------------------------------------
+;; Nested field paths
+;; ---------------------------------------------------------------------------
+
+(t/deftest test-collect-leaves-nested-keyword-path
+  (let [errors {:applyToken {:properties {:message "Unknown property"}}}]
+    (t/is (= #{[[:applyToken :properties] "Unknown property"]}
+             (as-leaves errors)))))
+
+(t/deftest test-collect-leaves-nested-mixed-path
+  (let [errors {:applyToken {1 {:message "Element type mismatch"}}}]
+    (t/is (= #{[[:applyToken 1] "Element type mismatch"]}
+             (as-leaves errors)))))
+
+(t/deftest test-collect-leaves-multiple-sibling-errors
+  (let [errors {:applyToken {:message "Token argument missing"}
+                :properties {:message "Property list invalid"}}]
+    (t/is (= #{[[:applyToken] "Token argument missing"]
+               [[:properties] "Property list invalid"]}
+             (as-leaves errors)))))
+
+(t/deftest test-collect-leaves-deep-and-shallow-mix
+  (let [errors {:a {:message "Top-level fail"}
+                :b {:c {:message "Nested fail"}
+                    :d {:e {:message "Deeper fail"}}}}]
+    (t/is (= #{[[:a]      "Top-level fail"]
+               [[:b :c]   "Nested fail"]
+               [[:b :d :e] "Deeper fail"]}
+             (as-leaves errors)))))
+
+;; ---------------------------------------------------------------------------
+;; Empty / degenerate inputs
+;; ---------------------------------------------------------------------------
+
+(t/deftest test-collect-leaves-empty-input
+  (t/is (empty? (pu/collect-schema-error-leaves {}))))
+
+(t/deftest test-collect-leaves-skips-nil-leaves
+  ;; ``interpret-schema-problem`` only emits ``{:message <string>}`` shapes,
+  ;; but defensive coverage keeps us safe if a future caller hands us a
+  ;; partial node.
+  (let [errors {:applyToken nil
+                :properties {:message "Real failure"}}]
+    (t/is (= #{[[:properties] "Real failure"]}
+             (as-leaves errors)))))
+
+;; ---------------------------------------------------------------------------
+;; ``error-messages`` — minimal smoke that the public entry point is still
+;; total. ``interpret-schema-problem`` is invoked over an empty ``:errors``
+;; sequence so we get a deterministic empty string without depending on the
+;; malli runtime to synthesize a realistic explain in the test environment.
+;; ---------------------------------------------------------------------------
+
+(t/deftest test-error-messages-empty-explain-returns-empty-string
+  (t/is (= "" (pu/error-messages {:errors []}))))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -22,6 +22,7 @@
    [frontend-tests.plugins.context-shapes-test]
    [frontend-tests.plugins.parser-test]
    [frontend-tests.plugins.tokens-test]
+   [frontend-tests.plugins.utils-test]
    [frontend-tests.svg-fills-test]
    [frontend-tests.tokens.import-export-test]
    [frontend-tests.tokens.logic.token-actions-test]
@@ -68,6 +69,7 @@
    'frontend-tests.plugins.context-shapes-test
    'frontend-tests.plugins.parser-test
    'frontend-tests.plugins.tokens-test
+   'frontend-tests.plugins.utils-test
    'frontend-tests.svg-fills-test
    'frontend-tests.tokens.import-export-test
    'frontend-tests.tokens.logic.token-actions-test


### PR DESCRIPTION
### Related Ticket

Fixes #9290 — `Plugin API: applyToken fails with "Field message is invalid" on color/dimension/opacity tokens (SDK 2.15)`.

### Summary

Plugins that exercised any schema-validated method (`shape.applyToken`, the `Library.createColor` parser, `font*` setters, etc.) saw a useless console error whenever a single-level schema check failed:

```
[PENPOT PLUGIN] Value not valid: Field message is invalid: . Code: :error
```

The literal token `message` came from the *internal* `:message` key of `interpret-schema-problem` — not from any user-facing field name — and the trailing colon-with-no-message came from the destructure binding to `nil`.

Root cause is in `app.plugins.utils/error-messages` (`frontend/src/app/plugins/utils.cljs`):

```clojure
;; before
(->> (:errors explain)
     (reduce csm/interpret-schema-problem {})
     (mapcat (comp seq val))
     (map (fn [[field {:keys [message]}]]
            (tr "plugins.validation.message" (name field) message)))
     (str/join ". "))
```

`interpret-schema-problem` builds a nested map and `assoc-in`s `{:message <string>}` under the offending field path. For the typical single-level failure (`{:applyToken {:message "…"}}`) the previous walker iterated the *inner* map, so:

- `field` was bound to `:message` (the leaf key) instead of the actual field name.
- `{:keys [message]}` was destructured against the *string* leaf, so `message` was `nil`.

The result was a fixed `"Field message is invalid: "` for every plugin schema failure — exactly the symptom in the bug report.

### Fix

Replaced the inline `mapcat` chain with a small recursive walker, `collect-schema-error-leaves`, that emits `[field-path message]` pairs from every leaf in the post-reduce tree. The renderer joins the path with `.` and falls back to `"value"` when the schema rejects the whole input. Numeric path segments (tuple positions) are stringified safely so callers like `applyToken` (whose schema is a `[:tuple …]`) now read `"applyToken.1"` instead of crashing through `name`.

After the fix, a `r.applyToken(tok, ['fill'])` call that hits the validator surfaces something like:

```
[PENPOT PLUGIN] Value not valid: Field applyToken.1 is invalid: Expected a set of token attributes. Code: :error
```

…which actually points at the offending argument.

### Steps to reproduce

The reporter's repro applies verbatim:

```js
const tokens = penpot.library.local.tokens;
const core   = tokens.sets.find(s => s.name === 'core');
const tok    = core.tokens.find(t => t.name === 'palette.gold.50');
const r      = penpot.createRectangle();
r.x = 100; r.y = 100; r.resize(80, 80);
r.applyToken(tok, ['fill']); // before: "Field message is invalid: ."
```

After the patch, if the call still fails (e.g. permission, attribute kind), the console message names the actual offending field and includes the schema's own message body. The original token-application bug surfaces *underneath* this fix and is out of scope here.

### Tests

Added `frontend/test/frontend_tests/plugins/utils_test.cljs` covering the walker:

- single-level keyword path
- single-level numeric (tuple) position — would previously crash through `name`
- single-level string path
- nested keyword and mixed paths
- multiple sibling errors
- empty input
- defensive nil-leaf handling

Plus a smoke test that `error-messages` returns `""` for an empty explain.

The new test namespace is registered in `frontend/test/frontend_tests/runner.cljs`.

`clj-kondo` lints clean on every touched file.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. *(Console-only error string change.)*
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide. *(No SCSS touched.)*
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable. *(Plugin-API error message detail — happy to add an entry if maintainers prefer.)*