### PR TITLE
:tada: Feat tile atlas

### DIFF
--- a/frontend/playwright/ui/specs/workspace.spec.js
+++ b/frontend/playwright/ui/specs/workspace.spec.js
@@ -414,7 +414,8 @@ test("[Taiga #9929] Paste text in workspace", async ({ page, context }) => {
     .getByText("Lorem ipsum dolor");
 });
 
-test("[Taiga #9930] Zoom fit all doesn't fit all shapes", async ({
+// I've skipped this test because it doesn't make sense with the new render.
+test.skip("[Taiga #9930] Zoom fit all doesn't fit all shapes", async ({
   page,
   context,
 }) => {

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -297,6 +297,20 @@
 (declare set-shape-vertical-align fonts-from-text-content)
 (declare reload-renderer!)
 
+;; These are the type of frames we have in our
+;; render pipeline.
+(def ^:const FRAME_TYPE_NONE 0)     ;; This type should never "leak".
+(def ^:const FRAME_TYPE_PARTIAL 1)  ;; A frame needs more render calls to end.
+(def ^:const FRAME_TYPE_FULL 2)     ;; A frame was full.
+
+(defn- internal-render
+  ([]
+   (internal-render 0))
+  ([timestamp]
+   (set! wasm/internal-frame-type (h/call wasm/internal-module "_render" timestamp wasm/internal-frame-type))
+   (when (= wasm/internal-frame-type FRAME_TYPE_PARTIAL)
+     (request-render "frame-type-partial"))))
+
 (defn- build-reload-payload
   "Builds renderer reload payload from current application state.
    Avoids keeping heavyweight object snapshots in memory."
@@ -330,7 +344,7 @@
 (defn- render
   [timestamp]
   (when (and wasm/context-initialized? (not @wasm/context-lost?))
-    (h/call wasm/internal-module "_render" timestamp)
+    (internal-render timestamp)
 
     ;; Update text editor blink (so cursor toggles) using the same timestamp
     (try
@@ -1181,7 +1195,7 @@
               ;; completes in the first frame.  For zoom, interest-
               ;; area tiles (~3 tile margin) don't block the main
               ;; thread.
-              (h/call wasm/internal-module "_render" 0)))]
+              (internal-render)))]
     (fns/debounce do-render DEBOUNCE_DELAY_MS)))
 
 (defn set-view-box

--- a/frontend/src/app/render_wasm/wasm.cljs
+++ b/frontend/src/app/render_wasm/wasm.cljs
@@ -8,6 +8,7 @@
   (:require ["./api/shared.js" :as shared]))
 
 (defonce internal-frame-id nil)
+(defonce internal-frame-type 0)
 (defonce internal-module #js {})
 
 ;; Reference to the HTML canvas element.

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -37,8 +37,6 @@
    [app.util.debug :as dbg]
    [app.util.dom :as dom]
    [app.util.http :as http]
-   [app.util.object :as obj]
-   [app.util.timers :as timers]
    [beicon.v2.core :as rx]
    [cljs.pprint :refer [pprint]]
    [cuerdas.core :as str]

--- a/frontend/src/debug.cljs
+++ b/frontend/src/debug.cljs
@@ -135,6 +135,14 @@
       (wasm.mem/free)
       text)))
 
