### PR TITLE
:recycle: Migrate inspect fill/stroke deprecated blocks to modern syntax

### DIFF
--- a/frontend/src/app/main/ui/inspect/attributes/fill.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/fill.cljs
@@ -27,8 +27,7 @@
 
 ;; DEPRECATED, use fill-block-styles* instead.
 ;; This component is kept for backward compatibility
-(mf/defc fill-block
-  {::mf/wrap-props false}
+(mf/defc fill-block*
   [{:keys [objects shape]}]
   (let [format*   (mf/use-state :hex)
         format    (deref format*)
@@ -84,7 +83,7 @@
                                       :shape shape}])
             (if (seq (:fills shape))
               (for [value (:fills shape [])]
-                [:& fill-block {:key (str "fill-block-" (:id shape) value)
-                                :shape value}])
-              [:& fill-block {:key (str "fill-block-only" (:id shape))
-                              :shape shape}])))]])))
+                [:> fill-block* {:key (str "fill-block-" (:id shape) value)
+                                 :shape value}])
+              [:> fill-block* {:key (str "fill-block-only" (:id shape))
+                               :shape shape}])))]])))

--- a/frontend/src/app/main/ui/inspect/attributes/stroke.cljs
+++ b/frontend/src/app/main/ui/inspect/attributes/stroke.cljs
@@ -31,8 +31,7 @@
 
 ;; DEPRECATED, use stroke-block-styles* instead.
 ;; This component is kept for backward compatibility
-(mf/defc stroke-block
-  {::mf/wrap-props false}
+(mf/defc stroke-block*
   [{:keys [objects shape stroke]}]
   (let [format*   (mf/use-state :hex)
         format    (deref format*)
@@ -100,6 +99,6 @@
                                         :shape shape
                                         :color-space color-space
                                         :stroke stroke}]
-              [:& stroke-block {:key (str "stroke-color-" (:id shape) stroke)
-                                :shape shape
-                                :stroke stroke}])))]])))
+              [:> stroke-block* {:key (str "stroke-color-" (:id shape) stroke)
+                                 :shape shape
+                                 :stroke stroke}])))]])))


### PR DESCRIPTION
### Related Ticket

Refs #9260 — Refactor penpot legacy components.

### Summary

Migrates the two deprecated-but-still-used `fill-block` and `stroke-block` components in the inspect attribute panels from the legacy `mf/defc` form (with `{::mf/wrap-props false}`) to the modern `mf/defc*` form, following the canonical pattern from #9264 and merged #9265.

Both components are explicitly marked `;; DEPRECATED, use *-block-styles* instead` in the source. They are still exercised when the `:inspect-styles` flag is **off** (the default branch), so this is a syntactic migration with zero behaviour change — the deprecation pathway stays alive for the flag-disabled fallback.

For each component:
- Drop `{::mf/wrap-props false}` from the metadata map.
- Append `*` to the component name.
- Update the two internal `[:&` call-sites (the in-file fallback branches in `fill-panel*` and `stroke-panel*`) to `[:>`.

Both components are *internally* used only — the deprecated names are not referenced from any other namespace, so this PR has no external call-site cascade.

### Steps to reproduce

The deprecated branches render whenever the experimental `:inspect-styles` feature flag is **not enabled**. To verify:

1. Run the frontend in dev mode with the default flag set (no `:inspect-styles`).
2. Open the inspect panel on a shape that has a fill and a stroke.
3. Confirm the Background and Border-color rows render with the expected per-property values and that the copy buttons still work.
4. Toggle `:inspect-styles` on and confirm the modern `*-block-styles*` branch still renders identically (it was untouched by this PR).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. *(No visual changes — purely a syntax / contract migration.)*
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable. *(No behaviour change.)*
- [ ] Refactor any modified SCSS files following the refactor guide. *(No SCSS touched.)*
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable. *(Internal refactor only — not user-visible.)*