### PR TITLE
:bug: Fix component thumbnail sync

### DIFF
--- a/frontend/src/app/main/data/workspace/thumbnails.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails.cljs
@@ -96,12 +96,14 @@
 
        ptk/UpdateEvent
        (update [_ state]
-         (update state :thumbnails
-                 (fn [thumbs]
-                   (if-let [uri (get thumbs object-id)]
-                     (do (vreset! pending uri)
-                         (dissoc thumbs object-id))
-                     thumbs))))
+         (-> state
+             (update :thumbnails
+                     (fn [thumbs]
+                       (if-let [uri (get thumbs object-id)]
+                         (do (vreset! pending uri)
+                             (dissoc thumbs object-id))
+                         thumbs)))
+             (update :thumbnails-meta dissoc object-id)))
 
        ptk/WatchEvent
        (watch [_ _ _]
@@ -124,10 +126,13 @@
     (ptk/reify ::assoc-thumbnail
       ptk/UpdateEvent
       (update [_ state]
-        (let [prev-uri (dm/get-in state [:thumbnails object-id])]
+        (let [prev-uri (dm/get-in state [:thumbnails object-id])
+              now      (.now js/Date)]
           (some->> prev-uri (vreset! prev-uri*))
           (l/trc :hint "assoc thumbnail" :object-id object-id :uri uri)
-          (update state :thumbnails assoc object-id uri)))
+          (-> state
+              (update :thumbnails assoc object-id uri)
+              (update :thumbnails-meta assoc object-id {:rendered-at now}))))
 
       ptk/EffectEvent
       (effect [_ _ _]

--- a/frontend/src/app/main/data/workspace/thumbnails_wasm.cljs
+++ b/frontend/src/app/main/data/workspace/thumbnails_wasm.cljs
@@ -63,8 +63,9 @@
               (try
                 (let [objects (dsh/lookup-page-objects @st/state file-id page-id)]
                   (if-let [frame (get objects frame-id)]
-                    (let [{:keys [width height]} (:selrect frame)
-                          max-size (mth/max width height)
+                    (let [{ext-w :width ext-h :height} (wasm.api/get-shape-extrect frame-id)
+                          {sel-w :width sel-h :height} (:selrect frame)
+                          max-size (mth/max (or ext-w sel-w) (or ext-h sel-h))
                           scale (mth/max 1 (/ target-size max-size))
                           png-bytes (wasm.api/render-shape-pixels frame-id scale)]
                       (if (or (nil? png-bytes) (zero? (.-length png-bytes)))

--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -588,6 +588,12 @@
              (cf/resolve-media)))
    st/state))
 
+(defn workspace-thumbnail-rendered-at
+  [object-id]
+  (l/derived
+   #(dm/get-in % [:thumbnails-meta object-id :rendered-at])
+   st/state))
+
 (def workspace-text-modifier
   (l/derived :workspace-text-modifier st/state))
 

--- a/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/assets/common.cljs
@@ -324,13 +324,34 @@
         current-page-id (mf/deref refs/current-page-id)
         thumbnail-requested? (mf/use-ref false)
 
-        thumbnail-uri*
+        object-id
         (mf/with-memo [file-id page-id root-id]
-          (let [object-id (thc/fmt-object-id file-id page-id root-id "component")]
-            (refs/workspace-thumbnail-by-id object-id)))
+          (thc/fmt-object-id file-id page-id root-id "component"))
+
+        thumbnail-uri*
+        (mf/with-memo [object-id]
+          (refs/workspace-thumbnail-by-id object-id))
 
         thumbnail-uri
         (mf/deref thumbnail-uri*)
+
+        rendered-at*
+        (mf/with-memo [object-id]
+          (refs/workspace-thumbnail-rendered-at object-id))
+
+        rendered-at
+        (mf/deref rendered-at*)
+
+        modified-at
+        (some-> (:modified-at component) (.getTime))
+
+        ;; Stale if there's no in-session render record
+        ;; or the component was modified after the last render
+        stale?
+        (and (some? thumbnail-uri)
+             (or (nil? rendered-at)
+                 (and (some? modified-at)
+                      (> modified-at rendered-at))))
 
         on-error
         (mf/use-fn
@@ -340,20 +361,21 @@
              (inc retry))))]
 
     ;; Lazy WASM thumbnail rendering: when the component becomes
-    ;; visible, has no cached thumbnail, and lives on the current page
-    ;; trigger a render. Ref is used to avoid triggering multiple renders
-    ;; while the component is still not rendered and the thumbnail URI
-    ;; is not available.
+    ;; visible and either has no cached thumbnail or the cached one is
+    ;; stale relative to the last recorded edit, trigger a render. Ref
+    ;; is used to avoid triggering multiple renders while the previous
+    ;; render is in flight.
     (mf/use-effect
-     (mf/deps is-hidden thumbnail-uri wasm? current-page-id file-id page-id)
+     (mf/deps is-hidden thumbnail-uri stale? wasm? current-page-id file-id page-id)
      (fn []
-       (if (some? thumbnail-uri)
+       (if (and (some? thumbnail-uri) (not stale?))
          (mf/set-ref-val! thumbnail-requested? false)
          (when (and wasm? (not is-hidden) (not (mf/ref-val thumbnail-requested?)) (= page-id current-page-id))
            (mf/set-ref-val! thumbnail-requested? true)
            (st/emit! (dwt.wasm/render-thumbnail file-id page-id root-id))))))
 
     (if (and (some? thumbnail-uri)
+             (not stale?)
              (or (contains? cf/flags :component-thumbnails)
                  wasm?))
       [:& component-svg-thumbnail

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -2172,6 +2172,24 @@
     (mem/free)
     result))
 
+(defn get-shape-extrect
+  [shape-id]
+  (let [buffer (uuid/get-u32 shape-id)
+        offset (h/call wasm/internal-module "_get_shape_extrect"
+                       (aget buffer 0)
+                       (aget buffer 1)
+                       (aget buffer 2)
+                       (aget buffer 3))]
+    (when (and (number? offset) (pos? offset))
+      (let [heapf32 (mem/get-heap-f32)
+            base    (mem/->offset-32 offset)
+            x       (aget heapf32 base)
+            y       (aget heapf32 (+ base 1))
+            w       (aget heapf32 (+ base 2))
+            h       (aget heapf32 (+ base 3))]
+        (mem/free)
+        {:x x :y y :width w :height h}))))
+
 (defn init-wasm-module
   [module]
   (let [default-fn (unchecked-get module "default")

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -880,6 +880,25 @@ pub extern "C" fn end_temp_objects() -> Result<()> {
 
 #[no_mangle]
 #[wasm_error]
+pub extern "C" fn get_shape_extrect(a: u32, b: u32, c: u32, d: u32) -> Result<*mut u8> {
+    let id = uuid_from_u32_quartet(a, b, c, d);
+
+    with_state!(state, {
+        let Some(shape) = state.shapes.get(&id) else {
+            return Err(Error::CriticalError("Shape not found".to_string()));
+        };
+        let extrect = get_render_state().get_cached_extrect(shape, &state.shapes, 1.0);
+        let mut buf = Vec::with_capacity(16);
+        buf.extend_from_slice(&extrect.x().to_le_bytes());
+        buf.extend_from_slice(&extrect.y().to_le_bytes());
+        buf.extend_from_slice(&extrect.width().to_le_bytes());
+        buf.extend_from_slice(&extrect.height().to_le_bytes());
+        Ok(mem::write_bytes(buf))
+    })
+}
+
+#[no_mangle]
+#[wasm_error]
 pub extern "C" fn render_shape_pixels(
     a: u32,
     b: u32,


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14038

### Summary

This PR solves two issues:

1. Update component thumbnails to always match the component of the current file. It compares rendered-at and modified-at to check whether it has to update the thumbnail or not
2. For render-wasm, we need to use the shape's extrect instead of the selrect, otherwise the thumbnail will be cut off.

Before:
<img width="1630" height="569" alt="Screenshot from 2026-05-11 17-25-59" src="https://github.com/user-attachments/assets/dc015543-95d4-4ece-9568-5aa7e7afd34e" />


After:
<img width="1668" height="668" alt="Screenshot from 2026-05-11 17-26-28" src="https://github.com/user-attachments/assets/1dde9289-8569-4118-a8d4-915c2de1daf5" />

### Steps to reproduce 

- Load the file attached to the issue
- Check component thumbnails are correctly rendered 
- Repeat the process for svg and wasm renders

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
