### PR TITLE
:sparkles: Add climit impl and config for file snapshot methods

### DIFF
--- a/backend/resources/climit.edn
+++ b/backend/resources/climit.edn
@@ -19,7 +19,7 @@
  {:permits 40}
 
  :root/by-profile
- {:permits 10}
+ {:permits 10 :queue 30 :timeout 30000}
 
  :file-thumbnail-ops/global
  {:permits 20}

--- a/backend/resources/climit.edn
+++ b/backend/resources/climit.edn
@@ -33,4 +33,10 @@
  {:permits 3}
 
  :restore-file-snapshot/by-profile
+ {:permits 1 :queue 2 :timeout 60000}
+
+ :create-file-snapshot/global
+ {:permits 3}
+
+ :create-file-snapshot/by-profile
  {:permits 1 :queue 2 :timeout 60000}}

--- a/backend/resources/climit.edn
+++ b/backend/resources/climit.edn
@@ -27,4 +27,10 @@
  {:permits 2}
 
  :submit-audit-events/by-profile
- {:permits 1 :queue 3}}
+ {:permits 1 :queue 3}
+
+ :restore-file-snapshot/global
+ {:permits 3}
+
+ :restore-file-snapshot/by-profile
+ {:permits 1 :queue 2 :timeout 60000}}

