### PR TITLE
:bug: Fix nitrate lookups to use nested organization

### DIFF
--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -189,7 +189,7 @@
                 (let [all-orgs (map dt/team->organization
                                     (filter #(and (:is-default %) (:organization %)) teams))
                       orgs     (filter (fn [org]
-                                         (let [perm    (get-in org [:permissions :create-teams])
+                                         (let [perm    (dm/get-in org [:permissions :create-teams])
                                                is-own? (= profile-id (:owner-id org))]
                                            (or (= perm "any") is-own?))) all-orgs)
                       team     (first (filter #(= (:id %) team-id) teams))

--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -187,7 +187,7 @@
              (rx/mapcat
               (fn [teams]
                 (let [all-orgs (map dt/team->organization
-                                    (filter #(and (:is-default %) (:organization-id %)) teams))
+                                    (filter #(and (:is-default %) (:organization %)) teams))
                       orgs     (filter (fn [org]
                                          (let [perm    (get-in org [:permissions :create-teams])
                                                is-own? (= profile-id (:owner-id org))]

--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -94,8 +94,7 @@
                                                     {:organization-id   (:id organization)
                                                      :organization-name (:name organization)}
                                                     {}))
-                           (modal/show :no-permission-modal {:type :create-team
-                                                             :organization-name (:name organization)})))))))))))
+                           (modal/show :no-permission-modal {:type :create-team})))))))))))
 
 (defn check-and-delete-team
   "Fetches fresh team data from the server to ensure up-to-date org
@@ -129,8 +128,7 @@
                              :message message
                              :accept-label (tr "modals.delete-team-confirm.accept")
                              :on-accept delete-fn})
-                           (modal/show :no-permission-modal {:type :delete-team
-                                                             :organization-name (:name org)})))))))))))
+                           (modal/show :no-permission-modal {:type :delete-team})))))))))))
 
 ;; --- EVENT: fetch-members
 

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -469,8 +469,7 @@
               (rx/of (ntf/error (tr "errors.team-leave.owner-cant-leave")))
 
               :not-allowed
-              (rx/of (modal/show :no-permission-modal {:type :delete-team
-                                                       :organization-name (dm/get-in team [:organization :name])}))
+              (rx/of (modal/show :no-permission-modal {:type :delete-team}))
 
               (rx/throw error))))
 
