### PR TITLE
:bug: Use copia not copiar for Spanish duplicate-suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Fix MCP SSE sessions leaking memory on zombie connections by adding inactivity timeout parity with Streamable HTTP sessions (by @bitloi) [Github #9432](https://github.com/penpot/penpot/issues/9432)
 - Fix missing `labels.open` translation (by @MilosM348) [Github #9320](https://github.com/penpot/penpot/pull/9320)
 - Fix two plugin error i18n keys broken by leading whitespace before `msgid` in `en.po` (by @MilosM348)
+- Use the noun "copia" instead of the verb "copiar" as the Spanish duplicate-suffix when duplicating design tokens [Github #9623](https://github.com/penpot/penpot/issues/9623)
 - Harden Nginx responses with standard security headers and hide upstream `X-Powered-By` headers
 - Expose Source Sans Pro semibold (weight 600) variants in the builtin fonts list, matching the bundled font assets and CSS @font-face declarations [Github #7378](https://github.com/penpot/penpot/issues/7378)
 - Fix plugin API `shape.fills` and `shape.strokes` arrays being read-only [Github #8357](https://github.com/penpot/penpot/issues/8357)

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -8088,7 +8088,7 @@ msgstr "Copiar ruta de token"
 
 #: src/app/main/data/workspace/tokens/library_edit.cljs:240, src/app/main/data/workspace/tokens/library_edit.cljs:509
 msgid "workspace.tokens.duplicate-suffix"
-msgstr "copiar"
+msgstr "copia"
 
 #: src/app/main/ui/workspace/tokens/management/context_menu.cljs:337
 msgid "workspace.tokens.edit"


### PR DESCRIPTION
### Related Ticket

Fixes [#9623](https://github.com/penpot/penpot/issues/9623) — *Use "copia" instead of "copiar" as duplicate suffix for Spanish*.

### Summary

The Spanish translation of `workspace.tokens.duplicate-suffix` was set to the infinitive verb **"copiar"** ("to copy"), so duplicating a design token produced names like `color/primary-copiar` — reading as a command rather than the noun every neighbouring locale uses.

- [`frontend/translations/es.po`](frontend/translations/es.po#L8091) — change the `msgstr` from `"copiar"` to `"copia"`, the noun form that matches French (`copie`), Italian (`copia`), German (`Kopie`), and English (`copy`).
- [`CHANGES.md`](CHANGES.md) — changelog entry referencing the issue.

**Out of scope:** the reporter also suggested auditing other locales. A scan turned up a few candidates that look like the same mistake — `fr_CA` (`copier`), `sv` (`kopiera`), `tr` (`kopyala`), `ukr_UA` (`копіювати`), `id` (`salin`) — but those changes should go through a separate PR with native-speaker review rather than be guessed at here.

### Steps to reproduce

1. Set the Penpot UI language to **Español**.
2. Open the **Tokens** panel and create any token (e.g. `color/primary`).
3. Right-click the token → **Duplicar**.
4. Observe the resulting token name.

**Before this PR:** `color/primary-copiar` (verb form — reads as a command).
**After this PR:** `color/primary-copia` (noun form — matches the other locales).

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.