### PR TITLE
:bug: Surface already-redeemed activation codes separately

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Show a read-only W × H size badge below the bounding box of the current selection (by @bittoby) [Github #9205](https://github.com/penpot/penpot/issues/9205)
 - Expose `variants` retrieval on `LibraryComponent` via `isVariant()` type guard in plugin API [Github #9185](https://github.com/penpot/penpot/issues/9185)
+- Nitrate activation codes: map HTTP 409, structured error `code`, and known reuse phrases from Nitrate to a dedicated `:already-redeemed-activation-code` validation and user-visible message (instead of only “invalid” or “expired”).
 
 ### :bug: Bugs fixed
 

--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -20,11 +20,22 @@
    [app.rpc :as-alias rpc]
    [app.setup :as-alias setup]
    [clojure.core :as c]
-   [integrant.core :as ig]))
+   [integrant.core :as ig])
+  (:import java.io.InputStream))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HELPERS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- http-error-body-string
+  [body]
+  (cond
+    (nil? body) nil
+    (string? body) body
+    (instance? InputStream body) (slurp body :encoding "UTF-8")
+    (instance? CharSequence body) (str body)
+    (bytes? body) (String. ^bytes body "UTF-8")
+    :else nil))
 
 (defn- request-builder
   [cfg method uri shared-key profile-id request-params]
@@ -77,6 +88,7 @@
           (if throw-on-error?
             (ex/raise :type :nitrate-http-error
                       :status status
+                      :body (http-error-body-string (:body response))
                       :hint (str "nitrate HTTP " status " at " uri))
             nil))
         (= status 204) ;; 204 doesn't return any body

--- a/backend/src/app/rpc/commands/nitrate.clj
+++ b/backend/src/app/rpc/commands/nitrate.clj
@@ -10,6 +10,7 @@
   (:require
    [app.common.data :as d]
    [app.common.exceptions :as ex]
+   [app.common.json :as json]
    [app.common.schema :as sm]
    [app.common.time :as ct]
    [app.common.types.nitrate-permissions :as nitrate-perms]
@@ -20,8 +21,45 @@
    [app.rpc.commands.teams :as teams]
    [app.rpc.doc :as-alias doc]
    [app.rpc.notifications :as notifications]
-   [app.util.services :as sv]))
+   [app.util.services :as sv]
+   [clojure.string :as cstr]))
 
+
+(def ^:private already-redeemed-nitrate-error-codes
+  #{:already-redeemed :activation-code-already-redeemed :code-already-used
+    :activation-code-fully-redeemed :fully-redeemed})
+
+(defn- json-code-keyword
+  [c]
+  (when c
+    (if (keyword? c)
+      (keyword (cstr/lower-case (name c)))
+      (keyword (cstr/lower-case (str c))))))
+
+(defn- already-redeemed-activation-body?
+  [body-str]
+  (when (seq body-str)
+    (let [sl (cstr/lower-case body-str)]
+      (or (cstr/includes? sl "already redeemed")
+          (cstr/includes? sl "already been redeemed")
+          (cstr/includes? sl "fully redeemed")
+          (cstr/includes? sl "activation code has already")
+          (cstr/includes? sl "code has already been used")
+          (cstr/includes? sl "code was already")
+          (try
+            (let [data (json/decode body-str :key-fn json/read-kebab-key)
+                  code (json-code-keyword (:code data))]
+              (contains? already-redeemed-nitrate-error-codes code))
+            (catch Throwable _ false))))))
+
+(defn- redeem-nitrate-http-validation-code
+  [status body]
+  (or (cond
+        (= status 410) :expired-activation-code
+        (= status 409) :already-redeemed-activation-code
+        :else nil)
+      (when (and (string? body) (already-redeemed-activation-body? body))
+        :already-redeemed-activation-code)))
 
 (defn assert-is-owner [cfg profile-id team-id]
   (let [perms (teams/get-permissions cfg profile-id team-id)]
@@ -85,12 +123,11 @@
                     :hint "The activation code is invalid, expired or fully redeemed"))
         result)
       (catch Exception cause
-        (let [{:keys [type status]} (ex-data cause)]
+        (let [{:keys [type status body]} (ex-data cause)]
           (if (= type :nitrate-http-error)
             (ex/raise :type :validation
-                      :code (case status
-                              410 :expired-activation-code
-                              :invalid-activation-code)
+                      :code (or (redeem-nitrate-http-validation-code status body)
+                                :invalid-activation-code)
                       :cause cause)
             (throw cause)))))))
 

--- a/backend/test/backend_tests/rpc_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_nitrate_test.clj
@@ -6,6 +6,7 @@
 
 (ns backend-tests.rpc-nitrate-test
   (:require
+   [app.common.exceptions :as ex]
    [app.common.uuid :as uuid]
    [app.db :as-alias db]
    [app.nitrate :as nitrate]
@@ -684,3 +685,42 @@
         (t/is (not (th/success? out)))
         (t/is (= :validation (th/ex-type (:error out))))
         (t/is (= :not-valid-teams (th/ex-code (:error out))))))))
