### PR TITLE
:bug: Fix problem with caret color value

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v2_editor.cljs
@@ -147,7 +147,13 @@
 
         on-style-change
         (fn [event]
-          (let [styles (styles/get-styles-from-event event)]
+          (let [styles     (styles/get-styles-from-event event)
+                fills      (:fills styles)
+                fill-color (when (sequential? fills) (some :fill-color fills))]
+            ;; Dynamically update the caret color as the cursor moves between spans
+            (when-let [container-node (mf/ref-val container-ref)]
+              (dom/set-style! container-node "--text-editor-caret-color"
+                              (or fill-color text-color)))
             (st/emit! (dwt/v2-update-text-editor-styles shape-id styles))))
 
         on-needs-layout
@@ -219,10 +225,18 @@
      (= (:vertical-align content) "bottom")]))
 
 (defn get-color-from-content [content]
-  (let [fills (->> (tree-seq map? :children content)
-                   (mapcat :fills)
-                   (filter :fill-color))]
-    (some :fill-color fills)))
+  (let [nodes     (tree-seq map? :children content)
+        get-color (fn [node]
+                    ;; Handle both new format (:fills vector) and old/deprecated format
+                    ;; (direct :fill-color on the content node — pre-fills-refactor files)
+                    (or (some :fill-color (:fills node))
+                        (:fill-color node)))]
+    ;; Prefer inline (leaf) text nodes over paragraph nodes. The paragraph's :fills
+    ;; tracks the last-typed color, so using it directly would make the caret take
+    ;; the last span's color rather than the first visible span's color.
+    ;; Inline nodes have no :type; they are identified by the presence of :text.
+    (or (->> nodes (filter #(contains? % :text)) (some get-color))
+        (->> nodes (some get-color)))))
 
 (defn get-default-text-color
   "Returns the appropriate text color based on fill, frame, and background."


### PR DESCRIPTION
### Related Ticket
https://tree.taiga.io/project/penpot/issue/14028

### Summary

Fixes several bugs related to the caret color on the text editor.

1. Caret invisible on old-format text
2. Caret takes the last span's colour on multi-colour text
3. Caret colour does not update as the cursor moves

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [x] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
