### PR TITLE
:bug: Fix text editor being hidden to playwright when empty text

### DIFF
--- a/frontend/playwright/ui/pages/WorkspacePage.js
+++ b/frontend/playwright/ui/pages/WorkspacePage.js
@@ -172,6 +172,7 @@ export class WorkspacePage extends BaseWebSocketPage {
     this.toolbarOptions = page.getByTestId("toolbar-options");
     this.rectShapeButton = page.getByRole("button", { name: "Rectangle (R)" });
     this.ellipseShapeButton = page.getByRole("button", { name: "Ellipse (E)" });
+    this.textShapeButton = page.getByRole("button", { name: "Text (T)" });
     this.moveButton = page.getByRole("button", { name: "Move (V)" });
     this.boardButton = page.getByRole("button", { name: "Board (B)" });
     this.toggleToolbarButton = page.getByRole("button", {

--- a/frontend/playwright/ui/specs/text-editor-v2.spec.js
+++ b/frontend/playwright/ui/specs/text-editor-v2.spec.js
@@ -315,3 +315,19 @@ test("BUG 11552 - Apply styles to the current caret", async ({ page }) => {
   await expect(fontSizeInput).toHaveValue("");
   await expect(fontSizeInput).toHaveAttribute("placeholder", "Mixed");
 });
+
+// This is to prevent QA tests from failing due to playwright
+// considering 0-width text boxes as invisible
+test("BUG 14098 - Fix text editor having 0 width or height", async ({ page }) => {
+  const workspace = new WasmWorkspacePage(page);
+
+  await workspace.setupEmptyFile();
+  await workspace.mockRPC("update-file?id=*", "text-editor/update-file.json");
+  await workspace.goToWorkspace();
+
+  await workspace.textShapeButton.click();
+  await workspace.clickAt(200, 200);
+
+  const textEditor = workspace.page.locator(`div[class*="viewport"]`).first().getByRole('textbox').first();
+  await expect(textEditor).toBeVisible();
+});

--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -423,8 +423,8 @@
           (obj/merge!
            #js {"--editor-container-width" "auto"
                 "--editor-container-height" "auto"
-                "--editor-container-min-width" (dm/str selrect-width "px")
-                "--editor-container-min-height" (dm/str selrect-height "px")
+                "--editor-container-min-width" (dm/str (max 1 selrect-width) "px")
+                "--editor-container-min-height" (dm/str (max 1 selrect-height) "px")
                 "--fallback-families" (if (seq fallback-families) (dm/str (str/join ", " fallback-families)) "sourcesanspro")
                 :display "flex"})
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14098

### Summary

It seems 0.01 is not enough for Playwright to consider something visible.

### Steps to reproduce 

Run the newly added test in Playwright.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
