### PR TITLE
:bug: Fix nested inherited transformations

### DIFF
--- a/render-wasm/src/shapes/modifiers.rs
+++ b/render-wasm/src/shapes/modifiers.rs
@@ -27,11 +27,14 @@ fn propagate_children(
     transform: Matrix,
     bounds: &HashMap<Uuid, Bounds>,
 ) -> Result<VecDeque<Modifier>> {
-    if identitish(&transform) {
-        return Ok(VecDeque::new());
-    }
-
     let mut result = VecDeque::new();
+
+    if identitish(&transform) {
+        for child_id in shape.children_ids_iter(true) {
+            result.push_back(Modifier::transform_propagate(*child_id, transform));
+        }
+        return Ok(result);
+    }
 
     for child_id in shape.children_ids_iter(true) {
         let Some(child) = shapes.get(child_id) else {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot/issue/14244

### Summary

We still need to propagate transforms to nested children, this change should not affect performance in drag / pan / zoom operations. I tested it in heavy files and there's no regression, but it'd be great to double check.

### Steps to reproduce 

- Add a rect
- Create a board and set the rect as a child
- Create another board and set the previous board as a child
- Translate the parent board and check it works ok - as in production
- Resize the parent board (all corners) and check it works ok - as in production

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
