### PR TITLE
:bug: Fix text color on tooltip

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/shared/token_option.scss
+++ b/frontend/src/app/main/ui/ds/controls/shared/token_option.scss
@@ -83,3 +83,7 @@
 .option-name {
   @include text-ellipsis;
 }
+
+.token-name-tooltip {
+  color: var(--color-foreground-primary);
+}

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/token_typography_row.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/token_typography_row.scss
@@ -69,10 +69,6 @@
   inline-size: inherit;
 }
 
-.token-name-tooltip {
-  color: var(--color-foreground-primary);
-}
-
 .detach-button {
   flex-shrink: 0;
   inline-size: 0;


### PR DESCRIPTION
### Related Ticket

This PR closes the comment on this task https://tree.taiga.io/project/penpot/task/14124

### Summary
<img width="606" height="390" alt="Screenshot from 2026-05-25 12-57-33" src="https://github.com/user-attachments/assets/f291c014-6a82-4e8f-af7f-6bcd24047473" />
Token name should be white on tooltip.
### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
