### PR TITLE
:bug: Fix shapes not being rendered after render switch

### DIFF
--- a/frontend/src/app/main/data/changes.cljs
+++ b/frontend/src/app/main/data/changes.cljs
@@ -18,7 +18,9 @@
    [app.main.data.helpers :as dsh]
    [app.main.features :as features]
    [app.main.worker :as mw]
+   [app.render-wasm.api :as wasm.api]
    [app.render-wasm.shape :as wasm.shape]
+   [app.render-wasm.wasm :as wasm]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -76,6 +78,31 @@
 (def ^:private xf:map-page-id
   (map :page-id))
 
+(def ^:private wasm-structural-change-types
+  #{:add-obj :mov-objects})
+
+(defn- redo-changes-need-wasm-object-sync?
+  [redo-changes]
+  (some #(contains? wasm-structural-change-types (:type %)) redo-changes))
+
+(defn- sync-wasm-structural-changes
+  [{:keys [redo-changes]}]
+  (ptk/reify ::sync-wasm-structural-changes
+    ptk/EffectEvent
+    (effect [_ state _]
+      (when (and wasm/context-initialized?
+                 (not @wasm/context-lost?))
+        (let [objects (dsh/lookup-page-objects state)]
+          (doseq [{:keys [type id parent-id]} redo-changes
+                  :when (contains? wasm-structural-change-types type)
+                  :let [shape-id (case type
+                                   :add-obj id
+                                   :mov-objects parent-id)
+                        shape (get objects shape-id)]
+                  :when shape]
+            (wasm.api/process-object shape))
+          (wasm.api/request-render "sync-wasm-structural-changes"))))))
+
 (defn- apply-changes-localy
   [{:keys [file-id redo-changes ignore-wasm?] :as commit} pending]
   (ptk/reify ::apply-changes-localy
@@ -118,7 +145,16 @@
             state)
 
           ;; wasm renderer deactivated
-          (update-in state [:files file-id :data] apply-changes))))))
+          (update-in state [:files file-id :data] apply-changes))))
+
+    ptk/WatchEvent
+    (watch [_ state _]
+      ;; `:add-obj` / `:mov-objects` are not tracked via `*shape-changes*`.
+      ;; Emit only for structural commits, after file data is in state.
+      (when (and (not ignore-wasm?)
+                 (features/active-feature? state "render-wasm/v1")
+                 (redo-changes-need-wasm-object-sync? redo-changes))
+        (rx/of (sync-wasm-structural-changes {:redo-changes redo-changes}))))))
 
 (defn commit
   "Create a commit event instance"

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -306,19 +306,6 @@
              (rx/map bundle-fetched)
              (rx/take-until stopper-s))))))
 
-;; FIXME: this need docstring
-(defn- process-wasm-object
-  [id]
-  (ptk/reify ::process-wasm-object
-    ptk/EffectEvent
-    (effect [_ state _]
-      (let [objects (dsh/lookup-page-objects state)
-            shape (get objects id)]
-        ;; Only process objects that exist in the current page
-        ;; This prevents errors when processing changes from other pages
-        (when shape
-          (wasm.api/process-object shape))))))
-
 (defn initialize-file
   [team-id file-id]
   (assert (uuid? team-id) "expected valud uuid for `team-id`")
@@ -443,18 +430,6 @@
                       (rx/observe-on :async)
                       (rx/take 1)
                       (rx/map #(dwcm/navigate-to-comment-id comment-id))))
-
-               (->> stream
-                    (rx/filter dch/commit?)
-                    (rx/filter render-wasm-ready?)
-                    (rx/map deref)
-                    (rx/mapcat
-                     (fn [{:keys [redo-changes]}]
-                       (let [added (->> redo-changes
-                                        (filter #(= (:type %) :add-obj))
-                                        (map :id))]
-                         (->> (rx/from added)
-                              (rx/map process-wasm-object))))))
 
                (let [local-commits-s
                      (->> stream


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14206

Closes #9743 

### Summary

This fixes newly created shapes not being rendered after hot swapping to the wasm renderer.

### Steps to reproduce 

See Taiga ticket.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
