### PR TITLE
:bug: Fix separate penpot from organizations

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -350,6 +350,8 @@
       (when (= default-team-id (:default-team-id organization))
         tick-icon)]
      [:hr {:role "separator" :class (stl/css :team-separator)}]
+     [:li {:role "presentation" :class (stl/css :org-section-label)}
+      (tr "dashboard.section.organizations")]
 
      (for [org-item organizations]
        [:> dropdown-menu-item* {:on-click    on-org-click
@@ -772,10 +774,10 @@
          [:div {:class (stl/css :team-name)}
           (if default-org?
             [:*
-             [:span {:class (stl/css :org-penpot-icon)}
-              [:> raw-svg* {:id penpot-logo-icon}]]
+             [:span {:class (stl/css :my-teams-icon-xxxl)}
+              [:> raw-svg* {:id penpot-logo-icon-subtle}]]
              [:span {:class (stl/css :team-text)}
-              "Penpot"]]
+              (tr "dashboard.my-teams")]]
             [:*
              [:> org-avatar* {:org current-org :size "xxxl"}]
              [:span {:class (stl/css :team-text)}

--- a/frontend/src/app/main/ui/dashboard/sidebar.scss
+++ b/frontend/src/app/main/ui/dashboard/sidebar.scss
@@ -229,6 +229,15 @@
   margin: 0;
 }
 
+.org-section-label {
+  @include t.use-typography("headline-small");
+
+  color: var(--color-foreground-secondary);
+  list-style: none;
+  padding: var(--sp-m) $sz-6 $sz-6;
+  text-transform: uppercase;
+}
+
 .tick-icon {
   @extend %button-icon-small;
 
@@ -653,6 +662,17 @@
     fill: var(--icon-stroke-color);
     width: var(--sp-xxl);
     height: var(--sp-xxl);
+  }
+}
+
+.my-teams-icon-xxxl {
+  height: var(--sp-xxxl);
+  width: var(--sp-xxxl);
+
+  svg {
+    fill: var(--icon-stroke-color);
+    width: var(--sp-xxxl);
+    height: var(--sp-xxxl);
   }
 }
 

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -383,6 +383,9 @@ msgstr "Create org"
 msgid "dashboard.my-teams"
 msgstr "My teams"
 
+msgid "dashboard.section.organizations"
+msgstr "Organizations"
+
 msgid "dashboard.go-to-admin-console"
 msgstr "Go to Admin Console"
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -392,6 +392,9 @@ msgstr "Crear org"
 msgid "dashboard.my-teams"
 msgstr "Mis equipos"
 
+msgid "dashboard.section.organizations"
+msgstr "Organizaciones"
+
 msgid "dashboard.go-to-admin-console"
 msgstr "Ir a la Admin Console"
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26253

### Summary
The label "Organizations" was missing before the list of organizations. Also, when "My Teams" was selected, "Your Penpot" was shown instead of "My Teams."

### Checklist

- [X] Choose the correct target branch; use `develop` by default.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
