### PR TITLE
:bug: Translate flex and grid layout panel button titles

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
@@ -163,6 +163,51 @@
         :space-between i/align-content-row-between
         :stretch       i/align-content-row-stretch))))
 
+(defn- direction-title
+  [val]
+  (case val
+    :row            (tr "workspace.options.layout.direction.row")
+    :row-reverse    (tr "workspace.options.layout.direction.row-reverse")
+    :column         (tr "workspace.options.layout.direction.column")
+    :column-reverse (tr "workspace.options.layout.direction.column-reverse")))
+
+(defn- align-items-title
+  [val]
+  (case val
+    :start  (tr "workspace.options.layout.align-items.start")
+    :center (tr "workspace.options.layout.align-items.center")
+    :end    (tr "workspace.options.layout.align-items.end")))
+
+(defn- align-content-title
+  [val]
+  (case val
+    :start         (tr "workspace.options.layout.align-content.start")
+    :center        (tr "workspace.options.layout.align-content.center")
+    :end           (tr "workspace.options.layout.align-content.end")
+    :space-between (tr "workspace.options.layout.align-content.space-between")
+    :space-around  (tr "workspace.options.layout.align-content.space-around")
+    :space-evenly  (tr "workspace.options.layout.align-content.space-evenly")))
+
+(defn- justify-content-title
+  [val]
+  (case val
+    :start         (tr "workspace.options.layout.justify-content.start")
+    :center        (tr "workspace.options.layout.justify-content.center")
+    :end           (tr "workspace.options.layout.justify-content.end")
+    :space-between (tr "workspace.options.layout.justify-content.space-between")
+    :space-around  (tr "workspace.options.layout.justify-content.space-around")
+    :space-evenly  (tr "workspace.options.layout.justify-content.space-evenly")))
+
+(defn- justify-items-title
+  [val]
+  (case val
+    :start         (tr "workspace.options.layout.justify-items.start")
+    :center        (tr "workspace.options.layout.justify-items.center")
+    :end           (tr "workspace.options.layout.justify-items.end")
+    :space-around  (tr "workspace.options.layout.justify-items.space-around")
+    :space-between (tr "workspace.options.layout.justify-items.space-between")
+    :stretch       (tr "workspace.options.layout.justify-items.stretch")))
+
 (mf/defc direction-row-flex
   {::mf/props :obj
    ::mf/private true}
@@ -174,19 +219,19 @@
                      :name "flex-direction"}
    [:& radio-button {:value "row"
                      :id "flex-direction-row"
-                     :title "Row"
+                     :title (direction-title :row)
                      :icon (dir-icons-refactor :row)}]
    [:& radio-button {:value "row-reverse"
                      :id "flex-direction-row-reverse"
-                     :title "Row reverse"
+                     :title (direction-title :row-reverse)
                      :icon (dir-icons-refactor :row-reverse)}]
    [:& radio-button {:value "column"
                      :id "flex-direction-column"
-                     :title "Column"
+                     :title (direction-title :column)
                      :icon (dir-icons-refactor :column)}]
    [:& radio-button {:value "column-reverse"
                      :id "flex-direction-column-reverse"
-                     :title "Column reverse"
+                     :title (direction-title :column-reverse)
                      :icon (dir-icons-refactor :column-reverse)}]])
 
 (mf/defc wrap-row
@@ -195,8 +240,8 @@
   [:button {:class (stl/css-case :wrap-button true
                                  :selected (= wrap-type :wrap))
             :title (if (= :wrap wrap-type)
-                     "No wrap"
-                     "Wrap")
+                     (tr "workspace.options.layout.no-wrap")
+                     (tr "workspace.options.layout.wrap"))
             :on-click on-click}
    deprecated-icon/wrap])
 
