### PR TITLE
:bug: Fix nitrate invitation empty state layout

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -816,16 +816,17 @@
                                                                      :origin :team
                                                                      :invite-email invite-email}))))]
     [:div {:class (stl/css :empty-invitations)}
-     [:span (tr "labels.no-invitations")]
+     [:div (tr "labels.no-invitations")]
      (if ^boolean can-invite
-       [[:span (tr "labels.no-invitations-gather-people")]
-        [:a
-         {:class (stl/css :btn-empty-invitations)
-          :on-click on-invite-member
-          :data-testid "invite-member"}
-         (tr "dashboard.invite-profile")]
+       [[:div (tr "labels.no-invitations-gather-people")]
+        [:div {:class (stl/css :empty-invitations-buttons)}
+         [:a
+          {:class (stl/css :btn-empty-invitations)
+           :on-click on-invite-member
+           :data-testid "invite-member"}
+          (tr "dashboard.invite-profile")]]
         [:div {:class (stl/css :blank-space)}]]
-       [:span (tr "dashboard.invitations.no-permission")])]))
+       [:div {:class (stl/css :no-permission-text)} (tr "dashboard.invitations.no-permission")])]))
 
 (mf/defc invitation-modal
   {::mf/register modal/components
@@ -1091,7 +1092,8 @@
      (when (and (not can-invite?)
                 (seq @invitations))
        [:div {:class (stl/css :empty-invitations)}
-        [:span (tr "dashboard.invitations.no-permission")]])
+        [:div {:class (stl/css :no-permission-text)}
+         (tr "dashboard.invitations.no-permission")]])
      (when (and can-invite?
                 (> (count @selected) 0))
        [:*

--- a/frontend/src/app/main/ui/dashboard/team.scss
+++ b/frontend/src/app/main/ui/dashboard/team.scss
@@ -430,16 +430,23 @@
 }
 
 .empty-invitations {
-  display: grid;
-  place-items: center;
-  align-content: center;
-  height: px2rem(156);
-  max-width: $sz-1000;
   width: 100%;
   margin-top: var(--sp-l);
   border: $b-1 solid var(--color-background-quaternary);
   border-radius: $br-8;
   color: var(--color-foreground-secondary);
+  padding: var(--sp-xxxl);
+  text-align: center;
+}
+
+.empty-invitations-buttons {
+  width: fit-content;
+  margin: auto;
+}
+
+.no-permission-text {
+  max-width: $sz-512;
+  margin: auto;
 }
 
 .btn-empty-invitations {

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -9608,5 +9608,5 @@ msgid "dashboard.no-permission-move-team.message"
 msgstr "You are not allowed to move teams that are part of %s organization. If you need more information, contact the organization's owner."
 
 msgid "dashboard.invitations.no-permission"
-msgstr "You do not have permission to invite people to join or to edit or delete invitations in this team."
+msgstr "You don’t have permission to invite people to join this team or to edit or delete invitations."
 

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -9283,5 +9283,5 @@ msgid "dashboard.no-permission-move-team.message"
 msgstr "No tienes permiso para mover equipos que son parte de la organización %s. Si necesitas más información, contacta con el propietario de la organización."
 
 msgid "dashboard.invitations.no-permission"
-msgstr "No tienes permiso para invitar a personas a unirse ni para editar o eliminar invitaciones en este equipo."
+msgstr "No tienes permiso para invitar a personas a unirse a este equipo, ni para editar o eliminar invitaciones."
 


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26438

### Summary

Cosmetic change, it improves the invitations empty state and no-permission message readability.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
