### PR TITLE
:bug: Fix round/square linecaps not being applied correctly in open paths

### DIFF
--- a/render-wasm/src/render/strokes.rs
+++ b/render-wasm/src/render/strokes.rs
@@ -302,6 +302,12 @@ fn handle_stroke_caps(
         return;
     }
 
+    // When both ends share the same simple line cap, Skia already drew it
+    // natively via `PaintCap` on the stroke paint, so skip the manual overlay.
+    if stroke.to_skia_linecap().is_some() {
+        return;
+    }
+
     // Curves can have duplicated points, so let's remove consecutive duplicated points
     let mut points = path.points().to_vec();
     points.dedup();

--- a/render-wasm/src/shapes/strokes.rs
+++ b/render-wasm/src/shapes/strokes.rs
@@ -293,6 +293,10 @@ impl Stroke {
             }
         }
 
+        if let Some(cap) = self.to_skia_linecap() {
+            paint.set_stroke_cap(cap);
+        }
+
         paint
     }
 
@@ -329,6 +333,19 @@ impl Stroke {
     pub fn cap_bounds_margin(&self) -> f32 {
         cap_margin_for_cap(self.cap_start, self.width)
             .max(cap_margin_for_cap(self.cap_end, self.width))
+    }
+
+    /// Returns a Skia `PaintCap` to apply natively on the stroke paint when
+    /// both ends share the same simple line cap (`Round/Round` or
+    /// `Square/Square`). Skia only emits cap geometry at sub-path endpoints,
+    /// so this is a no-op on closed paths and avoids the extra fill draw the
+    /// manual caps would otherwise require on open paths.
+    pub fn to_skia_linecap(&self) -> Option<skia::paint::Cap> {
+        match (self.cap_start, self.cap_end) {
+            (Some(StrokeCap::Round), Some(StrokeCap::Round)) => Some(skia::paint::Cap::Round),
+            (Some(StrokeCap::Square), Some(StrokeCap::Square)) => Some(skia::paint::Cap::Square),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14031

### Summary

This fixes basic linecaps (round/square) for open paths in which both ends share the same cap.

<img width="862" height="487" alt="Screenshot 2026-05-07 at 5 39 57 PM" src="https://github.com/user-attachments/assets/1d3035ea-2a8c-4ca5-9957-7e4e03854be8" />

### Steps to reproduce 

1. Open the `linecaps.penpot` file attached in the Taiga issue.
2. See that the icon renders correctly

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
