### PR TITLE
:sparkles: Remove nitrate teams with expired license from the teams list

### DIFF
--- a/backend/src/app/rpc/commands/teams.clj
+++ b/backend/src/app/rpc/commands/teams.clj
@@ -194,7 +194,9 @@
   (dm/with-open [conn (db/open pool)]
     (cond->> (get-teams conn profile-id)
       (contains? cf/flags :nitrate)
-      (map #(nitrate/add-org-info-to-team cfg % params)))))
+      (map #(nitrate/add-org-info-to-team cfg % params))
+      (contains? cf/flags :nitrate)
+      (remove #(get-in % [:organization :expired-license])))))
 
 (def ^:private sql:get-owned-teams
   "SELECT t.id, t.name,

--- a/common/src/app/common/types/organization.cljc
+++ b/common/src/app/common/types/organization.cljc
@@ -16,6 +16,7 @@
    [:owner-id ::sm/uuid]
    [:avatar-bg-url ::sm/uri]
    [:logo-id {:optional true} [:maybe ::sm/uuid]]
+   [:expired-license {:optional true} [:maybe :boolean]]
    [:permissions {:optional true}
     [:maybe [:map
              [:create-teams {:optional true} [:maybe [:enum "any" "onlyMe"]]]
@@ -30,7 +31,7 @@
 
 (def organization->team-keys
   "Organization field keys to include in the nested :organization map."
-  [:id :name :custom-photo :slug :avatar-bg-url :owner-id :permissions])
+  [:id :name :custom-photo :slug :avatar-bg-url :owner-id :expired-license :permissions])
 
 (defn apply-organization
   "Updates a team map with organization fields in a nested :organization map.


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/us/13839

### Summary

Remove nitrate teams with expired license from the teams list

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
