### PR TITLE
:bug: Add inactivity cleanup for MCP SSE sessions (#9432)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix MCP SSE sessions leaking memory on zombie connections by adding inactivity timeout parity with Streamable HTTP sessions (by @bitloi) [Github #9432](https://github.com/penpot/penpot/issues/9432)
 - Harden Nginx responses with standard security headers and hide upstream `X-Powered-By` headers
 
 ## 2.16.0 (Unreleased)

--- a/mcp/packages/server/src/PenpotMcpServer.ts
+++ b/mcp/packages/server/src/PenpotMcpServer.ts
@@ -45,7 +45,7 @@ class ToolInfo {
 
 export class PenpotMcpServer {
     /**
-     * Timeout, in minutes, for idle Streamable HTTP sessions before they are automatically closed and removed.
+     * Timeout, in minutes, for idle sessions (Streamable HTTP and SSE) before they are automatically closed and removed.
      */
     private static readonly SESSION_TIMEOUT_MINUTES = 60;
 
@@ -65,7 +65,10 @@ export class PenpotMcpServer {
     private readonly sessionContext = new AsyncLocalStorage<SessionContext>();
 
     private readonly streamableTransports: Record<string, StreamableSession> = {};
-    private readonly sseTransports: Record<string, { transport: SSEServerTransport; userToken?: string }> = {};
+    private readonly sseTransports: Record<
+        string,
+        { transport: SSEServerTransport; userToken?: string; lastActiveTime: number }
+    > = {};
 
     public readonly host: string;
     public readonly port: number;
@@ -179,7 +182,7 @@ export class PenpotMcpServer {
     }
 
     /**
-     * Starts a periodic timer that closes and removes Streamable HTTP sessions that have been
+     * Starts a periodic timer that closes and removes Streamable HTTP and SSE sessions that have been
      * idle for longer than {@link SESSION_TIMEOUT_MINUTES}.
      */
     private startSessionTimeoutChecker(): void {
@@ -195,8 +198,18 @@ export class PenpotMcpServer {
                     removed++;
                 }
             }
+            for (const [id, session] of Object.entries(this.sseTransports)) {
+                if (now - session.lastActiveTime > timeoutMs) {
+                    this.logger.info(`Closing stale SSE session ${id}`);
+                    session.transport.close();
+                    delete this.sseTransports[id];
+                    removed++;
+                }
+            }
             this.logger.info(
-                `Removed ${removed} stale session(s); total sessions remaining: ${Object.keys(this.streamableTransports).length}`
+                `Removed ${removed} stale session(s); total sessions remaining: ${
+                    Object.keys(this.streamableTransports).length + Object.keys(this.sseTransports).length
+                }`
             );
         }, checkIntervalMs);
     }
@@ -262,7 +275,7 @@ export class PenpotMcpServer {
 
             await this.sessionContext.run({ userToken }, async () => {
                 const transport = new SSEServerTransport("/messages", res);
-                this.sseTransports[transport.sessionId] = { transport, userToken };
+                this.sseTransports[transport.sessionId] = { transport, userToken, lastActiveTime: Date.now() };
 
                 const server = this.createMcpServer();
                 await server.connect(transport);
@@ -281,6 +294,7 @@ export class PenpotMcpServer {
             const session = this.sseTransports[sessionId];
 
             if (session) {
+                session.lastActiveTime = Date.now();
                 await this.sessionContext.run({ userToken: session.userToken }, async () => {
                     await session.transport.handlePostMessage(req, res, req.body);
                 });


### PR DESCRIPTION
## Summary

SSE MCP sessions were not covered by the periodic inactivity timeout checker. If a stale SSE connection did not trigger the normal TCP close path, its `SSEServerTransport` and `McpServer` could remain in memory indefinitely.

This PR adds inactivity-timeout cleanup for SSE sessions, matching the existing Streamable HTTP session behavior.

## Changes

- Track activity timestamps for SSE sessions alongside their transport and user token.
- Set the initial activity timestamp when `GET /sse` opens a new session.
- Update the timestamp whenever `POST /messages` receives activity for that session.
- Make the session timeout checker sweep SSE sessions as well as Streamable HTTP sessions.
- Close and remove SSE sessions that exceed `SESSION_TIMEOUT_MINUTES` of inactivity.
- Report the combined remaining session count in timeout checker logs.

The existing `res.on('close')` cleanup path is preserved as the primary cleanup for normal disconnects; the timeout checker is a safety net for zombie sessions.

## Testing

Please verify against the repository's standard MCP server test workflow.

Closes #9432