### PR TITLE
:bug: Fix editing a text element detaches applied tokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,7 @@
 - Fix several color picker issues [#9556](https://github.com/penpot/penpot/issues/9556) (PR: [#9558](https://github.com/penpot/penpot/pull/9558))
 - Fix asset icon broken on Asset tab [#9587](https://github.com/penpot/penpot/issues/9587) (PR: [#9612](https://github.com/penpot/penpot/pull/9612))
 - Fix text fill color stops updating in multiselect with texts [#9608](https://github.com/penpot/penpot/issues/9608) (PR: [#9549](https://github.com/penpot/penpot/pull/9549))
+- Fix editing a legacy text element silently detaches its color token [Taiga #13958](https://tree.taiga.io/project/penpot/issue/13958)
 
 ## 2.15.4 (Unreleased)
 

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -177,7 +177,9 @@
 
 (defn not-empty?
   [coll]
-  (boolean (seq coll)))
+  (if (coll? coll)
+    (boolean (seq coll))
+    (not (nil? coll))))
 
 (defn editable-collection?
   [m]

--- a/common/src/app/common/types/text.cljc
+++ b/common/src/app/common/types/text.cljc
@@ -242,8 +242,11 @@
                acc)
 
              :else
-             ;; If the key is not :text, and they are different, it is an attribute differece
-             (if (not= v1 v2)
+             ;; If the key is not :text, and they are different, it is an attribute difference.
+             ;; Take into account that some processes remove empty attributes, so in some
+             ;; cases we will compare [] with nil, and this is not a difference.
+             (if (and (not= v1 v2)
+                      (or (d/not-empty? v1) (d/not-empty? v2)))
                (attribute-cb acc k)
                acc))))
        #{}

--- a/frontend/playwright/data/workspace/get-file-13958.json
+++ b/frontend/playwright/data/workspace/get-file-13958.json
@@ -1,0 +1,4321 @@
+{
+    "~:features": {
+        "~#set": [
+            "fdata/path-data",
+            "design-tokens/v1",
+            "variants/v1",
+            "layout/grid",
+            "fdata/objects-map",
+            "components/v2",
+            "fdata/shape-data-type"
+        ]
+    },
+    "~:team-id": "~uc6b102e2-5aaa-809c-8007-dcd1eab2135d",
+    "~:permissions": {
+        "~:type": "~:membership",
+        "~:is-owner": true,
+        "~:is-admin": true,
+        "~:can-edit": true,
+        "~:can-read": true,
+        "~:is-logged": true
+    },
+    "~:has-media-trimmed": false,
+    "~:comment-thread-seqn": 0,
+    "~:name": "color tokens detach (copy)",
+    "~:revn": 11,
+    "~:modified-at": "~m1778577544627",
+    "~:vern": 151920609,
+    "~:id": "~u1bac06a1-a942-80a6-8008-0222e1ec38d5",
+    "~:is-shared": false,
+    "~:migrations": {
+        "~#ordered-set": [
+            "legacy-2",
+            "legacy-3",
+            "legacy-5",
+            "legacy-6",
+            "legacy-7",
+            "legacy-8",
+            "legacy-9",
+            "legacy-10",
+            "legacy-11",
+            "legacy-12",
+            "legacy-13",
+            "legacy-14",
+            "legacy-16",
+            "legacy-17",
+            "legacy-18",
+            "legacy-19",
+            "legacy-25",
+            "legacy-26",
+            "legacy-27",
+            "legacy-28",
+            "legacy-29",
+            "legacy-31",
+            "legacy-32",
+            "legacy-33",
+            "legacy-34",
+            "legacy-36",
+            "legacy-37",
+            "legacy-38",
+            "legacy-39",
+            "legacy-40",
+            "legacy-41",
+            "legacy-42",
+            "legacy-43",
+            "legacy-44",
+            "legacy-45",
+            "legacy-46",
+            "legacy-47",
+            "legacy-48",
+            "legacy-49",
+            "legacy-50",
+            "legacy-51",
+            "legacy-52",
+            "legacy-53",
+            "legacy-54",
+            "legacy-55",
+            "legacy-56",
+            "legacy-57",
+            "legacy-59",
+            "legacy-62",
+            "legacy-65",
+            "legacy-66",
+            "legacy-67",
+            "0001-remove-tokens-from-groups",
+            "0002-normalize-bool-content-v2",
+            "0002-clean-shape-interactions",
+            "0003-fix-root-shape",
+            "0003-convert-path-content-v2",
+            "0005-deprecate-image-type",
+            "0006-fix-old-texts-fills",
+            "0008-fix-library-colors-v4",
+            "0009-clean-library-colors",
+            "0009-add-partial-text-touched-flags",
+            "0010-fix-swap-slots-pointing-non-existent-shapes",
+            "0011-fix-invalid-text-touched-flags",
+            "0012-fix-position-data",
+            "0013-fix-component-path",
+            "0013-clear-invalid-strokes-and-fills",
+            "0014-fix-tokens-lib-duplicate-ids",
+            "0014-clear-components-nil-objects",
+            "0015-fix-text-attrs-blank-strings",
+            "0015-clean-shadow-color",
+            "0016-copy-fills-from-position-data-to-text-node",
+            "0017-fix-layout-flex-dir",
+            "0018-remove-unneeded-objects-from-components",
+            "0019-fix-missing-swap-slots",
+            "0020-sync-component-id-with-near-main",
+            "0021-repair-bad-tokens"
+        ]
+    },
+    "~:version": 67,
+    "~:project-id": "~u4cdd76d8-0e6d-8168-8008-0118118e1a1a",
+    "~:created-at": "~m1778507716647",
+    "~:backend": "legacy-db",
+    "~:data": {
+        "~:pages": [
+            "~u1919607f-7059-80e9-8007-d7b6ba437f17"
+        ],
+        "~:pages-index": {
+            "~u1919607f-7059-80e9-8007-d7b6ba437f17": {
+                "~:id": "~u1919607f-7059-80e9-8007-d7b6ba437f17",
+                "~:name": "Page 1",
+                "~:objects": {
+                    "~#penpot/objects-map/v2": {
+                        "~ufb6e1db9-e999-8049-8007-d7b7ac11fbac": "[\"~#shape\",[\"^ \",\"~:y\",603,\"~:layout-item-hsizing\",\"fill\",\"~:transform\",[\"~#matrix\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:rotation\",0,\"~:grow-type\",\"~:auto-height\",\"~:content\",[\"^ \",\"~:type\",\"root\",\"~:children\",[[\"^ \",\"^8\",\"paragraph-set\",\"^9\",[[\"^ \",\"~:line-height\",\"1.5\",\"~:path\",\"font-screen-lg / body\",\"~:font-style\",\"normal\",\"^9\",[[\"^ \",\"^:\",\"1.5\",\"^;\",\"font-screen-lg / body\",\"^<\",\"normal\",\"~:text-transform\",\"none\",\"~:text-align\",\"left\",\"~:font-id\",\"gfont-dm-sans\",\"~:text-style-id\",\"S:61089755d06cc251915221fee7a45ae2841996c6,\",\"~:font-size\",\"16\",\"~:font-weight\",\"400\",\"~:modified-at\",\"2025-01-24T18:57:32.766Z\",\"~:font-variant-id\",\"regular\",\"~:text-decoration\",\"none\",\"~:letter-spacing\",\"0\",\"~:fills\",[[\"^ \",\"~:fill-color\",\"#2f2c35\",\"~:fill-opacity\",1]],\"~:font-family\",\"DM Sans\",\"~:text\",\"Design tokens are a set of codified design decisions that store raw design values as named entities, making them core pieces of a design system. \\n\"],[\"^ \",\"^:\",\"1\",\"^<\",\"normal\",\"^?\",\"sourcesanspro\",\"^A\",\"16\",\"^B\",\"400\",\"^D\",\"regular\",\"^F\",\"0\",\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^K\",\"\\n\"],[\"^ \",\"^:\",\"1.5\",\"^;\",\"font-screen-lg / body\",\"^<\",\"normal\",\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"^@\",\"S:61089755d06cc251915221fee7a45ae2841996c6,\",\"^A\",\"16\",\"^B\",\"400\",\"^C\",\"2025-01-24T18:57:32.766Z\",\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0\",\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^J\",\"DM Sans\",\"^K\",\"\\n\"],[\"^ \",\"^:\",\"1\",\"^<\",\"normal\",\"^?\",\"sourcesanspro\",\"^A\",\"16\",\"^B\",\"400\",\"^D\",\"regular\",\"^F\",\"0\",\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^K\",\"\\n\"],[\"^ \",\"^:\",\"1.5\",\"^;\",\"font-screen-lg / body\",\"^<\",\"normal\",\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"^@\",\"S:61089755d06cc251915221fee7a45ae2841996c6,\",\"^A\",\"16\",\"^B\",\"400\",\"^C\",\"2025-01-24T18:57:32.766Z\",\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0\",\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^J\",\"DM Sans\",\"^K\",\"They are adaptable to any platform and are used to replace hard-coded variables.\"]],\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"~:key\",\"6m627\",\"^@\",\"S:61089755d06cc251915221fee7a45ae2841996c6,\",\"^A\",\"16\",\"^B\",\"400\",\"^8\",\"paragraph\",\"^C\",\"2025-01-24T18:57:32.766Z\",\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0\",\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^J\",\"DM Sans\"]]]],\"~:vertical-align\",\"top\",\"^G\",[]],\"~:blend-mode\",\"~:normal\",\"~:name\",\"Design tokens are a set\",\"~:width\",704,\"^8\",\"^K\",\"~:svg-attrs\",[\"^ \"],\"~:points\",[[\"~#point\",[\"^ \",\"~:x\",727,\"~:y\",603]],[\"^T\",[\"^ \",\"~:x\",1431,\"~:y\",603]],[\"^T\",[\"^ \",\"~:x\",1431,\"~:y\",747]],[\"^T\",[\"^ \",\"~:x\",727,\"~:y\",747]]],\"~:proportion-lock\",false,\"~:transform-inverse\",[\"^3\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:page-id\",\"~u1919607f-7059-80e9-8007-d7b6ba437f17\",\"~:hidden\",false,\"~:opacity\",1,\"~:id\",\"~ufb6e1db9-e999-8049-8007-d7b7ac11fbac\",\"~:parent-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:applied-tokens\",[\"^ \",\"~:fill\",\"xx.alias.color.text.default\"],\"~:layout-item-vsizing\",\"auto\",\"~:position-data\",[[\"^ \",\"~:y\",625.4199829101562,\"^:\",\"1.2\",\"^<\",\"normal\",\"~:typography-ref-id\",null,\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"^A\",\"16px\",\"^B\",\"400\",\"~:typography-ref-file\",null,\"~:text-direction\",\"ltr\",\"^Q\",676.6099853515625,\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0px\",\"~:x\",727,\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"~:direction\",\"ltr\",\"^J\",\"DM Sans\",\"~:height\",20.8399658203125,\"^K\",\"Design tokens are a set of codified design decisions that store raw design values as named \"],[\"^ \",\"~:y\",649.4199829101562,\"^:\",\"1.2\",\"^<\",\"normal\",\"^14\",null,\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"^A\",\"16px\",\"^B\",\"400\",\"^15\",null,\"^16\",\"ltr\",\"^Q\",400.2900390625,\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0px\",\"~:x\",727,\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^17\",\"ltr\",\"^J\",\"DM Sans\",\"^18\",20.8399658203125,\"^K\",\"entities, making them core pieces of a design system. \"],[\"^ \",\"~:y\",673.3599853515625,\"^:\",\"1.2\",\"^<\",\"normal\",\"^14\",null,\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"sourcesanspro\",\"^A\",\"16px\",\"^B\",\"400\",\"^15\",null,\"^16\",\"ltr\",\"^Q\",0,\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0px\",\"~:x\",727,\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^17\",\"ltr\",\"^J\",\"sourcesanspro\",\"^18\",20.719970703125,\"^K\",\"\"],[\"^ \",\"~:y\",697.4199829101562,\"^:\",\"1.2\",\"^<\",\"normal\",\"^14\",null,\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"^A\",\"16px\",\"^B\",\"400\",\"^15\",null,\"^16\",\"ltr\",\"^Q\",0,\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0px\",\"~:x\",727,\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^17\",\"ltr\",\"^J\",\"DM Sans\",\"^18\",20.8399658203125,\"^K\",\"\"],[\"^ \",\"~:y\",721.3599853515625,\"^:\",\"1.2\",\"^<\",\"normal\",\"^14\",null,\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"sourcesanspro\",\"^A\",\"16px\",\"^B\",\"400\",\"^15\",null,\"^16\",\"ltr\",\"^Q\",0,\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0px\",\"~:x\",727,\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^17\",\"ltr\",\"^J\",\"sourcesanspro\",\"^18\",20.719970703125,\"^K\",\"\"],[\"^ \",\"~:y\",745.4199829101562,\"^:\",\"1.2\",\"^<\",\"normal\",\"^14\",null,\"^=\",\"none\",\"^>\",\"left\",\"^?\",\"gfont-dm-sans\",\"^A\",\"16px\",\"^B\",\"400\",\"^15\",null,\"^16\",\"ltr\",\"^Q\",607.7900390625,\"^D\",\"regular\",\"^E\",\"none\",\"^F\",\"0px\",\"~:x\",727,\"^G\",[[\"^ \",\"^H\",\"#2f2c35\",\"^I\",1]],\"^17\",\"ltr\",\"^J\",\"DM Sans\",\"^18\",20.8399658203125,\"^K\",\"They are adaptable to any platform and are used to replace hard-coded variables.\"]],\"~:frame-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:strokes\",[],\"~:x\",727,\"~:blocked\",false,\"~:selrect\",[\"~#rect\",[\"^ \",\"~:x\",727,\"~:y\",603,\"^Q\",704,\"^18\",144,\"~:x1\",727,\"~:y1\",603,\"~:x2\",1431,\"~:y2\",747]],\"^G\",[],\"~:flip-x\",null,\"^18\",144,\"~:flip-y\",null]]",
+                        "~u00000000-0000-0000-0000-000000000000": "[\"~#shape\",[\"^ \",\"~:y\",0,\"~:hide-fill-on-export\",false,\"~:transform\",[\"~#matrix\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:rotation\",0,\"~:name\",\"Root Frame\",\"~:width\",0.01,\"~:type\",\"~:frame\",\"~:points\",[[\"~#point\",[\"^ \",\"~:x\",0.0,\"~:y\",0.0]],[\"^:\",[\"^ \",\"~:x\",0.01,\"~:y\",0.0]],[\"^:\",[\"^ \",\"~:x\",0.01,\"~:y\",0.01]],[\"^:\",[\"^ \",\"~:x\",0.0,\"~:y\",0.01]]],\"~:r2\",0,\"~:proportion-lock\",false,\"~:transform-inverse\",[\"^3\",[\"^ \",\"~:a\",1.0,\"~:b\",0.0,\"~:c\",0.0,\"~:d\",1.0,\"~:e\",0.0,\"~:f\",0.0]],\"~:page-id\",\"~u1919607f-7059-80e9-8007-d7b6ba437f17\",\"~:r3\",0,\"~:r1\",0,\"~:id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:parent-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:frame-id\",\"~u00000000-0000-0000-0000-000000000000\",\"~:strokes\",[],\"~:x\",0,\"~:proportion\",1.0,\"~:r4\",0,\"~:selrect\",[\"~#rect\",[\"^ \",\"~:x\",0,\"~:y\",0,\"^6\",0.01,\"~:height\",0.01,\"~:x1\",0,\"~:y1\",0,\"~:x2\",0.01,\"~:y2\",0.01]],\"~:fills\",[[\"^ \",\"~:fill-color\",\"#FFFFFF\",\"~:fill-opacity\",1]],\"~:flip-x\",null,\"^I\",0.01,\"~:flip-y\",null,\"~:shapes\",[\"~ufb6e1db9-e999-8049-8007-d7b7ac11fbac\"]]]"
+                    }
+                }
+            }
+        },
+        "~:tokens-lib": {
+            "~#penpot/tokens-lib": {
+                "~:sets": {
+                    "~#ordered-map": [
+                        [
+                            "G-global",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "S-color",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0cf6d3",
+                                                "~:name": "global/color",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716659",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.global.color.mint.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dcb",
+                                                                    "~:name": "xx.global.color.mint.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#188675",
+                                                                    "~:description": "global color mint of weight 500",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca44a",
+                                                                    "~:name": "xx.global.color.violet.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#D0D2F3",
+                                                                    "~:description": "global color violet of weight 200",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dba",
+                                                                    "~:name": "xx.global.color.neutral.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#DCDCDD",
+                                                                    "~:description": "global color neutral of weight 300",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc5",
+                                                                    "~:name": "xx.global.color.mint.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#1A6A5D",
+                                                                    "~:description": "global color mint of weight 600",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db8",
+                                                                    "~:name": "xx.global.color.neutral.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FCFCFC",
+                                                                    "~:description": "global color neutral of weight 50",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd5",
+                                                                    "~:name": "xx.global.color.orange.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#C07B4B",
+                                                                    "~:description": "global color orange of weight 500",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db9",
+                                                                    "~:name": "xx.global.color.neutral.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#747279",
+                                                                    "~:description": "global color neutral of weight 600",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db4",
+                                                                    "~:name": "xx.global.color.blue.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#B1DBEF",
+                                                                    "~:description": "global color blue of weight 200",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca466",
+                                                                    "~:name": "xx.global.color.red.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F37A73",
+                                                                    "~:description": "global color red of weight 400",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dae",
+                                                                    "~:name": "xx.global.color.blue.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F6FBFD",
+                                                                    "~:description": "global color blue of weight 50",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca44d",
+                                                                    "~:name": "xx.global.color.violet.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#39345A",
+                                                                    "~:description": "global color violet of weight 800",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca45e",
+                                                                    "~:name": "xx.global.color.green.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#B0E1AA",
+                                                                    "~:description": "global color green of weight 200",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd7",
+                                                                    "~:name": "xx.global.color.orange.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#6B432B",
+                                                                    "~:description": "global color orange of weight 800",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca44b",
+                                                                    "~:name": "xx.global.color.violet.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#686FC8",
+                                                                    "~:description": "global color violet of weight 500",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db1",
+                                                                    "~:name": "xx.global.color.blue.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#006596",
+                                                                    "~:description": "global color blue of weight 700",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db6",
+                                                                    "~:name": "xx.global.color.blue.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#003C5A",
+                                                                    "~:description": "global color blue of weight 900",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca458",
+                                                                    "~:name": "xx.global.color.green.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#f7fbeb",
+                                                                    "~:description": "global color green of weight 50",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca463",
+                                                                    "~:name": "xx.global.color.red.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#934846",
+                                                                    "~:description": "global color red of weight 600",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca450",
+                                                                    "~:name": "xx.global.color.yellow.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#D4BB5F",
+                                                                    "~:description": "global color yellow of weight 300",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd4",
+                                                                    "~:name": "xx.global.color.orange.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F9CCA9",
+                                                                    "~:description": "global color orange of weight 200",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca447",
+                                                                    "~:name": "xx.global.color.violet.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#49457A",
+                                                                    "~:description": "global color violet of weight 700",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca444",
+                                                                    "~:name": "xx.global.color.violet.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FCFCFE",
+                                                                    "~:description": "global color violet of weight 50",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca455",
+                                                                    "~:name": "xx.global.color.yellow.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#84773F",
+                                                                    "~:description": "global color yellow of weight 500",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca44e",
+                                                                    "~:name": "xx.global.color.yellow.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FFFCF5",
+                                                                    "~:description": "global color yellow of weight 50",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca448",
+                                                                    "~:name": "xx.global.color.violet.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#9598E0",
+                                                                    "~:description": "global color violet of weight 400",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca464",
+                                                                    "~:name": "xx.global.color.red.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FCA69C",
+                                                                    "~:description": "global color red of weight 300",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd1",
+                                                                    "~:name": "xx.global.color.orange.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#855435",
+                                                                    "~:description": "global color orange of weight 700",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca45c",
+                                                                    "~:name": "xx.global.color.green.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#69AD65",
+                                                                    "~:description": "global color green of weight 400",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db0",
+                                                                    "~:name": "xx.global.color.blue.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#84C5E6",
+                                                                    "~:description": "global color blue of weight 300",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db3",
+                                                                    "~:name": "xx.global.color.blue.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#E0F0F9",
+                                                                    "~:description": "global color blue of weight 100",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dcf",
+                                                                    "~:name": "xx.global.color.orange.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#9D633E",
+                                                                    "~:description": "global color orange of weight 600",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca454",
+                                                                    "~:name": "xx.global.color.yellow.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F0D36B",
+                                                                    "~:description": "global color yellow of weight 200",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca462",
+                                                                    "~:name": "xx.global.color.red.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FFFBFB",
+                                                                    "~:description": "global color red of weight 50",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dbf",
+                                                                    "~:name": "xx.global.color.neutral.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#8B898F",
+                                                                    "~:description": "global color neutral of weight 500",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca45a",
+                                                                    "~:name": "xx.global.color.green.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#7FCE7A",
+                                                                    "~:description": "global color green of weight 300",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca45f",
+                                                                    "~:name": "xx.global.color.green.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#51834E",
+                                                                    "~:description": "global color green of weight 500",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca468",
+                                                                    "~:name": "xx.global.color.red.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FFC7BF",
+                                                                    "~:description": "global color red of weight 200",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca451",
+                                                                    "~:name": "xx.global.color.yellow.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#534B2B",
+                                                                    "~:description": "global color yellow of weight 700",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db7",
+                                                                    "~:name": "xx.global.color.blue.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#005179",
+                                                                    "~:description": "global color blue of weight 800",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca469",
+                                                                    "~:name": "xx.global.color.red.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#BA5A56",
+                                                                    "~:description": "global color red of weight 500",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4daf",
+                                                                    "~:name": "xx.global.color.blue.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#0077B2",
+                                                                    "~:description": "global color blue of weight 600",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca44f",
+                                                                    "~:name": "xx.global.color.yellow.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#685E34",
+                                                                    "~:description": "global color yellow of weight 600",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca453",
+                                                                    "~:name": "xx.global.color.yellow.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FDECC3",
+                                                                    "~:description": "global color yellow of weight 100",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca465",
+                                                                    "~:name": "xx.global.color.red.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#743A3A",
+                                                                    "~:description": "global color red of weight 700",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca446",
+                                                                    "~:name": "xx.global.color.violet.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#B6B8EB",
+                                                                    "~:description": "global color violet of weight 300",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd6",
+                                                                    "~:name": "xx.global.color.orange.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#4F3120",
+                                                                    "~:description": "global color orange of weight 900",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc4",
+                                                                    "~:name": "xx.global.color.mint.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F6FEFB",
+                                                                    "~:description": "global color mint of weight 50",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca457",
+                                                                    "~:name": "xx.global.color.yellow.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#3E3922",
+                                                                    "~:description": "global color yellow of weight 800",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.black",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca46c",
+                                                                    "~:name": "xx.global.color.black",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#000000",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.500",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db5",
+                                                                    "~:name": "xx.global.color.blue.500",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#1993D0",
+                                                                    "~:description": "global color blue of weight 500",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dcd",
+                                                                    "~:name": "xx.global.color.mint.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#174039",
+                                                                    "~:description": "global color mint of weight 800",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.950",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc2",
+                                                                    "~:name": "xx.global.color.neutral.950",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#1C1C1E",
+                                                                    "~:description": "global color neutral of weight 950",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca445",
+                                                                    "~:name": "xx.global.color.violet.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#57579C",
+                                                                    "~:description": "global color violet of weight 600",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dbe",
+                                                                    "~:name": "xx.global.color.neutral.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F3F3F4",
+                                                                    "~:description": "global color neutral of weight 200",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc1",
+                                                                    "~:name": "xx.global.color.neutral.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#3B3741",
+                                                                    "~:description": "global color neutral of weight 800",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca46a",
+                                                                    "~:name": "xx.global.color.red.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#3B2020",
+                                                                    "~:description": "global color red of weight 900",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca456",
+                                                                    "~:name": "xx.global.color.yellow.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2B2819",
+                                                                    "~:description": "global color yellow of weight 900",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd3",
+                                                                    "~:name": "xx.global.color.orange.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FCEBDC",
+                                                                    "~:description": "global color orange of weight 100",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca467",
+                                                                    "~:name": "xx.global.color.red.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FFE9E5",
+                                                                    "~:description": "global color red of weight 100",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dbc",
+                                                                    "~:name": "xx.global.color.neutral.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#AEADB1",
+                                                                    "~:description": "global color neutral of weight 400",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.red.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca46b",
+                                                                    "~:name": "xx.global.color.red.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#572D2D",
+                                                                    "~:description": "global color red of weight 800",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dce",
+                                                                    "~:name": "xx.global.color.orange.50",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FEF9F5",
+                                                                    "~:description": "global color orange of weight 50",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.200",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dca",
+                                                                    "~:name": "xx.global.color.mint.200",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#55EBCE",
+                                                                    "~:description": "global color mint of weight 200",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dcc",
+                                                                    "~:name": "xx.global.color.mint.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#142C28",
+                                                                    "~:description": "global color mint of weight 900",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc6",
+                                                                    "~:name": "xx.global.color.mint.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#00D4B6",
+                                                                    "~:description": "global color mint of weight 300",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.800",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca461",
+                                                                    "~:name": "xx.global.color.green.800",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2A3E28",
+                                                                    "~:description": "global color green of weight 800",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.600",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca459",
+                                                                    "~:name": "xx.global.color.green.600",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#42673F",
+                                                                    "~:description": "global color green of weight 600",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca45b",
+                                                                    "~:name": "xx.global.color.green.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#365233",
+                                                                    "~:description": "global color green of weight 700",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca45d",
+                                                                    "~:name": "xx.global.color.green.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#DFF3DC",
+                                                                    "~:description": "global color green of weight 100",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc0",
+                                                                    "~:name": "xx.global.color.neutral.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2F2C35",
+                                                                    "~:description": "global color neutral of weight 900",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dbb",
+                                                                    "~:name": "xx.global.color.neutral.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#49454E",
+                                                                    "~:description": "global color neutral of weight 700",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd2",
+                                                                    "~:name": "xx.global.color.orange.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#E39258",
+                                                                    "~:description": "global color orange of weight 400",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc8",
+                                                                    "~:name": "xx.global.color.mint.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#0AB29A",
+                                                                    "~:description": "global color mint of weight 400",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.700",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc7",
+                                                                    "~:name": "xx.global.color.mint.700",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#19544B",
+                                                                    "~:description": "global color mint of weight 700",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.yellow.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca452",
+                                                                    "~:name": "xx.global.color.yellow.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#B19D51",
+                                                                    "~:description": "global color yellow of weight 400",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.neutral.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dbd",
+                                                                    "~:name": "xx.global.color.neutral.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#FAFAFB",
+                                                                    "~:description": "global color neutral of weight 100",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca449",
+                                                                    "~:name": "xx.global.color.violet.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ECEDFA",
+                                                                    "~:description": "global color violet of weight 100",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.orange.300",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dd0",
+                                                                    "~:name": "xx.global.color.orange.300",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F6AD76",
+                                                                    "~:description": "global color orange of weight 300",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.white",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc3",
+                                                                    "~:name": "xx.global.color.white",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ffffff",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.mint.100",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dc9",
+                                                                    "~:name": "xx.global.color.mint.100",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#C5F8EA",
+                                                                    "~:description": "global color mint of weight 100",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.blue.400",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4db2",
+                                                                    "~:name": "xx.global.color.blue.400",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#53AFDC",
+                                                                    "~:description": "global color blue of weight 400",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.violet.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca44c",
+                                                                    "~:name": "xx.global.color.violet.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#29253C",
+                                                                    "~:description": "global color violet of weight 900",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.color.green.900",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca460",
+                                                                    "~:name": "xx.global.color.green.900",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#1E2B1D",
+                                                                    "~:description": "global color green of weight 900",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-dimension",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0e2151",
+                                                "~:name": "global/dimension",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716664",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.global.dimensions.13",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da8",
+                                                                    "~:name": "xx.global.dimensions.13",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "64px",
+                                                                    "~:description": "13th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.11",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dab",
+                                                                    "~:name": "xx.global.dimensions.11",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "52px",
+                                                                    "~:description": "11th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.14",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da3",
+                                                                    "~:name": "xx.global.dimensions.14",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "72px",
+                                                                    "~:description": "14th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.10",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dad",
+                                                                    "~:name": "xx.global.dimensions.10",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "48px",
+                                                                    "~:description": "10th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.6",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da9",
+                                                                    "~:name": "xx.global.dimensions.6",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "20px",
+                                                                    "~:description": "6th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.3",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da0",
+                                                                    "~:name": "xx.global.dimensions.3",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "8px",
+                                                                    "~:description": "3rd step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.2",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4dac",
+                                                                    "~:name": "xx.global.dimensions.2",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "4px",
+                                                                    "~:description": "2nd step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.12",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da7",
+                                                                    "~:name": "xx.global.dimensions.12",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "60px",
+                                                                    "~:description": "12th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.8",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da2",
+                                                                    "~:name": "xx.global.dimensions.8",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "32px",
+                                                                    "~:description": "8th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.7",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da5",
+                                                                    "~:name": "xx.global.dimensions.7",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "24px",
+                                                                    "~:description": "7th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.15",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da4",
+                                                                    "~:name": "xx.global.dimensions.15",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "80px",
+                                                                    "~:description": "15th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.4",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da1",
+                                                                    "~:name": "xx.global.dimensions.4",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "12px",
+                                                                    "~:description": "4th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.9",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d9f",
+                                                                    "~:name": "xx.global.dimensions.9",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "44px",
+                                                                    "~:description": "9th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.1",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4daa",
+                                                                    "~:name": "xx.global.dimensions.1",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "2px",
+                                                                    "~:description": "1st step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.global.dimensions.5",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4da6",
+                                                                    "~:name": "xx.global.dimensions.5",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "16px",
+                                                                    "~:description": "5th step of global dimensions sequence",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-Opacity",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0e7da8",
+                                                "~:name": "global/Opacity",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716665",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "opacity.0",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca494",
+                                                                    "~:name": "opacity.0",
+                                                                    "~:type": "~:opacity",
+                                                                    "~:value": "0",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "opacity.10",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca495",
+                                                                    "~:name": "opacity.10",
+                                                                    "~:type": "~:opacity",
+                                                                    "~:value": "0.1",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "opacity.50",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca496",
+                                                                    "~:name": "opacity.50",
+                                                                    "~:type": "~:opacity",
+                                                                    "~:value": "0.5",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "G-alias",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "S-border",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ece1d",
+                                                "~:name": "alias/border",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716667",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.alias.border.radius.sm",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b0",
+                                                                    "~:name": "xx.alias.border.radius.sm",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "{xx.global.dimensions.2}",
+                                                                    "~:description": "small border radius",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.border.radius.md",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b1",
+                                                                    "~:name": "xx.alias.border.radius.md",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "{xx.global.dimensions.3}",
+                                                                    "~:description": "medium border radius",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.border.radius.lg",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b2",
+                                                                    "~:name": "xx.alias.border.radius.lg",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "{xx.global.dimensions.5}",
+                                                                    "~:description": "large border radius",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.border.radius.round",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b3",
+                                                                    "~:name": "xx.alias.border.radius.round",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "100%",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "stroke.outline",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b4",
+                                                                    "~:name": "stroke.outline",
+                                                                    "~:type": "~:stroke-width",
+                                                                    "~:value": "{xx.global.dimensions.1}",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "stroke.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b5",
+                                                                    "~:name": "stroke.medium",
+                                                                    "~:type": "~:stroke-width",
+                                                                    "~:value": "3",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "stroke.small",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b6",
+                                                                    "~:name": "stroke.small",
+                                                                    "~:type": "~:stroke-width",
+                                                                    "~:value": "1",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "stroke.large-test",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b7",
+                                                                    "~:name": "stroke.large-test",
+                                                                    "~:type": "~:stroke-width",
+                                                                    "~:value": "25",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-dimension",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f101a3f",
+                                                "~:name": "alias/dimension",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716672",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.alias.size.xs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca499",
+                                                                    "~:name": "xx.alias.size.xs",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.6}",
+                                                                    "~:description": "extra small size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "rotation.45",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0cf6d1",
+                                                                    "~:name": "rotation.45",
+                                                                    "~:type": "~:rotation",
+                                                                    "~:value": "45",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716659"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.lg",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a7",
+                                                                    "~:name": "xx.alias.spacing.lg",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.7}",
+                                                                    "~:description": "large spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "dimension.top.position",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0cf6d2",
+                                                                    "~:name": "dimension.top.position",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "{xx.global.dimensions.7}",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716659"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.icon.size.m",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0cf6ce",
+                                                                    "~:name": "xx.alias.icon.size.m",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "24",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716659"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.xxxl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4ab",
+                                                                    "~:name": "xx.alias.spacing.xxxl",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.13}",
+                                                                    "~:description": "extra extra extra small spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.lg",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca49d",
+                                                                    "~:name": "xx.alias.size.lg",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.10}",
+                                                                    "~:description": "large size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.xxxs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a9",
+                                                                    "~:name": "xx.alias.spacing.xxxs",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.1}",
+                                                                    "~:description": "extra extra extra small spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a3",
+                                                                    "~:name": "xx.alias.size.xxl",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.13}",
+                                                                    "~:description": "extra extra large size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxxxl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca49c",
+                                                                    "~:name": "xx.alias.size.xxxxl",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.15}",
+                                                                    "~:description": "extra extra extra large size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.xxs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a8",
+                                                                    "~:name": "xx.alias.spacing.xxs",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.2}",
+                                                                    "~:description": "extra extra small spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.icon.size.xs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0cf6cf",
+                                                                    "~:name": "xx.alias.icon.size.xs",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "12",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716659"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca49e",
+                                                                    "~:name": "xx.alias.size.xxs",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.5}",
+                                                                    "~:description": "extra extra small size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.sm",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4ad",
+                                                                    "~:name": "xx.alias.spacing.sm",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.4}",
+                                                                    "~:description": "small spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.sm",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a4",
+                                                                    "~:name": "xx.alias.size.sm",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.7}",
+                                                                    "~:description": "small size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.icon.size.s",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0cf6d0",
+                                                                    "~:name": "xx.alias.icon.size.s",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "16",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716659"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a1",
+                                                                    "~:name": "xx.alias.size.xl",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.11}",
+                                                                    "~:description": "extra large size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.xxl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4ac",
+                                                                    "~:name": "xx.alias.spacing.xxl",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.10}",
+                                                                    "~:description": "extra extra small spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxxxs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a0",
+                                                                    "~:name": "xx.alias.size.xxxxs",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.3}",
+                                                                    "~:description": "extra extra extra small size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxxs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca49f",
+                                                                    "~:name": "xx.alias.size.xxxs",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.4}",
+                                                                    "~:description": "extra extra extra small size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.xl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4aa",
+                                                                    "~:name": "xx.alias.spacing.xl",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.8}",
+                                                                    "~:description": "extra large spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.md",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca49a",
+                                                                    "~:name": "xx.alias.size.md",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.8}",
+                                                                    "~:description": "medium size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.md",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a6",
+                                                                    "~:name": "xx.alias.spacing.md",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.5}",
+                                                                    "~:description": "medium spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxxxxs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca49b",
+                                                                    "~:name": "xx.alias.size.xxxxxs",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.2}",
+                                                                    "~:description": "extra extra extra small size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.size.xxxl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a2",
+                                                                    "~:name": "xx.alias.size.xxxl",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.global.dimensions.14}",
+                                                                    "~:description": "extra extra extra large size unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.spacing.xs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca4a5",
+                                                                    "~:name": "xx.alias.spacing.xs",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.global.dimensions.3}",
+                                                                    "~:description": "extra small spacing unit",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-color-dark",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f12beff",
+                                                "~:name": "alias/color-dark",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716682",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.alias.color.purpose.onInfo",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d7e",
+                                                                    "~:name": "xx.alias.color.purpose.onInfo",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.blue.800}",
+                                                                    "~:description": "color for elements placed on informational purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.heavy",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d85",
+                                                                    "~:name": "xx.alias.color.border.heavy",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.200}",
+                                                                    "~:description": "heavy border color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.select",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d8d",
+                                                                    "~:name": "xx.alias.color.state.select",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.100}",
+                                                                    "~:description": "background color for selected elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.onBrand",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d92",
+                                                                    "~:name": "xx.alias.color.primary.onBrand",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.800}",
+                                                                    "~:description": "color for elements that are placed on brand background color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.focus",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d8a",
+                                                                    "~:name": "xx.alias.color.state.focus",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba({xx.global.color.neutral.100},0.16)",
+                                                                    "~:description": "Background color for state overlay of a focused element",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.press",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d8c",
+                                                                    "~:name": "xx.alias.color.state.press",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba({xx.global.color.neutral.100},0.8)",
+                                                                    "~:description": "Background color for state overlay of a pressed element",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.warningHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d83",
+                                                                    "~:name": "xx.alias.color.purpose.warningHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.yellow.100}",
+                                                                    "~:description": "color for elements with warning purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onSelect",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d91",
+                                                                    "~:name": "xx.alias.color.state.onSelect",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.600}",
+                                                                    "~:description": "Foreground color for selected elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.interaction",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d93",
+                                                                    "~:name": "xx.alias.color.primary.interaction",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.600}",
+                                                                    "~:description": "Color that indicates interactions",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.focusOutline",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d86",
+                                                                    "~:name": "xx.alias.color.border.focusOutline",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba({xx.global.color.blue.400},0.5)",
+                                                                    "~:description": "color for default focus outline",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.disable",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d8e",
+                                                                    "~:name": "xx.alias.color.state.disable",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.300}",
+                                                                    "~:description": "background color for disabled elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.infoHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d84",
+                                                                    "~:name": "xx.alias.color.purpose.infoHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.blue.200}",
+                                                                    "~:description": "color for elements with informational purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.infoLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d79",
+                                                                    "~:name": "xx.alias.color.purpose.infoLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.blue.400}",
+                                                                    "~:description": "color for elements with informational purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.brand",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d94",
+                                                                    "~:name": "xx.alias.color.primary.brand",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.400}",
+                                                                    "~:description": "background color for primary brand elements ",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.default",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d96",
+                                                                    "~:name": "xx.alias.color.text.default",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.50}",
+                                                                    "~:description": "Default text color ",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.inverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d97",
+                                                                    "~:name": "xx.alias.color.text.inverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.900}",
+                                                                    "~:description": "Inverted text color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onSuccess",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d81",
+                                                                    "~:name": "xx.alias.color.purpose.onSuccess",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.green.800}",
+                                                                    "~:description": "color for elements placed on success purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.criticalLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d7f",
+                                                                    "~:name": "xx.alias.color.purpose.criticalLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.red.400}",
+                                                                    "~:description": "color for elements with critical purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.mediumEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d9b",
+                                                                    "~:name": "xx.alias.color.background.mediumEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.800}",
+                                                                    "~:description": "Background Color for components with medium emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.emphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d98",
+                                                                    "~:name": "xx.alias.color.text.emphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.white}",
+                                                                    "~:description": "Default text color ",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.highEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d9c",
+                                                                    "~:name": "xx.alias.color.background.highEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.700}",
+                                                                    "~:description": "Background Color for components with high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.hover",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d90",
+                                                                    "~:name": "xx.alias.color.state.hover",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba({xx.global.color.neutral.100},0.16)",
+                                                                    "~:description": "Background color for state overlay of a hovered element",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.body",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d9d",
+                                                                    "~:name": "xx.alias.color.background.body",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.950}",
+                                                                    "~:description": "Body background color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.successLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d7d",
+                                                                    "~:name": "xx.alias.color.purpose.successLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.green.400}",
+                                                                    "~:description": "color for elements with success purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.onInteraction",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d95",
+                                                                    "~:name": "xx.alias.color.primary.onInteraction",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.900}",
+                                                                    "~:description": "color for elements that are placed on interactive background colors",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onCritical",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d7a",
+                                                                    "~:name": "xx.alias.color.purpose.onCritical",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.red.900}",
+                                                                    "~:description": "color for elements placed on critical purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d99",
+                                                                    "~:name": "xx.alias.color.text.medium",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.600}",
+                                                                    "~:description": "Text color in subtle weight",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.criticalHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d7b",
+                                                                    "~:name": "xx.alias.color.purpose.criticalHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.red.200}",
+                                                                    "~:description": "color for elements with critical purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d87",
+                                                                    "~:name": "xx.alias.color.border.medium",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.500}",
+                                                                    "~:description": "medium border color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.subtle",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d88",
+                                                                    "~:name": "xx.alias.color.border.subtle",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.700}",
+                                                                    "~:description": "subtle border color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.lowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d9e",
+                                                                    "~:name": "xx.alias.color.background.lowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.900}",
+                                                                    "~:description": "background color for elements with a low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onWarning",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d80",
+                                                                    "~:name": "xx.alias.color.purpose.onWarning",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.yellow.800}",
+                                                                    "~:description": "color for elements placed on warning purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.subtle",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d9a",
+                                                                    "~:name": "xx.alias.color.text.subtle",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.400}",
+                                                                    "~:description": "Text color in subtle weight",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.successHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d7c",
+                                                                    "~:name": "xx.alias.color.purpose.successHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.green.100}",
+                                                                    "~:description": "color for elements with success purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onDisable",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d8b",
+                                                                    "~:name": "xx.alias.color.state.onDisable",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.700}",
+                                                                    "~:description": "color for elements that are palced on disabled background color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.selectInverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d8f",
+                                                                    "~:name": "xx.alias.color.state.selectInverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.600}",
+                                                                    "~:description": "Inverted background color for selected elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.warningLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d82",
+                                                                    "~:name": "xx.alias.color.purpose.warningLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.yellow.400}",
+                                                                    "~:description": "color for elements with warning purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onSelectInverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d89",
+                                                                    "~:name": "xx.alias.color.state.onSelectInverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.100}",
+                                                                    "~:description": "inverted color for elements on selected backgrounds",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-color-light",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f161e35",
+                                                "~:name": "alias/color-light",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716696",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.alias.color.purpose.onInfo",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca472",
+                                                                    "~:name": "xx.alias.color.purpose.onInfo",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.blue.100}",
+                                                                    "~:description": "color for elements placed on informational purpose background",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.heavy",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca479",
+                                                                    "~:name": "xx.alias.color.border.heavy",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.700}",
+                                                                    "~:description": "heavy border color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.select",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca481",
+                                                                    "~:name": "xx.alias.color.state.select",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.100}",
+                                                                    "~:description": "background color for selected elements",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.onBrand",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca486",
+                                                                    "~:name": "xx.alias.color.primary.onBrand",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.200}",
+                                                                    "~:description": "color for elements that are placed on brand background color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.focus",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca47e",
+                                                                    "~:name": "xx.alias.color.state.focus",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.100}",
+                                                                    "~:description": "Background color for state overlay of a focused element",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.press",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca480",
+                                                                    "~:name": "xx.alias.color.state.press",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.100}",
+                                                                    "~:description": "Background color for state overlay of a pressed element",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.warningHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca477",
+                                                                    "~:name": "xx.alias.color.purpose.warningHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.yellow.500}",
+                                                                    "~:description": "color for elements with warning purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onSelect",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca485",
+                                                                    "~:name": "xx.alias.color.state.onSelect",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.600}",
+                                                                    "~:description": "Foreground color for selected elements",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.interaction",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca487",
+                                                                    "~:name": "xx.alias.color.primary.interaction",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.600}",
+                                                                    "~:description": "Color that indicates interactions",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.focusOutline",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca47a",
+                                                                    "~:name": "xx.alias.color.border.focusOutline",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba({xx.global.color.blue.500},0.8)",
+                                                                    "~:description": "color for default focus outline",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.disable",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca482",
+                                                                    "~:name": "xx.alias.color.state.disable",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.300}",
+                                                                    "~:description": "background color for disabled elements",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.infoHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca478",
+                                                                    "~:name": "xx.alias.color.purpose.infoHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.blue.500}",
+                                                                    "~:description": "color for elements with informational purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.infoLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca46d",
+                                                                    "~:name": "xx.alias.color.purpose.infoLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.blue.400}",
+                                                                    "~:description": "color for elements with informational purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.brand",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca488",
+                                                                    "~:name": "xx.alias.color.primary.brand",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.500}",
+                                                                    "~:description": "background color for primary brand elements ",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.default",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca48b",
+                                                                    "~:name": "xx.alias.color.text.default",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.900}",
+                                                                    "~:description": "Default text color ",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.inverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca48c",
+                                                                    "~:name": "xx.alias.color.text.inverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.50}",
+                                                                    "~:description": "Inverted text color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onSuccess",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca475",
+                                                                    "~:name": "xx.alias.color.purpose.onSuccess",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.green.100}",
+                                                                    "~:description": "color for elements placed on success purpose background",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.criticalLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca473",
+                                                                    "~:name": "xx.alias.color.purpose.criticalLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.red.500}",
+                                                                    "~:description": "color for elements with critical purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.mediumEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca490",
+                                                                    "~:name": "xx.alias.color.background.mediumEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.100}",
+                                                                    "~:description": "background Color for components with medium emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.emphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca48d",
+                                                                    "~:name": "xx.alias.color.text.emphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.black}",
+                                                                    "~:description": "Default text color ",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.highEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca491",
+                                                                    "~:name": "xx.alias.color.background.highEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.50}",
+                                                                    "~:description": "background Color for components with high emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.hover",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca484",
+                                                                    "~:name": "xx.alias.color.state.hover",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.100}",
+                                                                    "~:description": "Background color for state overlay of a hovered element",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.body",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca492",
+                                                                    "~:name": "xx.alias.color.background.body",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.200}",
+                                                                    "~:description": "body background color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.successLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca471",
+                                                                    "~:name": "xx.alias.color.purpose.successLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.green.400}",
+                                                                    "~:description": "color for elements with success purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.onInteraction",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca489",
+                                                                    "~:name": "xx.alias.color.primary.onInteraction",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.300}",
+                                                                    "~:description": "color for elements that are placed on interactive background colors",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onCritical",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca46e",
+                                                                    "~:name": "xx.alias.color.purpose.onCritical",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.red.200}",
+                                                                    "~:description": "color for elements placed on critical purpose background",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca48e",
+                                                                    "~:name": "xx.alias.color.text.medium",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.400}",
+                                                                    "~:description": "Text color in subtle weight",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.criticalHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca46f",
+                                                                    "~:name": "xx.alias.color.purpose.criticalHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.red.600}",
+                                                                    "~:description": "color for elements with critical purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca47b",
+                                                                    "~:name": "xx.alias.color.border.medium",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.500}",
+                                                                    "~:description": "medium border color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.subtle",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca47c",
+                                                                    "~:name": "xx.alias.color.border.subtle",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.300}",
+                                                                    "~:description": "subtle border color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.lowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca493",
+                                                                    "~:name": "xx.alias.color.background.lowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.300}",
+                                                                    "~:description": "background color for elements with a low emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onWarning",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca474",
+                                                                    "~:name": "xx.alias.color.purpose.onWarning",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.yellow.100}",
+                                                                    "~:description": "color for elements placed on warning purpose background",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.subtle",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca48f",
+                                                                    "~:name": "xx.alias.color.text.subtle",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.600}",
+                                                                    "~:description": "Text color in subtle weight",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.successHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca470",
+                                                                    "~:name": "xx.alias.color.purpose.successHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.green.500}",
+                                                                    "~:description": "color for elements with success purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onDisable",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca47f",
+                                                                    "~:name": "xx.alias.color.state.onDisable",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.neutral.700}",
+                                                                    "~:description": "color for elements that are palced on disabled background color",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.selectInverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca483",
+                                                                    "~:name": "xx.alias.color.state.selectInverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.600}",
+                                                                    "~:description": "Inverted background color for selected elements",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.warningLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca476",
+                                                                    "~:name": "xx.alias.color.purpose.warningLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.yellow.400}",
+                                                                    "~:description": "color for elements with warning purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onSelectInverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca47d",
+                                                                    "~:name": "xx.alias.color.state.onSelectInverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.mint.100}",
+                                                                    "~:description": "inverted color for elements on selected backgrounds",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.highEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca48a",
+                                                                    "~:name": "xx.alias.color.primary.highEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.global.color.violet.200}",
+                                                                    "~:description": "background color for primary brand elements ",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-media-queries",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f16cbda",
+                                                "~:name": "alias/media-queries",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716699",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.media.xs",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d3a",
+                                                                    "~:name": "xx.media.xs",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "576px",
+                                                                    "~:description": "(min-width: 576px)",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.media.sm",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d3b",
+                                                                    "~:name": "xx.media.sm",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "768px",
+                                                                    "~:description": "(min-width: 768px)",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.media.md",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d3c",
+                                                                    "~:name": "xx.media.md",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "992px",
+                                                                    "~:description": "min-width: 992px - Tablet portrait",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.media.lg",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d3d",
+                                                                    "~:name": "xx.media.lg",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "1200px",
+                                                                    "~:description": " (min-width: 1200px)  - Tablet landscape",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.media.xl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d3e",
+                                                                    "~:name": "xx.media.xl",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "1440px",
+                                                                    "~:description": " (min-width: 1440px) - Desktop small",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.media.2xl",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d3f",
+                                                                    "~:name": "xx.media.2xl",
+                                                                    "~:type": "~:dimensions",
+                                                                    "~:value": "1680px",
+                                                                    "~:description": " (min-width: 1680px) - Desktop Large",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-web-typography",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f171543",
+                                                "~:name": "alias/web-typography",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716700",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "lineHeight.paragraph",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca497",
+                                                                    "~:name": "lineHeight.paragraph",
+                                                                    "~:type": "~:number",
+                                                                    "~:value": "1.5",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "lineHeight.inline",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0ca498",
+                                                                    "~:name": "lineHeight.inline",
+                                                                    "~:type": "~:number",
+                                                                    "~:value": "1.2",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716658"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-app-typography",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f17704b",
+                                                "~:name": "alias/app-typography",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716701",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "lineHeight.paragraph",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b8",
+                                                                    "~:name": "lineHeight.paragraph",
+                                                                    "~:type": "~:number",
+                                                                    "~:value": "1.4",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "lineHeight.inline",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c38b9",
+                                                                    "~:name": "lineHeight.inline",
+                                                                    "~:type": "~:number",
+                                                                    "~:value": "1.2",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716656"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "S-shadows",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f18b19c",
+                                                "~:name": "alias/shadows",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716706",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "color.shadow.strong",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d63",
+                                                                    "~:name": "color.shadow.strong",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba(\t24,20,31, 0.30)",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "shadow.lower.hover",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d68",
+                                                                    "~:name": "shadow.lower.hover",
+                                                                    "~:type": "~:shadow",
+                                                                    "~:value": [
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "1",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.strong}",
+                                                                            "~:inset": false
+                                                                        },
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "0",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.base}",
+                                                                            "~:inset": false
+                                                                        }
+                                                                    ],
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "shadow.lower.default",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d69",
+                                                                    "~:name": "shadow.lower.default",
+                                                                    "~:type": "~:shadow",
+                                                                    "~:value": [
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "1",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.low}",
+                                                                            "~:inset": false
+                                                                        },
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "0",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.base}",
+                                                                            "~:inset": false
+                                                                        }
+                                                                    ],
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "shadow.low.hover",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d6a",
+                                                                    "~:name": "shadow.low.hover",
+                                                                    "~:type": "~:shadow",
+                                                                    "~:value": [
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "2",
+                                                                            "~:blur": "8",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.strong}",
+                                                                            "~:inset": false
+                                                                        },
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "0",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.base}",
+                                                                            "~:inset": false
+                                                                        }
+                                                                    ],
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "color.shadow.base",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d64",
+                                                                    "~:name": "color.shadow.base",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba(\t24,20,31, 0.06)",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "lower",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d6c",
+                                                                    "~:name": "lower",
+                                                                    "~:type": "~:shadow",
+                                                                    "~:value": [
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "1",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.low}",
+                                                                            "~:inset": false
+                                                                        }
+                                                                    ],
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "color.shadow.stronger",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d65",
+                                                                    "~:name": "color.shadow.stronger",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba(\t24,20,31, 0.35)",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "color.shadow.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d66",
+                                                                    "~:name": "color.shadow.medium",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba(\t24,20,31, 0.25)",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "shadow.low.default",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d6b",
+                                                                    "~:name": "shadow.low.default",
+                                                                    "~:type": "~:shadow",
+                                                                    "~:value": [
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "2",
+                                                                            "~:blur": "8",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.low}",
+                                                                            "~:inset": false
+                                                                        },
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "0",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.base}",
+                                                                            "~:inset": false
+                                                                        }
+                                                                    ],
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "color.shadow.low",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d67",
+                                                                    "~:name": "color.shadow.low",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "rgba(\t24,20,31, 0.20)",
+                                                                    "~:description": "",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "base.shadow",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d6d",
+                                                                    "~:name": "base.shadow",
+                                                                    "~:type": "~:shadow",
+                                                                    "~:value": [
+                                                                        {
+                                                                            "~:offset-x": "0",
+                                                                            "~:offset-y": "0",
+                                                                            "~:blur": "2",
+                                                                            "~:spread": "0",
+                                                                            "~:color": "{color.shadow.base}",
+                                                                            "~:inset": false
+                                                                        }
+                                                                    ],
+                                                                    "~:description": "sombra común",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "G-components",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "S-section-message",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f1a31f0",
+                                                "~:name": "components/section-message",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716712",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.component.sectionMessage.warning.icon",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d6e",
+                                                                    "~:name": "xx.component.sectionMessage.warning.icon",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.alias.color.purpose.onWarning}",
+                                                                    "~:description": "icon color for warning section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.warning.background",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d6f",
+                                                                    "~:name": "xx.component.sectionMessage.warning.background",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.alias.color.purpose.warningHighEmphasis}",
+                                                                    "~:description": "background color for warning section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.borderRadius",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d71",
+                                                                    "~:name": "xx.component.sectionMessage.borderRadius",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "{xx.alias.border.radius.md}",
+                                                                    "~:description": "border radius for section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.spacing.innerY",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d72",
+                                                                    "~:name": "xx.component.sectionMessage.spacing.innerY",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.alias.spacing.md}",
+                                                                    "~:description": "top and bottom inner spacing for section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.height.min",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d75",
+                                                                    "~:name": "xx.component.sectionMessage.height.min",
+                                                                    "~:type": "~:sizing",
+                                                                    "~:value": "{xx.alias.size.md}",
+                                                                    "~:description": "min height of section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.success.background",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d76",
+                                                                    "~:name": "xx.component.sectionMessage.success.background",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.alias.color.purpose.successHighEmphasis}",
+                                                                    "~:description": "background color for success section messages ",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.spacing.innerX",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d73",
+                                                                    "~:name": "xx.component.sectionMessage.spacing.innerX",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.alias.spacing.sm}",
+                                                                    "~:description": "left and right inner spacing for section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.warning.text",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d70",
+                                                                    "~:name": "xx.component.sectionMessage.warning.text",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.alias.color.purpose.onWarning}",
+                                                                    "~:description": "text color for warning section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.spacing.gap",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d74",
+                                                                    "~:name": "xx.component.sectionMessage.spacing.gap",
+                                                                    "~:type": "~:spacing",
+                                                                    "~:value": "{xx.alias.spacing.xs}",
+                                                                    "~:description": "gap for separating elements in section message",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.success.icon",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d77",
+                                                                    "~:name": "xx.component.sectionMessage.success.icon",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.alias.color.purpose.onSuccess}",
+                                                                    "~:description": "icon color for success section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.component.sectionMessage.success.text",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d78",
+                                                                    "~:name": "xx.component.sectionMessage.success.text",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "{xx.alias.color.purpose.onSuccess}",
+                                                                    "~:description": "text color for success section messages",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "G-wl-themes",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "S-client_theme_template",
+                                        {
+                                            "~#penpot/token-set": {
+                                                "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f1eae34",
+                                                "~:name": "wl-themes/client_theme_template",
+                                                "~:description": "",
+                                                "~:modified-at": "~m1778507716730",
+                                                "~:tokens": {
+                                                    "~#ordered-map": [
+                                                        [
+                                                            "xx.alias.color.purpose.onInfo",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d45",
+                                                                    "~:name": "xx.alias.color.purpose.onInfo",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ffffff",
+                                                                    "~:description": "color for elements placed on informational purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.heavy",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d4c",
+                                                                    "~:name": "xx.alias.color.border.heavy",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#728090",
+                                                                    "~:description": "heavy border color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.select",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d50",
+                                                                    "~:name": "xx.alias.color.state.select",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#B4B4F2",
+                                                                    "~:description": "background color for selected elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.onBrand",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d56",
+                                                                    "~:name": "xx.alias.color.primary.onBrand",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#f5f5fa",
+                                                                    "~:description": "color for elements that are placed on brand background color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.warningHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d4a",
+                                                                    "~:name": "xx.alias.color.purpose.warningHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#f1c40f",
+                                                                    "~:description": "color for elements with warning purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onSelect",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d51",
+                                                                    "~:name": "xx.alias.color.state.onSelect",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#0707D3",
+                                                                    "~:description": "Foreground color for selected elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.interaction",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d57",
+                                                                    "~:name": "xx.alias.color.primary.interaction",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#DC7258",
+                                                                    "~:description": "Color that indicates interactions",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.focusOutline",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d4d",
+                                                                    "~:name": "xx.alias.color.border.focusOutline",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#0505A3",
+                                                                    "~:description": "color for default focus outline",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.disable",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d52",
+                                                                    "~:name": "xx.alias.color.state.disable",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#bdc3c7",
+                                                                    "~:description": "background color for disabled elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.infoHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d4b",
+                                                                    "~:name": "xx.alias.color.purpose.infoHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2980b9",
+                                                                    "~:description": "color for elements with informational purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.infoLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d40",
+                                                                    "~:name": "xx.alias.color.purpose.infoLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2980b9",
+                                                                    "~:description": "color for elements with informational purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.brand",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d58",
+                                                                    "~:name": "xx.alias.color.primary.brand",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#3333C2",
+                                                                    "~:description": "background color for primary brand elements ",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.default",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d5a",
+                                                                    "~:name": "xx.alias.color.text.default",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#353535",
+                                                                    "~:description": "Default text color ",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.inverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d5b",
+                                                                    "~:name": "xx.alias.color.text.inverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#f5f5fa",
+                                                                    "~:description": "Inverted text color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onSuccess",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d48",
+                                                                    "~:name": "xx.alias.color.purpose.onSuccess",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ffffff",
+                                                                    "~:description": "color for elements placed on success purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.criticalLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d46",
+                                                                    "~:name": "xx.alias.color.purpose.criticalLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#e74c3c",
+                                                                    "~:description": "color for elements with critical purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.highEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d5d",
+                                                                    "~:name": "xx.alias.color.background.highEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ffffff",
+                                                                    "~:description": "background Color for components with high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.border.radius.md",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d60",
+                                                                    "~:name": "xx.alias.border.radius.md",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "4px",
+                                                                    "~:description": "medium border radius",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.body",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d5e",
+                                                                    "~:name": "xx.alias.color.background.body",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#E3E6E9",
+                                                                    "~:description": "body background color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.successLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d44",
+                                                                    "~:name": "xx.alias.color.purpose.successLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2ecc71",
+                                                                    "~:description": "color for elements with success purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.primary.onInteraction",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d59",
+                                                                    "~:name": "xx.alias.color.primary.onInteraction",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#f5f5fa",
+                                                                    "~:description": "color for elements that are placed on interactive background colors",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onCritical",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d41",
+                                                                    "~:name": "xx.alias.color.purpose.onCritical",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ffffff",
+                                                                    "~:description": "color for elements placed on critical purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.criticalHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d42",
+                                                                    "~:name": "xx.alias.color.purpose.criticalHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#e74c3c",
+                                                                    "~:description": "color for elements with critical purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.border.radius.lg",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d61",
+                                                                    "~:name": "xx.alias.border.radius.lg",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "8px",
+                                                                    "~:description": "large border radius",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.medium",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d4e",
+                                                                    "~:name": "xx.alias.color.border.medium",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#9AA5B1",
+                                                                    "~:description": "medium border color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.border.subtle",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d4f",
+                                                                    "~:name": "xx.alias.color.border.subtle",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#C3C9D0",
+                                                                    "~:description": "subtle border color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.background.lowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d5f",
+                                                                    "~:name": "xx.alias.color.background.lowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#F6F7F8",
+                                                                    "~:description": "background color for elements with a low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.onWarning",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d47",
+                                                                    "~:name": "xx.alias.color.purpose.onWarning",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#ffffff",
+                                                                    "~:description": "color for elements placed on warning purpose background",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.text.subtle",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d5c",
+                                                                    "~:name": "xx.alias.color.text.subtle",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#9E9E9E",
+                                                                    "~:description": "Text color in subtle weight",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.successHighEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d43",
+                                                                    "~:name": "xx.alias.color.purpose.successHighEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#2ecc71",
+                                                                    "~:description": "color for elements with success purpose of high emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onDisable",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d53",
+                                                                    "~:name": "xx.alias.color.state.onDisable",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#7f8c8d",
+                                                                    "~:description": "color for elements that are palced on disabled background color",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.border.radius.sm",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d62",
+                                                                    "~:name": "xx.alias.border.radius.sm",
+                                                                    "~:type": "~:border-radius",
+                                                                    "~:value": "0",
+                                                                    "~:description": "small border radius",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.selectInverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d54",
+                                                                    "~:name": "xx.alias.color.state.selectInverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#0707D3",
+                                                                    "~:description": "Inverted background color for selected elements",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.purpose.warningLowEmphasis",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d49",
+                                                                    "~:name": "xx.alias.color.purpose.warningLowEmphasis",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#f1c40f",
+                                                                    "~:description": "color for elements with warning purpose of low emphasis",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ],
+                                                        [
+                                                            "xx.alias.color.state.onSelectInverted",
+                                                            {
+                                                                "~#penpot/token": {
+                                                                    "~:id": "~u4cdd76d8-0e6d-8168-8008-01189f0c4d55",
+                                                                    "~:name": "xx.alias.color.state.onSelectInverted",
+                                                                    "~:type": "~:color",
+                                                                    "~:value": "#B4B4F2",
+                                                                    "~:description": "inverted color for elements on selected backgrounds",
+                                                                    "~:modified-at": "~m1778507716657"
+                                                                }
+                                                            }
+                                                        ]
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ]
+                    ]
+                },
+                "~:themes": {
+                    "~#ordered-map": [
+                        [
+                            "",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "__PENPOT__HIDDEN__TOKEN__THEME__",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~u00000000-0000-0000-0000-000000000000",
+                                                "~:name": "__PENPOT__HIDDEN__TOKEN__THEME__",
+                                                "~:group": "",
+                                                "~:description": "",
+                                                "~:is-source": false,
+                                                "~:external-id": "",
+                                                "~:modified-at": "~m1778507716730",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "alias/border",
+                                                        "global/dimension",
+                                                        "global/color",
+                                                        "alias/color-light",
+                                                        "global/Opacity",
+                                                        "alias/dimension"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "Global",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "Brand",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~uc00d9d2e-76f9-815b-8005-e1260332abac",
+                                                "~:name": "Brand",
+                                                "~:group": "Global",
+                                                "~:description": "",
+                                                "~:is-source": true,
+                                                "~:external-id": "c00d9d2e-76f9-815b-8005-e1260332abac",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "global/dimension",
+                                                        "global/color",
+                                                        "global/Opacity"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "Alias",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "Light Mode",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~uc00d9d2e-76f9-815b-8005-e1260332abb0",
+                                                "~:name": "Light Mode",
+                                                "~:group": "Alias",
+                                                "~:description": "",
+                                                "~:is-source": true,
+                                                "~:external-id": "c00d9d2e-76f9-815b-8005-e1260332abb0",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "alias/border",
+                                                        "alias/color-light",
+                                                        "alias/dimension"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "Dark Mode",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~uc00d9d2e-76f9-815b-8005-e1260332abb2",
+                                                "~:name": "Dark Mode",
+                                                "~:group": "Alias",
+                                                "~:description": "",
+                                                "~:is-source": true,
+                                                "~:external-id": "c00d9d2e-76f9-815b-8005-e1260332abb2",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "alias/border",
+                                                        "alias/color-dark",
+                                                        "alias/dimension"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "Components",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "Section Message",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~uc00d9d2e-76f9-815b-8005-e1260332abb4",
+                                                "~:name": "Section Message",
+                                                "~:group": "Components",
+                                                "~:description": "",
+                                                "~:is-source": true,
+                                                "~:external-id": "c00d9d2e-76f9-815b-8005-e1260332abb4",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "components/section-message"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "White Label",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "Client Theme Template",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~uc00d9d2e-76f9-815b-8005-e1260332abb6",
+                                                "~:name": "Client Theme Template",
+                                                "~:group": "White Label",
+                                                "~:description": "",
+                                                "~:is-source": true,
+                                                "~:external-id": "c00d9d2e-76f9-815b-8005-e1260332abb6",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "wl-themes/client_theme_template"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "patata",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "patatilla",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~uc00d9d2e-76f9-815b-8005-e1260332abb8",
+                                                "~:name": "patatilla",
+                                                "~:group": "patata",
+                                                "~:description": "",
+                                                "~:is-source": false,
+                                                "~:external-id": "c00d9d2e-76f9-815b-8005-e1260332abb8",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": []
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        [
+                            "typography",
+                            {
+                                "~#ordered-map": [
+                                    [
+                                        "web",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~u312c1822-c99f-807a-8006-62605689cee0",
+                                                "~:name": "web",
+                                                "~:group": "typography",
+                                                "~:description": "",
+                                                "~:is-source": false,
+                                                "~:external-id": "312c1822-c99f-807a-8006-62605689cee0",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "alias/web-typography"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    [
+                                        "app",
+                                        {
+                                            "~#penpot/token-theme": {
+                                                "~:id": "~u312c1822-c99f-807a-8006-626064817196",
+                                                "~:name": "app",
+                                                "~:group": "typography",
+                                                "~:description": "",
+                                                "~:is-source": false,
+                                                "~:external-id": "312c1822-c99f-807a-8006-626064817196",
+                                                "~:modified-at": "~m1778507716656",
+                                                "~:sets": {
+                                                    "~#set": [
+                                                        "alias/app-typography"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                ]
+                            }
+                        ]
+                    ]
+                },
+                "~:active-themes": {
+                    "~#set": [
+                        "Global/Brand",
+                        "Alias/Light Mode",
+                        "/__PENPOT__HIDDEN__TOKEN__THEME__"
+                    ]
+                }
+            }
+        },
+        "~:id": "~u1bac06a1-a942-80a6-8008-0222e1ec38d5",
+        "~:options": {
+            "~:components-v2": true,
+            "~:base-font-size": "16px"
+        }
+    }
+}

--- a/frontend/playwright/ui/specs/tokens/text.spec.js
+++ b/frontend/playwright/ui/specs/tokens/text.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { WasmWorkspacePage } from "../../pages/WasmWorkspacePage";
+
+test.beforeEach(async ({ page }) => {
+  await WasmWorkspacePage.init(page);
+});
+
+test("BUG 13958 - Fill token gets detached when editing text shape", async ({ page }) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  // Load a file that has a text shape, whose content contains a `:fills []` in the root node.
+  // This attribute is removed when editing the text, causing the old code to detect that the
+  // fills had changed and detaching the token.
+  await workspacePage.mockGetFile("workspace/get-file-13958.json");
+  await workspacePage.goToWorkspace();
+
+  // Check token is attached to the shape
+  await workspacePage.clickLeafLayer("Design tokens are a set");
+  await expect(workspacePage.rightSidebar.getByLabel("xx.alias.color.text.default", { exact: true })).toBeVisible();
+
+  // Enter and exit the text editor
+  await workspacePage.page.keyboard.press("Enter");
+  await expect(workspacePage.page.getByTestId("text-editor")).toBeVisible();
+  await workspacePage.page.keyboard.press("Escape");
+  await expect(workspacePage.page.getByTestId("text-editor")).not.toBeAttached();
+
+  // Assert token is still attached to the shape
+  await expect(workspacePage.rightSidebar.getByLabel("xx.alias.color.text.default", { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/13958

### Summary

In some cases, editing a text shape with no changes detaches applied tokens.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->


See also this PR, overriden by this one: https://github.com/penpot/penpot/pull/8933