--- a/backend/src/app/db.clj
+++ b/backend/src/app/db.clj
@@ -27,7 +27,9 @@
    [next.jdbc.transaction])
   (:import
    com.zaxxer.hikari.HikariConfig
+   com.zaxxer.hikari.HikariConfigMXBean
    com.zaxxer.hikari.HikariDataSource
+   com.zaxxer.hikari.HikariPoolMXBean
    com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
    io.whitfin.siphash.SipHasher
    io.whitfin.siphash.SipHasherContainer
@@ -67,9 +69,8 @@
 
 (def defaults
   {::name :main
-   ::min-size 0
    ::max-size 60
-   ::connection-timeout 10000
+   ::connection-timeout 30000
    ::validation-timeout 10000
    ::idle-timeout 120000 ; 2min
    ::max-lifetime 1800000 ; 30m
@@ -82,7 +83,7 @@
 (defmethod ig/init-key ::pool
   [_ cfg]
   (let [{:keys [::uri ::read-only] :as cfg}
-        (merge defaults cfg)]
+        (merge defaults (d/without-nils cfg))]
     (when uri
       (l/info :hint "initialize connection pool"
               :name (d/name (::name cfg))
@@ -90,7 +91,8 @@
               :read-only read-only
               :credentials (and (contains? cfg ::username)
                                 (contains? cfg ::password))
-              :min-size (::min-size cfg)
+              :min-size (or (::min-size cfg)
+                            (::max-size cfg))
               :max-size (::max-size cfg))
       (create-pool cfg))))
 
@@ -111,7 +113,9 @@
   [{:keys [::uri] :as cfg}]
 
   ;; (app.common.pprint/pprint cfg)
-  (let [config (HikariConfig.)]
+  (let [config   (HikariConfig.)
+        max-size (::max-size cfg)
+        min-size (or (::min-size cfg) max-size)]
     (doto config
       (.setJdbcUrl           (str "jdbc:" uri))
       (.setPoolName          (d/name (::name cfg)))
@@ -121,8 +125,8 @@
       (.setValidationTimeout (::validation-timeout cfg))
       (.setIdleTimeout       (::idle-timeout cfg))
       (.setMaxLifetime       (::max-lifetime cfg))
-      (.setMinimumIdle       (::min-size cfg))
-      (.setMaximumPoolSize   (::max-size cfg))
+      (.setMinimumIdle       min-size)
+      (.setMaximumPoolSize   max-size)
       (.setConnectionInitSql initsql)
       (.setInitializationFailTimeout -1))
 
@@ -179,6 +183,20 @@
     (ex/raise :type :internal
               :code :invalid-connection
               :hint "invalid connection provided")))
+
+(defn pool-stats
+  "Given a HikariDataSource instance, returns a map with current pool
+  statistics: active/idle connections, threads awaiting connection,
+  total connections, maximum pool size, and minimum idle connections."
+  [^HikariDataSource pool]
+  (let [^HikariPoolMXBean pool-mxbean (.getHikariPoolMXBean pool)
+        ^HikariConfigMXBean cfg-mxbean  (.getHikariConfigMXBean pool)]
+    {:active-connections        (.getActiveConnections pool-mxbean)
+     :idle-connections          (.getIdleConnections pool-mxbean)
+     :threads-awaiting-connection (.getThreadsAwaitingConnection pool-mxbean)
+     :total-connections         (.getTotalConnections pool-mxbean)
+     :maximum-pool-size         (.getMaximumPoolSize cfg-mxbean)
+     :minimum-idle              (.getMinimumIdle cfg-mxbean)}))
 
 (defn create-pool
   [cfg]

--- a/backend/src/app/features/file_snapshots.clj
+++ b/backend/src/app/features/file_snapshots.clj
@@ -66,11 +66,6 @@
      LEFT JOIN file_data AS fd ON (fd.file_id = f.id AND fd.id = f.id)
     WHERE f.id = ?")
 
-(defn- get-minimal-file
-  [cfg id & {:as opts}]
-  (-> (db/get-with-sql cfg [sql:get-minimal-file id] opts)
-      (d/update-when :metadata fdata/decode-metadata)))
-
 (def ^:private sql:get-snapshot-without-data
   (str "WITH snapshots AS (" sql:snapshots ")"
        "SELECT c.id,

--- a/backend/src/app/features/file_snapshots.clj
+++ b/backend/src/app/features/file_snapshots.clj
@@ -319,79 +319,87 @@
 
 (defn restore!
   [{:keys [::db/conn] :as cfg} file-id snapshot-id]
-  (let [file (get-minimal-file conn file-id {::db/for-update true})
-        vern (rand-int Integer/MAX_VALUE)
+  (let [lock-sql (str sql:get-minimal-file " FOR UPDATE OF f SKIP LOCKED")
+        row      (db/exec-one! conn [lock-sql file-id])]
 
-        storage
-        (sto/resolve cfg {::db/reuse-conn true})
+    (when-not row
+      (ex/raise :type :conflict
+                :code :file-locked
+                :hint "the file is currently locked by another operation, retry later"))
 
-        snapshot
-        (get-snapshot cfg file-id snapshot-id)]
+    (let [file (d/update-when row :metadata fdata/decode-metadata)
+          vern (rand-int Integer/MAX_VALUE)
 
-    (when-not snapshot
-      (ex/raise :type :not-found
-                :code :snapshot-not-found
-                :hint "unable to find snapshot with the provided label"
-                :snapshot-id snapshot-id
-                :file-id file-id))
+          storage
+          (sto/resolve cfg {::db/reuse-conn true})
 
-    (when-not (:data snapshot)
-      (ex/raise :type :internal
-                :code :snapshot-without-data
-                :hint "snapshot has no data"
-                :label (:label snapshot)
-                :file-id file-id))
+          snapshot
+          (get-snapshot cfg file-id snapshot-id)]
 
-    (let [;; If the snapshot has applied migrations stored, we reuse
-          ;; them, if not, we take a safest set of migrations as
-          ;; starting point. This is because, at the time of
-          ;; implementing snapshots, migrations were not taken into
-          ;; account so we need to make this backward compatible in
-          ;; some way.
-          migrations
-          (or (:migrations snapshot)
-              (fmg/generate-migrations-from-version 67))
+      (when-not snapshot
+        (ex/raise :type :not-found
+                  :code :snapshot-not-found
+                  :hint "unable to find snapshot with the provided label"
+                  :snapshot-id snapshot-id
+                  :file-id file-id))
 
-          file
-          (-> file
-              (update :revn inc)
-              (assoc :migrations migrations)
-              (assoc :data (:data snapshot))
-              (assoc :vern vern)
-              (assoc :version (:version snapshot))
-              (assoc :has-media-trimmed false)
-              (assoc :modified-at (:modified-at snapshot))
-              (assoc :features (:features snapshot)))]
+      (when-not (:data snapshot)
+        (ex/raise :type :internal
+                  :code :snapshot-without-data
+                  :hint "snapshot has no data"
+                  :label (:label snapshot)
+                  :file-id file-id))
 
-      (l/dbg :hint "restoring snapshot"
-             :file-id (str file-id)
-             :label (:label snapshot)
-             :snapshot-id (str (:id snapshot)))
+      (let [;; If the snapshot has applied migrations stored, we reuse
+            ;; them, if not, we take a safest set of migrations as
+            ;; starting point. This is because, at the time of
+            ;; implementing snapshots, migrations were not taken into
+            ;; account so we need to make this backward compatible in
+            ;; some way.
+            migrations
+            (or (:migrations snapshot)
+                (fmg/generate-migrations-from-version 67))
 
-      ;; In the same way, on reseting the file data, we need to restore
-      ;; the applied migrations on the moment of taking the snapshot
-      (bfc/update-file! cfg file ::bfc/reset-migrations? true)
+            file
+            (-> file
+                (update :revn inc)
+                (assoc :migrations migrations)
+                (assoc :data (:data snapshot))
+                (assoc :vern vern)
+                (assoc :version (:version snapshot))
+                (assoc :has-media-trimmed false)
+                (assoc :modified-at (:modified-at snapshot))
+                (assoc :features (:features snapshot)))]
 
-      ;; FIXME: this should be separated functions, we should not have
-      ;; inline sql here.
+        (l/dbg :hint "restoring snapshot"
+               :file-id (str file-id)
+               :label (:label snapshot)
+               :snapshot-id (str (:id snapshot)))
 
-      ;; clean object thumbnails
-      (let [sql (str "update file_tagged_object_thumbnail "
-                     "   set deleted_at = now() "
-                     " where file_id=? returning media_id")
-            res (db/exec! conn [sql file-id])]
-        (doseq [media-id (into #{} (keep :media-id) res)]
-          (sto/touch-object! storage media-id)))
+        ;; In the same way, on reseting the file data, we need to restore
+        ;; the applied migrations on the moment of taking the snapshot
+        (bfc/update-file! cfg file ::bfc/reset-migrations? true)
 
-      ;; clean file thumbnails
-      (let [sql (str "update file_thumbnail "
-                     "   set deleted_at = now() "
-                     " where file_id=? returning media_id")
-            res (db/exec! conn [sql file-id])]
-        (doseq [media-id (into #{} (keep :media-id) res)]
-          (sto/touch-object! storage media-id)))
+        ;; FIXME: this should be separated functions, we should not have
+        ;; inline sql here.
 
-      vern)))
+        ;; clean object thumbnails
+        (let [sql (str "update file_tagged_object_thumbnail "
+                       "   set deleted_at = now() "
+                       " where file_id=? returning media_id")
+              res (db/exec! conn [sql file-id])]
+          (doseq [media-id (into #{} (keep :media-id) res)]
+            (sto/touch-object! storage media-id)))
+
+        ;; clean file thumbnails
+        (let [sql (str "update file_thumbnail "
+                       "   set deleted_at = now() "
+                       " where file_id=? returning media_id")
+              res (db/exec! conn [sql file-id])]
+          (doseq [media-id (into #{} (keep :media-id) res)]
+            (sto/touch-object! storage media-id)))
+
+        vern))))
 
 (defn delete!
   [cfg & {:keys [id file-id deleted-at]}]

--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -154,8 +154,8 @@
     ::db/username   (cf/get :database-username)
     ::db/password   (cf/get :database-password)
     ::db/read-only  (cf/get :database-readonly false)
-    ::db/min-size   (cf/get :database-min-pool-size 0)
-    ::db/max-size   (cf/get :database-max-pool-size 60)
+    ::db/min-size   (cf/get :database-min-pool-size)
+    ::db/max-size   (cf/get :database-max-pool-size)
     ::mtx/metrics   (ig/ref ::mtx/metrics)}
 
    ;; Default netty IO pool (shared between several services)

--- a/backend/src/app/rpc/commands/files_snapshot.clj
+++ b/backend/src/app/rpc/commands/files_snapshot.clj
@@ -71,31 +71,43 @@
 (sv/defmethod ::restore-file-snapshot
   {::doc/added "1.20"
    ::sm/params schema:restore-file-snapshot
-   ::db/transaction true
    ::climit/id [[:restore-file-snapshot/by-profile ::rpc/profile-id]
                 [:restore-file-snapshot/global]]}
-  [{:keys [::db/conn ::mbus/msgbus] :as cfg} {:keys [::rpc/profile-id ::rpc/session-id file-id id] :as params}]
-  (files/check-edition-permissions! conn profile-id file-id)
+  [{:keys [::db/pool ::mbus/msgbus] :as cfg} {:keys [::rpc/profile-id ::rpc/session-id file-id id] :as params}]
+
+  ;; Check permissions and read current file state (short-lived, outside restore transaction)
+  (files/check-edition-permissions! pool profile-id file-id)
   (let [file  (bfc/get-file cfg file-id)
-        team  (teams/get-team conn
+        team  (teams/get-team pool
                               :profile-id profile-id
                               :file-id file-id)
-        delay (ldel/get-deletion-delay team)]
+        delay (ldel/get-deletion-delay team)
+        file-revn (:revn file)]
 
+    ;; Create backup snapshot of the current state (committed immediately
+    ;; independently of the restore outcome)
     (fsnap/create! cfg file
                    {:profile-id profile-id
                     :deleted-at (ct/in-future delay)
                     :created-by "system"})
 
-    (let [vern (fsnap/restore! cfg file-id id)]
-      ;; Send to the clients a notification to reload the file
-      (mbus/pub! msgbus
-                 :topic (:id file)
-                 :message {:type :file-restored
-                           :session-id session-id
-                           :file-id (:id file)
-                           :vern vern})
-      nil)))
+    ;; Restore snapshot inside its own transaction; the revn check
+    ;; ensures no data is lost if the file was edited concurrently
+    (db/tx-run! cfg
+                (fn [{:keys [::db/conn] :as cfg}]
+                  (let [current (bfc/get-minimal-file conn file-id {::db/for-update true})]
+                    (when (not= (:revn current) file-revn)
+                      (ex/raise :type :conflict
+                                :code :file-modified
+                                :hint "the file was modified during the restore process, please retry")))
+                  (let [vern (fsnap/restore! cfg file-id id)]
+                    (mbus/pub! msgbus
+                               :topic (:id file)
+                               :message {:type :file-restored
+                                         :session-id session-id
+                                         :file-id (:id file)
+                                         :vern vern})
+                    nil)))))
 
 (def ^:private schema:update-file-snapshot
   [:map {:title "update-file-snapshot"}

--- a/backend/src/app/rpc/commands/files_snapshot.clj
+++ b/backend/src/app/rpc/commands/files_snapshot.clj
@@ -43,7 +43,9 @@
 
 (sv/defmethod ::create-file-snapshot
   {::doc/added "1.20"
-   ::sm/params schema:create-file-snapshot}
+   ::sm/params schema:create-file-snapshot
+   ::climit/id [[:create-file-snapshot/by-profile ::rpc/profile-id]
+                [:create-file-snapshot/global]]}
   [cfg {:keys [::rpc/profile-id file-id label]}]
   (files/check-edition-permissions! cfg profile-id file-id)
   (let [file    (bfc/get-file cfg file-id :realize? true)

--- a/backend/src/app/rpc/commands/files_snapshot.clj
+++ b/backend/src/app/rpc/commands/files_snapshot.clj
@@ -43,10 +43,9 @@
 
 (sv/defmethod ::create-file-snapshot
   {::doc/added "1.20"
-   ::sm/params schema:create-file-snapshot
-   ::db/transaction true}
-  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id file-id label]}]
-  (files/check-edition-permissions! conn profile-id file-id)
+   ::sm/params schema:create-file-snapshot}
+  [cfg {:keys [::rpc/profile-id file-id label]}]
+  (files/check-edition-permissions! cfg profile-id file-id)
   (let [file    (bfc/get-file cfg file-id :realize? true)
         project (db/get-by-id cfg :project (:project-id file))]
 
@@ -58,10 +57,10 @@
         (quotes/check! {::quotes/id ::quotes/snapshots-per-file}
                        {::quotes/id ::quotes/snapshots-per-team}))
 
-    (fsnap/create! cfg file
-                   {:label label
-                    :profile-id profile-id
-                    :created-by "user"})))
+    (db/tx-run! cfg fsnap/create! file
+                {:label label
+                 :profile-id profile-id
+                 :created-by "user"})))
 
 (def ^:private schema:restore-file-snapshot
   [:map {:title "restore-file-snapshot"}

--- a/backend/src/app/rpc/commands/files_snapshot.clj
+++ b/backend/src/app/rpc/commands/files_snapshot.clj
@@ -17,6 +17,7 @@
    [app.main :as-alias main]
    [app.msgbus :as mbus]
    [app.rpc :as-alias rpc]
+   [app.rpc.climit :as-alias climit]
    [app.rpc.commands.files :as files]
    [app.rpc.commands.teams :as teams]
    [app.rpc.doc :as-alias doc]
@@ -70,7 +71,9 @@
 (sv/defmethod ::restore-file-snapshot
   {::doc/added "1.20"
    ::sm/params schema:restore-file-snapshot
-   ::db/transaction true}
+   ::db/transaction true
+   ::climit/id [[:restore-file-snapshot/by-profile ::rpc/profile-id]
+                [:restore-file-snapshot/global]]}
   [{:keys [::db/conn ::mbus/msgbus] :as cfg} {:keys [::rpc/profile-id ::rpc/session-id file-id id] :as params}]
   (files/check-edition-permissions! conn profile-id file-id)
   (let [file  (bfc/get-file cfg file-id)

--- a/backend/test/backend_tests/db_test.clj
+++ b/backend/test/backend_tests/db_test.clj
@@ -1,0 +1,43 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC
+
+(ns backend-tests.db-test
+  (:require
+   [app.db :as db]
+   [backend-tests.helpers :as th]
+   [clojure.test :as t])
+  (:import
+   com.zaxxer.hikari.HikariConfig
+   com.zaxxer.hikari.HikariDataSource
+   java.sql.Connection))
+
+(t/use-fixtures :once th/state-init)
+
+(t/deftest pool-stats-returns-expected-keys
+  (let [stats (db/pool-stats th/*pool*)]
+    (t/testing "all expected keys are present"
+      (t/is (contains? stats :active-connections))
+      (t/is (contains? stats :idle-connections))
+      (t/is (contains? stats :threads-awaiting-connection))
+      (t/is (contains? stats :total-connections))
+      (t/is (contains? stats :maximum-pool-size))
+      (t/is (contains? stats :minimum-idle)))
+
+    (t/testing "values are non-negative integers"
+      (t/is (>= (:active-connections stats) 0))
+      (t/is (>= (:idle-connections stats) 0))
+      (t/is (>= (:threads-awaiting-connection stats) 0))
+      (t/is (>= (:total-connections stats) 0))
+      (t/is (>= (:maximum-pool-size stats) 0))
+      (t/is (>= (:minimum-idle stats) 0)))
+
+    (t/testing "total connections equals active + idle"
+      (t/is (= (:total-connections stats)
+               (+ (:active-connections stats)
+                  (:idle-connections stats)))))
+
+    (t/testing "maximum pool size is reasonable"
+      (t/is (pos? (:maximum-pool-size stats))))))


### PR DESCRIPTION
### Summary

Add concurrency limits (climit) and configuration for file snapshot operations (create and restore), preventing resource exhaustion under concurrent snapshot requests.

### Changes

- **Rate limiting**: Added `climit` configuration entries for `create-file-snapshot` and `restore-file-snapshot` operations (global and per-profile limits) in `climit.edn`.
- **Locking**: Changed `restore!` to acquire a row-level lock with `SKIP LOCKED` on the file, raising a `:file-locked` conflict if the file is already being operated on.
- **Concurrency safety**: Restructured `restore-file-snapshot` to create a backup snapshot before entering the restore transaction, and added a `revn` check inside the transaction to detect concurrent edits. The restore no longer runs in an implicit top-level transaction — it uses `db/tx-run!` for finer control.
- **Transaction scoping**: `create-file-snapshot` now uses `db/tx-run!` instead of `::db/transaction true`, allowing the climit middleware to enforce limits outside the transaction.
- **DB pool config**: Changed defaults so `min-size` defaults to `max-size` when not set. Added `pool-stats` function exposing HikariCP pool metrics.
- **Test**: Added `backend_tests/db_test.clj` with unit tests for `pool-stats`.

### How to test

Only regression tests:

- You should be able to create snapshots
- You should be able to restore snapshots


**Merge with SQUASH**

Closes #9723
