### PR TITLE
:bug: Reload libraries when the tokens change

### DIFF
--- a/backend/src/app/rpc/commands/files_update.clj
+++ b/backend/src/app/rpc/commands/files_update.clj
@@ -101,6 +101,17 @@
     :mod-typography
     :del-typography})
 
+(def ^:private token-change-types
+  #{:set-tokens-lib
+    :set-token
+    :set-token-set
+    :set-token-theme
+    :set-active-token-themes
+    :rename-token-set-group
+    :move-token-set
+    :move-token-set-group
+    :set-base-font-size})
+
 (def ^:private file-change-types
   #{:add-obj
     :mod-obj
@@ -111,6 +122,7 @@
 (defn- library-change?
   [{:keys [type] :as change}]
   (or (contains? library-change-types type)
+      (contains? token-change-types type)
       (contains? file-change-types type)))
 
 ;; If features are specified from params and the final feature


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/9328

### Summary

Add notification of token changes in a library. This way the library will be reloaded in the open files. And when the tokens are imported in the file, we get the latest version.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
