### PR TITLE
:bug: Fix dependency libraries visible in UI after unlinking main library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -125,6 +125,7 @@
 - Fix `:heigth` typo in clipboard frame-same-size? (by @iot2edge) [Github #9250](https://github.com/penpot/penpot/pull/9250)
 - Fix Settings and Notifications "Update Settings" button enabled state when form has no changes (by @moorsecopers99) [Github #9090](https://github.com/penpot/penpot/issues/9090)
 - Fix library updates reappear after being applied and the file is reloaded [Taiga #14040](https://tree.taiga.io/project/penpot/issue/14040)
+- Fix dependency libraries remaining visible in UI after unlinking main library [Taiga #14020](https://tree.taiga.io/project/penpot/issue/14020)
 
 ## 2.15.0 (Unreleased)
 

--- a/frontend/src/app/main/data/workspace/libraries.cljs
+++ b/frontend/src/app/main/data/workspace/libraries.cljs
@@ -1558,6 +1558,27 @@
                                      :variants-count variants-count
                                      :library-used-in (:used-in library-usage)}))))))))))
 
+(defn cleanup-unlinked-libraries
+  "Remove libraries from state that are no longer linked to the given file.
+  This is used after unlinking a library to clean up transitive dependencies."
+  [file-id libraries]
+  (ptk/reify ::cleanup-unlinked-libraries
+    ptk/UpdateEvent
+    (update [_ state]
+      (let [linked-ids (into #{} (map :id) libraries)]
+        (update state :files
+                (fn [files]
+                  (reduce-kv
+                   (fn [acc id file]
+                     (if (and (= (:library-of file) file-id)
+                              (not (contains? linked-ids id))
+                              (not= id file-id))
+                       (dissoc acc id)
+                       acc))
+                   files
+                   files)))))))
+
+
 (defn unlink-file-from-library
   [file-id library-id]
   (ptk/reify ::detach-library
@@ -1573,7 +1594,11 @@
 
     ptk/WatchEvent
     (watch [_ _ _]
-      (let [params {:file-id file-id
-                    :library-id library-id}]
-        (->> (rp/cmd! :unlink-file-from-library params)
-             (rx/ignore))))))
+      ;; Unlink the library, then fetch the current list of linked libraries
+      ;; and remove any that are no longer linked (e.g., transitive dependencies)
+      (->> (rp/cmd! :unlink-file-from-library {:file-id file-id :library-id library-id})
+           (rx/mapcat (fn [_]
+                        (rp/cmd! :get-file-libraries {:file-id file-id})))
+           (rx/map (partial cleanup-unlinked-libraries file-id))))))
+
+


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14020

### Summary

See Taiga

### Steps to reproduce 

See taiga

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
