### PR TITLE
:whale: Add securty headers to nginx on docker images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 ### :bug: Bugs fixed
 
+- Harden Nginx responses with standard security headers and hide upstream `X-Powered-By` headers
 - Fix keep-alive interval leak in PluginBridge (by @opcode81) [Github #9435](https://github.com/penpot/penpot/pull/9435)
 - Fix MCP "active in another tab" notification not clearing (by @Dexterity104) [Github #9321](https://github.com/penpot/penpot/pull/9321)
 - Fix swapped analytics event names on MCP tab-switch dialog (by @Dexterity104) [Github #9322](https://github.com/penpot/penpot/pull/9322)

--- a/docker/devenv/files/nginx-security-headers.conf
+++ b/docker/devenv/files/nginx-security-headers.conf
@@ -1,0 +1,4 @@
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header X-Frame-Options SAMEORIGIN always;

--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -74,6 +74,8 @@ http {
         resolver 127.0.0.11 ipv6=off;
 
         etag off;
+        proxy_hide_header X-Powered-By;
+        include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
 
         root /home/penpot/penpot/frontend/resources/public;
 
@@ -92,6 +94,7 @@ http {
             proxy_pass $redirect_uri;
             proxy_ssl_server_name on;
 
+            include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
             add_header x-internal-redirect "$redirect_uri";
             add_header x-cache-control "$redirect_cache_control";
             add_header cache-control "$redirect_cache_control";
@@ -108,6 +111,7 @@ http {
         location /internal/assets {
             internal;
             alias /home/penpot/penpot/backend/assets;
+            include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
             add_header x-internal-redirect "$upstream_http_x_accel_redirect";
         }
 
@@ -186,6 +190,7 @@ http {
 
         location /wasm-playground {
             alias /home/penpot/penpot/frontend/resources/public/wasm-playground/;
+            include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
             add_header Cache-Control "no-cache, max-age=0";
             autoindex on;
         }
@@ -211,6 +216,7 @@ http {
                 proxy_set_header User-Agent "curl/8.5.0";
                 proxy_set_header Host "raw.githubusercontent.com";
                 proxy_set_header Accept "*/*";
+                include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
                 add_header Access-Control-Allow-Origin $http_origin;
                 proxy_buffering off;
             }
@@ -235,6 +241,7 @@ http {
 
                 proxy_cache penpot;
 
+                include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
                 add_header Access-Control-Allow-Origin $http_origin;
                 add_header Cache-Control max-age=86400;
                 add_header X-Cache-Status $upstream_cache_status;
@@ -257,16 +264,19 @@ http {
 
                 proxy_cache penpot;
 
+                include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
                 add_header Access-Control-Allow-Origin $http_origin;
                 add_header Cache-Control max-age=86400;
                 add_header X-Cache-Status $upstream_cache_status;
             }
 
             location ~* \.(jpg|png|svg|ttf|woff|woff2|gif)$ {
+                include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
                 add_header Cache-Control "public, max-age=604800" always; # 7 days
             }
 
             location ~* \.(js|css|wasm)$ {
+                include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
                 add_header Cache-Control "no-store" always;
             }
 
@@ -274,6 +284,7 @@ http {
                 return 301 " /404";
             }
 
+            include /home/penpot/penpot/docker/devenv/files/nginx-security-headers.conf;
             add_header Cache-Control "no-store" always;
             try_files $uri /index.html$is_args$args /index.html =404;
         }

--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -17,6 +17,7 @@ ARG BUNDLE_PATH="./bundle-frontend/"
 COPY $BUNDLE_PATH /var/www/app/
 COPY ./files/config.js /var/www/app/js/config.js
 COPY ./files/nginx.conf.template /tmp/nginx.conf.template
+COPY ./files/nginx-security-headers.conf /etc/nginx/nginx-security-headers.conf
 COPY ./files/nginx-resolvers.conf.template /tmp/resolvers.conf.template
 COPY ./files/nginx-mime.types /etc/nginx/mime.types
 COPY ./files/nginx-external-locations.conf /etc/nginx/overrides/location.d/external-locations.conf

--- a/docker/images/files/nginx-security-headers.conf
+++ b/docker/images/files/nginx-security-headers.conf
@@ -1,0 +1,4 @@
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header X-Frame-Options SAMEORIGIN always;

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -80,6 +80,8 @@ http {
         charset utf-8;
 
         etag off;
+        proxy_hide_header X-Powered-By;
+        include /etc/nginx/nginx-security-headers.conf;
 
         root /var/www/app/;
 
@@ -100,6 +102,7 @@ http {
             proxy_ssl_server_name on;
             proxy_pass $redirect_uri;
 
+            include /etc/nginx/nginx-security-headers.conf;
             add_header x-internal-redirect "$redirect_uri";
             add_header x-cache-control "$redirect_cache_control";
             add_header cache-control "$redirect_cache_control";
@@ -118,6 +121,7 @@ http {
         location /internal/assets {
             internal;
             alias /opt/data/assets;
+            include /etc/nginx/nginx-security-headers.conf;
             add_header x-internal-redirect "$upstream_http_x_accel_redirect";
         }
 
@@ -177,6 +181,7 @@ http {
             include /etc/nginx/overrides/location.d/*.conf;
 
             location ~* \.(js|css|jpg|png|svg|gif|ttf|woff|woff2|wasm|map)$ {
+                include /etc/nginx/nginx-security-headers.conf;
                 add_header Cache-Control "public, max-age=604800" always; # 7 days
             }
 
@@ -184,7 +189,7 @@ http {
                 return 301 " /404";
             }
 
-            add_header X-Frame-Options SAMEORIGIN always;
+            include /etc/nginx/nginx-security-headers.conf;
             add_header Cache-Control "no-store, no-cache, max-age=0" always;
             try_files $uri /index.html$is_args$args /index.html =404;
 


### PR DESCRIPTION
![k](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2JkeXFjamEydDEwOGwzemwzZnZ0NnNjd2tybzEycmw1OGZwdHNsNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UZQCbV4OW1mXdHJNPS/giphy.gif)

Changes included

  - Add X-Content-Type-Options: nosniff
  - Add Referrer-Policy: strict-origin-when-cross-origin
  - Add Permissions-Policy: camera=(), microphone=(), geolocation=()
  - Keep X-Frame-Options: SAMEORIGIN
  - Hide upstream X-Powered-By
  - Reuse a shared Nginx security headers config via include