### PR TITLE
:bug: Fix rendering glitch when exiting focus mode

### DIFF
--- a/frontend/src/app/main/data/workspace/selection.cljs
+++ b/frontend/src/app/main/data/workspace/selection.cljs
@@ -27,6 +27,7 @@
    [app.main.data.workspace.pages :as-alias dwpg]
    [app.main.data.workspace.specialized-panel :as-alias dwsp]
    [app.main.data.workspace.undo :as dwu]
+   [app.main.data.workspace.viewport-wasm :as dwvw]
    [app.main.data.workspace.zoom :as dwz]
    [app.main.refs :as refs]
    [app.main.router :as rt]
@@ -601,6 +602,10 @@
                 (assoc :workspace-focus-selected selected)
                 (assoc :workspace-pre-focus (:workspace-local state)))
             state))))
+
+    ptk/EffectEvent
+    (effect [_ state _]
+      (dwvw/maybe-sync-workspace-local-viewport! state))
 
     ptk/WatchEvent
     (watch [_ state stream]


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14185

### Summary

<img width="1608" height="1100" alt="Focus mode (fix)" src="https://github.com/user-attachments/assets/de8f98f8-b42e-4546-9ab1-87e9629565e9" />

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
