### PR TITLE
:bug: Fix problem with viewer texts

### DIFF
--- a/frontend/playwright/ui/specs/multiseleccion.spec.js
+++ b/frontend/playwright/ui/specs/multiseleccion.spec.js
@@ -214,6 +214,11 @@ test("Multiselection of text and typographies", async ({ page }) => {
     pageId: "1062e0a0-8fe0-80ae-8007-e70b4993f5f0",
   });
 
+  await workspacePage.mockRPC(
+    "update-file?id=*",
+    "workspace/update-file-empty.json",
+  );
+
   const plainTextLayer = workspacePage.layers.getByTestId("layer-row").nth(5);
   const plainTextLayerTwo = workspacePage.layers
     .getByTestId("layer-row")

--- a/frontend/playwright/ui/specs/versions.spec.js
+++ b/frontend/playwright/ui/specs/versions.spec.js
@@ -121,6 +121,11 @@ test("BUG 13385 - Fix viewport not updating when restoring version", async ({ pa
   await workspacePage.mockGetFile("workspace/get-file-13385.json");
   await workspacePage.mockRPC("get-profiles-for-file-comments?file-id=*", "workspace/get-profiles-for-file-comments-13385.json");
 
+  await workspacePage.mockRPC(
+    "update-file?id=*",
+    "workspace/update-file-empty.json",
+  );
+
   // navigate to workspace and check that the circle shape is not there
   await workspacePage.goToWorkspace();
   await expect(workspacePage.layers.getByText("Ellipse")).not.toBeVisible();

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -203,6 +203,38 @@
               (rx/of (ptk/data-event ::all-libraries-resolved {:file-id file-id})))
              (rx/take-until stopper-s))))))
 
+
+(defn check-file-position-data
+  [file-id]
+  (ptk/reify ::fix-position-data
+    ptk/WatchEvent
+    (watch [it state _]
+      (let [file (dsh/lookup-file state file-id)
+            changes
+            (->> file :data :pages
+                 (mapcat
+                  (fn [page-id]
+                    (->> (dsh/lookup-page-objects state file-id page-id)
+                         (vals)
+                         (filter cfh/text-shape?)
+                         (filter #(nil? (:position-data %)))
+                         (map (fn [shape]
+                                {:type :mod-obj
+                                 :id (:id shape)
+                                 :page-id page-id
+                                 :operations
+                                 [{:type :set
+                                   :attr :position-data
+                                   :val (wasm.api/calculate-position-data shape)
+                                   :ignore-touched true
+                                   :ignore-geometry true}]})))))
+                 (into []))]
+        (rx/of (dch/commit-changes
+                {:redo-changes changes :undo-changes []
+                 :save-undo? false
+                 :origin it
+                 :tags #{:position-data}}))))))
+
 (defn- workspace-initialized
   [file-id]
   (ptk/reify ::workspace-initialized

--- a/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport_wasm.cljs
@@ -17,6 +17,7 @@
    [app.common.types.shape :as cts]
    [app.common.types.shape.layout :as ctl]
    [app.main.data.modal :as modal]
+   [app.main.data.workspace :as dw]
    [app.main.data.workspace.transforms :as dwt]
    [app.main.data.workspace.variants :as dwv]
    [app.main.features :as features]
@@ -455,7 +456,10 @@
             ;; blank canvas (first load) visible while shapes load.
             ;; The loading overlay is suppressed because on-shapes-ready
             ;; is set.
-            (wasm.api/initialize-viewport base-objects zoom vbox :background background)
+            (wasm.api/initialize-viewport base-objects zoom vbox
+                                          :background background
+                                          :on-shapes-ready
+                                          #(st/emit! (dw/check-file-position-data file-id)))
             (reset! initialized? true))
 
           (when (and (some? vern) (not= vern (mf/ref-val last-vern-ref)))


### PR DESCRIPTION

### Summary

Fix a problem with imported files texts that doesn't have the position-data information. This creates a new process on load that will calculate the data for the missing text elements.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