+
+(t/deftest redeem-nitrate-activation-code-409-maps-to-already-redeemed
+  (let [profile (th/create-profile* 1 {:is-active true})]
+    (with-redefs [nitrate/call (fn [_cfg method _params]
+                                 (when (= method :redeem-activation-code)
+                                   (ex/raise :type :nitrate-http-error
+                                             :status 409
+                                             :body "")))]
+      (let [out (th/command! {::th/type :redeem-nitrate-activation-code
+                              ::rpc/profile-id (:id profile)
+                              :activation-code "X"})]
+        (t/is (not (th/success? out)))
+        (t/is (= :already-redeemed-activation-code (th/ex-code (:error out))))))))
+
+(t/deftest redeem-nitrate-activation-code-json-body-maps-to-already-redeemed
+  (let [profile (th/create-profile* 1 {:is-active true})]
+    (with-redefs [nitrate/call (fn [_cfg method _params]
+                                 (when (= method :redeem-activation-code)
+                                   (ex/raise :type :nitrate-http-error
+                                             :status 400
+                                             :body "{\"code\":\"already-redeemed\"}")))]
+      (let [out (th/command! {::th/type :redeem-nitrate-activation-code
+                              ::rpc/profile-id (:id profile)
+                              :activation-code "X"})]
+        (t/is (not (th/success? out)))
+        (t/is (= :already-redeemed-activation-code (th/ex-code (:error out))))))))
+
+(t/deftest redeem-nitrate-activation-code-410-still-expired
+  (let [profile (th/create-profile* 1 {:is-active true})]
+    (with-redefs [nitrate/call (fn [_cfg method _params]
+                                 (when (= method :redeem-activation-code)
+                                   (ex/raise :type :nitrate-http-error
+                                             :status 410
+                                             :body "")))]
+      (let [out (th/command! {::th/type :redeem-nitrate-activation-code
+                              ::rpc/profile-id (:id profile)
+                              :activation-code "X"})]
+        (t/is (not (th/success? out)))
+        (t/is (= :expired-activation-code (th/ex-code (:error out))))))))

--- a/frontend/src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_code_activation_modal.cljs
@@ -47,10 +47,10 @@
                         (modal/show {:type :nitrate-activation-success})
                         (dprof/refresh-profile)))
                      (fn [error]
-                       ;; TODO: "Already used" is not yet detectable (CC upserts on reuse).
                        (let [code (-> error ex-data :code)]
                          (reset! error* (case code
                                           :expired-activation-code (tr "nitrate.activation-code.expired-error")
+                                          :already-redeemed-activation-code (tr "nitrate.activation-code.already-redeemed-error")
                                           (tr "nitrate.activation-code.invalid-error")))))))))))
 
         on-key-down

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -9401,6 +9401,9 @@ msgstr "Invalid code."
 msgid "nitrate.activation-code.expired-error"
 msgstr "This code has expired."
 
+msgid "nitrate.activation-code.already-redeemed-error"
+msgstr "This code has already been used. If you believe this is a mistake, contact support."
+
 msgid "nitrate.contact-sales.title"
 msgstr "Switch to %s plan?"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -9093,6 +9093,9 @@ msgstr "Código inválido."
 msgid "nitrate.activation-code.expired-error"
 msgstr "Este código ha caducado."
 
+msgid "nitrate.activation-code.already-redeemed-error"
+msgstr "Este código ya se ha utilizado. Si cree que es un error, contacte con soporte."
+
 msgid "nitrate.contact-sales.title"
 msgstr "¿Cambiar al plan %s?"
 


### PR DESCRIPTION
### Related Ticket

Closes #9624

### Summary

This pull request improves the **Business Nitrate** activation-code flow when Nitrate reports that a code is **already redeemed** or otherwise exhausted, instead of collapsing every non-expired failure into **“invalid code”**.

**Backend**

- `app.nitrate`: Nitrate HTTP error exceptions now include a normalized **`:body`** string when the upstream response has a body, so redeem logic can inspect JSON or plain text without re-fetching.
- `app.rpc.commands.nitrate` / `::redeem-nitrate-activation-code`: After a `:nitrate-http-error`, Penpot maps:
  - **410** → `:expired-activation-code` (unchanged),
  - **409** → `:already-redeemed-activation-code`,
  - response **body** → `:already-redeemed-activation-code` when JSON `code` matches a small allowlist (e.g. `already-redeemed`, `activation-code-already-redeemed`) or when the body text matches safe English phrases (e.g. “fully redeemed”, “already redeemed”, “code has already been used”).
  - Any other case still raises `:invalid-activation-code`.

**Frontend**

- `nitrate_code_activation_modal.cljs`: Handles `:already-redeemed-activation-code` with a dedicated translation; removes the obsolete TODO about reuse not being detectable.

**i18n**

- New `nitrate.activation-code.already-redeemed-error` in `en.po` and `es.po`.

**Tests**

- `backend-tests.rpc-nitrate-test`: coverage for 409, JSON `code`, and 410 behavior.

**Changelog**

- `CHANGES.md` (2.17.0) updated with a short entry.

**Note:** If Nitrate returns **200** on reuse and only upserts silently, Penpot still cannot infer “already used” without a Nitrate API change. This PR is aligned with Nitrate returning **409**, structured error `code`, or recognizable error text.

### Steps to reproduce

1. Use an instance with Nitrate enabled and the activation-code modal available.
2. Redeem a valid activation code successfully.
3. Trigger a second redeem with the same code in a situation where Nitrate responds with **409**, a JSON body whose `code` indicates reuse, or body text such as “fully redeemed” / “already redeemed” (per Nitrate behavior).
4. **Before:** the modal typically showed the generic invalid message (or only distinguished expired via 410).
5. **After:** the modal shows the **already redeemed** string when the backend maps to `:already-redeemed-activation-code`.

**Automated verification:** from `backend/`, with test dependencies and DB/redis as documented for Penpot:

`clojure -M:test --focus backend-tests.rpc-nitrate-test`

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.