### PR TITLE
:bug: Fix invitation token propagation in login flow

### DIFF
--- a/frontend/src/app/main/data/auth.cljs
+++ b/frontend/src/app/main/data/auth.cljs
@@ -195,16 +195,19 @@
 
 (defn login-from-token
   "Used mainly as flow continuation after token validation."
-  [{:keys [profile] :as tdata}]
+  [{:keys [profile invitation-token] :as tdata}]
   (ptk/reify ::login-from-token
     ptk/WatchEvent
     (watch [_ _ _]
       (->> (dp/on-fetch-profile-success profile)
            (rx/map (fn [profile]
-                     (logged-in (with-meta profile {::ev/source "login-with-token"}))))
-           ;; NOTE: we need this to be asynchronous because the effect
-           ;; should be called before proceed with the login process
-           (rx/observe-on :async)))))
+                     (let [profile (cond-> profile
+                                     invitation-token
+                                     (assoc :invitation-token invitation-token)
+
+                                     :always
+                                     (with-meta {::ev/source "login-with-token"}))]
+                       (logged-in profile))))))))
 
 (defn login-from-register
   "Event used mainly for mark current session as logged-in in after the

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -189,7 +189,7 @@
        [:? [:& auth-page {:route route}]]
 
        :auth-verify-token
-       [:? [:& verify-token-page* {:route route}]]
+       [:? [:> verify-token-page* {:route route}]]
 
        :nitrate-entry
        [:> nitrate-entry/nitrate-entry-page* {:profile profile}]

--- a/frontend/src/app/main/ui/auth/verify_token.cljs
+++ b/frontend/src/app/main/ui/auth/verify_token.cljs
@@ -25,19 +25,11 @@
 (defmulti handle-token (fn [token] (:iss token)))
 
 (defmethod handle-token :verify-email
-  [{:keys [invitation-token] :as data}]
+  [data]
   (cf/external-notify-register-success (:profile-id data))
   (let [msg (tr "dashboard.notifications.email-verified-successfully")]
     (ts/schedule 1000 #(st/emit! (ntf/success msg)))
-    ;; If the verify-email JWE carries an :invitation-token, it means
-    ;; the user registered via a team-invitation flow but had to verify
-    ;; their email first. Log them in and then redirect to
-    ;; :auth-verify-token with the invitation token, which will accept
-    ;; the invitation as a logged-in user.
-    (if invitation-token
-      (st/emit! (da/login-from-token data)
-                (rt/nav :auth-verify-token {:token invitation-token}))
-      (st/emit! (da/login-from-token data)))))
+    (st/emit! (da/login-from-token data))))
 
 (defmethod handle-token :change-email
   [_data]
@@ -86,7 +78,7 @@
         ;;   :invalid-token   -> corrupted / unknown / fallback
         bad-token-reason (mf/use-state nil)]
 
-    (mf/with-effect []
+    (mf/with-effect [token]
       (dom/set-html-title (tr "title.default"))
       (->> (rp/cmd! :verify-token {:token token})
            (rx/subs!


### PR DESCRIPTION
## Summary

Pass invitation-token through login-from-token event so it reaches the logged-in state. Fix component render syntax (:& -> :>) for the verify-token route. Remove redundant navigation that re-visited verify-token after login. Fix missing dependency in effect hook to re-run when token changes.

Closes: https://github.com/penpot/penpot/issues/9776
