### PR TITLE
:bug: Fix two plugin error i18n keys broken by leading whitespace in en.po

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fix plugin API `LibraryTypography.remove()` failing with a UUID assertion error [Github #8223](https://github.com/penpot/penpot/issues/8223)
 - Fix MCP SSE sessions leaking memory on zombie connections by adding inactivity timeout parity with Streamable HTTP sessions (by @bitloi) [Github #9432](https://github.com/penpot/penpot/issues/9432)
 - Fix missing `labels.open` translation (by @MilosM348) [Github #9320](https://github.com/penpot/penpot/pull/9320)
+- Fix two plugin error i18n keys broken by leading whitespace before `msgid` in `en.po` (by @MilosM348)
 - Harden Nginx responses with standard security headers and hide upstream `X-Powered-By` headers
 - Expose Source Sans Pro semibold (weight 600) variants in the builtin fonts list, matching the bundled font assets and CSS @font-face declarations [Github #7378](https://github.com/penpot/penpot/issues/7378)
 - Fix plugin API `shape.fills` and `shape.strokes` arrays being read-only [Github #8357](https://github.com/penpot/penpot/issues/8357)

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -7696,14 +7696,14 @@ msgid "workspace.plugins.empty-plugins"
 msgstr "No plugins installed yet"
 
 #: src/app/main/ui/workspace/plugins.cljs:193
- msgid "workspace.plugins.error.manifest"
- msgstr "The plugin manifest is incorrect."
+msgid "workspace.plugins.error.manifest"
+msgstr "The plugin manifest is incorrect."
 
 msgid "plugins.validation.message"
 msgstr "Field %s is invalid: %s"
 
 #: src/app/main/data/plugins.cljs:105, src/app/main/ui/workspace/main_menu.cljs:766, src/app/main/ui/workspace/plugins.cljs:84
- msgid "workspace.plugins.error.need-editor"
+msgid "workspace.plugins.error.need-editor"
 msgstr "You need to be an editor to use this plugin"
 
 #: src/app/main/ui/workspace/plugins.cljs:189


### PR DESCRIPTION
## Summary

Fix two plugin error i18n keys in `frontend/translations/en.po` that were
silently broken by a leading space before `msgid`. Per the gettext format
spec, `msgid` lines must start at column 0; leading-whitespace `msgid`
lines are treated as continuations of the previous entry, so the keys
were never registered as translation entries.

Affected keys (both shown in the plugin error UI to end users):

- `workspace.plugins.error.manifest` — surfaces in the plugins panel when
  a plugin manifest cannot be parsed
  (`frontend/src/app/main/ui/workspace/plugins.cljs`).
- `workspace.plugins.error.need-editor` — surfaces in the main menu
  tooltip and as a `ntf/warn` notification when a non-editor user tries
  to launch an edit-permission plugin
  (`frontend/src/app/main/data/plugins.cljs`,
  `frontend/src/app/main/ui/workspace/main_menu.cljs`,
  `frontend/src/app/main/ui/workspace/plugins.cljs`).

Without this fix, end users see the raw key string (e.g.
`workspace.plugins.error.manifest`) instead of the intended English text.
This is the same class of bug as #9320.

## Fix

Remove the leading whitespace from the two `msgid` lines (and the
adjacent `msgstr` for the manifest entry) so they parse as proper
gettext entries. Same template as the `labels.open` fix from #9320.

## Verification

- `grep -P '^\s+msgid' frontend/translations/en.po` returns 0 matches
  after the fix (was 2 before).
- Both keys now appear as standalone entries during a normal `gettext`
  parse pass.
- Other 47 language `.po` files in `frontend/translations/` already
  reference these keys with proper translations and are unaffected.
