### PR TITLE
:bug: Remove dead css/ui.css <link> from frontend index template (fixes #9135)

### DIFF
--- a/frontend/resources/templates/index.mustache
+++ b/frontend/resources/templates/index.mustache
@@ -18,7 +18,6 @@
     <meta name="twitter:creator" content="@penpotapp">
     <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)">
     <link id="theme" href="css/main.css?version={{& version_tag}}" rel="stylesheet" type="text/css" />
-    <link href="css/ui.css?ts={{& version_tag}}" rel="stylesheet" type="text/css" />
     {{#isDebug}}
     <link href="css/debug.css?version={{& version_tag}}" rel="stylesheet" type="text/css" />
     {{/isDebug}}


### PR DESCRIPTION
## Summary

Fixes #9135.

Removes a dead `<link href="css/ui.css">` tag from `frontend/resources/templates/index.mustache`. The build pipeline never produces `ui.css`, so the browser issues a 404 on every page load. In self-hosted deployments behind a reverse proxy, this 404 causes the SPA's CSS init promise to reject, the React root never mounts, and users see a black screen.

## Reproduction

1. Build any Penpot frontend image since 2.14.x: `cd frontend && pnpm install && pnpm run build:app:assets`
2. Inspect the output: `ls resources/public/css/` → contains `main.css` only (plus `debug.css` in dev). **No `ui.css`.**
3. Inspect `resources/public/index.html` → contains `<link href="css/ui.css?ts=...">`
4. Serve via nginx + load the page → 404 on `/css/ui.css` → black screen in self-hosted

## Root cause analysis

`frontend/resources/templates/index.mustache:21` references a file that the build pipeline never produces:

- **`compileStyles()`** in `frontend/scripts/_helpers.js` writes only `main.css` (always) and `debug.css` (dev-only). No write to `ui.css`.
- **`compileStorybookStyles()`** writes `ds.css` (design system), not `ui.css`.
- No `ui.scss` source exists anywhere in `frontend/resources/styles/`.

The reference was added in 45d04942c (":sparkles: Add example ui storybook", Jan 2026) as part of the new `frontend/packages/ui/` storybook package, but no corresponding build step was added to emit `ui.css`. The reference appears to be either:
- A typo (the storybook actually produces `ds.css`, so possibly intended that)
- A forward-reference to a UI bundle that hasn't shipped yet

Either way, it's dead in the current tree.

## Fix

Remove the dead `<link>` tag. One-line deletion in `index.mustache`.

If a future change does start producing `ui.css` (or another distinct UI bundle), the `<link>` can be re-added at that time alongside the build step that emits it.

## Why not write `ui.css` instead?

Alternatives considered:
- **Add a `ui.css` write to `compileStyles()`** — but we don't know what content was intended. Symlinking `main.css` would waste bandwidth (~17 MB delivered for an 8.6 MB stylesheet). Emitting empty content would be misleading.
- **Wrap the `<link>` in a conditional** (like the `{{#isDebug}}` block around `debug.css`) — would work but adds template complexity for a feature that doesn't ship yet. Easier to re-add the link when the feature lands.

Removal is the minimal, demonstrably correct fix.

## Impact

- **Self-hosters**: black-screen bug goes away. No further action needed.
- **Penpot Cloud**: should be a no-op — the cloud CDN may already serve `/css/ui.css` as a redirect to `main.css` or similar, OR the cloud build pipeline may produce the file via a build step not present in this repo. Either way, removing the dead `<link>` only stops the request from being made; nothing depends on the file's contents.
- **Storybook users**: no impact — storybook uses its own templates and produces `ds.css` separately.

## Verification

Locally, after applying this patch:
```bash
cd frontend && pnpm run build:app:assets
grep "ui\.css" resources/public/index.html
# (no output — link removed)
```

Tested in a production self-hosted deployment (Railway, Penpot 2.15.3-based wrapper image) — the previously-failing login + SPA-mount flow now works end-to-end.

## Notes

- Branch is based off `develop`
- One-line change to `frontend/resources/templates/index.mustache`
- No tests to update (nothing tested the dead link's presence)
- Submitted for the NACA-Studio project at https://github.com/OpenCircuitPlatform/NACA-Studio (we maintain a wrapper image with this exact patch applied; this PR makes that wrapper unnecessary)