### PR TITLE
:bug: Fix text styles sometimes being overidden when chaging shape text attrs

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -36,6 +36,7 @@
    [app.main.fonts :as fonts]
    [app.main.router :as rt]
    [app.render-wasm.api :as wasm.api]
+   [app.render-wasm.text-editor :as wasm.text-editor]
    [app.util.text-editor :as ted]
    [app.util.text.content.styles :as styles]
    [app.util.timers :as ts]
@@ -465,13 +466,23 @@
       (when-not (some? (get-in state [:workspace-editor-state id]))
         (let [objects   (dsh/lookup-page-objects state)
               shape     (get objects id)
+              wasm?     (features/active-feature? state "render-wasm/v1")
               update-node? (fn [node]
                              (or (txt/is-text-node? node)
                                  (txt/is-paragraph-node? node)))
               shape-ids (cond
                           (cfh/text-shape? shape)  [id]
-                          (cfh/group-shape? shape) (cfh/get-children-ids objects id))]
-          (rx/of (dwsh/update-shapes shape-ids #(txt/update-text-content % update-node? d/txt-merge attrs))))))))
+                          (cfh/group-shape? shape) (cfh/get-children-ids objects id))
+              ;; Keep WASM editor cache in sync with merged :content so a following
+              ;; `apply-styles-to-selection` in `update-attrs` does not read stale
+              ;; `shape-text-contents` and overwrite per-run fills (e.g. line-height).
+              merge-shape
+              (fn [sh]
+                (let [updated-shape (txt/update-text-content sh update-node? d/txt-merge attrs)]
+                  (when wasm?
+                    (wasm.text-editor/cache-shape-text-content! (:id updated-shape) (:content updated-shape)))
+                  updated-shape))]
+          (rx/of (dwsh/update-shapes shape-ids merge-shape)))))))
 
 (defn migrate-node
   [node]
@@ -851,11 +862,13 @@
     (effect [_ state _]
       (when (features/active-feature? state "text-editor/v2")
         (when-let [instance (:workspace-editor state)]
-          (let [attrs-to-override (some-> (editor.v2/getCurrentStyle instance)
-                                          (styles/get-styles-from-style-declaration))
-                overriden-attrs (merge attrs-to-override attrs)
-                styles  (styles/attrs->styles overriden-attrs)]
-            (editor.v2/applyStylesToSelection instance styles)))))))
+          (when (seq attrs)
+            ;; DOM `getCurrentStyle` reflects one resolved style (e.g. caret color). Merging
+            ;; it with sidebar `attrs` and applying to the whole selection collapses mixed
+            ;; fills/fonts when the user only changes one property (e.g. line-height).
+            ;; Apply only the explicit attributes from this action.
+            (let [styles (styles/attrs->styles attrs)]
+              (editor.v2/applyStylesToSelection instance styles))))))))
 
 (defn update-all-attrs
   [ids attrs]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14033

### Summary

https://github.com/user-attachments/assets/59f98efa-e596-4918-b5a6-1d0222fb99ec

### Steps to reproduce 

1. Download the Penpot file attached in the Taiga issue and import it.
2. Select the shape with the heading "Ideate and build powerful products. Together".
3. Change the shape line height

Expected behavior:

Line height is changing while respecting text styles (i.e. "Together" remains in teal color)

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
