### PR TITLE
:recycle: Migrate workspace shared dialogs to modern syntax

### DIFF
--- a/frontend/src/app/main/ui/confirm.cljs
+++ b/frontend/src/app/main/ui/confirm.cljs
@@ -21,7 +21,7 @@
   (:import
    goog.events.EventType))
 
-(mf/defc confirm-dialog
+(mf/defc confirm-dialog*
   {::mf/register modal/components
    ::mf/register-as :confirm}
   [{:keys [message

--- a/frontend/src/app/main/ui/delete_shared.cljs
+++ b/frontend/src/app/main/ui/delete_shared.cljs
@@ -22,10 +22,9 @@
 
 (def ^:private noop (constantly nil))
 
-(mf/defc delete-shared-dialog
+(mf/defc delete-shared-dialog*
   {::mf/register modal/components
-   ::mf/register-as :delete-shared-libraries
-   ::mf/wrap-props false}
+   ::mf/register-as :delete-shared-libraries}
   [{:keys [ids on-accept on-cancel accept-style origin count-libraries]}]
   (let [references*  (mf/use-state nil)
         references   (deref references*)

--- a/frontend/src/app/main/ui/workspace/nudge.cljs
+++ b/frontend/src/app/main/ui/workspace/nudge.cljs
@@ -27,7 +27,7 @@
     (dom/stop-propagation event)
     (modal/hide!)))
 
-(mf/defc nudge-modal
+(mf/defc nudge-modal*
   {::mf/register modal/components
    ::mf/register-as :nudge-option}
   []

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs
@@ -19,7 +19,7 @@
    [app.util.i18n :as i18n :refer [tr]]
    [rumext.v2 :as mf]))
 
-(mf/defc variants-help-modal
+(mf/defc variants-help-modal*
   {::mf/register modal/components
    ::mf/register-as :variants-help-modal}
   []


### PR DESCRIPTION
### Related Ticket

Refs #9260

### Summary

Migrates 4 standalone modal-dialog components scattered across the workspace UI to the modern `mf/defc name*` syntax described in [`frontend/AGENTS.md`](https://github.com/penpot/penpot/blob/develop/frontend/AGENTS.md#ui-components-react--rumext-mfdefc).

This is one of the incremental refactors requested by #9260. Modern syntax avoids per-render JS→CLJS prop-conversion overhead.

**Components migrated (4):**

| File                                                                                              | Old name                | New name                  | Registry key                  |
|---------------------------------------------------------------------------------------------------|-------------------------|---------------------------|-------------------------------|
| `frontend/src/app/main/ui/confirm.cljs`                                                           | `confirm-dialog`        | `confirm-dialog*`         | `:confirm`                    |
| `frontend/src/app/main/ui/delete_shared.cljs`                                                     | `delete-shared-dialog`  | `delete-shared-dialog*`   | `:delete-shared-libraries`    |
| `frontend/src/app/main/ui/workspace/nudge.cljs`                                                   | `nudge-modal`           | `nudge-modal*`            | `:nudge-option`               |
| `frontend/src/app/main/ui/workspace/sidebar/options/menus/variants_help_modal.cljs`               | `variants-help-modal`   | `variants-help-modal*`    | `:variants-help-modal`        |

**Other cleanups bundled with the rename:**

- Dropped the now-redundant `{::mf/wrap-props false}` marker from `delete-shared-dialog*` (the `*` suffix already implies modern props handling).

**Why no external callsite changes are needed:**

All four components are registered with `::mf/register modal/components` + `::mf/register-as :foo-key` and dispatched via
`(modal/show! {:type :foo-key})`. They are looked up by **registry key**, not by var name, so renaming the var to add `*` is safe. Verified via `grep` that no caller references the old var names directly.

**Preserved:** All registry keys, all `:data-testid` HTML attributes, all event handlers, all `tr` translation keys, all DOM key-listener
effects, and all caller dispatch sites in `workspace/sidebar/options/menus/component.cljs` (which calls `(modal/show! {:type :variants-help-modal})`).

### Steps to reproduce

To verify the migration in the running app:

1. **Confirm dialog** — trigger any "Are you sure?" prompt (e.g. delete  a project, delete a file). Confirm the dialog renders, the title /  message / hint render correctly, the destructive accept button  triggers the action, the cancel button dismisses, and the Enter  keypress accepts.
2. **Delete shared library dialog** — try to delete or unpublish a  shared library. Confirm the dialog lists the files referencing the
   library, the hint banner appears, and accept/cancel work.
3. **Nudge modal** — open Workspace > preferences and trigger the  nudge-options modal (set keyboard nudge values). Confirm the small  and big numeric inputs accept values and persist them. Confirm Enter  key closes the modal.
4. **Variants help modal** — in the workspace, select a component and  open the "variants help" modal from the component options panel.  Confirm the modal renders with the three rule items, image, and  close behavior (both X button and click-outside).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. <!-- not applicable: no UI-visible change -->
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable. <!-- not applicable: pure refactor -->
- [ ] Refactor any modified SCSS files following the refactor guide. <!-- not applicable: no SCSS changes -->
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable. <!-- not applicable: no user-facing change -->
