### PR TITLE
:bug: Fix changed font size when editing a text with no changes

### DIFF
--- a/frontend/src/app/util/text/content/from_dom.cljs
+++ b/frontend/src/app/util/text/content/from_dom.cljs
@@ -8,6 +8,7 @@
   (:require
    [app.common.data :as d]
    [app.common.types.text :as txt]
+   [app.util.dom :as dom]
    [app.util.text.content.styles :as styles]))
 
 (defn is-text-node
@@ -60,7 +61,15 @@
 
 (defn get-paragraph-styles
   [element]
-  (get-attrs-from-styles element (d/concat-set txt/paragraph-attrs txt/text-node-attrs) (d/merge txt/default-paragraph-attrs txt/default-text-attrs)))
+  (let [styles (get-attrs-from-styles element
+                                      (d/concat-set txt/paragraph-attrs txt/text-node-attrs)
+                                      (d/merge txt/default-paragraph-attrs txt/default-text-attrs))
+        ;; Recover real font-size from data attribute, which to_dom/get-paragraph-styles may have
+        ;; changed to "0" ("0" trick to avoid it interfering with height calculation in the browser).
+        saved-font-size (dom/get-data element "saved-font-size")]
+    (cond-> styles
+      (some? saved-font-size)
+      (assoc :font-size saved-font-size))))
 
 (defn get-root-styles
   [element]

--- a/frontend/src/app/util/text/content/to_dom.cljs
+++ b/frontend/src/app/util/text/content/to_dom.cljs
@@ -133,7 +133,11 @@
   (create-element
    "div"
    {:id (or (:key paragraph) (create-random-key))
-    :data {:itype "paragraph"}
+    :data {:itype "paragraph"
+           ;; Save the real font size to be restored later in from-dom/get-paragraph-styles,
+           ;; because the function get-paragraph-styles here sets it to "0" in the css properties, 
+           ;; to avoid the browser affecting the height calculation.
+           :saved-font-size (:font-size paragraph)}
     :style (get-paragraph-styles paragraph)}
    (mapv #(create-text-span % paragraph) (:children paragraph))))
 


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/9255

### Summary

As an additional problem of the bug, when attaching a typography token to a shape, and then editing its, silently detaches the token, when using editor v2.

### Steps to reproduce 

- Ensure editor v2 is used.
- Create a typography token.
- Create a text shape.
- Attach the token to the shape.
- Double click the shape to open edit mode.
- You can change something of the text or not.
- Click outside to close edit mode.

**Expected behavior**:

The token is still attached.

**Actual behavior**:

The token appears detached.

Probably this occurs with other typography tokens.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
