### PR TITLE
:sparkles: Detect serialisation issues in MCP plugin, preventing timeout

### DIFF
--- a/mcp/packages/plugin/src/TaskHandler.ts
+++ b/mcp/packages/plugin/src/TaskHandler.ts
@@ -35,7 +35,29 @@ export class Task<TParams = any> {
         };
 
         // Send to main.ts which will forward to MCP server via WebSocket
-        penpot.ui.sendMessage(response);
+        try {
+            // TODO: Remove ts-ignore once Penpot types have been updated
+            // @ts-ignore
+            penpot.ui.sendMessage(response, true);
+        } catch (sendError) {
+            console.error("Failed to transfer task response for transmission to MCP server", sendError);
+            if (success) {
+                console.info("Original response was a success response, sending an error response instead.");
+                // If we were trying to send a success response, send an error response instead
+                let cause = sendError instanceof Error ? sendError.message : String(sendError);
+                this.sendError(
+                    "Unexpected error sending task response: " +
+                        cause +
+                        " If you are an LLM and tried to serialize a regular object (shape, token, etc.), " +
+                        "tell the user to report this error, providing information on the request you made."
+                );
+            } else {
+                console.info(
+                    "Original response was an error response, abandoning attempt to send alternative response to avoid infinite error loop."
+                );
+            }
+            return;
+        }
         console.log("Sent task response:", response);
         this.isResponseSent = true;
     }

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.5.0 (Unreleased)
 
 - **plugins-runtime**: Added `version` field that returns the current version
+- **plugins-runtime**: Added optional parameter `throwOnError` to `penpot.ui.sendMessage` (default false, backwards-compatible)
 - **plugin-types**: Added a flags subcontexts with the flag `naturalChildrenOrdering`
 - **plugin-types**: Fix penpot.openPage() to navigate in same tab by default
 - **plugin-types:** Change `LibraryComponent.isVariant()` return type to type guard `this is LibraryVariantComponent`

--- a/plugins/libs/plugin-types/index.d.ts
+++ b/plugins/libs/plugin-types/index.d.ts
@@ -54,13 +54,14 @@ export interface Penpot extends Omit<
      * Sends a message to the plugin UI.
      *
      * @param message content usually is an object
+     * @param throwOnError if true, throws an error when the message cannot be cloned instead of logging to console (default: false)
      *
      * @example
      * ```js
      * this.sendMessage({ type: 'example-type', content: 'data we want to share' });
      * ```
      */
-    sendMessage: (message: unknown) => void;
+    sendMessage: (message: unknown, throwOnError?: boolean) => void;
     /**
      * This is usually used in the `plugin.ts` file in order to handle the data sent by our plugin
      *

--- a/plugins/libs/plugins-runtime/src/lib/api/index.ts
+++ b/plugins/libs/plugins-runtime/src/lib/api/index.ts
@@ -67,17 +67,24 @@ export function createApi(
         return plugin.resizeModal(width, height);
       },
 
-      sendMessage(message: unknown) {
+      sendMessage(message: unknown, throwOnError = false) {
         let cloneableMessage: unknown;
 
         try {
           cloneableMessage = structuredClone(message);
         } catch (err) {
-          console.error(
+          const msg =
             'plugin sendMessage: the message could not be cloned. ' +
-              'Ensure the message does not contain functions, DOM nodes, or other non-serializable values.',
-            err,
-          );
+            'Ensure the message does not contain functions, DOM nodes, or other non-serializable values.';
+          if (throwOnError) {
+            throw new Error(
+              msg +
+                ' Original error: ' +
+                (err instanceof Error ? err.message : String(err)),
+            );
+          } else {
+            console.error(msg, err);
+          }
           return;
         }
 


### PR DESCRIPTION
### Related Ticket

* #9634 

### Summary

* Add optional parameter `throwOnError` to `penpot.ui.sendMessage` to facilitate downstream error handling
* In MCP plugin, react to `sendMessage` failure by sending an error response, avoiding timeouts in the client (i.e. MCP server) 
