### PR TITLE
:bug: Fix delete page icon being clipped

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.cljs
@@ -220,10 +220,11 @@
                name]
               [:div {:class (stl/css :page-actions)}
                (when (and deletable? (not read-only?))
-                 [:> icon-button* {:variant "ghost"
+                 [:> icon-button* {:variant "action"
                                    :aria-label (tr "modals.delete-page.title")
                                    :on-click on-delete
                                    :icon-size "s"
+                                   :icon-class (stl/css :page-delete-button-icon)
                                    :icon i/delete}])]])])]])))
 
 ;; --- Page Item Wrapper

--- a/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/sitemap.scss
@@ -55,6 +55,10 @@
   margin-bottom: deprecated.$s-12;
 }
 
+.page-delete-button-icon {
+  color: transparent;
+}
+
 .page-element {
   @include deprecated.body-small-typography;
 
@@ -102,23 +106,6 @@
       height: deprecated.$s-32;
       display: flex;
       align-items: center;
-
-      button {
-        @include deprecated.button-style;
-        @include deprecated.flex-center;
-
-        width: deprecated.$s-24;
-        height: 100%;
-        opacity: deprecated.$op-0;
-
-        svg {
-          @extend %button-icon-small;
-
-          color: transparent;
-          fill: none;
-          stroke: var(--icon-foreground);
-        }
-      }
     }
 
     .element-name {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14196

### Summary

This fixes a glitch in the delete page icon by using the proper variant and removing legacy CSS code.

<img width="315" height="116" alt="Screenshot" src="https://github.com/user-attachments/assets/eb33b25a-03a6-4780-872d-c4d2bac80255" />

### Steps to reproduce 

See taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
