### PR TITLE
:bug: Fix resize line between sitemaps and layers

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layers.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.scss
@@ -23,7 +23,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--sp-xs);
-  padding: var(--sp-m) var(--sp-m) 0 var(--sp-m);
+  margin: var(--sp-m) var(--sp-m) 0 var(--sp-m);
 }
 
 .tool-window-bar-title {


### PR DESCRIPTION
### Related Ticket

This PR closes #9811 (issue [#14242](https://tree.taiga.io/project/penpot/issue/14242) in Taiga) 

### Summary

Bring back the resize functionality between sitemap and layers in the left panel.