### PR TITLE
:bug: Fix date issue in nitrate activation success modal

### DIFF
--- a/frontend/src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs
@@ -7,7 +7,6 @@
 (ns app.main.ui.nitrate.nitrate-activation-success-modal
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.data.macros :as dm]
    [app.common.time :as ct]
    [app.main.data.modal :as modal]
    [app.main.data.nitrate :as dnt]
@@ -20,17 +19,18 @@
 
 (mf/defc nitrate-activation-success-modal*
   {::mf/register modal/components
-   ::mf/register-as :nitrate-activation-success
-   ::mf/wrap-props true}
-  [props]
+   ::mf/register-as :nitrate-activation-success}
+  []
 
-  (let [profile      (mf/deref refs/profile)
-        light?       (= "light" (:theme profile))
-        svg-id       (if light? "logo-subscription-light" "logo-subscription")
+  (let [profile         (mf/deref refs/profile)
+        light?          (= "light" (:theme profile))
+        svg-id          (if light? "logo-subscription-light" "logo-subscription")
 
-        cancel-at     (dm/get-in props [:subscription :cancel-at])
-        date-str      (when cancel-at
-                        (ct/format-inst cancel-at "d MMMM, yyyy"))
+        nitrate-license (:subscription profile)
+        cancel-at       (:cancel-at nitrate-license)
+        manual?         (:manual nitrate-license)
+        date-str        (when cancel-at
+                          (ct/format-inst cancel-at "d MMMM, yyyy"))
 
         on-create-org
         (mf/use-fn
@@ -52,8 +52,9 @@
         [:div {:class (stl/css :modal-title)}
          (tr "nitrate.activation-success.title")]
 
-        [:p {:class (stl/css :modal-text-primary)}
-         (tr "nitrate.activation-success.active-until" date-str)]
+        (when (and manual? date-str)
+          [:p {:class (stl/css :modal-text-primary)}
+           (tr "nitrate.activation-success.active-until" date-str)])
 
         [:p {:class (stl/css :modal-text)}
          (tr "nitrate.activation-success.manage-info")]

--- a/frontend/src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs
@@ -41,10 +41,10 @@
              (when (seq code)
                (->> (rp/cmd! ::redeem-nitrate-activation-code {:activation-code code})
                     (rx/subs!
-                     (fn [result]
+                     (fn [_]
                        (modal/hide!)
                        (st/emit!
-                        (modal/show {:type :nitrate-activation-success :subscription result})
+                        (modal/show {:type :nitrate-activation-success})
                         (dprof/refresh-profile)))
                      (fn [error]
                        ;; TODO: "Already used" is not yet detectable (CC upserts on reuse).

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -499,7 +499,7 @@
           ^boolean show-subscription-success-modal?
           (st/emit!
            (if (= params-subscription "subscribed-to-penpot-nitrate")
-             (modal/show :nitrate-activation-success {})
+             (modal/show :nitrate-activation-success)
              (modal/show :subscription-success
                          {:subscription-name (if (= params-subscription "subscribed-to-penpot-unlimited")
                                                (if (= success-modal-is-trial? "true")


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26374

### Summary

Cancelation date in the activation success modal should only appear on manual subscriptions.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
