### PR TITLE
:bug: Fix text focus on empty text

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -290,8 +290,8 @@
       :data-testid "text-editor-container"
       :style {:width "var(--editor-container-width)"
               :height "var(--editor-container-height)"
-              :min-width "1px"
-              :min-height "1px"}}
+              :min-width "var(--editor-container-min-width, 1px)"
+              :min-height "var(--editor-container-min-height, 1px)"}}
      ;; We hide the editor when is blurred because otherwise the
      ;; selection won't let us see the underlying text. Use opacity
      ;; because display or visibility won't allow to recover focus
@@ -381,7 +381,7 @@
 
         render-wasm? (mf/use-memo #(features/active-feature? @st/state "render-wasm/v1"))
 
-        [{:keys [x y width height]} transform]
+        [{:keys [x y width height selrect-width selrect-height]} transform]
         (if render-wasm?
           (let [{:keys [width height]} (wasm.api/get-text-dimensions shape-id)
                 selrect-transform (mf/deref refs/workspace-selrect)
@@ -403,7 +403,8 @@
                     "bottom" (+ y (- selrect-height height))
                     "center" (+ y (/ (- selrect-height height) 2))
                     y)]
-            [(assoc selrect :y y :width overlay-width :height max-height) transform])
+            [(assoc selrect :y y :width overlay-width :height max-height
+                    :selrect-width selrect-width :selrect-height selrect-height) transform])
 
           (let [bounds (gst/shape->rect shape)
                 x      (mth/min (dm/get-prop bounds :x)
@@ -422,6 +423,8 @@
           (obj/merge!
            #js {"--editor-container-width" "auto"
                 "--editor-container-height" "auto"
+                "--editor-container-min-width" (dm/str selrect-width "px")
+                "--editor-container-min-height" (dm/str selrect-height "px")
                 "--fallback-families" (if (seq fallback-families) (dm/str (str/join ", " fallback-families)) "sourcesanspro")
                 :display "flex"})
 


### PR DESCRIPTION
### Related Ticket

### Summary

This PR keeps the v2 editor editable when there's no text and the user clicks on the text shape 

### Steps to reproduce 

- create a text shape
- click on it before writing anything
- it should be possible to write after click

also:
- create a text shape and add text or use an existing text shape
- remove all text content (for instance, select all + delete)
- click on the empty shape
- it should be possible to write after click

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