@@ -717,7 +716,7 @@
         org-teams (mf/with-memo [teams current-org]
                     (->> teams
                          vals
-                         (filter #(= (:organization-id %) (:id current-org)))))
+                         (filter #(= (get-in % [:organization :id]) (:id current-org)))))
 
         default-org? (nil? (:id current-org))
 

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -716,7 +716,7 @@
         org-teams (mf/with-memo [teams current-org]
                     (->> teams
                          vals
-                         (filter #(= (get-in % [:organization :id]) (:id current-org)))))
+                         (filter #(= (dm/get-in % [:organization :id]) (:id current-org)))))
 
         default-org? (nil? (:id current-org))
 

--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -3,7 +3,6 @@
 (ns app.main.ui.dashboard.subscription
   (:require-macros [app.main.style :as stl])
   (:require
-   [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.config :as cf]
    [app.main.data.event :as ev]
@@ -122,13 +121,10 @@
   (let [nitrate? (dnt/is-valid-license? profile)
         nitrate-license (:subscription profile)
         subscription-type (if nitrate? (:type nitrate-license) (get-subscription-type (-> profile :props :subscription)))
-        orgs (mf/with-memo [teams]
-               (->> teams
-                    vals
-                    (keep :organization)
-                    (d/index-by :id)))
-
-        no-orgs-created? (empty? orgs)
+        no-orgs-created? (mf/with-memo [teams]
+                           (->> teams
+                                vals
+                                (not-any? :organization)))
 
         handle-click
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -123,15 +123,12 @@
         nitrate-license (:subscription profile)
         subscription-type (if nitrate? (:type nitrate-license) (get-subscription-type (-> profile :props :subscription)))
         orgs (mf/with-memo [teams]
-               (let [orgs (->> teams
-                               vals
-                               (group-by :organization-id)
-                               (map (fn [[_group entries]] (first entries)))
-                               vec
-                               (d/index-by :id))]
-                 orgs))
+               (->> teams
+                    vals
+                    (keep :organization)
+                    (d/index-by :id)))
 
-        no-orgs-created? (= (count orgs) 1)
+        no-orgs-created? (empty? orgs)
 
         handle-click
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -1374,7 +1374,7 @@
         all-organizations (mf/with-memo [all-organizations]
                             (->> (vals all-organizations)
                                  (filter :is-default)
-                                 (filter :organization-id)
+                                 (filter :organization)
                                  (map dtm/team->organization)))
 
         ;; Filter to orgs where user is allowed to create/add teams

--- a/frontend/src/app/main/ui/dashboard/team_form.cljs
+++ b/frontend/src/app/main/ui/dashboard/team_form.cljs
@@ -7,6 +7,7 @@
 (ns app.main.ui.dashboard.team-form
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data.macros :as dm]
    [app.common.schema :as sm]
    [app.common.types.team :as ctt]
    [app.main.data.common :as dcm]
@@ -97,6 +98,7 @@
                     (partial on-submit form))
         handle-keydown
         (mf/use-fn
+         (mf/deps form)
          (fn [e]
            (when (kbd/enter? e)
              (dom/prevent-default e)
@@ -144,7 +146,7 @@
    ::mf/register-as :no-permission-modal}
   [{:keys [type]}]
   (let [team             (mf/deref refs/team)
-        organization-name (get-in team [:organization :name])
+        organization-name (dm/get-in team [:organization :name])
         [title message] (case type
                           :create-team [(tr "labels.create-team")
                                         (tr "dashboard.no-permission-create-team.message" organization-name)]

--- a/frontend/src/app/main/ui/dashboard/team_form.cljs
+++ b/frontend/src/app/main/ui/dashboard/team_form.cljs
@@ -14,6 +14,7 @@
    [app.main.data.modal :as modal]
    [app.main.data.notifications :as ntf]
    [app.main.data.team :as dtm]
+   [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.components.forms :as fm]
    [app.main.ui.icons :as deprecated-icon]
@@ -42,20 +43,19 @@
               (modal/hide))))
 
 (defn- on-error
-  [form organization-name response]
+  [form response]
   (let [id   (get-in @form [:clean-data :id])
         code (-> response ex-data :code)]
     (if (= code :not-allowed)
-      (rx/of (modal/show :no-permission-modal {:type :create-team
-                                               :organization-name organization-name}))
+      (rx/of (modal/show :no-permission-modal {:type :create-team}))
       (if id
         (rx/of (ntf/error "Error on updating team."))
         (rx/of (ntf/error "Error on creating team."))))))
 
 (defn- on-create-submit
-  [form organization-name]
+  [form]
   (let [mdata  {:on-success (partial on-create-success form)
-                :on-error   (partial on-error form organization-name)}
+                :on-error   (partial on-error form)}
         data   (:clean-data @form)
         params (cond-> {:name (:name data)}
                  (:organization-id data) (assoc :organization-id (:organization-id data)))]
@@ -65,23 +65,23 @@
 (defn- on-update-submit
   [form]
   (let [mdata  {:on-success (partial on-update-success form)
-                :on-error   (partial on-error form nil)}
+                :on-error   (partial on-error form)}
         data   (:clean-data @form)
         team   (select-keys data [:id :name])]
     (st/emit! (dtm/update-team (with-meta team mdata))
               (modal/hide))))
 
 (defn- on-submit
-  [organization-name form _]
+  [form _]
   (let [data (:clean-data @form)]
     (if (:id data)
       (on-update-submit form)
-      (on-create-submit form organization-name))))
+      (on-create-submit form))))
 
 (mf/defc team-form-modal
   {::mf/register modal/components
    ::mf/register-as :team-form}
-  [{:keys [team organization-id organization-name] :as props}]
+  [{:keys [team organization-id] :as props}]
   (let [initial (mf/use-memo
                  (mf/deps team organization-id)
                  (fn []
@@ -94,16 +94,14 @@
         form    (fm/use-form :schema schema:team-form
                              :initial initial)
         on-submit* (mf/use-fn
-                    (mf/deps organization-name)
-                    (partial on-submit organization-name))
+                    (partial on-submit form))
         handle-keydown
         (mf/use-fn
-         (mf/deps organization-name)
          (fn [e]
            (when (kbd/enter? e)
              (dom/prevent-default e)
              (dom/stop-propagation e)
-             (on-submit organization-name form e))))]
+             (on-submit form e))))]
 
     [:div {:class (stl/css :modal-overlay)}
      [:div {:class (stl/css :modal-container)}
@@ -144,8 +142,10 @@
   "Generic modal for displaying permission-related messages based on error type"
   {::mf/register modal/components
    ::mf/register-as :no-permission-modal}
-  [{:keys [type organization-name]}]
-  (let [[title message] (case type
+  [{:keys [type]}]
+  (let [team             (mf/deref refs/team)
+        organization-name (get-in team [:organization :name])
+        [title message] (case type
                           :create-team [(tr "labels.create-team")
                                         (tr "dashboard.no-permission-create-team.message" organization-name)]
                           :delete-team [(tr "dashboard.delete-team")


### PR DESCRIPTION
### Related Ticket

Resolves https://tree.taiga.io/project/penpot-nitrate/task/26380

### Summary

Fixes all remaining places in the frontend where team organization data was still accessed using the old flat keys (e.g., :organization-id). All lookups and filters now use the nested :organization structure introduced in the recent refactor. This resolves issues with organization detection in the nitrate sidebar, team move-to-org options, and related modals. No logic changes beyond updating to the new data shape.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
