### PR TITLE
:recycle: Rename control center to admin console

### DIFF
--- a/backend/scripts/_env
+++ b/backend/scripts/_env
@@ -66,7 +66,7 @@ export PENPOT_OBJECTS_STORAGE_BACKEND=s3
 export PENPOT_OBJECTS_STORAGE_S3_ENDPOINT=http://minio:9000
 export PENPOT_OBJECTS_STORAGE_S3_BUCKET=penpot
 
-export PENPOT_NITRATE_BACKEND_URI=http://localhost:3000/control-center
+export PENPOT_NITRATE_BACKEND_URI=http://localhost:3000/admin-console
 
 export JAVA_OPTS="\
        -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \

--- a/docker/devenv/files/nginx.conf
+++ b/docker/devenv/files/nginx.conf
@@ -178,7 +178,7 @@ http {
             proxy_pass http://127.0.0.1:5000;
         }
 
-        location /control-center {
+        location /admin-console {
            proxy_pass http://127.0.0.1:3000;
            proxy_http_version 1.1;
 

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -167,7 +167,7 @@ http {
             proxy_pass $PENPOT_BACKEND_URI/ws/notifications;
         }
 
-        location /control-center {
+        location /admin-console {
             proxy_http_version 1.1;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $http_cf_connecting_ip;

--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -51,28 +51,28 @@
             (rx/map (fn [connectivity]
                       (modal/show popup-type (merge (or connectivity {}) extra-props)))))))))
 
-(defn go-to-nitrate-cc
+(defn go-to-nitrate-ac
   ([]
-   (st/emit! (rt/nav-raw :href "/control-center/")))
+   (st/emit! (rt/nav-raw :href "/admin-console/")))
   ([{:keys [organization-id organization-slug]}]
    (if (and organization-id organization-slug)
-     (let [href (dm/str "/control-center/org/"
+     (let [href (dm/str "/admin-console/org/"
                         (u/percent-encode organization-slug)
                         "/"
                         (u/percent-encode (str organization-id))
                         "/people/")]
        (st/emit! (rt/nav-raw :href href)))
-     (st/emit! (rt/nav-raw :href "/control-center/")))))
+     (st/emit! (rt/nav-raw :href "/admin-console/")))))
 
-(defn go-to-nitrate-cc-create-org
+(defn go-to-nitrate-ac-create-org
   []
-  (st/emit! (rt/nav-raw :href "/control-center/?action=create-org")))
+  (st/emit! (rt/nav-raw :href "/admin-console/?action=create-org")))
 
 (def go-to-subscription-url (u/join cf/public-uri "#/settings/subscriptions"))
 
 (defn go-to-nitrate-billing
   []
-  (let [href (dm/str "/control-center/licenses/billing?callback=" (js/encodeURIComponent go-to-subscription-url))]
+  (let [href (dm/str "/admin-console/licenses/billing?callback=" (js/encodeURIComponent go-to-subscription-url))]
     (st/emit! (rt/nav-raw :href href))))
 
 (def nitrate-checkout-error-token "nitrate-checkout-error")
@@ -115,7 +115,7 @@
                 :error_callback error-callback
                 :finish_error_callback finish-error-callback
                 :cancel_callback cancel-callback}
-        href   (dm/str "/control-center/licenses/start?" (u/map->query-string params))]
+        href   (dm/str "/admin-console/licenses/start?" (u/map->query-string params))]
     (st/emit! (rt/nav-raw :href href))))
 
 (defn fetch-connectivity

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -314,7 +314,7 @@
          (mf/deps profile)
          (fn []
            (if (dnt/is-valid-license? profile)
-             (dnt/go-to-nitrate-cc-create-org)
+             (dnt/go-to-nitrate-ac-create-org)
              (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
 
         on-go-to-cc-click
@@ -324,8 +324,8 @@
            ;; Navigate to active org if user owns it, otherwise to last visited org
            (if (and (:id organization)
                     (= (:id profile) (:owner-id organization)))
-             (dnt/go-to-nitrate-cc organization)
-             (dnt/go-to-nitrate-cc))))
+             (dnt/go-to-nitrate-ac organization)
+             (dnt/go-to-nitrate-ac))))
 
         empty-org (d/seek #(nil? (:id %)) organizations)
         default-team-id (or (:default-team-id empty-org)
@@ -366,7 +366,7 @@
        [:> dropdown-menu-item* {:on-click    on-go-to-cc-click
                                 :class       (stl/css :org-dropdown-item :action)}
         [:span {:class (stl/css :icon-wrapper)} arrow-up-right-icon]
-        [:span {:class (stl/css :team-text)} (tr "dashboard.go-to-control-center")]])]))
+        [:span {:class (stl/css :team-text)} (tr "dashboard.go-to-admin-console")]])]))
 
 (mf/defc teams-selector-dropdown*
   {::mf/private true}
@@ -754,7 +754,7 @@
          (mf/deps profile)
          (fn []
            (if (dnt/is-valid-license? profile)
-             (dnt/go-to-nitrate-cc-create-org)
+             (dnt/go-to-nitrate-ac-create-org)
              (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))]
     (if show-dropdown?
       [:div {:class (stl/css :sidebar-org-switch)}

--- a/frontend/src/app/main/ui/dashboard/subscription.cljs
+++ b/frontend/src/app/main/ui/dashboard/subscription.cljs
@@ -134,7 +134,7 @@
              (st/emit! (dnt/show-nitrate-popup :nitrate-form)))))
 
         handle-go-to-cc
