### PR TITLE
:bug: Fix redirect after leaving team

### DIFF
--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -82,7 +82,15 @@
      (watch [_ state _]
        (when-let [team-id (or team-id (:current-team-id state))]
          (->> (rp/cmd! :get-team-members {:team-id team-id})
-              (rx/map (partial members-fetched team-id))))))))
+              (rx/map (partial members-fetched team-id))
+              (rx/catch (fn [cause]
+                          (let [{:keys [type]} (ex-data cause)]
+                            (if (= :not-found type)
+                              (do
+                                (log/warn :hint "fetch-members: team not found, skipping"
+                                          :team-id (str team-id))
+                                (rx/empty))
+                              (rx/throw cause)))))))))))
 
 (defn- invitations-fetched
   [team-id invitations]

--- a/frontend/src/app/main/ui/static.cljs
+++ b/frontend/src/app/main/ui/static.cljs
@@ -228,7 +228,8 @@
          (mf/deps profile)
          (fn []
            (let [team-id (:default-team-id profile)]
-             (st/emit! (dcm/go-to-dashboard-recent :team-id team-id)))))
+             (st/emit! (rt/assign-exception nil)
+                       (dcm/go-to-dashboard-recent :team-id team-id)))))
 
         on-success
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/9710
https://tree.taiga.io/project/penpot/issue/14201

### Summary

* fetch-members now catches :not-found errors and returns rx/empty (adding a log/warn instead of propagating, so there's a trace of what happened just in case) -> a 404 on a member refresh should never trigger a full exception page
* **to review**: `request-access on-close` now explicitly dispatches (rt/assign-exception nil) before navigating

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