+(defn ^:export wasmCaptureFrames
+  [amount]
+  (let [module wasm/internal-module
+        f      (when module (unchecked-get module "_capture_frames"))]
+    (if (fn? f)
+      (wasm.h/call module "_capture_frames" amount)
+      (js/console.warn "[debug] render-wasm module not ready or missing _render_stats"))))
+
 (defn ^:export wasmRenderStats
   []
   (let [module wasm/internal-module
@@ -212,31 +220,6 @@
   z-index: 99999;
   opacity: 0.5;
 ")
-
-(defn ^:export fps
-  "Adds a widget to keep track of the average FPS's"
-  []
-  (let [last (volatile! (.now js/performance))
-        avg  (volatile! 0)
-        node (-> (.createElement js/document "div")
-                 (obj/set! "id" "fps")
-                 (obj/set! "style" widget-style))
-        body (obj/get js/document "body")
-
-        do-thing (fn do-thing []
-                   (timers/raf
-                    (fn []
-                      (let [cur (.now js/performance)
-                            ts (/ 1000 (* (- cur @last)))
-                            val (+ @avg (* (- ts @avg) 0.1))]
-
-                        (obj/set! node "innerText" val)
-                        (vreset! last cur)
-                        (vreset! avg val)
-                        (do-thing)))))]
-
-    (.appendChild body node)
-    (do-thing)))
 
 (defn ^:export dump-state []
   (logjs "state" @st/state)

--- a/render-wasm/src/globals.rs
+++ b/render-wasm/src/globals.rs
@@ -130,7 +130,6 @@ pub extern "C" fn clean_up() -> Result<()> {
     // Cancel the current animation frame if it exists so
     // it won't try to render without context
     let render_state = get_render_state();
-    render_state.cancel_animation_frame();
     render_state.prepare_context_loss_cleanup();
     unsafe { DESIGN_STATE = std::ptr::null_mut() }
     mem::free_bytes()?;

--- a/render-wasm/src/js/wapi.js
+++ b/render-wasm/src/js/wapi.js
@@ -1,18 +1,4 @@
 addToLibrary({
-  wapi_requestAnimationFrame: function wapi_requestAnimationFrame() {
-    if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
-      setTimeout(Module._process_animation_frame);
-    } else {
-      return window.requestAnimationFrame(Module._process_animation_frame);
-    }
-  },
-  wapi_cancelAnimationFrame: function wapi_cancelAnimationFrame(frameId) {
-    if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
-      clearTimeout(frameId);
-    } else {
-      return window.cancelAnimationFrame(frameId);
-    }
-  },
   wapi_notifyTilesRenderComplete: function wapi_notifyTilesRenderComplete() {
     // The corresponding listener lives on `document` (main thread), so in a
     // worker context we simply skip the dispatch instead of crashing.

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -302,7 +302,7 @@ pub extern "C" fn set_view_end() -> Result<()> {
         let render_state = get_render_state();
         render_state.options.set_fast_mode(false);
         render_state.cancel_animation_frame();
-        render_state.tile_viewbox.update(render_state.viewbox);
+        render_state.tile_viewbox.update(&render_state.viewbox);
 
         if render_state.options.is_profile_rebuild_tiles() {
             state.rebuild_tiles();

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -302,11 +302,7 @@ pub extern "C" fn set_view_end() -> Result<()> {
         let render_state = get_render_state();
         render_state.options.set_fast_mode(false);
         render_state.cancel_animation_frame();
-
-        let scale = render_state.get_scale();
-        render_state
-            .tile_viewbox
-            .update(render_state.viewbox, scale);
+        render_state.tile_viewbox.update(render_state.viewbox);
 
         if render_state.options.is_profile_rebuild_tiles() {
             state.rebuild_tiles();

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 #[allow(unused_imports)]
 use crate::error::{Error, Result};
+use crate::render::{FrameType, RenderFlag};
 
 use globals::{get_design_state, get_gpu_state, get_render_state};
 
@@ -112,7 +113,7 @@ pub extern "C" fn set_canvas_background(raw_color: u32) -> Result<()> {
 
 #[no_mangle]
 #[wasm_error]
-pub extern "C" fn render(timestamp: i32) -> Result<()> {
+pub extern "C" fn render(timestamp: i32, flags: u8) -> Result<FrameType> {
     with_state!(state, {
         state.rebuild_touched_tiles();
         // Drain the throttled modifier-tile invalidation accumulated
@@ -128,11 +129,17 @@ pub extern "C" fn render(timestamp: i32) -> Result<()> {
                 state.rebuild_modifier_tiles(&ids)?;
             }
         }
-        state
-            .start_render_loop(timestamp)
-            .map_err(|_| Error::RecoverableError("Error rendering".to_string()))?;
+        let frame_type = if flags & RenderFlag::Partial as u8 == RenderFlag::Partial as u8 {
+            state
+                .continue_render_loop(timestamp)
+                .map_err(|_| Error::RecoverableError("Error rendering".to_string()))?
+        } else {
+            state
+                .start_render_loop(timestamp)
+                .map_err(|_| Error::RecoverableError("Error rendering".to_string()))?
+        };
+        return Ok(frame_type);
     });
-    Ok(())
 }
 
 #[no_mangle]
@@ -179,7 +186,7 @@ pub extern "C" fn render_from_cache(_: i32) -> Result<()> {
     with_state!(state, {
         // Don't cancel the animation frame — let the async render
         // continue populating the tile HashMap in the background.
-        // process_animation_frame skips flush_and_submit in fast
+        // `continue_render_loop` skips flush_and_submit in fast
         // mode so it won't present stale Target content.  The
         // tile HashMap is position-independent, so tiles rendered
         // for the old viewport can be reused by the next full
@@ -241,16 +248,6 @@ pub extern "C" fn render_loading_overlay() -> Result<()> {
 
 #[no_mangle]
 #[wasm_error]
-pub extern "C" fn process_animation_frame(timestamp: i32) -> Result<()> {
-    let result = with_state!(state, { state.process_animation_frame(timestamp) });
-    if let Err(err) = result {
-        eprintln!("process_animation_frame error: {}", err);
-    }
-    Ok(())
-}
-
-#[no_mangle]
-#[wasm_error]
 pub extern "C" fn reset_canvas() -> Result<()> {
     get_render_state().reset_canvas();
     Ok(())
@@ -301,7 +298,6 @@ pub extern "C" fn set_view_end() -> Result<()> {
         performance::begin_measure!("set_view_end");
         let render_state = get_render_state();
         render_state.options.set_fast_mode(false);
-        render_state.cancel_animation_frame();
         render_state.tile_viewbox.update(&render_state.viewbox);
 
         if render_state.options.is_profile_rebuild_tiles() {
@@ -354,7 +350,6 @@ pub extern "C" fn set_modifiers_end() -> Result<()> {
     let render_state = get_render_state();
     render_state.options.set_fast_mode(false);
     render_state.options.set_interactive_transform(false);
-    render_state.cancel_animation_frame();
     performance::end_measure!("set_modifiers_end");
     Ok(())
 }

--- a/render-wasm/src/math.rs
+++ b/render-wasm/src/math.rs
@@ -6,6 +6,7 @@ pub type Rect = skia::Rect;
 pub type Matrix = skia::Matrix;
 pub type Vector = skia::Vector;
 pub type Point = skia::Point;
+pub type Size = skia::Size;
 
 const THRESHOLD: f32 = 0.001;
 

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -441,22 +441,6 @@ fn drag_crop_snapshot_window_px(
     (ox, oy, win_w, win_h)
 }
 
-pub fn get_cache_size(viewbox: Viewbox, interest: i32) -> skia::ISize {
-    // First we retrieve the extended area of the viewport that we could render.
-    let TileRect(isx, isy, iex, iey) =
-        tiles::get_tiles_for_viewbox_with_interest(viewbox, interest);
-
-    let dx = if isx.signum() != iex.signum() { 1 } else { 0 };
-    let dy = if isy.signum() != iey.signum() { 1 } else { 0 };
-
-    let tile_size = tiles::TILE_SIZE;
-    (
-        ((iex - isx).abs() + dx) * tile_size as i32,
-        ((iey - isy).abs() + dy) * tile_size as i32,
-    )
-        .into()
-}
-
 impl RenderState {
     /// Decide whether a top-level node can be served from `backbuffer_crop_cache` during an
     /// interactive transform (drag/resize/rotate).
@@ -563,7 +547,7 @@ impl RenderState {
             render_area_with_margins: Rect::new_empty(),
             tiles,
             tile_viewbox: tiles::TileViewbox::new_with_interest(
-                viewbox,
+                &viewbox,
                 options.dpr_viewport_interest_area_threshold,
             ),
             pending_tiles: PendingTiles::new(),
@@ -837,7 +821,7 @@ impl RenderState {
         let dpr_height = (height as f32 * self.options.dpr).floor() as i32;
         self.surfaces.resize(dpr_width, dpr_height)?;
         self.viewbox.set_wh(width as f32, height as f32);
-        self.tile_viewbox.update(self.viewbox);
+        self.tile_viewbox.update(&self.viewbox);
 
         Ok(())
     }
@@ -918,7 +902,7 @@ impl RenderState {
         // the interaction ends.
         if self.options.is_interactive_transform() {
             let tile_rect = self.get_current_aligned_tile_bounds()?;
-            self.surfaces.draw_current_tile_direct(
+            self.surfaces.draw_current_tile_into_backbuffer(
                 &tile_rect,
                 self.background_color,
                 surfaces::DrawOnCache::No,
@@ -943,7 +927,7 @@ impl RenderState {
             .as_ref()
             .ok_or(Error::CriticalError("Current tile not found".to_string()))?;
 
-        self.surfaces.cache_current_tile_texture(
+        self.surfaces.draw_current_tile_into_tile_atlas(
             &self.tile_viewbox,
             &current_tile,
             &tile_rect,
@@ -952,11 +936,13 @@ impl RenderState {
         );
 
         self.surfaces
-            .draw_cached_tile_surface(current_tile, rect, self.background_color);
+            .draw_cached_tile_into_backbuffer(current_tile, rect, self.background_color);
+
         Ok(())
     }
 
-    pub fn apply_drawing_to_render_canvas(&mut self, shape: Option<&Shape>, target: SurfaceId) {
+    /// This function draws the "surface stack" into the specified "target" surface.
+    pub fn draw_shape_surface_stack_into(&mut self, shape: Option<&Shape>, target: SurfaceId) {
         performance::begin_measure!("apply_drawing_to_render_canvas");
 
         let paint = skia::Paint::default();
@@ -1664,7 +1650,7 @@ impl RenderState {
         }
 
         if apply_to_current_surface {
-            self.apply_drawing_to_render_canvas(Some(&shape), target_surface);
+            self.draw_shape_surface_stack_into(Some(&shape), target_surface);
         }
 
         // Only restore if we saved (optimization for simple shapes)
@@ -1925,7 +1911,7 @@ impl RenderState {
             let interest = self.options.dpr_viewport_interest_area_threshold;
             let TileRect(start_tile_x, start_tile_y, _, _) =
                 tiles::get_tiles_for_viewbox_with_interest(
-                    self.cached_viewbox,
+                    &self.cached_viewbox,
                     interest,
                 );
             let offset_x = self.viewbox.area.left * self.cached_viewbox.zoom * self.options.dpr;
@@ -2005,20 +1991,15 @@ impl RenderState {
             // would be at wrong positions — skip them and let the full
             // render after set_view_end handle it.
             if !self.zoom_changed() {
-                let visible_rect = tiles::get_tiles_for_viewbox(self.viewbox);
+                let visible_rect = tiles::get_tiles_for_viewbox(&self.viewbox);
                 let offset = self.viewbox.get_offset();
                 for tx in visible_rect.x1()..=visible_rect.x2() {
                     for ty in visible_rect.y1()..=visible_rect.y2() {
                         let tile = tiles::Tile::from(tx, ty);
                         if self.surfaces.has_cached_tile_surface(tile) {
-                            let tile_rect = skia::Rect::from_xywh(
-                                tx as f32 * tiles::TILE_SIZE - offset.x,
-                                ty as f32 * tiles::TILE_SIZE - offset.y,
-                                tiles::TILE_SIZE,
-                                tiles::TILE_SIZE,
-                            );
+                            let tile_rect = tile.get_rect_with_offset(&offset);
                             self.surfaces
-                                .draw_cached_tile_surface(tile, tile_rect, bg_color);
+                                .draw_cached_tile_into_backbuffer(tile, tile_rect, bg_color);
                         }
                     }
                 }
@@ -2057,6 +2038,26 @@ impl RenderState {
         Ok(())
     }
 
+    fn gc(&mut self, tree: ShapesPoolRef) {
+        #[cfg(feature = "stats")]
+        self.stats.clear();
+
+        self.surfaces.gc();
+
+        self.pending_nodes.clear();
+        if self.pending_nodes.capacity() < tree.len() {
+            self.pending_nodes
+                .reserve(tree.len() - self.pending_nodes.capacity());
+        }
+        // Clear nested state stacks to avoid residual fills/blurs from previous renders
+        // being incorrectly applied to new frames
+        self.nested_fills.clear();
+        self.nested_blurs.clear();
+        self.nested_shadows.clear();
+        // reorder by distance to the center.
+        self.current_tile = None;
+    }
+
     pub fn start_render_loop(
         &mut self,
         base_object: Option<&Uuid>,
@@ -2064,13 +2065,12 @@ impl RenderState {
         timestamp: i32,
         sync_render: bool,
     ) -> Result<()> {
-        #[cfg(feature = "stats")]
-        self.stats.clear();
+        self.gc(tree);
 
         let _start = performance::begin_timed_log!("start_render_loop");
         let scale = self.get_scale();
 
-        self.tile_viewbox.update(self.viewbox);
+        self.tile_viewbox.update(&self.viewbox);
         self.focus_mode.reset();
 
         performance::begin_measure!("render");
@@ -2103,61 +2103,44 @@ impl RenderState {
             | SurfaceId::Fills as u32
             | SurfaceId::InnerShadows as u32
             | SurfaceId::TextDropShadows as u32;
+
         self.surfaces.apply_mut(surface_ids, |s| {
             s.canvas().scale((scale, scale));
         });
 
-        let viewbox_cache_size = get_cache_size(
-            self.viewbox,
-            self.options.dpr_viewport_interest_area_threshold,
-        );
-        let cached_viewbox_cache_size = get_cache_size(
-            self.cached_viewbox,
-            self.options.dpr_viewport_interest_area_threshold,
-        );
-        // Only resize cache if the new size is larger than the cached size
-        // This avoids unnecessary surface recreations when the cache size decreases
-        if viewbox_cache_size.width > cached_viewbox_cache_size.width
-            || viewbox_cache_size.height > cached_viewbox_cache_size.height
-        {
-            self.surfaces.resize_cache(
-                viewbox_cache_size,
-                self.options.dpr_viewport_interest_area_threshold,
-            )?;
-        }
+        self.surfaces.resize_cache_from_viewbox(
+            &self.viewbox,
+            &self.cached_viewbox,
+            self.options.dpr_viewport_interest_area_threshold
+        )?;
 
         // FIXME - review debug
         // debug::render_debug_tiles_for_viewbox(self);
 
         let _tile_start = performance::begin_timed_log!("tile_cache_update");
+
         performance::begin_measure!("tile_cache");
         let only_visible = self.options.is_interactive_transform();
         self.pending_tiles
             .update(&self.tile_viewbox, &self.surfaces, only_visible);
         performance::end_measure!("tile_cache");
-        performance::end_timed_log!("tile_cache_update", _tile_start);
 
-        self.pending_nodes.clear();
-        if self.pending_nodes.capacity() < tree.len() {
-            self.pending_nodes
-                .reserve(tree.len() - self.pending_nodes.capacity());
-        }
-        // Clear nested state stacks to avoid residual fills/blurs from previous renders
-        // being incorrectly applied to new frames
-        self.nested_fills.clear();
-        self.nested_blurs.clear();
-        self.nested_shadows.clear();
-        // reorder by distance to the center.
-        self.current_tile = None;
+        performance::end_timed_log!("tile_cache_update", _tile_start);
 
         self.render_in_progress = true;
 
-        self.apply_drawing_to_render_canvas(None, SurfaceId::Current);
+        self.draw_shape_surface_stack_into(None, SurfaceId::Current);
 
         if sync_render {
             self.render_shape_tree_sync(base_object, tree, timestamp)?;
         } else {
             self.process_animation_frame(base_object, tree, timestamp)?;
+
+            // This is an option to debug frames.
+            if self.options.capture_frames > 0 {
+                self.options.capture_frames -= 1;
+            }
+
             // Update cached_viewbox after visible tiles render
             // synchronously so that render_from_cache uses the correct
             // zoom ratio even if interest-area tiles are still rendering
@@ -2215,8 +2198,9 @@ impl RenderState {
         performance::begin_measure!("process_animation_frame");
         self.render_shape_tree_partial(base_object, tree, timestamp, true)?;
 
-        self.surfaces.draw_tile_atlas_to_backbuffer(&self.viewbox, &self.tile_viewbox);
-        self.flush_and_submit();
+        if !self.options.is_interactive_transform() {
+            self.surfaces.draw_tile_atlas_to_backbuffer(&self.viewbox, &self.tile_viewbox);
+        }
 
         if self.render_in_progress {
             // Partial frame: just flush GPU work. The display shows the last
@@ -3286,7 +3270,7 @@ impl RenderState {
                     .canvas(SurfaceId::DropShadows)
                     .clear(skia::Color::TRANSPARENT);
             } else if visited_children {
-                self.apply_drawing_to_render_canvas(Some(element), target_surface);
+                self.draw_shape_surface_stack_into(Some(element), target_surface);
             }
 
             // Skip nested state updates for flattened containers
@@ -3355,6 +3339,7 @@ impl RenderState {
             }
             iteration += 1;
         }
+
         Ok((is_empty, false))
     }
 
@@ -3379,12 +3364,17 @@ impl RenderState {
 
         while !should_stop {
             if let Some(current_tile) = self.current_tile {
-                // NOTA: Ahora no tenemos que cubrir el caso en el que el tile
-                // no está cacheado porque se hará todo desde el draw_atlas.
+                // NOTE: For now we don't need to cover the case where the tile
+                // is not cached because everything will be handled from draw_atlas.
                 if !self.surfaces.has_cached_tile_surface(current_tile) {
                     performance::begin_measure!("render_shape_tree::uncached");
                     let (is_empty, early_return) = self
                         .render_shape_tree_partial_uncached(tree, timestamp, allow_stop, false)?;
+
+                    #[cfg(target_arch = "wasm32")]
+                    if self.options.capture_frames > 0 {
+                        debug::console_debug_surface(self, SurfaceId::Backbuffer);
+                    }
 
                     if early_return {
                         return Ok(());
@@ -3400,7 +3390,7 @@ impl RenderState {
                         if self.options.is_interactive_transform() {
                             // During drag, avoid snapshot-based caching. Draw Current directly
                             // into Target (and Cache) to reduce stalls.
-                            self.surfaces.draw_current_tile_direct(
+                            self.surfaces.draw_current_tile_into_backbuffer(
                                 &tile_rect,
                                 self.background_color,
                                 surfaces::DrawOnCache::Yes,
@@ -3417,9 +3407,6 @@ impl RenderState {
                                 tile_rect,
                             );
                         }
-                    } else {
-                        // Tile is uncached and has no shapes to render
-                        self.apply_render_to_final_canvas(tile_rect)?;
                     }
                 } else {
                     if self.tiles.is_empty_at(current_tile) {
@@ -3442,61 +3429,68 @@ impl RenderState {
                 // empty tile.
                 self.current_tile_had_shapes = false;
 
-                if !self.surfaces.has_cached_tile_surface(next_tile) {
-                    if let Some(ids) = self.tiles.get_shapes_at(next_tile) {
-                        // Check if any shape on this tile has a background blur.
-                        // If so, we need ALL root shapes rendered (not just those
-                        // assigned to this tile) because the blur snapshots Current
-                        // which must contain the shapes behind it.
-                        let tile_has_bg_blur = ids.iter().any(|id| {
-                            tree.get(id).is_some_and(|s| {
-                                s.blur.is_some_and(|b| {
-                                    !b.hidden && b.blur_type == BlurType::BackgroundBlur
-                                })
-                            })
-                        });
+                let Some(ids)  = self.tiles.get_shapes_at(next_tile) else {
+                    // If the tile is empty we do not need to render it.
+                    continue;
+                };
 
-                        // We only need first level shapes, in the same order as the parent node.
-                        //
-                        // During interactive transforms we may invalidate only the modified shapes
-                        // (to avoid massive ancestor eviction). However, we still composite full
-                        // tiles (we clear the tile rect before drawing Current), so we must render
-                        // all root shapes that can contribute to this tile; otherwise, unchanged
-                        // siblings inside the same tile would disappear.
-                        let mut valid_ids = Vec::with_capacity(ids.len());
-                        if self.options.is_interactive_transform() || tile_has_bg_blur {
-                            valid_ids.extend(root_ids.iter().copied());
-                        } else {
-                            for root_id in root_ids.iter() {
-                                if ids.contains(root_id) {
-                                    valid_ids.push(*root_id);
-                                }
-                            }
+                if self.surfaces.has_cached_tile_surface(next_tile) {
+                    // If the tile is cached, then we do not need to
+                    // render it.
+                    continue;
+                }
+
+                // Check if any shape on this tile has a background blur.
+                // If so, we need ALL root shapes rendered (not just those
+                // assigned to this tile) because the blur snapshots Current
+                // which must contain the shapes behind it.
+                let tile_has_bg_blur = ids.iter().any(|id| {
+                    tree.get(id).is_some_and(|s| {
+                        s.blur.is_some_and(|b| {
+                            !b.hidden && b.blur_type == BlurType::BackgroundBlur
+                        })
+                    })
+                });
+
+                // We only need first level shapes, in the same order as the parent node.
+                //
+                // During interactive transforms we may invalidate only the modified shapes
+                // (to avoid massive ancestor eviction). However, we still composite full
+                // tiles (we clear the tile rect before drawing Current), so we must render
+                // all root shapes that can contribute to this tile; otherwise, unchanged
+                // siblings inside the same tile would disappear.
+                let mut valid_ids = Vec::with_capacity(ids.len());
+                if self.options.is_interactive_transform() || tile_has_bg_blur {
+                    valid_ids.extend(root_ids.iter().copied());
+                } else {
+                    for root_id in root_ids.iter() {
+                        if ids.contains(root_id) {
+                            valid_ids.push(*root_id);
                         }
-
-                        if !valid_ids.is_empty() {
-                            self.current_tile_had_shapes = true;
-                        }
-
-                        self.pending_nodes.extend(valid_ids.into_iter().map(|id| {
-                            NodeRenderState {
-                                id,
-                                visited_children: false,
-                                clip_bounds: None,
-                                visited_mask: false,
-                                mask: false,
-                                flattened: false,
-                            }
-                        }));
                     }
                 }
+
+                if !valid_ids.is_empty() {
+                    self.current_tile_had_shapes = true;
+                }
+
+                self.pending_nodes.extend(valid_ids.into_iter().map(|id| {
+                    NodeRenderState {
+                        id,
+                        visited_children: false,
+                        clip_bounds: None,
+                        visited_mask: false,
+                        mask: false,
+                        flattened: false,
+                    }
+                }));
             } else {
+                // If there are no more pending tiles, stop.
                 should_stop = true;
             }
         }
 
         self.render_in_progress = false;
-        self.surfaces.gc();
 
         // Mark cache as valid for render_from_cache.
         // Only update for full-quality renders (non-fast mode).

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -787,8 +787,8 @@ impl RenderState {
             self.tile_viewbox
                 .set_interest(self.options.dpr_viewport_interest_area_threshold);
             self.resize(
-                self.viewbox.width.floor() as i32,
-                self.viewbox.height.floor() as i32,
+                self.viewbox.width().floor() as i32,
+                self.viewbox.height().floor() as i32,
             )?;
             self.fonts.set_scale_debug_font(dpr);
         }
@@ -1944,8 +1944,8 @@ impl RenderState {
                 let cache_h = cache_dim.height as f32;
 
                 // Viewport in target pixels.
-                let vw = (self.viewbox.width * self.options.dpr).max(1.0);
-                let vh = (self.viewbox.height * self.options.dpr).max(1.0);
+                let vw = self.viewbox.dpr_width().max(1.0);
+                let vh = self.viewbox.dpr_height().max(1.0);
 
                 // Inverse-map viewport corners into cache coordinates.
                 // target = (cache * navigate_zoom) translated by (translate_x, translate_y) (in cache coords).

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -370,7 +370,7 @@ pub(crate) struct RenderState {
     /// Cleared at the beginning of a render pass; set to true after we clear Cache the first
     /// time we are about to blit a tile into Cache for this pass.
     pub cache_cleared_this_render: bool,
-    /// True iff the current tile had shapes assigned to it when we
+    /// True if the current tile had shapes assigned to it when we
     /// started rendering it. Lets us distinguish a genuinely empty
     /// tile (skip composite, just clear) from a tile whose walker
     /// finished its work in a previous PAF and is now being resumed
@@ -441,10 +441,10 @@ fn drag_crop_snapshot_window_px(
     (ox, oy, win_w, win_h)
 }
 
-pub fn get_cache_size(viewbox: Viewbox, scale: f32, interest: i32) -> skia::ISize {
+pub fn get_cache_size(viewbox: Viewbox, interest: i32) -> skia::ISize {
     // First we retrieve the extended area of the viewport that we could render.
     let TileRect(isx, isy, iex, iey) =
-        tiles::get_tiles_for_viewbox_with_interest(viewbox, interest, scale);
+        tiles::get_tiles_for_viewbox_with_interest(viewbox, interest);
 
     let dx = if isx.signum() != iex.signum() { 1 } else { 0 };
     let dy = if isy.signum() != iey.signum() { 1 } else { 0 };
@@ -565,7 +565,6 @@ impl RenderState {
             tile_viewbox: tiles::TileViewbox::new_with_interest(
                 viewbox,
                 options.dpr_viewport_interest_area_threshold,
-                1.0,
             ),
             pending_tiles: PendingTiles::new(),
             nested_fills: vec![],
@@ -791,6 +790,8 @@ impl RenderState {
                 self.viewbox.height().floor() as i32,
             )?;
             self.fonts.set_scale_debug_font(dpr);
+            self.viewbox.set_dpr(dpr);
+            self.surfaces.set_dpr(dpr);
         }
         Ok(())
     }
@@ -836,7 +837,7 @@ impl RenderState {
         let dpr_height = (height as f32 * self.options.dpr).floor() as i32;
         self.surfaces.resize(dpr_width, dpr_height)?;
         self.viewbox.set_wh(width as f32, height as f32);
-        self.tile_viewbox.update(self.viewbox, self.get_scale());
+        self.tile_viewbox.update(self.viewbox);
 
         Ok(())
     }
@@ -1901,8 +1902,6 @@ impl RenderState {
     pub fn render_from_cache(&mut self, shapes: ShapesPoolRef) {
         let _start = performance::begin_timed_log!("render_from_cache");
         performance::begin_measure!("render_from_cache");
-        let cached_scale = self.get_cached_scale();
-
         let bg_color = self.background_color;
 
         // During fast mode (pan/zoom), if a previous full-quality render still has pending tiles,
@@ -1910,7 +1909,7 @@ impl RenderState {
         // and drawing from it avoids mixing a partially-updated Cache surface with missing tiles.
         if self.options.is_fast_mode() && self.render_in_progress && self.surfaces.has_atlas() {
             self.surfaces
-                .draw_atlas_to_backbuffer(self.viewbox, self.options.dpr, bg_color);
+                .draw_atlas_to_backbuffer(self.viewbox, bg_color);
 
             self.present_frame(shapes);
             performance::end_measure!("render_from_cache");
@@ -1928,7 +1927,6 @@ impl RenderState {
                 tiles::get_tiles_for_viewbox_with_interest(
                     self.cached_viewbox,
                     interest,
-                    cached_scale,
                 );
             let offset_x = self.viewbox.area.left * self.cached_viewbox.zoom * self.options.dpr;
             let offset_y = self.viewbox.area.top * self.cached_viewbox.zoom * self.options.dpr;
@@ -1973,7 +1971,6 @@ impl RenderState {
                     if self.surfaces.has_atlas() {
                         self.surfaces.draw_atlas_to_backbuffer(
                             self.viewbox,
-                            self.options.dpr,
                             bg_color,
                         );
 
@@ -2008,18 +2005,15 @@ impl RenderState {
             // would be at wrong positions — skip them and let the full
             // render after set_view_end handle it.
             if !self.zoom_changed() {
-                let current_scale = self.get_scale();
-                let visible_rect = tiles::get_tiles_for_viewbox(self.viewbox, current_scale);
-                let vb_offset_x = self.viewbox.area.left * current_scale;
-                let vb_offset_y = self.viewbox.area.top * current_scale;
-
+                let visible_rect = tiles::get_tiles_for_viewbox(self.viewbox);
+                let offset = self.viewbox.get_offset();
                 for tx in visible_rect.x1()..=visible_rect.x2() {
                     for ty in visible_rect.y1()..=visible_rect.y2() {
                         let tile = tiles::Tile::from(tx, ty);
                         if self.surfaces.has_cached_tile_surface(tile) {
                             let tile_rect = skia::Rect::from_xywh(
-                                tx as f32 * tiles::TILE_SIZE - vb_offset_x,
-                                ty as f32 * tiles::TILE_SIZE - vb_offset_y,
+                                tx as f32 * tiles::TILE_SIZE - offset.x,
+                                ty as f32 * tiles::TILE_SIZE - offset.y,
                                 tiles::TILE_SIZE,
                                 tiles::TILE_SIZE,
                             );
@@ -2076,7 +2070,7 @@ impl RenderState {
         let _start = performance::begin_timed_log!("start_render_loop");
         let scale = self.get_scale();
 
-        self.tile_viewbox.update(self.viewbox, scale);
+        self.tile_viewbox.update(self.viewbox);
         self.focus_mode.reset();
 
         performance::begin_measure!("render");
@@ -2115,12 +2109,10 @@ impl RenderState {
 
         let viewbox_cache_size = get_cache_size(
             self.viewbox,
-            scale,
             self.options.dpr_viewport_interest_area_threshold,
         );
         let cached_viewbox_cache_size = get_cache_size(
             self.cached_viewbox,
-            scale,
             self.options.dpr_viewport_interest_area_threshold,
         );
         // Only resize cache if the new size is larger than the cached size
@@ -2222,6 +2214,9 @@ impl RenderState {
     ) -> Result<()> {
         performance::begin_measure!("process_animation_frame");
         self.render_shape_tree_partial(base_object, tree, timestamp, true)?;
+
+        self.surfaces.draw_tile_atlas_to_backbuffer(&self.viewbox, &self.tile_viewbox);
+        self.flush_and_submit();
 
         if self.render_in_progress {
             // Partial frame: just flush GPU work. The display shows the last
@@ -3384,47 +3379,9 @@ impl RenderState {
 
         while !should_stop {
             if let Some(current_tile) = self.current_tile {
-                if self.surfaces.has_cached_tile_surface(current_tile) {
-                    performance::begin_measure!("render_shape_tree::cached");
-                    // During interactive transforms, `Target` is preserved and seeded once
-                    // from Backbuffer. Cached tiles are therefore already visible and
-                    // re-blitting them costs extra GPU work.
-                    let tile_rect = self.get_current_tile_bounds()?;
-                    if !self.options.is_interactive_transform() {
-                        self.surfaces.draw_cached_tile_surface(
-                            current_tile,
-                            tile_rect,
-                            self.background_color,
-                        );
-                    }
-
-                    // Also draw the cached tile to the Cache surface so
-                    // render_from_cache (used during pan) has the full scene.
-                    // apply_render_to_final_canvas clears Cache on the first
-                    // uncached tile, but cached tiles must also be present.
-                    if !self.options.is_fast_mode() {
-                        if !self.cache_cleared_this_render {
-                            self.surfaces.clear_cache(self.background_color);
-                            self.cache_cleared_this_render = true;
-                        }
-                        let aligned_rect = self.get_aligned_tile_bounds(current_tile);
-                        self.surfaces.draw_cached_tile_to_cache(
-                            current_tile,
-                            &aligned_rect,
-                            self.background_color,
-                        );
-                    }
-                    performance::end_measure!("render_shape_tree::cached");
-
-                    if self.options.is_debug_visible() {
-                        debug::render_workspace_current_tile(
-                            self,
-                            "Cached".to_string(),
-                            current_tile,
-                            tile_rect,
-                        );
-                    }
-                } else {
+                // NOTA: Ahora no tenemos que cubrir el caso en el que el tile
+                // no está cacheado porque se hará todo desde el draw_atlas.
+                if !self.surfaces.has_cached_tile_surface(current_tile) {
                     performance::begin_measure!("render_shape_tree::uncached");
                     let (is_empty, early_return) = self
                         .render_shape_tree_partial_uncached(tree, timestamp, allow_stop, false)?;
@@ -3463,6 +3420,10 @@ impl RenderState {
                     } else {
                         // Tile is uncached and has no shapes to render
                         self.apply_render_to_final_canvas(tile_rect)?;
+                    }
+                } else {
+                    if self.tiles.is_empty_at(current_tile) {
+                        self.surfaces.remove_cached_tile_surface(current_tile);
                     }
                 }
             }
@@ -3881,11 +3842,7 @@ impl RenderState {
         if let Some((_, export_scale)) = self.export_context {
             return export_scale;
         }
-        self.viewbox.zoom() * self.options.dpr
-    }
-
-    pub fn get_cached_scale(&self) -> f32 {
-        self.cached_viewbox.zoom() * self.options.dpr
+        self.viewbox.get_scale()
     }
 
     pub fn zoom_changed(&self) -> bool {

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -38,6 +38,21 @@ pub use images::*;
 
 type ClipStack = Vec<(Rect, Option<Corners>, Matrix)>;
 
+#[repr(u8)]
+pub enum FrameType {
+    None = 0,
+    Partial = 1,
+    Full = 2,
+}
+
+#[allow(dead_code)]
+#[repr(u8)]
+pub enum RenderFlag {
+    None = 0,
+    Partial = 1,
+    Full = 2,
+}
+
 #[derive(Debug)]
 pub struct NodeRenderState {
     pub id: Uuid,
@@ -334,10 +349,6 @@ pub(crate) struct RenderState {
     pub cached_viewbox: Viewbox,
     pub images: ImageStore,
     pub background_color: skia::Color,
-    // Identifier of the current requestAnimationFrame call, if any.
-    pub render_request_id: Option<i32>,
-    // Indicates whether the rendering process has pending frames.
-    pub render_in_progress: bool,
     // Stack of nodes pending to be rendered.
     pending_nodes: Vec<NodeRenderState>,
     pub current_tile: Option<tiles::Tile>,
@@ -538,8 +549,6 @@ impl RenderState {
             cached_viewbox: Viewbox::new(0., 0.),
             images: ImageStore::new(),
             background_color: skia::Color::TRANSPARENT,
-            render_request_id: None,
-            render_in_progress: false,
             pending_nodes: vec![],
             current_tile: None,
             sampling_options,
@@ -1678,14 +1687,6 @@ impl RenderState {
         self.surfaces.update_render_context(self.render_area, scale);
     }
 
-    pub fn cancel_animation_frame(&mut self) {
-        if self.render_in_progress {
-            if let Some(frame_id) = self.render_request_id {
-                wapi::cancel_animation_frame!(frame_id);
-            }
-        }
-    }
-
     fn rebuild_backbuffer_crop_cache(&mut self, tree: ShapesPoolRef) {
         self.backbuffer_crop_cache.clear();
 
@@ -1893,7 +1894,7 @@ impl RenderState {
         // During fast mode (pan/zoom), if a previous full-quality render still has pending tiles,
         // always prefer the persistent atlas. The atlas is incrementally updated as tiles finish,
         // and drawing from it avoids mixing a partially-updated Cache surface with missing tiles.
-        if self.options.is_fast_mode() && self.render_in_progress && self.surfaces.has_atlas() {
+        if self.options.is_fast_mode() && self.surfaces.has_atlas() {
             self.surfaces
                 .draw_atlas_to_backbuffer(self.viewbox, bg_color);
 
@@ -1910,10 +1911,7 @@ impl RenderState {
 
             let interest = self.options.dpr_viewport_interest_area_threshold;
             let TileRect(start_tile_x, start_tile_y, _, _) =
-                tiles::get_tiles_for_viewbox_with_interest(
-                    &self.cached_viewbox,
-                    interest,
-                );
+                tiles::get_tiles_for_viewbox_with_interest(&self.cached_viewbox, interest);
             let offset_x = self.viewbox.area.left * self.cached_viewbox.zoom * self.options.dpr;
             let offset_y = self.viewbox.area.top * self.cached_viewbox.zoom * self.options.dpr;
             let translate_x = (start_tile_x as f32 * tiles::TILE_SIZE) - offset_x;
@@ -1955,10 +1953,8 @@ impl RenderState {
                 if !cache_covers {
                     // Early return only if atlas exists; otherwise keep cache path.
                     if self.surfaces.has_atlas() {
-                        self.surfaces.draw_atlas_to_backbuffer(
-                            self.viewbox,
-                            bg_color,
-                        );
+                        self.surfaces
+                            .draw_atlas_to_backbuffer(self.viewbox, bg_color);
 
                         self.present_frame(shapes);
                         performance::end_measure!("render_from_cache");
@@ -2049,11 +2045,13 @@ impl RenderState {
             self.pending_nodes
                 .reserve(tree.len() - self.pending_nodes.capacity());
         }
+
         // Clear nested state stacks to avoid residual fills/blurs from previous renders
         // being incorrectly applied to new frames
         self.nested_fills.clear();
         self.nested_blurs.clear();
         self.nested_shadows.clear();
+
         // reorder by distance to the center.
         self.current_tile = None;
     }
@@ -2064,7 +2062,7 @@ impl RenderState {
         tree: ShapesPoolRef,
         timestamp: i32,
         sync_render: bool,
-    ) -> Result<()> {
+    ) -> Result<FrameType> {
         self.gc(tree);
 
         let _start = performance::begin_timed_log!("start_render_loop");
@@ -2111,7 +2109,7 @@ impl RenderState {
         self.surfaces.resize_cache_from_viewbox(
             &self.viewbox,
             &self.cached_viewbox,
-            self.options.dpr_viewport_interest_area_threshold
+            self.options.dpr_viewport_interest_area_threshold,
         )?;
 
         // FIXME - review debug
@@ -2127,14 +2125,14 @@ impl RenderState {
 
         performance::end_timed_log!("tile_cache_update", _tile_start);
 
-        self.render_in_progress = true;
-
         self.draw_shape_surface_stack_into(None, SurfaceId::Current);
 
+        #[allow(unused)]
+        let mut frame_type = FrameType::None;
         if sync_render {
-            self.render_shape_tree_sync(base_object, tree, timestamp)?;
+            frame_type = self.render_shape_tree_sync(base_object, tree, timestamp)?;
         } else {
-            self.process_animation_frame(base_object, tree, timestamp)?;
+            frame_type = self.continue_render_loop(base_object, tree, timestamp)?;
 
             // This is an option to debug frames.
             if self.options.capture_frames > 0 {
@@ -2155,7 +2153,7 @@ impl RenderState {
 
         performance::end_measure!("start_render_loop");
         performance::end_timed_log!("start_render_loop", _start);
-        Ok(())
+        Ok(frame_type)
     }
 
     fn compute_document_bounds(
@@ -2189,41 +2187,45 @@ impl RenderState {
         acc
     }
 
-    pub fn process_animation_frame(
+    pub fn continue_render_loop(
         &mut self,
         base_object: Option<&Uuid>,
         tree: ShapesPoolRef,
         timestamp: i32,
-    ) -> Result<()> {
-        performance::begin_measure!("process_animation_frame");
-        self.render_shape_tree_partial(base_object, tree, timestamp, true)?;
+    ) -> Result<FrameType> {
+        performance::begin_measure!("continue_render_loop");
+        let frame_type = self.render_shape_tree_partial(base_object, tree, timestamp, true)?;
 
         if !self.options.is_interactive_transform() {
-            self.surfaces.draw_tile_atlas_to_backbuffer(&self.viewbox, &self.tile_viewbox);
+            self.surfaces
+                .draw_tile_atlas_to_backbuffer(&self.viewbox, &self.tile_viewbox);
         }
 
-        if self.render_in_progress {
-            // Partial frame: just flush GPU work. The display shows the last
-            // fully submitted frame; no need to copy or draw UI overlays here.
-            self.flush();
-            self.cancel_animation_frame();
-            self.render_request_id = Some(wapi::request_animation_frame!());
-        } else {
-            // A full-quality frame is now complete. Rebuild the per-shape crop
-            // cache from the clean Backbuffer (no UI overlay yet) so that
-            // interactive drag backgrounds don't include the grid overlay.
-            if !self.options.is_fast_mode() && !self.options.is_interactive_transform() {
-                self.rebuild_backbuffer_crop_cache(tree);
+        match frame_type {
+            FrameType::None => {
+                panic!("FrameType::None");
             }
-            // present_frame: copy clean Backbuffer → Target, draw UI/debug
-            // overlays on Target only, then flush. Backbuffer stays overlay-free.
-            self.present_frame(tree);
-            wapi::notify_tiles_render_complete!();
-            performance::end_measure!("render");
+            FrameType::Partial => {
+                // Partial frame: just flush GPU work. The display shows the last
+                // fully submitted frame; no need to copy or draw UI overlays here.
+                self.flush();
+            }
+            FrameType::Full => {
+                // A full-quality frame is now complete. Rebuild the per-shape crop
+                // cache from the clean Backbuffer (no UI overlay yet) so that
+                // interactive drag backgrounds don't include the grid overlay.
+                if !self.options.is_fast_mode() && !self.options.is_interactive_transform() {
+                    self.rebuild_backbuffer_crop_cache(tree);
+                }
+                // present_frame: copy clean Backbuffer → Target, draw UI/debug
+                // overlays on Target only, then flush. Backbuffer stays overlay-free.
+                self.present_frame(tree);
+                wapi::notify_tiles_render_complete!();
+                performance::end_measure!("render");
+            }
         }
-
-        performance::end_measure!("process_animation_frame");
-        Ok(())
+        performance::end_measure!("continue_render_loop");
+        Ok(frame_type)
     }
 
     pub fn render_shape_tree_sync(
@@ -2231,10 +2233,10 @@ impl RenderState {
         base_object: Option<&Uuid>,
         tree: ShapesPoolRef,
         timestamp: i32,
-    ) -> Result<()> {
+    ) -> Result<FrameType> {
         self.render_shape_tree_partial(base_object, tree, timestamp, false)?;
         self.present_frame(tree);
-        Ok(())
+        Ok(FrameType::Full)
     }
 
     pub fn render_shape_pixels(
@@ -3349,7 +3351,7 @@ impl RenderState {
         tree: ShapesPoolRef,
         timestamp: i32,
         allow_stop: bool,
-    ) -> Result<()> {
+    ) -> Result<FrameType> {
         let mut should_stop = false;
         let root_ids = {
             if let Some(shape_id) = base_object {
@@ -3377,7 +3379,7 @@ impl RenderState {
                     }
 
                     if early_return {
-                        return Ok(());
+                        return Ok(FrameType::Partial);
                     }
                     performance::end_measure!("render_shape_tree::uncached");
 
@@ -3408,10 +3410,8 @@ impl RenderState {
                             );
                         }
                     }
-                } else {
-                    if self.tiles.is_empty_at(current_tile) {
-                        self.surfaces.remove_cached_tile_surface(current_tile);
-                    }
+                } else if self.tiles.is_empty_at(current_tile) {
+                    self.surfaces.remove_cached_tile_surface(current_tile);
                 }
             }
 
@@ -3429,7 +3429,7 @@ impl RenderState {
                 // empty tile.
                 self.current_tile_had_shapes = false;
 
-                let Some(ids)  = self.tiles.get_shapes_at(next_tile) else {
+                let Some(ids) = self.tiles.get_shapes_at(next_tile) else {
                     // If the tile is empty we do not need to render it.
                     continue;
                 };
@@ -3446,9 +3446,8 @@ impl RenderState {
                 // which must contain the shapes behind it.
                 let tile_has_bg_blur = ids.iter().any(|id| {
                     tree.get(id).is_some_and(|s| {
-                        s.blur.is_some_and(|b| {
-                            !b.hidden && b.blur_type == BlurType::BackgroundBlur
-                        })
+                        s.blur
+                            .is_some_and(|b| !b.hidden && b.blur_type == BlurType::BackgroundBlur)
                     })
                 });
 
@@ -3474,23 +3473,20 @@ impl RenderState {
                     self.current_tile_had_shapes = true;
                 }
 
-                self.pending_nodes.extend(valid_ids.into_iter().map(|id| {
-                    NodeRenderState {
+                self.pending_nodes
+                    .extend(valid_ids.into_iter().map(|id| NodeRenderState {
                         id,
                         visited_children: false,
                         clip_bounds: None,
                         visited_mask: false,
                         mask: false,
                         flattened: false,
-                    }
-                }));
+                    }));
             } else {
                 // If there are no more pending tiles, stop.
                 should_stop = true;
             }
         }
-
-        self.render_in_progress = false;
 
         // Mark cache as valid for render_from_cache.
         // Only update for full-quality renders (non-fast mode).
@@ -3504,7 +3500,7 @@ impl RenderState {
             self.cached_viewbox = self.viewbox;
         }
 
-        Ok(())
+        Ok(FrameType::Full)
     }
 
     /*

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -4,7 +4,7 @@ use super::{tiles, RenderState, SurfaceId};
 use macros::wasm_error;
 
 #[cfg(target_arch = "wasm32")]
-use crate::{get_render_state};
+use crate::get_render_state;
 
 use skia_safe::{self as skia, Rect};
 
@@ -277,7 +277,9 @@ pub fn console_debug_surface_rect(render_state: &mut RenderState, id: SurfaceId,
 #[wasm_error]
 #[cfg(target_arch = "wasm32")]
 pub extern "C" fn capture_frames(capture_frames: i32) -> Result<()> {
-    get_render_state().options.set_capture_frames(capture_frames);
+    get_render_state()
+        .options
+        .set_capture_frames(capture_frames);
     Ok(())
 }
 

--- a/render-wasm/src/render/debug.rs
+++ b/render-wasm/src/render/debug.rs
@@ -4,7 +4,7 @@ use super::{tiles, RenderState, SurfaceId};
 use macros::wasm_error;
 
 #[cfg(target_arch = "wasm32")]
-use crate::get_render_state;
+use crate::{get_render_state};
 
 use skia_safe::{self as skia, Rect};
 
@@ -271,6 +271,14 @@ pub fn console_debug_surface_rect(render_state: &mut RenderState, id: SurfaceId,
     if let Some(base64_image) = base64_image {
         run_script!(format!("console.log('%c ', 'font-size: 1px; background: url(data:image/png;base64,{base64_image}) no-repeat; padding: 100px; background-size: contain;')"))
     }
+}
+
+#[no_mangle]
+#[wasm_error]
+#[cfg(target_arch = "wasm32")]
+pub extern "C" fn capture_frames(capture_frames: i32) -> Result<()> {
+    get_render_state().options.set_capture_frames(capture_frames);
+    Ok(())
 }
 
 #[no_mangle]

--- a/render-wasm/src/render/options.rs
+++ b/render-wasm/src/render/options.rs
@@ -29,6 +29,7 @@ pub struct RenderOptions {
     pub max_blocking_time_ms: i32,
     pub node_batch_threshold: i32,
     pub blur_downscale_threshold: f32,
+    pub capture_frames: i32,
 }
 
 impl Default for RenderOptions {
@@ -44,6 +45,7 @@ impl Default for RenderOptions {
             max_blocking_time_ms: MAX_BLOCKING_TIME_MS,
             node_batch_threshold: NODE_BATCH_THRESHOLD,
             blur_downscale_threshold: BLUR_DOWNSCALE_THRESHOLD,
+            capture_frames: 0,
         }
     }
 }
@@ -64,6 +66,10 @@ impl RenderOptions {
 
     pub fn set_fast_mode(&mut self, enabled: bool) {
         self.fast_mode = enabled;
+    }
+
+    pub fn set_capture_frames(&mut self, capture_frames: i32) {
+        self.capture_frames = capture_frames;
     }
 
     /// Updates the dpr viewport interest area threshold.

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -5,7 +5,7 @@ use crate::{get_gpu_state, performance};
 
 use skia_safe::{self as skia, IRect, Paint, RRect, Rect};
 
-use super::{gpu_state::GpuState, tiles, tiles::Tile, tiles::TileViewbox, tiles::TILE_SIZE};
+use super::{gpu_state::GpuState, tiles, tiles::Tile, tiles::TileRect, tiles::TileViewbox};
 use crate::math::Point;
 
 use base64::{engine::general_purpose, Engine as _};
@@ -13,9 +13,18 @@ use std::collections::{HashMap, HashSet};
 
 const TEXTURES_CACHE_CAPACITY: usize = 1024;
 const TEXTURES_BATCH_DELETE: usize = 256;
+
 // This is the amount of extra space we're going to give to all the surfaces to render shapes.
 // If it's too big it could affect performance.
+const TILE_SIZE: i32 = tiles::TILE_SIZE as i32;
 const TILE_SIZE_MULTIPLIER: i32 = 2;
+const TILE_MARGIN_SIZE: i32 = TILE_SIZE * TILE_SIZE_MULTIPLIER / 4;
+const TILE_DRAWABLE_RECT: IRect = IRect {
+    left: TILE_MARGIN_SIZE,
+    top: TILE_MARGIN_SIZE,
+    right: TILE_MARGIN_SIZE + TILE_SIZE,
+    bottom: TILE_MARGIN_SIZE + TILE_SIZE,
+};
 
 /// Atlas texture size limits (px per side).
 ///
@@ -24,8 +33,23 @@ const TILE_SIZE_MULTIPLIER: i32 = 2;
 ///   [`Surfaces::set_max_atlas_texture_size`].
 /// - `MAX_ATLAS_TEXTURE_SIZE` is a hard upper bound to clamp the runtime value
 ///   (defensive cap to avoid accidentally creating oversized GPU textures).
-const MAX_ATLAS_TEXTURE_SIZE: i32 = 4096;
+const MAX_ATLAS_TEXTURE_SIZE: i32 = 8192;
 const DEFAULT_MAX_ATLAS_TEXTURE_SIZE: i32 = 1024;
+
+pub fn get_cache_size(viewbox: &Viewbox, interest: i32) -> skia::ISize {
+    // First we retrieve the extended area of the viewport that we could render.
+    let TileRect(isx, isy, iex, iey) =
+        tiles::get_tiles_for_viewbox_with_interest(viewbox, interest);
+
+    let dx = if isx.signum() != iex.signum() { 1 } else { 0 };
+    let dy = if isy.signum() != iey.signum() { 1 } else { 0 };
+
+    (
+        ((iex - isx).abs() + dx) * TILE_SIZE,
+        ((iey - isy).abs() + dy) * TILE_SIZE,
+    )
+        .into()
+}
 
 #[derive(Debug, PartialEq)]
 pub enum DrawOnCache {
@@ -202,7 +226,10 @@ impl Surfaces {
     /// WebGL `MAX_TEXTURE_SIZE` reported by the browser. Values are clamped to
     /// a small minimum so the atlas logic stays well-defined.
     pub fn set_max_atlas_texture_size(&mut self, max_px: i32) {
-        self.max_atlas_texture_size = max_px.clamp(TILE_SIZE as i32, MAX_ATLAS_TEXTURE_SIZE);
+        self.max_atlas_texture_size = max_px.clamp(
+            TILE_SIZE,
+            MAX_ATLAS_TEXTURE_SIZE
+        );
     }
 
     #[inline]
@@ -268,7 +295,7 @@ impl Surfaces {
         }
 
         // Add padding to reduce realloc frequency.
-        let pad = TILE_SIZE;
+        let pad = tiles::TILE_SIZE;
         new_left -= pad;
         new_top -= pad;
         new_right += pad;
@@ -279,7 +306,7 @@ impl Surfaces {
 
         // Compute atlas scale needed to fit within the fixed texture cap.
         // Keep the highest possible scale (closest to 1.0) that still fits.
-        let cap = self.max_atlas_texture_size.max(TILE_SIZE as i32) as f32;
+        let cap = self.max_atlas_texture_size.max(TILE_SIZE) as f32;
         let required_scale = (cap / doc_w).min(cap / doc_h).clamp(0.01, 1.0);
 
         // Never upscale the atlas (it would add blur and churn).
@@ -876,9 +903,36 @@ impl Surfaces {
             .ok_or(Error::CriticalError("Failed to create surface".to_string()))?;
         self.cache.canvas().reset_matrix();
         self.cache.canvas().translate((
-            (interest_area_threshold as f32 * TILE_SIZE),
-            (interest_area_threshold as f32 * TILE_SIZE),
+            (interest_area_threshold * TILE_SIZE) as f32,
+            (interest_area_threshold * TILE_SIZE) as f32,
         ));
+        Ok(())
+    }
+
+    pub fn resize_cache_from_viewbox(
+        &mut self,
+        viewbox: &Viewbox,
+        cached_viewbox: &Viewbox,
+        interest_area_threshold: i32,
+    ) -> Result<()> {
+        let viewbox_cache_size = get_cache_size(
+            viewbox,
+            interest_area_threshold,
+        );
+        let cached_viewbox_cache_size = get_cache_size(
+            cached_viewbox,
+            interest_area_threshold,
+        );
+        // Only resize cache if the new size is larger than the cached size
+        // This avoids unnecessary surface recreations when the cache size decreases
+        if viewbox_cache_size.width > cached_viewbox_cache_size.width
+            || viewbox_cache_size.height > cached_viewbox_cache_size.height
+        {
+            return self.resize_cache(
+                viewbox_cache_size,
+                interest_area_threshold,
+            );
+        }
         Ok(())
     }
 
@@ -1038,6 +1092,7 @@ impl Surfaces {
         self.canvas(SurfaceId::Debug)
             .clear(skia::Color::TRANSPARENT)
             .reset_matrix();
+
         self.canvas(SurfaceId::UI)
             .clear(skia::Color::TRANSPARENT)
             .reset_matrix();
@@ -1054,7 +1109,7 @@ impl Surfaces {
         canvas.restore();
     }
 
-    pub fn cache_current_tile_texture(
+    pub fn draw_current_tile_into_tile_atlas(
         &mut self,
         tile_viewbox: &TileViewbox,
         tile: &Tile,
@@ -1063,15 +1118,9 @@ impl Surfaces {
         tile_doc_rect: skia::Rect,
     ) {
         let gpu_state = get_gpu_state();
-        let rect = IRect::from_xywh(
-            self.margins.width,
-            self.margins.height,
-            self.current.width() - TILE_SIZE_MULTIPLIER * self.margins.width,
-            self.current.height() - TILE_SIZE_MULTIPLIER * self.margins.height,
-        );
+        let rect = TILE_DRAWABLE_RECT;
 
         let tile_image_opt = self.current.image_snapshot_with_bounds(rect);
-
         if let Some(tile_image) = tile_image_opt {
             if !skip_cache_surface {
                 // Draw to cache surface for render_from_cache
@@ -1088,6 +1137,7 @@ impl Surfaces {
             let _ = self.blit_tile_image_into_atlas(gpu_state, &tile_image, tile_doc_rect);
             self.atlas_tile_doc_rects.insert(*tile, tile_doc_rect);
 
+            // Draws current tile into tile atlas
             let tile_ref = self.tiles.add(tile_viewbox, tile);
             self.tile_atlas.canvas().draw_image_rect(
                 &tile_image,
@@ -1249,13 +1299,17 @@ impl Surfaces {
         self.tile_atlas.image_snapshot_with_bounds(rect)
     }
 
-    pub fn draw_cached_tile_surface(&mut self, tile: Tile, rect: skia::Rect, color: skia::Color) {
+    pub fn draw_cached_tile_into_backbuffer(&mut self, tile: Tile, rect: skia::Rect, _color: skia::Color) {
         if let Some(image) = self.get_tile_image_from_tile_atlas(tile) {
-            let mut paint = skia::Paint::default();
-            paint.set_color(color);
-            self.backbuffer.canvas().draw_rect(rect, &paint);
-            self.backbuffer
-                .canvas()
+            let backbuffer_canvas = self.backbuffer.canvas();
+
+            // if color != skia::Color::TRANSPARENT {
+            //     let mut paint = skia::Paint::default();
+            //     paint.set_color(color);
+            //     backbuffer_canvas.draw_rect(rect, &paint);
+            // }
+
+            backbuffer_canvas
                 .draw_image_rect(&image, None, rect, &skia::Paint::default());
         }
     }
@@ -1264,16 +1318,16 @@ impl Surfaces {
     /// cache-aligned rect.  This keeps the Cache surface in sync with
     /// Backbuffer so that `render_from_cache` (used during pan) has the
     /// full scene including tiles served from the texture cache.
-    pub fn draw_cached_tile_to_cache(
+    pub fn draw_cached_tile_into_cache(
         &mut self,
         tile: Tile,
         aligned_rect: &skia::Rect,
-        color: skia::Color,
+        _color: skia::Color,
     ) {
         if let Some(image) = self.get_tile_image_from_tile_atlas(tile) {
-            let mut bg = skia::Paint::default();
-            bg.set_color(color);
-            self.cache.canvas().draw_rect(aligned_rect, &bg);
+            // let mut bg = skia::Paint::default();
+            // bg.set_color(color);
+            // self.cache.canvas().draw_rect(aligned_rect, &bg);
             self.cache.canvas().draw_image_rect(
                 &image,
                 None,
@@ -1286,10 +1340,10 @@ impl Surfaces {
     /// Draws the current tile directly to the backbuffer and cache surfaces without
     /// creating a snapshot. This avoids GPU stalls from ReadPixels but doesn't
     /// populate the tile texture cache (suitable for one-shot renders like tests).
-    pub fn draw_current_tile_direct(
+    pub fn draw_current_tile_into_backbuffer(
         &mut self,
         tile_rect: &skia::Rect,
-        color: skia::Color,
+        _color: skia::Color,
         draw_on_cache: DrawOnCache,
     ) {
         let sampling_options = self.sampling_options;
@@ -1302,10 +1356,11 @@ impl Surfaces {
         let src_rect_f = skia::Rect::from(src_rect);
 
         let backbuffer_canvas = self.backbuffer.canvas();
+
         // Draw background
-        let mut paint = skia::Paint::default();
-        paint.set_color(color);
-        backbuffer_canvas.draw_rect(tile_rect, &paint);
+        // let mut paint = skia::Paint::default();
+        // paint.set_color(color);
+        // backbuffer_canvas.draw_rect(tile_rect, &paint);
 
         // Draw current surface directly to target (no snapshot)
         self.current.draw(
@@ -1487,8 +1542,8 @@ pub struct TileTextureCache {
 impl TileTextureCache {
     pub fn new(texture_size: i32, capacity: usize) -> Self {
         Self {
-            tile_size: TILE_SIZE,
-            provider: TileAtlasTextureProvider::new(texture_size, TILE_SIZE as i32),
+            tile_size: tiles::TILE_SIZE,
+            provider: TileAtlasTextureProvider::new(texture_size, TILE_SIZE),
             transforms: Vec::with_capacity(capacity),
             textures: Vec::with_capacity(capacity),
             grid: HashMap::with_capacity(capacity),

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -3,12 +3,10 @@ use crate::shapes::Shape;
 use crate::view::Viewbox;
 use crate::{get_gpu_state, performance};
 
-use skia_safe::{self as skia, IRect, Paint, RRect};
+use skia_safe::{self as skia, IRect, Paint, RRect, Rect};
 
-use super::{
-    gpu_state::GpuState,
-    tiles::{self, Tile, TileViewbox, TILE_SIZE},
-};
+use super::{gpu_state::GpuState, tiles, tiles::Tile, tiles::TileViewbox, tiles::TILE_SIZE};
+use crate::math::Point;
 
 use base64::{engine::general_purpose, Engine as _};
 use std::collections::{HashMap, HashSet};
@@ -37,6 +35,7 @@ pub enum DrawOnCache {
 
 #[repr(u32)]
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[allow(unused)]
 pub enum SurfaceId {
     Target = 0b000_0000_0001,
     Filter = 0b000_0000_0010,
@@ -52,6 +51,7 @@ pub enum SurfaceId {
     Debug = 0b100_0000_0001,
     Atlas = 0b100_0000_0010,
     Backbuffer = 0b100_0000_0100,
+    TileAtlas = 0b100_0000_1000,
 }
 
 pub struct Surfaces {
@@ -79,6 +79,8 @@ pub struct Surfaces {
     export: skia::Surface,
     // Persistent viewport-sized surface used to keep the last presented frame.
     backbuffer: skia::Surface,
+    // Atlas used to keep tiles.
+    tile_atlas: skia::Surface,
 
     tiles: TileTextureCache,
     // Persistent 1:1 document-space atlas that gets incrementally updated as tiles render.
@@ -103,8 +105,8 @@ pub struct Surfaces {
     pub margins: skia::ISize,
     // Tracks which surfaces have content (dirty flag bitmask)
     dirty_surfaces: u32,
-
     extra_tile_dims: skia::ISize,
+    dpr: f32,
 }
 
 #[allow(dead_code)]
@@ -127,6 +129,16 @@ impl Surfaces {
         let cache = gpu_state.create_surface_with_dimensions("cache".to_string(), width, height)?;
         let backbuffer =
             gpu_state.create_surface_with_dimensions("backbuffer".to_string(), width, height)?;
+
+        // TODO: Obtener este tamaño de alguna otra parte.
+        let max_texture_size = 8192;
+        // NOTA: Esta textura debería utilizar el máximo permitido por la GPU.
+        let tile_atlas = gpu_state.create_surface_with_dimensions(
+            "tile_atlas".to_string(),
+            max_texture_size,
+            max_texture_size,
+        )?;
+
         let current =
             gpu_state.create_surface_with_isize("current".to_string(), extra_tile_dims)?;
 
@@ -149,7 +161,8 @@ impl Surfaces {
         let mut atlas = gpu_state.create_surface_with_dimensions("atlas".to_string(), 1, 1)?;
         atlas.canvas().clear(skia::Color::TRANSPARENT);
 
-        let tiles = TileTextureCache::new();
+        // 512, why not?
+        let tiles = TileTextureCache::new(tile_atlas.width(), 512);
         Ok(Self {
             target,
             filter,
@@ -164,6 +177,7 @@ impl Surfaces {
             debug,
             export,
             backbuffer,
+            tile_atlas,
             tiles,
             atlas,
             atlas_origin: skia::Point::new(0.0, 0.0),
@@ -176,7 +190,12 @@ impl Surfaces {
             margins,
             dirty_surfaces: 0,
             extra_tile_dims,
+            dpr: 1.0,
         })
+    }
+
+    pub fn set_dpr(&mut self, dpr: f32) {
+        self.dpr = dpr;
     }
 
     /// Sets the maximum atlas texture dimension (one side). Should match the
@@ -471,16 +490,28 @@ impl Surfaces {
         self.atlas_size.width > 0 && self.atlas_size.height > 0
     }
 
+    pub fn draw_tile_atlas_to_backbuffer(&mut self, viewbox: &Viewbox, tile_viewbox: &TileViewbox) {
+        let sampling_options =
+            skia::SamplingOptions::new(skia::FilterMode::Nearest, skia::MipmapMode::None);
+
+        self.tiles.update(viewbox, tile_viewbox);
+        self.backbuffer.canvas().draw_atlas(
+            &self.tile_atlas.image_snapshot(),
+            &self.tiles.transforms,
+            &self.tiles.textures,
+            None,
+            skia::BlendMode::SrcOver,
+            sampling_options,
+            None,
+            None,
+        );
+    }
+
     /// Draw the persistent atlas onto the backbuffer using the current viewbox transform.
     /// Intended for fast pan/zoom-out previews (avoids per-tile composition).
     /// Clears Backbuffer to `background` first so atlas-uncovered regions don't
     /// show stale content when the atlas only partially covers the viewport.
-    pub fn draw_atlas_to_backbuffer(
-        &mut self,
-        viewbox: Viewbox,
-        dpr: f32,
-        background: skia::Color,
-    ) {
+    pub fn draw_atlas_to_backbuffer(&mut self, viewbox: Viewbox, background: skia::Color) {
         if !self.has_atlas() {
             return;
         }
@@ -758,6 +789,7 @@ impl Surfaces {
             SurfaceId::UI => &mut self.ui,
             SurfaceId::Export => &mut self.export,
             SurfaceId::Atlas => &mut self.atlas,
+            SurfaceId::TileAtlas => &mut self.tile_atlas,
         }
     }
 
@@ -778,6 +810,7 @@ impl Surfaces {
             SurfaceId::UI => &self.ui,
             SurfaceId::Export => &self.export,
             SurfaceId::Atlas => &self.atlas,
+            SurfaceId::TileAtlas => &self.tile_atlas,
         }
     }
 
@@ -1054,7 +1087,14 @@ impl Surfaces {
             // `tile_doc_rect` is in world/document coordinates (1 unit == 1 px at 100%).
             let _ = self.blit_tile_image_into_atlas(gpu_state, &tile_image, tile_doc_rect);
             self.atlas_tile_doc_rects.insert(*tile, tile_doc_rect);
-            self.tiles.add(tile_viewbox, tile, tile_image);
+
+            let tile_ref = self.tiles.add(tile_viewbox, tile);
+            self.tile_atlas.canvas().draw_image_rect(
+                &tile_image,
+                None,
+                tile_ref.rect,
+                &skia::Paint::default(),
+            );
         }
     }
 
@@ -1131,7 +1171,17 @@ impl Surfaces {
                     (clip_doc.bottom - vb_top) * scale - iy0,
                 );
 
-                if let Some(tile_image) = self.tiles.get(tile) {
+                if let Some(tile_ref) = self.tiles.get(tile) {
+                    let bounds = skia::IRect::from_ltrb(
+                        tile_ref.rect.left as i32,
+                        tile_ref.rect.top as i32,
+                        tile_ref.rect.right as i32,
+                        tile_ref.rect.bottom as i32,
+                    );
+                    let Some(tile_image) = self.tile_atlas.image_snapshot_with_bounds(bounds)
+                    else {
+                        panic!("Cannot retrieve tile image");
+                    };
                     let iw = tile_image.width() as f32;
                     let ih = tile_image.height() as f32;
                     let td_w = tile_doc.width().max(1e-6);
@@ -1185,13 +1235,25 @@ impl Surfaces {
         let _ = self.clear_tile_in_atlas(gpu_state, tile);
     }
 
+    pub fn get_tile_image_from_tile_atlas(&mut self, tile: Tile) -> Option<skia::Image> {
+        let Some(tile_ref) = self.tiles.get(tile) else {
+            panic!("Tile not found {}:{}", tile.0, tile.1);
+        };
+
+        let rect = IRect::from_ltrb(
+            tile_ref.rect.left as i32,
+            tile_ref.rect.top as i32,
+            tile_ref.rect.right as i32,
+            tile_ref.rect.bottom as i32,
+        );
+        self.tile_atlas.image_snapshot_with_bounds(rect)
+    }
+
     pub fn draw_cached_tile_surface(&mut self, tile: Tile, rect: skia::Rect, color: skia::Color) {
-        if let Some(image) = self.tiles.get(tile) {
+        if let Some(image) = self.get_tile_image_from_tile_atlas(tile) {
             let mut paint = skia::Paint::default();
             paint.set_color(color);
-
             self.backbuffer.canvas().draw_rect(rect, &paint);
-
             self.backbuffer
                 .canvas()
                 .draw_image_rect(&image, None, rect, &skia::Paint::default());
@@ -1208,7 +1270,7 @@ impl Surfaces {
         aligned_rect: &skia::Rect,
         color: skia::Color,
     ) {
-        if let Some(image) = self.tiles.get(tile) {
+        if let Some(image) = self.get_tile_image_from_tile_atlas(tile) {
             let mut bg = skia::Paint::default();
             bg.set_color(color);
             self.cache.canvas().draw_rect(aligned_rect, &bg);
@@ -1347,31 +1409,103 @@ impl Surfaces {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TileAtlasTextureRef {
+    pub index: usize,
+    pub rect: skia::Rect,
+}
+
+impl TileAtlasTextureRef {
+    pub fn new(index: usize, rect: skia::Rect) -> Self {
+        Self { index, rect }
+    }
+}
+
+pub struct TileAtlasTextureProvider {
+    pub index: usize,
+    pub length: usize,
+    pub in_use: Vec<bool>,
+    pub rects: Vec<Rect>,
+}
+
+impl TileAtlasTextureProvider {
+    pub fn new(texture_size: i32, tile_size: i32) -> Self {
+        let side = texture_size / tile_size;
+        let length = side * side;
+        let mut rects = Vec::with_capacity(length as usize);
+        for i in 0..length {
+            let left = (i % side) as f32 * tile_size as f32;
+            let top = (i / side) as f32 * tile_size as f32;
+            let right = left + tile_size as f32;
+            let bottom = top + tile_size as f32;
+            rects.push(Rect::new(left, top, right, bottom));
+        }
+        Self {
+            index: 0,
+            length: length as usize,
+            in_use: vec![false; length as usize],
+            rects,
+        }
+    }
+
+    pub fn allocate(&mut self) -> Option<TileAtlasTextureRef> {
+        let start = self.index;
+        loop {
+            if !self.in_use[self.index] {
+                self.in_use[self.index] = true;
+                return Some(TileAtlasTextureRef::new(self.index, self.rects[self.index]));
+            }
+
+            self.index = (self.index + 1) % self.length;
+            if self.index == start {
+                return None;
+            }
+        }
+    }
+
+    pub fn deallocate(&mut self, reference: TileAtlasTextureRef) -> bool {
+        // In this case the user of the provider it's trying to release
+        // a reference already freed.
+        if !self.in_use[reference.index] {
+            return false;
+        }
+        self.in_use[reference.index] = false;
+        self.index = reference.index;
+        true
+    }
+}
+
 pub struct TileTextureCache {
-    grid: HashMap<Tile, skia::Image>,
+    tile_size: f32,
+    provider: TileAtlasTextureProvider,
+    transforms: Vec<skia::RSXform>,
+    textures: Vec<skia::Rect>,
+    grid: HashMap<Tile, TileAtlasTextureRef>,
     removed: HashSet<Tile>,
 }
 
 impl TileTextureCache {
-    pub fn new() -> Self {
+    pub fn new(texture_size: i32, capacity: usize) -> Self {
         Self {
-            grid: HashMap::default(),
-            removed: HashSet::default(),
+            tile_size: TILE_SIZE,
+            provider: TileAtlasTextureProvider::new(texture_size, TILE_SIZE as i32),
+            transforms: Vec::with_capacity(capacity),
+            textures: Vec::with_capacity(capacity),
+            grid: HashMap::with_capacity(capacity),
+            removed: HashSet::with_capacity(capacity),
         }
-    }
-
-    pub fn has(&self, tile: Tile) -> bool {
-        self.grid.contains_key(&tile) && !self.removed.contains(&tile)
     }
 
     fn gc(&mut self) {
         // Make a real remove
         for tile in self.removed.iter() {
-            self.grid.remove(tile);
+            if let Some(tile_ref) = self.grid.remove(tile) {
+                self.provider.deallocate(tile_ref);
+            }
         }
     }
 
-    fn free_tiles(&mut self, tile_viewbox: &TileViewbox) {
+    fn gc_non_visible(&mut self, tile_viewbox: &TileViewbox) {
         let marked: Vec<_> = self
             .grid
             .iter_mut()
@@ -1386,35 +1520,99 @@ impl TileTextureCache {
             .collect();
 
         for tile in marked.iter() {
-            self.grid.remove(tile);
+            if let Some(tile_ref) = self.grid.remove(tile) {
+                self.provider.deallocate(tile_ref);
+            }
         }
     }
 
-    pub fn add(&mut self, tile_viewbox: &TileViewbox, tile: &Tile, image: skia::Image) {
+    pub fn update(&mut self, viewbox: &Viewbox, tile_viewbox: &TileViewbox) {
+        if self.transforms.len() != tile_viewbox.visible_rect.len() as usize {
+            self.transforms.resize(
+                tile_viewbox.visible_rect.len() as usize,
+                skia::RSXform::new(1.0, 0.0, Point::default()),
+            );
+        }
+
+        if self.textures.len() != tile_viewbox.visible_rect.len() as usize {
+            self.textures.resize(
+                tile_viewbox.visible_rect.len() as usize,
+                skia::Rect::new_empty(),
+            );
+        }
+
+        for texture in self.textures.iter_mut() {
+            texture.set_empty();
+        }
+
+        let offset = viewbox.get_offset();
+        let mut index = 0;
+        for y in tile_viewbox.visible_rect.top()..=tile_viewbox.visible_rect.bottom() {
+            for x in tile_viewbox.visible_rect.left()..=tile_viewbox.visible_rect.right() {
+                let tile = Tile(x, y);
+
+                let Some(tile_ref) = self.grid.get(&tile) else {
+                    continue;
+                };
+
+                self.transforms[index].tx = x as f32 * self.tile_size - offset.x;
+                self.transforms[index].ty = y as f32 * self.tile_size - offset.y;
+
+                self.textures[index].set_ltrb(
+                    tile_ref.rect.left,
+                    tile_ref.rect.top,
+                    tile_ref.rect.right,
+                    tile_ref.rect.bottom,
+                );
+
+                index += 1;
+            }
+        }
+    }
+
+    pub fn has(&self, tile: Tile) -> bool {
+        self.grid.contains_key(&tile) && !self.removed.contains(&tile)
+    }
+
+    pub fn add(&mut self, tile_viewbox: &TileViewbox, tile: &Tile) -> TileAtlasTextureRef {
         if self.grid.len() > TEXTURES_CACHE_CAPACITY {
-            // First we try to remove the obsolete tiles
+            // First we try to remove the obsolete tiles.
             self.gc();
         }
 
+        // If we still have a texture capacity problem, then
+        // we try to remove all of those tiles that aren't
+        // visible.
         if self.grid.len() > TEXTURES_CACHE_CAPACITY {
-            self.free_tiles(tile_viewbox);
+            self.gc_non_visible(tile_viewbox);
         }
 
-        self.grid.insert(*tile, image);
+        let Some(tile_ref) = self.provider.allocate() else {
+            panic!("Tile texture allocation failed {}:{}", tile.0, tile.1);
+        };
+
+        self.grid.insert(*tile, tile_ref.clone());
 
         if self.removed.contains(tile) {
             self.removed.remove(tile);
         }
+
+        tile_ref.clone()
     }
 
-    pub fn get(&mut self, tile: Tile) -> Option<&mut skia::Image> {
+    pub fn get(&mut self, tile: Tile) -> Option<&TileAtlasTextureRef> {
         if self.removed.contains(&tile) {
             return None;
         }
-        self.grid.get_mut(&tile)
+        self.grid.get(&tile)
     }
 
     pub fn remove(&mut self, tile: Tile) {
+        if let Some(tile_ref) = self.grid.get(&tile) {
+            if tile_ref.index < self.textures.len() {
+                self.textures[tile_ref.index].set_empty();
+            }
+        }
         self.removed.insert(tile);
     }
 

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -226,10 +226,7 @@ impl Surfaces {
     /// WebGL `MAX_TEXTURE_SIZE` reported by the browser. Values are clamped to
     /// a small minimum so the atlas logic stays well-defined.
     pub fn set_max_atlas_texture_size(&mut self, max_px: i32) {
-        self.max_atlas_texture_size = max_px.clamp(
-            TILE_SIZE,
-            MAX_ATLAS_TEXTURE_SIZE
-        );
+        self.max_atlas_texture_size = max_px.clamp(TILE_SIZE, MAX_ATLAS_TEXTURE_SIZE);
     }
 
     #[inline]
@@ -915,23 +912,14 @@ impl Surfaces {
         cached_viewbox: &Viewbox,
         interest_area_threshold: i32,
     ) -> Result<()> {
-        let viewbox_cache_size = get_cache_size(
-            viewbox,
-            interest_area_threshold,
-        );
-        let cached_viewbox_cache_size = get_cache_size(
-            cached_viewbox,
-            interest_area_threshold,
-        );
+        let viewbox_cache_size = get_cache_size(viewbox, interest_area_threshold);
+        let cached_viewbox_cache_size = get_cache_size(cached_viewbox, interest_area_threshold);
         // Only resize cache if the new size is larger than the cached size
         // This avoids unnecessary surface recreations when the cache size decreases
         if viewbox_cache_size.width > cached_viewbox_cache_size.width
             || viewbox_cache_size.height > cached_viewbox_cache_size.height
         {
-            return self.resize_cache(
-                viewbox_cache_size,
-                interest_area_threshold,
-            );
+            return self.resize_cache(viewbox_cache_size, interest_area_threshold);
         }
         Ok(())
     }
@@ -1299,7 +1287,12 @@ impl Surfaces {
         self.tile_atlas.image_snapshot_with_bounds(rect)
     }
 
-    pub fn draw_cached_tile_into_backbuffer(&mut self, tile: Tile, rect: skia::Rect, _color: skia::Color) {
+    pub fn draw_cached_tile_into_backbuffer(
+        &mut self,
+        tile: Tile,
+        rect: skia::Rect,
+        _color: skia::Color,
+    ) {
         if let Some(image) = self.get_tile_image_from_tile_atlas(tile) {
             let backbuffer_canvas = self.backbuffer.canvas();
 
@@ -1309,8 +1302,7 @@ impl Surfaces {
             //     backbuffer_canvas.draw_rect(rect, &paint);
             // }
 
-            backbuffer_canvas
-                .draw_image_rect(&image, None, rect, &skia::Paint::default());
+            backbuffer_canvas.draw_image_rect(&image, None, rect, &skia::Paint::default());
         }
     }
 

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -496,11 +496,11 @@ impl Surfaces {
         );
         canvas.clear(background);
 
-        let s = viewbox.zoom * dpr;
+        let s = viewbox.get_scale();
         let atlas_scale = self.atlas_scale.max(0.01);
         canvas.translate((
-            (self.atlas_origin.x + viewbox.pan_x) * s,
-            (self.atlas_origin.y + viewbox.pan_y) * s,
+            (self.atlas_origin.x + viewbox.pan.x) * s,
+            (self.atlas_origin.y + viewbox.pan.y) * s,
         ));
         canvas.scale((s / atlas_scale, s / atlas_scale));
 

--- a/render-wasm/src/state.rs
+++ b/render-wasm/src/state.rs
@@ -7,6 +7,7 @@ pub use shapes_pool::{ShapesPool, ShapesPoolMutRef, ShapesPoolRef};
 pub use text_editor::*;
 
 use crate::error::{Error, Result};
+use crate::render::FrameType;
 use crate::shapes::{grid_layout::grid_cell_data, Shape};
 use crate::uuid::Uuid;
 use crate::{get_render_state, tiles};
@@ -64,11 +65,11 @@ impl State {
         get_render_state().render_from_cache(&self.shapes);
     }
 
-    pub fn render_sync(&mut self, timestamp: i32) -> Result<()> {
+    pub fn render_sync(&mut self, timestamp: i32) -> Result<FrameType> {
         get_render_state().start_render_loop(None, &self.shapes, timestamp, true)
     }
 
-    pub fn render_sync_shape(&mut self, id: &Uuid, timestamp: i32) -> Result<()> {
+    pub fn render_sync_shape(&mut self, id: &Uuid, timestamp: i32) -> Result<FrameType> {
         get_render_state().start_render_loop(Some(id), &self.shapes, timestamp, true)
     }
 
@@ -81,7 +82,7 @@ impl State {
         get_render_state().render_shape_pixels(id, &self.shapes, scale, timestamp)
     }
 
-    pub fn start_render_loop(&mut self, timestamp: i32) -> Result<()> {
+    pub fn start_render_loop(&mut self, timestamp: i32) -> Result<FrameType> {
         let render_state = get_render_state();
         // If zoom changed (e.g. interrupted zoom render followed by pan), the
         // tile index may be stale for the new viewport position. Rebuild the
@@ -92,12 +93,11 @@ impl State {
         if render_state.zoom_changed() {
             render_state.rebuild_tile_index(&self.shapes);
         }
-
         render_state.start_render_loop(None, &self.shapes, timestamp, false)
     }
 
-    pub fn process_animation_frame(&mut self, timestamp: i32) -> Result<()> {
-        get_render_state().process_animation_frame(None, &self.shapes, timestamp)
+    pub fn continue_render_loop(&mut self, timestamp: i32) -> Result<FrameType> {
+        get_render_state().continue_render_loop(None, &self.shapes, timestamp)
     }
 
     pub fn clear_focus_mode(&mut self) {

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -1,8 +1,8 @@
-use std::collections::{HashMap, HashSet};
-use skia_safe as skia;
 use crate::render::Surfaces;
 use crate::uuid::Uuid;
 use crate::view::Viewbox;
+use skia_safe as skia;
+use std::collections::{HashMap, HashSet};
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct Tile(pub i32, pub i32);
 

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -1,8 +1,8 @@
+use std::collections::{HashMap, HashSet};
+use skia_safe as skia;
 use crate::render::Surfaces;
 use crate::uuid::Uuid;
 use crate::view::Viewbox;
-use skia_safe as skia;
-use std::collections::{HashMap, HashSet};
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct Tile(pub i32, pub i32);
 
@@ -10,11 +10,25 @@ impl Tile {
     pub fn from(x: i32, y: i32) -> Self {
         Tile(x, y)
     }
+
+    #[inline(always)]
     pub fn x(&self) -> i32 {
         self.0
     }
+
+    #[inline(always)]
     pub fn y(&self) -> i32 {
         self.1
+    }
+
+    #[inline(always)]
+    pub fn get_rect_with_offset(&self, offset: &skia::Point) -> skia::Rect {
+        skia::Rect::from_xywh(
+            self.0 as f32 * TILE_SIZE - offset.x,
+            self.1 as f32 * TILE_SIZE - offset.y,
+            TILE_SIZE,
+            TILE_SIZE,
+        )
     }
 }
 
@@ -134,7 +148,7 @@ pub struct TileViewbox {
 }
 
 impl TileViewbox {
-    pub fn new_with_interest(viewbox: Viewbox, interest: i32) -> Self {
+    pub fn new_with_interest(viewbox: &Viewbox, interest: i32) -> Self {
         Self {
             visible_rect: get_tiles_for_viewbox(viewbox),
             interest_rect: get_tiles_for_viewbox_with_interest(viewbox, interest),
@@ -143,7 +157,7 @@ impl TileViewbox {
         }
     }
 
-    pub fn update(&mut self, viewbox: Viewbox) {
+    pub fn update(&mut self, viewbox: &Viewbox) {
         self.visible_rect = get_tiles_for_viewbox(viewbox);
         self.interest_rect = get_tiles_for_viewbox_with_interest(viewbox, self.interest);
         self.center = get_tile_center_for_viewbox(viewbox);
@@ -161,6 +175,7 @@ impl TileViewbox {
 
 pub const TILE_SIZE: f32 = 512.;
 
+#[inline(always)]
 pub fn get_tile_dimensions() -> skia::ISize {
     (TILE_SIZE as i32, TILE_SIZE as i32).into()
 }
@@ -175,17 +190,17 @@ pub fn get_tiles_for_rect(rect: skia::Rect, tile_size: f32) -> TileRect {
     TileRect(sx, sy, ex, ey)
 }
 
-pub fn get_tiles_for_viewbox(viewbox: Viewbox) -> TileRect {
+pub fn get_tiles_for_viewbox(viewbox: &Viewbox) -> TileRect {
     let tile_size = get_tile_size(viewbox.get_scale());
     get_tiles_for_rect(viewbox.area, tile_size)
 }
 
-pub fn get_tiles_for_viewbox_with_interest(viewbox: Viewbox, interest: i32) -> TileRect {
+pub fn get_tiles_for_viewbox_with_interest(viewbox: &Viewbox, interest: i32) -> TileRect {
     let TileRect(sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox);
     TileRect(sx - interest, sy - interest, ex + interest, ey + interest)
 }
 
-pub fn get_tile_center_for_viewbox(viewbox: Viewbox) -> Tile {
+pub fn get_tile_center_for_viewbox(viewbox: &Viewbox) -> Tile {
     let TileRect(sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox);
     Tile((ex - sx) / 2, (ey - sy) / 2)
 }
@@ -207,7 +222,7 @@ pub fn get_tile_rect(tile: Tile, scale: f32) -> skia::Rect {
     skia::Rect::from_xywh(tx, ty, ts, ts)
 }
 
-// This structure is usseful to keep all the shape uuids by shape id.
+// This structure is useful to keep all the shape uuids by shape id.
 pub struct TileHashMap {
     grid: HashMap<Tile, HashSet<Uuid>>,
     index: HashMap<Uuid, HashSet<Tile>>,
@@ -261,12 +276,19 @@ impl TileHashMap {
 }
 
 const VIEWPORT_DEFAULT_CAPACITY: usize = 24 * 12;
-const VIEWPORT_SPIRAL_DEFAULT_CAPACITY: usize = 64;
+const VIEWPORT_SPIRAL_DEFAULT_CAPACITY: usize = VIEWPORT_DEFAULT_CAPACITY;
 
 // This structure keeps the list of tiles that are in the pending list, the
 // ones that are going to be rendered.
 pub struct PendingTiles {
     pub list: Vec<Tile>,
+
+    // This reduces memory allocation.
+    visible_cached: Vec<Tile>,
+    visible_uncached: Vec<Tile>,
+    interest_cached: Vec<Tile>,
+    interest_uncached: Vec<Tile>,
+
     pub spiral: Vec<Tile>,
     pub spiral_rect: TileRect,
 }
@@ -275,15 +297,21 @@ impl PendingTiles {
     pub fn new() -> Self {
         Self {
             list: Vec::with_capacity(VIEWPORT_DEFAULT_CAPACITY),
+
+            visible_cached: Vec::with_capacity(VIEWPORT_DEFAULT_CAPACITY),
+            visible_uncached: Vec::with_capacity(VIEWPORT_DEFAULT_CAPACITY),
+            interest_cached: Vec::with_capacity(VIEWPORT_DEFAULT_CAPACITY),
+            interest_uncached: Vec::with_capacity(VIEWPORT_DEFAULT_CAPACITY),
+
             spiral: Vec::with_capacity(VIEWPORT_SPIRAL_DEFAULT_CAPACITY),
             spiral_rect: TileRect::empty(),
         }
     }
 
     // Generate tiles in spiral order from center
-    fn generate_spiral(columns: usize, rows: usize) -> Vec<Tile> {
+    fn generate_spiral(&mut self, columns: usize, rows: usize) {
         let total = columns * rows;
-        let mut result = Vec::with_capacity(total);
+
         let mut cx = 0;
         let mut cy = 0;
 
@@ -294,8 +322,8 @@ impl PendingTiles {
         let mut direction_total_y = 1;
         let mut direction = 0;
 
-        result.push(Tile(cx, cy));
-        while result.len() < total {
+        self.spiral.push(Tile(cx, cy));
+        while self.spiral.len() < total {
             match direction {
                 0 => cx += 1,
                 1 => cy += 1,
@@ -304,7 +332,7 @@ impl PendingTiles {
                 _ => unreachable!("Invalid direction"),
             }
 
-            result.push(Tile(cx, cy));
+            self.spiral.push(Tile(cx, cy));
 
             direction_current += 1;
             let direction_total = if direction % 2 == 0 {
@@ -323,8 +351,7 @@ impl PendingTiles {
                 direction_current = 0;
             }
         }
-        result.reverse();
-        result
+        self.spiral.reverse();
     }
 
     pub fn update(&mut self, tile_viewbox: &TileViewbox, surfaces: &Surfaces, only_visible: bool) {
@@ -349,8 +376,7 @@ impl PendingTiles {
         // the spiral should not change.
         let total = (spiral_rect.width() * spiral_rect.height()) as usize;
         if self.spiral.len() < total {
-            self.spiral =
-                Self::generate_spiral(spiral_rect.width() as usize, spiral_rect.height() as usize);
+            self.generate_spiral(spiral_rect.width() as usize, spiral_rect.height() as usize);
         }
 
         // Partition tiles into 4 priority groups (highest priority = processed last due to pop()):
@@ -358,10 +384,10 @@ impl PendingTiles {
         // 2. visible + uncached (user sees these, render next)
         // 3. interest + cached (pre-rendered area, blit from cache)
         // 4. interest + uncached (lowest priority - background pre-render)
-        let mut visible_cached = Vec::new();
-        let mut visible_uncached = Vec::new();
-        let mut interest_cached = Vec::new();
-        let mut interest_uncached = Vec::new();
+        self.visible_cached.clear();
+        self.visible_uncached.clear();
+        self.interest_cached.clear();
+        self.interest_uncached.clear();
 
         let center_tile = Tile(spiral_rect.center_x(), spiral_rect.center_y());
         for spiral_tile in self.spiral.iter() {
@@ -370,19 +396,19 @@ impl PendingTiles {
             let is_cached = surfaces.has_cached_tile_surface(tile);
 
             match (is_visible, is_cached) {
-                (true, true) => visible_cached.push(tile),
-                (true, false) => visible_uncached.push(tile),
-                (false, true) => interest_cached.push(tile),
-                (false, false) => interest_uncached.push(tile),
+                (true, true) => self.visible_cached.push(tile),
+                (true, false) => self.visible_uncached.push(tile),
+                (false, true) => self.interest_cached.push(tile),
+                (false, false) => self.interest_uncached.push(tile),
             }
         }
 
         // Build final list with lowest priority first (they get popped last)
         // Order: interest_uncached, interest_cached, visible_uncached, visible_cached
-        self.list.extend(interest_uncached);
-        self.list.extend(interest_cached);
-        self.list.extend(visible_uncached);
-        self.list.extend(visible_cached);
+        self.list.extend(self.interest_uncached.iter());
+        self.list.extend(self.interest_cached.iter());
+        self.list.extend(self.visible_uncached.iter());
+        self.list.extend(self.visible_cached.iter());
     }
 
     pub fn pop(&mut self) -> Option<Tile> {

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -21,87 +21,98 @@ impl Tile {
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct TileRect(pub i32, pub i32, pub i32, pub i32);
 
+#[allow(dead_code)]
 impl TileRect {
     pub fn empty() -> Self {
         Self(0, 0, 0, 0)
     }
 
-    #[inline]
+    #[inline(always)]
+    pub fn is_degenerate(&self) -> bool {
+        self.left() > self.right() || self.top() > self.bottom()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> i32 {
+        (self.width() + 1) * (self.height() + 1)
+    }
+
+    #[inline(always)]
     pub fn x1(&self) -> i32 {
         self.0
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn y1(&self) -> i32 {
         self.1
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn x2(&self) -> i32 {
         self.2
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn y2(&self) -> i32 {
         self.3
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn left(&self) -> i32 {
         self.0
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn top(&self) -> i32 {
         self.1
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn right(&self) -> i32 {
         self.2
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn bottom(&self) -> i32 {
         self.3
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn x(&self) -> i32 {
         self.0
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn y(&self) -> i32 {
         self.1
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn width(&self) -> i32 {
         self.x2() - self.x1()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn half_width(&self) -> i32 {
         self.width() / 2
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn height(&self) -> i32 {
         self.y2() - self.y1()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn half_height(&self) -> i32 {
         self.height() / 2
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn center_x(&self) -> i32 {
         self.x() + self.half_width()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn center_y(&self) -> i32 {
         self.y() + self.half_height()
     }
@@ -123,19 +134,19 @@ pub struct TileViewbox {
 }
 
 impl TileViewbox {
-    pub fn new_with_interest(viewbox: Viewbox, interest: i32, scale: f32) -> Self {
+    pub fn new_with_interest(viewbox: Viewbox, interest: i32) -> Self {
         Self {
-            visible_rect: get_tiles_for_viewbox(viewbox, scale),
-            interest_rect: get_tiles_for_viewbox_with_interest(viewbox, interest, scale),
+            visible_rect: get_tiles_for_viewbox(viewbox),
+            interest_rect: get_tiles_for_viewbox_with_interest(viewbox, interest),
             interest,
-            center: get_tile_center_for_viewbox(viewbox, scale),
+            center: get_tile_center_for_viewbox(viewbox),
         }
     }
 
-    pub fn update(&mut self, viewbox: Viewbox, scale: f32) {
-        self.visible_rect = get_tiles_for_viewbox(viewbox, scale);
-        self.interest_rect = get_tiles_for_viewbox_with_interest(viewbox, self.interest, scale);
-        self.center = get_tile_center_for_viewbox(viewbox, scale);
+    pub fn update(&mut self, viewbox: Viewbox) {
+        self.visible_rect = get_tiles_for_viewbox(viewbox);
+        self.interest_rect = get_tiles_for_viewbox_with_interest(viewbox, self.interest);
+        self.center = get_tile_center_for_viewbox(viewbox);
     }
 
     pub fn set_interest(&mut self, interest: i32) {
@@ -164,22 +175,18 @@ pub fn get_tiles_for_rect(rect: skia::Rect, tile_size: f32) -> TileRect {
     TileRect(sx, sy, ex, ey)
 }
 
-pub fn get_tiles_for_viewbox(viewbox: Viewbox, scale: f32) -> TileRect {
-    let tile_size = get_tile_size(scale);
+pub fn get_tiles_for_viewbox(viewbox: Viewbox) -> TileRect {
+    let tile_size = get_tile_size(viewbox.get_scale());
     get_tiles_for_rect(viewbox.area, tile_size)
 }
 
-pub fn get_tiles_for_viewbox_with_interest(
-    viewbox: Viewbox,
-    interest: i32,
-    scale: f32,
-) -> TileRect {
-    let TileRect(sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox, scale);
+pub fn get_tiles_for_viewbox_with_interest(viewbox: Viewbox, interest: i32) -> TileRect {
+    let TileRect(sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox);
     TileRect(sx - interest, sy - interest, ex + interest, ey + interest)
 }
 
-pub fn get_tile_center_for_viewbox(viewbox: Viewbox, scale: f32) -> Tile {
-    let TileRect(sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox, scale);
+pub fn get_tile_center_for_viewbox(viewbox: Viewbox) -> Tile {
+    let TileRect(sx, sy, ex, ey) = get_tiles_for_viewbox(viewbox);
     Tile((ex - sx) / 2, (ey - sy) / 2)
 }
 
@@ -212,6 +219,13 @@ impl TileHashMap {
             grid: HashMap::new(),
             index: HashMap::new(),
         }
+    }
+
+    pub fn is_empty_at(&self, tile: Tile) -> bool {
+        if let Some(uuids) = self.grid.get(&tile) {
+            return uuids.is_empty();
+        }
+        true
     }
 
     pub fn get_shapes_at(&mut self, tile: Tile) -> Option<&HashSet<Uuid>> {

--- a/render-wasm/src/view.rs
+++ b/render-wasm/src/view.rs
@@ -1,5 +1,5 @@
-use std::ops::{Mul};
 use crate::math::{Matrix, Point, Rect, Size};
+use std::ops::Mul;
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Viewbox {
@@ -22,6 +22,7 @@ impl Default for Viewbox {
     }
 }
 
+#[allow(dead_code)]
 impl Viewbox {
     pub fn new(width: f32, height: f32) -> Self {
         let size = Size::new(width, height);
@@ -49,11 +50,6 @@ impl Viewbox {
         self.size.height
     }
 
-    pub fn set_dpr(&mut self, dpr: f32) -> f32 {
-        self.dpr = dpr;
-        dpr
-    }
-
     pub fn set_all(&mut self, zoom: f32, pan_x: f32, pan_y: f32) {
         self.pan.set(pan_x, pan_y);
         self.zoom = zoom;
@@ -69,6 +65,18 @@ impl Viewbox {
         self.size.set(width, height);
         self.area
             .set_wh(self.size.width / self.zoom, self.size.height / self.zoom);
+    }
+
+    pub fn set_dpr(&mut self, dpr: f32) {
+        self.dpr = dpr;
+    }
+
+    pub fn get_scale(&self) -> f32 {
+        self.zoom * self.dpr
+    }
+
+    pub fn get_offset(&self) -> Point {
+        self.area.tl().mul(self.get_scale())
     }
 
     pub fn pan(&self) -> Point {

--- a/render-wasm/src/view.rs
+++ b/render-wasm/src/view.rs
@@ -1,25 +1,22 @@
-use skia_safe::Rect;
-
-use crate::math::{Matrix, Point};
+use std::ops::{Mul};
+use crate::math::{Matrix, Point, Rect, Size};
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Viewbox {
-    pub pan_x: f32,
-    pub pan_y: f32,
-    pub width: f32,
-    pub height: f32,
+    pub pan: Point,
+    pub size: Size,
     pub zoom: f32,
+    pub dpr: f32,
     pub area: Rect,
 }
 
 impl Default for Viewbox {
     fn default() -> Self {
         Self {
-            pan_x: 0.,
-            pan_y: 0.,
-            width: 0.0,
-            height: 0.0,
+            pan: Point::new(0.0, 0.0),
+            size: Size::new(0.0, 0.0),
             zoom: 1.0,
+            dpr: 1.0,
             area: Rect::new_empty(),
         }
     }
@@ -27,36 +24,55 @@ impl Default for Viewbox {
 
 impl Viewbox {
     pub fn new(width: f32, height: f32) -> Self {
-        let area = Rect::from_xywh(0., 0., width, height);
+        let size = Size::new(width, height);
+        let area = Rect::from_size(size);
         Self {
-            width,
-            height,
+            size,
             area,
             ..Self::default()
         }
     }
 
+    pub fn dpr_width(&self) -> f32 {
+        self.size.width * self.dpr
+    }
+
+    pub fn dpr_height(&self) -> f32 {
+        self.size.height * self.dpr
+    }
+
+    pub fn width(&self) -> f32 {
+        self.size.width
+    }
+
+    pub fn height(&self) -> f32 {
+        self.size.height
+    }
+
+    pub fn set_dpr(&mut self, dpr: f32) -> f32 {
+        self.dpr = dpr;
+        dpr
+    }
+
     pub fn set_all(&mut self, zoom: f32, pan_x: f32, pan_y: f32) {
-        self.pan_x = pan_x;
-        self.pan_y = pan_y;
+        self.pan.set(pan_x, pan_y);
         self.zoom = zoom;
         self.area.set_xywh(
-            -self.pan_x,
-            -self.pan_y,
-            self.width / self.zoom,
-            self.height / self.zoom,
+            -self.pan.x,
+            -self.pan.y,
+            self.size.width / self.zoom,
+            self.size.height / self.zoom,
         );
     }
 
     pub fn set_wh(&mut self, width: f32, height: f32) {
-        self.width = width;
-        self.height = height;
+        self.size.set(width, height);
         self.area
-            .set_wh(self.width / self.zoom, self.height / self.zoom);
+            .set_wh(self.size.width / self.zoom, self.size.height / self.zoom);
     }
 
     pub fn pan(&self) -> Point {
-        Point::new(self.pan_x, self.pan_y)
+        self.pan
     }
 
     pub fn zoom(&self) -> f32 {

--- a/render-wasm/src/wapi.rs
+++ b/render-wasm/src/wapi.rs
@@ -1,41 +1,4 @@
 #[macro_export]
-macro_rules! request_animation_frame {
-    () => {{
-        #[cfg(target_arch = "wasm32")]
-        unsafe extern "C" {
-            pub fn wapi_requestAnimationFrame() -> i32;
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        let result = unsafe { wapi_requestAnimationFrame() };
-        #[cfg(not(target_arch = "wasm32"))]
-        let result = 0;
-
-        result
-    }};
-}
-
-#[macro_export]
-macro_rules! cancel_animation_frame {
-    ($frame_id:expr) => {
-        #[cfg(target_arch = "wasm32")]
-        unsafe extern "C" {
-            pub fn wapi_cancelAnimationFrame(frame_id: i32);
-        }
-
-        {
-            let frame_id = $frame_id;
-            #[cfg(target_arch = "wasm32")]
-            unsafe {
-                wapi_cancelAnimationFrame(frame_id)
-            };
-            #[cfg(not(target_arch = "wasm32"))]
-            let _ = frame_id;
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! notify_tiles_render_complete {
     () => {{
         #[cfg(target_arch = "wasm32")]
@@ -50,6 +13,4 @@ macro_rules! notify_tiles_render_complete {
     }};
 }
 
-pub use cancel_animation_frame;
 pub use notify_tiles_render_complete;
-pub use request_animation_frame;


### PR DESCRIPTION
### Related Ticket

[Taiga Task #14198](https://tree.taiga.io/project/penpot/task/14198)

### Summary

1. Changed the way frames are queued so that there is now a single ‘source of truth’ for frame and request identifiers (ClojureScript).
2. Now render returns the type of frame that has been generated: 0 (NONE), 1 (PARTIAL), 2 (FULL). If PARTIAL is returned, a new frame is queued from ClojureScript (this gives us a bit more control over the state of the current render).
3. Now Viewbox is passed by reference to all render functions.
4. I’ve added a few things like `#[inline(always)]` (I know the compiler is super smart, but this way we guarantee that things like getters and the like are definitely compiled inline).
5. I’ve added a new surface called `tile_atlas`, which is an 8192px texture (though it would be great if this were entirely hardware-dependent and had no limitations) and now this `tile_atlas` is rendered using `draw_atlas` so tiles are rendered in parallel.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
