### PR TITLE
:bug: Fix 2.15 release notes crash on invalid slide index

### DIFF
--- a/frontend/src/app/main/ui/releases/v2_15.cljs
+++ b/frontend/src/app/main/ui/releases/v2_15.cljs
@@ -77,7 +77,7 @@
           [:& c/navigation-bullets
            {:slide slide
             :navigate navigate
-            :total 4}]
+            :total 3}]
 
           [:button {:on-click next
                     :class (stl/css :next-btn)} "Continue"]]]]]]
@@ -118,7 +118,7 @@
           [:& c/navigation-bullets
            {:slide slide
             :navigate navigate
-            :total 4}]
+            :total 3}]
 
           [:button {:on-click next
                     :class (stl/css :next-btn)} "Continue"]]]]]]


### PR DESCRIPTION
### Related Ticket

### Summary

Opening the 2.15 release notes modal (from the dashboard profile menu or on first visit after upgrade) can crash the app with:

Error: No matching clause: 3

Root cause: Slides 0 and 1 use navigation-bullets with total set to 4, but the release notes only define slides 0, 1, and 2 (plus the initial :start screen). Clicking the fourth navigation dot calls navigate with index 3, which sets slide to 3. The case in v2_15.cljs has no clause for 3, so ClojureScript throws at render time.

### Steps to reproduce 

Log in and go to the dashboard (e.g. Recent projects).
Open release notes for version 2.15 (profile menu → Release notes, or auto-show on first visit).
Advance to slide 1 or 2.
Click the fourth dot in the step indicator.
Expected: Only three content slides are shown; navigation is limited to slides 0–2.

Actual: The UI offers a fourth dot; selecting it crashes with No matching clause: 3.

Fix: Set total to 3 on slides 0 and 1 so it matches the three slides and the last slide’s configuration.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
