### PR TITLE
:bug: Fix blurry boards (svg renderer)

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes.cljs
@@ -87,7 +87,7 @@
        (for [shape shapes]
          (let [thumbnail?
                (and (not disable-thumbnails)
-                    (contains? active-frames (dm/get-prop shape :id)))]
+                    (not (contains? active-frames (dm/get-prop shape :id))))]
            [:g.ws-shape-wrapper {:key (dm/str (dm/get-prop shape :id))}
             (if ^boolean (cfh/frame-shape? shape)
               [:& root-frame-wrapper


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14227

Fixes #9775 

### Summary

This fixes boards always displaying the thumbnail imposters (SVG renderer) even if they are active.

### Steps to reproduce 

1. Enable the SVG renderer
2. Create a new file
3. Add a new board
4. Add shapes inside the board (more noticeable with text shapes or images)
5. Reload the file
6. Select the board

Expected result: the board should be displayed crisp, and if you look at the DOM there are SVG shapes for it.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] ~~Include screenshots or videos, if applicable.~~
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [ ] Check CI passes successfully.
- [x] ~~Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.~~

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
