### PR TITLE
:bug: Fix asset icon

### DIFF
--- a/frontend/src/app/main/ui/ds/foundations/assets/icon.cljs
+++ b/frontend/src/app/main/ui/ds/foundations/assets/icon.cljs
@@ -325,13 +325,16 @@
   (let [size-px (cond (= size "l") icon-size-l
                       (= size "s") icon-size-s
                       :else        icon-size-m)
-
+        offset  (if (or (= size "s") (= size "m"))
+                  (/ (- icon-size-m size-px) 2)
+                  0)
         props   (mf/spread-props props
                                  {:class [class (stl/css :icon)]
-                                  :width size-px
-                                  :height size-px})]
-
+                                  :width (max icon-size-m size-px)
+                                  :height (max icon-size-m size-px)})]
     [:> :svg props
      [:use {:href (dm/str "#icon-" icon-id)
+            :x offset
+            :y offset
             :width size-px
             :height size-px}]]))

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
@@ -96,14 +96,6 @@
       height: deprecated.$s-32;
       width: deprecated.$s-24;
       padding: 0 deprecated.$s-4 0 deprecated.$s-8;
-
-      svg {
-        @extend %button-icon-small;
-
-        color: transparent;
-        fill: none;
-        stroke: var(--icon-foreground);
-      }
     }
 
     .page-actions {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14180

#9587 

### Summary

Recent changes to the `<Icon>` component in the DS caused this regression (see Taiga ticket). This fixes it.

<img width="314" height="241" alt="Screenshot 2026-05-13 at 4 40 33 PM" src="https://github.com/user-attachments/assets/965b8733-d460-499b-8596-ef62d8f57e03" />

### Steps to reproduce 

1. Create a component
2. Go to the assets tab

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