@@ -210,15 +255,15 @@
                      :name "flex-align-items"}
    [:& radio-button {:value "start"
                      :icon  (get-layout-flex-icon :align-items :start is-column)
-                     :title "Align items start"
+                     :title (align-items-title :start)
                      :id     "align-items-start"}]
    [:& radio-button {:value "center"
                      :icon  (get-layout-flex-icon :align-items :center is-column)
-                     :title "Align items center"
+                     :title (align-items-title :center)
                      :id    "align-items-center"}]
    [:& radio-button {:value "end"
                      :icon  (get-layout-flex-icon :align-items :end is-column)
-                     :title "Align items end"
+                     :title (align-items-title :end)
                      :id    "align-items-end"}]])
 
 (mf/defc align-content-row
@@ -231,27 +276,27 @@
                      :name "flex-align-content"}
    [:& radio-button {:value "start"
                      :icon  (get-layout-flex-icon :align-content :start is-column)
-                     :title "Align content start"
+                     :title (align-content-title :start)
                      :id    "align-content-start"}]
    [:& radio-button {:value "center"
                      :icon  (get-layout-flex-icon :align-content :center is-column)
-                     :title "Align content center"
+                     :title (align-content-title :center)
                      :id    "align-content-center"}]
    [:& radio-button {:value "end"
                      :icon  (get-layout-flex-icon :align-content :end is-column)
-                     :title "Align content end"
+                     :title (align-content-title :end)
                      :id    "align-content-end"}]
    [:& radio-button {:value "space-between"
                      :icon  (get-layout-flex-icon :align-content :space-between is-column)
-                     :title "Align content space-between"
+                     :title (align-content-title :space-between)
                      :id    "align-content-space-between"}]
    [:& radio-button {:value "space-around"
                      :icon  (get-layout-flex-icon :align-content :space-around is-column)
-                     :title "Align content space-around"
+                     :title (align-content-title :space-around)
                      :id    "align-content-space-around"}]
    [:& radio-button {:value "space-evenly"
                      :icon  (get-layout-flex-icon :align-content :space-evenly is-column)
-                     :title "Align content space-evenly"
+                     :title (align-content-title :space-evenly)
                      :id    "align-content-space-evenly"}]])
 
 (mf/defc justify-content-row
@@ -263,27 +308,27 @@
                      :name "flex-justify"}
    [:& radio-button {:value "start"
                      :icon  (get-layout-flex-icon :justify-content :start is-column)
-                     :title "Justify content start"
+                     :title (justify-content-title :start)
                      :id    "justify-content-start"}]
    [:& radio-button {:value "center"
                      :icon  (get-layout-flex-icon :justify-content :center is-column)
-                     :title "Justify content center"
+                     :title (justify-content-title :center)
                      :id    "justify-content-center"}]
    [:& radio-button {:value "end"
                      :icon  (get-layout-flex-icon :justify-content :end is-column)
-                     :title "Justify content end"
+                     :title (justify-content-title :end)
                      :id    "justify-content-end"}]
    [:& radio-button {:value "space-between"
                      :icon  (get-layout-flex-icon :justify-content :space-between is-column)
-                     :title "Justify content space-between"
+                     :title (justify-content-title :space-between)
                      :id    "justify-content-space-between"}]
    [:& radio-button {:value "space-around"
                      :icon  (get-layout-flex-icon :justify-content :space-around is-column)
-                     :title "Justify content space-around"
+                     :title (justify-content-title :space-around)
                      :id    "justify-content-space-around"}]
    [:& radio-button {:value "space-evenly"
                      :icon  (get-layout-flex-icon :justify-content :space-evenly is-column)
-                     :title "Justify content space-evenly"
+                     :title (justify-content-title :space-evenly)
                      :id    "justify-content-space-evenly"}]])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -747,7 +792,7 @@
          :nillable true
          :min 0
          :attr :row-gap
