### PR TITLE
:bug: Fix font selection position is hiding fonts

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/text.scss
@@ -9,8 +9,6 @@
 
 .element-set {
   @include sidebar.option-grid-structure;
-
-  position: relative;
 }
 
 .element-title {


### PR DESCRIPTION
### Related Ticket

Closes #9489 

### Summary

The font selector has an absolute positional attribute to cover all the right side panel. But it only works if the closest ancestor with the relative positional attribute is the one that covers the panel.

### Steps to reproduce 

- Create a text and select it.
- Open the font selector in the design panel.
- Check that the dropdown covers all the right panel, no matter of the size or the scroll position. 