### PR TITLE
:bug: Fix race condition on trying to persist file changes after going to dashboard

### DIFF
--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -209,7 +209,8 @@
             permissions (get state :permissions)]
 
         ;; Prevent commit changes by a viewer team member (it really should never happen)
-        (when (:can-edit permissions)
+        ;; or if there is no file
+        (when (and (:can-edit permissions) file-id)
           (log/trace :hint "commit-changes" :redo-changes redo-changes)
           (let [selected (dm/get-in state [:workspace-local :selected])]
             (rx/of (-> params

--- a/frontend/src/app/main/data/persistence.cljs
+++ b/frontend/src/app/main/data/persistence.cljs
@@ -121,9 +121,11 @@
                         :features features}
               permissions (:permissions state)]
 
-          ;; Prevent saving changes when in version preview (read-only) mode
-          ;; or when the user does not have edition permission.
-          (when (and (:can-edit permissions)
+          ;; Prevent saving changes when in version preview (read-only) mode,
+          ;; when the user does not have edition permission, or when file-id is nil
+          ;; (race condition: navigation can clear :current-file-id before commit fires).
+          (when (and file-id
+                     (:can-edit permissions)
                      (not (get-in state [:workspace-global :read-only?])))
             (->> (rp/cmd! :update-file params)
                  (rx/mapcat (fn [{:keys [revn lagged] :as response}]


### PR DESCRIPTION
### Reference ticket

https://github.com/penpot/penpot/issues/9766
https://tree.taiga.io/project/penpot/issue/14213

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
