### PR TITLE
:bug: Fix clamp backbuffer crop origin for partially off-screen shapes

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1721,6 +1721,16 @@ impl RenderState {
                 && doc_bounds.top >= viewport.top
                 && doc_bounds.right <= viewport.right
                 && doc_bounds.bottom <= viewport.bottom;
+
+            // When the shape extends beyond the viewport to the left or top,
+            // `left`/`top` are negative. Skia clamps `makeImageSnapshot` to the
+            // surface bounds, so the returned image actually starts at pixel 0 —
+            // not at the negative coordinate. Store the clamped value so that
+            // `doc_left`/`doc_top` computed during the drag reflects the true
+            // image origin in the backbuffer.
+            let capture_src_left = left.max(0);
+            let capture_src_top = top.max(0);
+
             self.backbuffer_crop_cache.insert(
                 id,
                 InteractiveDragCrop {
@@ -1729,8 +1739,8 @@ impl RenderState {
                     fits_viewport_at_capture,
                     capture_vb_left: vb_left,
                     capture_vb_top: vb_top,
-                    capture_src_left: src_irect.left,
-                    capture_src_top: src_irect.top,
+                    capture_src_left,
+                    capture_src_top,
                     image,
                 },
             );


### PR DESCRIPTION
### Related Ticket

When a shape extends beyond the viewport to the left or top, the
computed pixel coordinates for the backbuffer snapshot were negative.
Skia clamps makeImageSnapshot to the surface bounds (pixel 0), but
the old code stored the unclamped negative value as capture_src_left/
capture_src_top. During drag, this caused the cached image to be
placed far off-screen, making the stationary shape appear clipped or
invisible while a nearby shape was being dragged.

Fix by clamping capture_src_left/top to 0 so the stored origin always
reflects the actual start of the Skia-returned image.


https://github.com/user-attachments/assets/71de03e5-253f-4e83-920a-0073f4691108

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