-         :property "Row gap"
+         :property (tr "workspace.options.layout.row-gap")
          :values {:row-gap (:row-gap value)}
          :disabled row-gap-disabled?
          :placeholder (if (or (= :multiple (:row-gap applied-tokens))
@@ -760,7 +805,7 @@
        [:div {:class (stl/css-case
                       :row-gap true
                       :disabled row-gap-disabled?)
-              :title "Row gap"}
+              :title (tr "workspace.options.layout.row-gap")}
         [:span {:class (stl/css :icon)} deprecated-icon/gap-vertical]
         [:> deprecated-input/numeric-input*
          {:class (stl/css :numeric-input true)
@@ -787,7 +832,7 @@
          :min 0
          :attr :column-gap
          :align :right
-         :property "Column gap"
+         :property (tr "workspace.options.layout.column-gap")
          :placeholder (if (or (= :multiple (:column-gap applied-tokens))
                               (= :multiple (:column-gap value)))
                         (tr "settings.multiple")
@@ -799,7 +844,7 @@
        [:div {:class (stl/css-case
                       :column-gap true
                       :disabled col-gap-disabled?)
-              :title "Column gap"}
+              :title (tr "workspace.options.layout.column-gap")}
         [:span {:class (stl/css :icon)} deprecated-icon/gap-horizontal]
         [:> deprecated-input/numeric-input*
          {:class (stl/css :numeric-input true)
@@ -827,11 +872,11 @@
                      :name "grid-direction"}
    [:& radio-button {:value "row"
                      :id "grid-direction-row"
-                     :title "Row"
+                     :title (direction-title :row)
                      :icon (dir-icons-refactor :row)}]
    [:& radio-button {:value "column"
                      :id "grid-direction-column"
-                     :title "Column"
+                     :title (direction-title :column)
                      :icon (dir-icons-refactor :column)}]])
 
 (mf/defc grid-edit-mode
@@ -865,15 +910,15 @@
                        :name (dm/str "flex-align-items-" type)}
      [:& radio-button {:value "start"
                        :icon  (get-layout-grid-icon :align-items :start is-column)
-                       :title "Align items start"
+                       :title (align-items-title :start)
                        :id     (dm/str "align-items-start-" type)}]
      [:& radio-button {:value "center"
                        :icon  (get-layout-grid-icon :align-items :center is-column)
-                       :title "Align items center"
+                       :title (align-items-title :center)
                        :id    (dm/str "align-items-center-" type)}]
      [:& radio-button {:value "end"
                        :icon  (get-layout-grid-icon :align-items :end is-column)
-                       :title "Align items end"
+                       :title (align-items-title :end)
                        :id    (dm/str "align-items-end-" type)}]]))
 
 (mf/defc justify-grid-row
@@ -890,37 +935,37 @@
      [:& radio-button {:key "justify-item-start"
                        :value "start"
                        :icon (get-layout-grid-icon :justify-items :start is-column)
-                       :title "Justify items start"
+                       :title (justify-items-title :start)
                        :id (dm/str "justify-items-start-" type)}]
 
      [:& radio-button {:key "justify-item-center"
                        :value "center"
                        :icon (get-layout-grid-icon :justify-items :center is-column)
-                       :title "Justify items center"
+                       :title (justify-items-title :center)
                        :id (dm/str "justify-items-center-" type)}]
 
      [:& radio-button {:key "justify-item-end"
                        :value "end"
                        :icon (get-layout-grid-icon :justify-items :end is-column)
-                       :title "Justify items end"
+                       :title (justify-items-title :end)
                        :id (dm/str "justify-items-end-" type)}]
 
      [:& radio-button {:key "justify-item-space-around"
                        :value "space-around"
                        :icon (get-layout-grid-icon :justify-items :space-around is-column)
-                       :title "Justify items space-around"
+                       :title (justify-items-title :space-around)
                        :id (dm/str "justify-items-space-around-" type)}]
 
      [:& radio-button {:key "justify-item-space-between"
                        :value "space-between"
                        :icon (get-layout-grid-icon :justify-items :space-between is-column)
-                       :title "Justify items space-between"
+                       :title (justify-items-title :space-between)
                        :id (dm/str "justify-items-space-between-" type)}]
 
      [:& radio-button {:key "justify-item-stretch"
                        :value "stretch"
                        :icon (get-layout-grid-icon :justify-items :stretch is-column)
-                       :title "Justify items stretch"
+                       :title (justify-items-title :stretch)
                        :id (dm/str "justify-items-stretch-" type)}]]))
 
 (defn- manage-values

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7131,10 +7131,50 @@ msgstr "Minimum height"
 msgid "workspace.options.layout-item.title.layout-item-min-w"
 msgstr "Minimum width"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-content.center"
+msgstr "Align content center"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-content.end"
+msgstr "Align content end"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-content.space-around"
+msgstr "Align content space-around"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-content.space-between"
+msgstr "Align content space-between"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-content.space-evenly"
+msgstr "Align content space-evenly"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-content.start"
+msgstr "Align content start"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-items.center"
+msgstr "Align items center"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-items.end"
+msgstr "Align items end"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.align-items.start"
+msgstr "Align items start"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/layout.cljs
 #, unused
 msgid "workspace.options.layout.bottom"
 msgstr "Bottom"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.column-gap"
+msgstr "Column gap"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/layout.cljs
 #, unused
@@ -7161,6 +7201,54 @@ msgstr "Reverse row"
 msgid "workspace.options.layout.gap"
 msgstr "Gap"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-content.center"
+msgstr "Justify content center"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-content.end"
+msgstr "Justify content end"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-content.space-around"
+msgstr "Justify content space-around"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-content.space-between"
+msgstr "Justify content space-between"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-content.space-evenly"
+msgstr "Justify content space-evenly"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-content.start"
+msgstr "Justify content start"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-items.center"
+msgstr "Justify items center"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-items.end"
+msgstr "Justify items end"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-items.space-around"
+msgstr "Justify items space-around"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-items.space-between"
+msgstr "Justify items space-between"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-items.start"
+msgstr "Justify items start"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.justify-items.stretch"
+msgstr "Justify items stretch"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/layout.cljs
 #, unused
 msgid "workspace.options.layout.left"
@@ -7180,6 +7268,10 @@ msgstr "All sides"
 #, unused
 msgid "workspace.options.layout.margin-simple"
 msgstr "Simple margin"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.no-wrap"
+msgstr "No wrap"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/layout.cljs
 #, unused
@@ -7206,6 +7298,10 @@ msgstr "Simple padding"
 msgid "workspace.options.layout.right"
 msgstr "Right"
 
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.row-gap"
+msgstr "Row gap"
+
 #: src/app/main/ui/workspace/sidebar/options/menus/layout.cljs
 #, unused
 msgid "workspace.options.layout.space-around"
@@ -7220,6 +7316,10 @@ msgstr "space between"
 #, unused
 msgid "workspace.options.layout.top"
 msgstr "Top"
+
+#: src/app/main/ui/workspace/sidebar/options/menus/layout_container.cljs
+msgid "workspace.options.layout.wrap"
+msgstr "Wrap"
 
 #: src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs:241
 msgid "workspace.options.more-colors"


### PR DESCRIPTION
### Related Ticket

N/A

### Summary

Direction, alignment, justification, wrap, and gap buttons in the flex and grid layout sidebar carried hardcoded English `:title` attributes. Since the radio inputs they sit on have no `:aria-label`, the title also acted as the accessible name, leaving non-English locales with English tooltips and English screen reader output.

Every affected title now goes through `(tr ...)`. The existing `workspace.options.layout.direction.*` keys (already translated in es, fr, de, zh_CN) are reused, and 25 new entries cover `align-items`, `align-content`, `justify-items`, `justify-content`, `row-gap`, `column-gap`, `wrap`, and `no-wrap`. Five small dispatch helpers in `layout_container.cljs` keep the call sites tidy and prevent drift between the flex and grid panels. The two `:property` aria-labels on the gap inputs received the same treatment since they had the identical problem.

### Steps to reproduce

1. Switch the workspace language to any non-English locale (Spanish, French, German, etc.).
2. Open a board, then add a flex layout from the layout sidebar.
3. Hover any direction, alignment, justification, or wrap button and inspect the tooltip.
4. Repeat with a grid layout for the grid-specific buttons.

Before the fix the tooltip and accessible name read English strings such as "Align items center", "Justify content space-evenly", or "Row gap". After the fix the active locale's translation appears, falling back to English when a translation is still pending.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.