-        (mf/use-fn dnt/go-to-nitrate-cc-create-org)]
+        (mf/use-fn dnt/go-to-nitrate-ac-create-org)]
 
     ;; TODO add translations for this texts when we have the definitive ones
     (if (and nitrate? no-orgs-created?)

--- a/frontend/src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_activation_success_modal.cljs
@@ -36,7 +36,7 @@
         (mf/use-fn
          (fn []
            (modal/hide!)
-           (dnt/go-to-nitrate-cc-create-org)))]
+           (dnt/go-to-nitrate-ac-create-org)))]
 
     [:div {:class (stl/css :modal-overlay)}
      [:div {:class (stl/css :modal-dialog)}

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -576,8 +576,8 @@
                          :benefits ["Loren ipsum",
                                     "Loren ipsum",
                                     "Loren ipsum"]
-                         :cta-text-with-icon (when (not (:manual nitrate-license)) "Control Center")
-                         :cta-link-with-icon (when (not (:manual nitrate-license)) dnt/go-to-nitrate-cc)
+                         :cta-text-with-icon (when (not (:manual nitrate-license)) "Admin Console")
+                         :cta-link-with-icon (when (not (:manual nitrate-license)) dnt/go-to-nitrate-ac)
                          :cta-text (if (and (:licenses connectivity) (not (:manual nitrate-license)))
                                      (tr "subscription.settings.manage-your-subscription")
                                      (tr "nitrate.subscription.settings.manual-cancel"))
@@ -723,7 +723,7 @@
                          :price-period (tr "subscription.settings.organization-member-month")
                          :benefits-title (tr "subscription.settings.benefits.all-unlimited-benefits")
                          :benefits ["Crea organizaciones y añade personas, que usarán Penpot con las reglas que configures."
-                                    "Acceso exclusivo al Control Center"
+                                    "Acceso exclusivo a la Admin Console"
                                     "Lorem ipsum"]
                          :cta-text (if nitrate-license (tr "subscription.settings.subscribe") "Try 14 days for free")
                          :cta-link (if (= subscription-type "unlimited") #(open-contact-sales-modal subscription-type "Nitrate") #(open-subscription-modal "nitrate" subscription))

--- a/frontend/test/frontend_tests/data/nitrate_test.cljs
+++ b/frontend/test/frontend_tests/data/nitrate_test.cljs
@@ -33,8 +33,8 @@
 (t/deftest build-nitrate-callback-urls-adds-regular-query-without-hash
   (t/testing "falls back to the regular URL query when there is no hash route"
     (let [callbacks (dnt/build-nitrate-callback-urls
-                     "https://localhost:3449/control-center/licenses/billing?foo=bar")]
-      (t/is (= "https://localhost:3449/control-center/licenses/billing?foo=bar&subscription=subscribed-to-penpot-nitrate"
+                     "https://localhost:3449/admin-console/licenses/billing?foo=bar")]
+      (t/is (= "https://localhost:3449/admin-console/licenses/billing?foo=bar&subscription=subscribed-to-penpot-nitrate"
                (:success-callback callbacks))))))
 
 (t/deftest build-nitrate-callback-urls-accepts-uri-object

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -380,8 +380,8 @@ msgstr "+ Create org"
 msgid "dashboard.create-new-org"
 msgstr "Create org"
 
-msgid "dashboard.go-to-control-center"
-msgstr "Go to Control Center"
+msgid "dashboard.go-to-admin-console"
+msgstr "Go to Admin Console"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:340
 msgid "dashboard.create-new-team"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -389,8 +389,8 @@ msgstr "+ Crear org"
 msgid "dashboard.create-new-org"
 msgstr "Crear org"
 
-msgid "dashboard.go-to-control-center"
-msgstr "Ir al centro de control"
+msgid "dashboard.go-to-admin-console"
+msgstr "Ir a la Admin Console"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:340
 msgid "dashboard.create-new-team"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26363

It has to be merged with https://github.com/penpot/penpot-nitrate/pull/203

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
