### PR TITLE
:bug: Fix incorrect content-type on doc endpoint response

### DIFF
--- a/backend/src/app/rpc/doc.clj
+++ b/backend/src/app/rpc/doc.clj
@@ -96,6 +96,7 @@
               context (assoc @context :param-style pstyle)]
 
           {::yres/status 200
+           ::yres/headers {"content-type" "text/html; charset=utf-8"}
            ::yres/body (-> (io/resource template)
                            (tmpl/render context))})))
     (fn [_]

--- a/backend/test/backend_tests/rpc_doc_test.clj
+++ b/backend/test/backend_tests/rpc_doc_test.clj
@@ -12,10 +12,12 @@
    [app.common.schema :as sm]
    [app.common.schema.generators :as sg]
    [app.common.schema.test :as smt]
+   [app.config :as cf]
    [app.rpc :as-alias rpc]
    [app.rpc.doc :as rpc.doc]
    [backend-tests.helpers :as th]
-   [clojure.test :as t]))
+   [clojure.test :as t]
+   [yetti.response :as-alias yres]))
 
 (t/use-fixtures :once th/state-init)
 
@@ -31,6 +33,17 @@
          false)))
    {:num 15}))
 
-
-
+(t/deftest doc-handler-returns-html-content-type
+  (with-redefs [cf/flags #{:backend-api-doc}]
+    (let [methods (::rpc/methods th/*system*)
+          handler (#'rpc.doc/handler :methods methods
+                                     :label "main"
+                                     :entrypoint "http://localhost/api/main/methods"
+                                     :openapi "http://localhost/api/main/doc/openapi"
+                                     :template "app/templates/main-api-doc.tmpl")
+          request {}
+          response (handler request)]
+      (t/is (= 200 (::yres/status response)))
+      (t/is (= "text/html; charset=utf-8"
+               (get-in response [::yres/headers "content-type"]))))))
 


### PR DESCRIPTION
## Summary

- Fix `/api/main/doc` endpoint returning HTML with `text/plain` content-type instead of `text/html`
- Add regression test to prevent future occurrences

Closes #9680