### PR TITLE
:bug: Fix plugin error-messages dropping field name on nested validation failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - Fix `Ctrl+'` "Show guides" shortcut on non-US keyboard layouts by matching the physical key location (by @RenzoMXD) [Github #8423](https://github.com/penpot/penpot/issues/8423)
 - Fix lost-update race on `team.features` during concurrent file creation (by @web-dev0521) [Github #9197](https://github.com/penpot/penpot/issues/9197)
 - Fix copy and paste actions crashing the workspace on insecure origins (plain HTTP / non-`localhost`) where the Clipboard API is unavailable (by @MilosM348) [Github #6514](https://github.com/penpot/penpot/issues/6514)
+- Fix plugin schema validation errors surfacing as `Field message is invalid` when the failing schema is nested (by @MilosM348) [Github #9417](https://github.com/penpot/penpot/issues/9417)
 
 
 ## 2.16.0 (Unreleased)

--- a/frontend/src/app/plugins/utils.cljs
+++ b/frontend/src/app/plugins/utils.cljs
@@ -276,12 +276,31 @@
   (let [s (set values)]
     (if (= (count s) 1) (first s) "mixed")))
 
+(defn- collect-message-leaves
+  "Walk an error tree produced by `csm/interpret-schema-problem` and return a
+   sequence of `[field-keyword message-string]` pairs. The accumulator can be
+   either flat (`{:field {:message \"...\"}}`) when the failing schema is at
+   the top level, or nested (`{:field {:subfield {:message \"...\"}}}`) when
+   the failure happens deeper. Both shapes are flattened to the inner-most
+   field name so `error-messages` can render them uniformly."
+  ([m] (collect-message-leaves m []))
+  ([m path]
+   (cond
+     (and (map? m) (string? (:message m)))
+     [[(or (last path) :_) (:message m)]]
+
+     (map? m)
+     (mapcat (fn [[k v]] (collect-message-leaves v (conj path k))) m)
+
+     :else
+     nil)))
+
 (defn error-messages
   [explain]
   (->> (:errors explain)
        (reduce csm/interpret-schema-problem {})
-       #_(mapcat (comp seq val))     ;; FIXME: why is this for? it breaks the message
-       (map (fn [[field {:keys [message]}]]
+       (collect-message-leaves)
+       (map (fn [[field message]]
               (tr "plugins.validation.message" (name field) message)))
        (str/join ". ")))
 


### PR DESCRIPTION
## Summary

Fixes #9417 — plugin schema validation errors surfacing as
`Field message is invalid` instead of the proper `Field <field-name> is
invalid: <reason>` when the failing schema sits one level below where
`error-messages` previously assumed.

`csm/interpret-schema-problem` writes errors via `assoc-in acc field-path`,
so the resulting tree may be either flat (`{:field {:message "..."}}`)
when the failing schema is at the top of the explain output, or nested
(`{:field {:subfield {:message "..."}}}`) when the failure happens
deeper. The previous `error-messages` destructured each top-level entry
as `[field {:keys [message]}]`, which silently dropped the field name
for any nested shape because `{:keys [message]}` saw a sub-map of
sub-fields rather than a leaf. The earlier `(mapcat (comp seq val))`
attempt to flatten was commented out (with the FIXME on line 280) because
it had the symmetric failure mode for the flat shape.

## Fix

Add a small `collect-message-leaves` helper that walks the error tree
and emits `[field-keyword message-string]` pairs from each `{:message
"..."}` leaf, using the leaf's last path element as the field name.
Both the flat and the nested shape now produce identical output, so
`error-messages` can render every case uniformly.

The change is local to `app.plugins.utils/error-messages` only; it does
not touch `csm/interpret-schema-problem` itself, which other consumers
(`forms.cljs`, `collect-schema-errors`) intentionally rely on for its
nested `{:field {:subfield ...}}` shape (see e.g. `(get-in @form
[:errors :value value-subfield index input-name])` in the tokens-form
controls).

## Verification

Manual reasoning, given the existing accumulator shapes from
`csm/interpret-schema-problem`:

| Accumulator shape                                  | Old output                       | New output                                |
| -------------------------------------------------- | -------------------------------- | ----------------------------------------- |
| `{:group {:message "..."}}` (already worked)       | `Field group is invalid: ...`    | `Field group is invalid: ...` (unchanged) |
| `{:sets {:message "..."}}` (the #9417 case)        | `Field message is invalid:`      | `Field sets is invalid: ...`              |
| `{:group {:name {:message "..."}}}` (nested cases) | `Field group is invalid:` (nil)  | `Field name is invalid: ...`              |

## Closes

Closes #9417.
