### PR TITLE
:bug: Route Google fonts fetch warning through project logger

### DIFF
--- a/frontend/src/app/main/fonts.cljs
+++ b/frontend/src/app/main/fonts.cljs
@@ -151,7 +151,7 @@
   (->> (http/send! {:method :get :uri url :mode :cors :response-type :text})
        (rx/map :body)
        (rx/catch (fn [err]
-                   (.warn js/console "Cannot find the font" (obj/get err "message"))
+                   (log/wrn :hint "cannot find the font" :cause err)
                    (rx/empty)))))
 
 (defmethod load-font :google


### PR DESCRIPTION
### Related Ticket

N/A.

### Summary

The catch handler in `fetch-gfont-css` (`frontend/src/app/main/fonts.cljs`) was the only call site in the namespace that wrote straight to `js/console.warn`. The rest of the file already routes through `app.common.logging`, and the namespace sets `(log/set-level! :warn)` at the top, so the stray `console.warn` was inconsistent both in formatting and in level handling.

The catch now calls `(log/wrn :hint "cannot find the font" :cause err)`. Recovery behaviour is unchanged: the stream still continues with `rx/empty` once the warning has been logged.

### Steps to reproduce

1. Run the frontend offline, or block requests to `https://fonts.gstatic.com`.
2. Open a file that uses a Google font.
3. Open the browser DevTools console.

Before: a bare `Cannot find the font <message>` line printed via `console.warn`, with no logger header and no exception context.

After: a regular project log line, formatted as `WRN <ts> [app.main.fonts] hint="cannot find the font"`, followed by the wrapped network error with its `ex-data` and stack trace.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
