### PR TITLE
:recycle: Migrate render entry-point components to modern syntax

### DIFF
--- a/frontend/src/app/render.cljs
+++ b/frontend/src/app/render.cljs
@@ -62,8 +62,7 @@
 (def ^:private ref:objects
   (l/derived :objects st/state))
 
-(mf/defc object-svg
-  {::mf/wrap-props false}
+(mf/defc object-svg*
   [{:keys [object-id embed skip-children wasm scale]}]
   (let [objects (mf/deref ref:objects)]
 
@@ -93,8 +92,7 @@
            :embed embed
            :skip-children skip-children}]]))))
 
-(mf/defc objects-svg
-  {::mf/wrap-props false}
+(mf/defc objects-svg*
   [{:keys [object-ids embed skip-children wasm scale]}]
   (let [limit
         (mf/use-state (if wasm (min 1 (count object-ids)) (count object-ids)))
@@ -168,7 +166,7 @@
       (st/emit! (fetch-objects-bundle :file-id file-id :page-id page-id :share-id share-id :object-id object-id))
       (if (uuid? object-id)
         (mf/html
-         [:& object-svg
+         [:> object-svg*
           {:file-id file-id
            :page-id page-id
            :share-id share-id
@@ -179,7 +177,7 @@
            :scale scale}])
 
         (mf/html
-         [:& objects-svg
+         [:> objects-svg*
           {:file-id file-id
            :page-id page-id
            :share-id share-id
@@ -196,8 +194,7 @@
 
 ;; ---- COMPONENTS SPRITE
 
-(mf/defc components-svg
-  {::mf/wrap-props false}
+(mf/defc components-svg*
   [{:keys [embed component-id]}]
   (let [file-ref (mf/with-memo [] (l/derived :file st/state))
         state    (mf/use-state {:component-id component-id})]
@@ -291,7 +288,7 @@
                           (rx/map fetch-components-bundle))))))
 
       (mf/html
-       [:& components-svg
+       [:> components-svg*
         {:component-id component-id
          :embed embed}]))
 


### PR DESCRIPTION
### Related Ticket

Refs #9260 — Refactor penpot legacy components.

### Summary

Migrates the three components in `app.render` (`object-svg`, `objects-svg`, `components-svg`) — the entry namespace for the `:render` shadow-cljs bundle used by the exporter — from the legacy `mf/defc` form (with `{::mf/wrap-props false}`) to the modern `mf/defc *` form, following the canonical pattern from #9264 and merged #9265.

For each component:
- Drop `{::mf/wrap-props false}` from the metadata map (the only entry, so the whole map is removed).
- Append `*` to the component name.
- Update the three internal `[:&` callsites in `render-objects` and `render-components` to `[:>` against the renamed components.

The components already used keyword destructuring (`[{:keys [...]}]`), so no prop-handling rewrite was required. There are no `?`-suffixed boolean props, no `obj/merge!` / `mf/spread-props` chains, no `#js` literals at the callsites, and no `::mf/register` metadata.

The forwarded `[:& render/object-svg …]` and `[:& render/components-svg …]` calls target the `app.main.render` namespace (a different file, out of scope here) and remain unchanged. The `app.render` namespace is not imported by any other namespace, so there are no external callsites to update.

### Steps to reproduce

`app.render` is the bundle entry for the headless exporter (`:render` build target in `frontend/shadow-cljs.edn`, exposed via `render.html`). To verify there is no behaviour change:

1. Run the frontend in dev mode and start the exporter service.
2. Trigger an SVG/PNG export of a single object — exercises `object-svg*` (single-uuid branch of `render-objects`).
3. Trigger an SVG/PNG export of multiple objects in one render — exercises `objects-svg*` (set-of-uuids branch).
4. Open `render.html?route=components&file-id=<uuid>` and confirm the components-sprite browser still renders the side nav and the central `<svg>` preview — exercises `components-svg*`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. *(No visual changes — internal syntax migration.)*
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable. *(No behaviour change.)*
- [ ] Refactor any modified SCSS files following the refactor guide. *(No SCSS touched.)*
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable. *(Internal refactor only — not user-visible.)*