### PR TITLE
:bug: Fix nitrate remove-team permission flow

### DIFF
--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -215,7 +215,45 @@
       (->> (rp/cmd! ::remove-team-from-org {:team-id team-id :organization-id organization-id :organization-name organization-name})
            (rx/mapcat
             (fn [_]
-              (rx/of (modal/hide))))))))
+              (rx/of (modal/hide))))
+           (rx/catch
+            (fn [cause]
+              (let [code (-> cause ex-data :code)]
+                (if (= code :not-allowed)
+                  (rx/of (modal/show :no-permission-modal {:type :no-orgs-change}))
+                  (rx/throw cause)))))))))
+
+(defn show-remove-team-from-org-modal
+  "Fetches fresh team/org data, then shows the remove-from-org confirmation
+  modal or the no-permission modal if the move-team permission blocks it."
+  [{:keys [team-id]}]
+  (ptk/reify ::show-remove-team-from-org-modal
+    ptk/WatchEvent
+    (watch [_ state _]
+      (let [profile-id (dm/get-in state [:profile :id])]
+        (dt/with-refreshed-team team-id
+          (fn [team]
+            (let [source-org (:organization team)
+                  can-move?  (nitrate-perms/allowed?
+                              :move-team
+                              {:org-perms {:owner-id    (:owner-id source-org)
+                                           :permissions (:permissions source-org)}
+                               :profile-id profile-id
+                               :team-perms (:permissions team)
+                               :target-org-same-owner? false})]
+              (rx/of (if can-move?
+                       (modal/show
+                        {:type :confirm
+                         :title (tr "modals.remove-team-org.title")
+                         :message (tr "modals.remove-team-org.text" (:name team) (dm/get-in team [:organization :name]))
+                         :hint (tr "modals.remove-team-org.info")
+                         :hint-level :default
+                         :accept-label (tr "modals.remove-team-org.accept")
+                         :on-accept #(st/emit! (remove-team-from-org {:team-id team-id
+                                                                      :organization-id (dm/get-in team [:organization :id])
+                                                                      :organization-name (dm/get-in team [:organization :name])}))
+                         :accept-style :danger})
+                       (modal/show :no-permission-modal {:type :no-orgs-change}))))))))))
 
 
 (defn add-team-to-org

--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -215,7 +215,8 @@
       (->> (rp/cmd! ::remove-team-from-org {:team-id team-id :organization-id organization-id :organization-name organization-name})
            (rx/mapcat
             (fn [_]
-              (rx/of (modal/hide))))
+              (rx/of (dt/fetch-teams)
+                     (modal/hide))))
            (rx/catch
             (fn [cause]
               (let [code (-> cause ex-data :code)]
@@ -245,13 +246,13 @@
                        (modal/show
                         {:type :confirm
                          :title (tr "modals.remove-team-org.title")
-                         :message (tr "modals.remove-team-org.text" (:name team) (dm/get-in team [:organization :name]))
+                         :message (tr "modals.remove-team-org.text" (:name team) (:name source-org))
                          :hint (tr "modals.remove-team-org.info")
                          :hint-level :default
                          :accept-label (tr "modals.remove-team-org.accept")
                          :on-accept #(st/emit! (remove-team-from-org {:team-id team-id
-                                                                      :organization-id (dm/get-in team [:organization :id])
-                                                                      :organization-name (dm/get-in team [:organization :name])}))
+                                                                      :organization-id (:id source-org)
+                                                                      :organization-name (:name source-org)}))
                          :accept-style :danger})
                        (modal/show :no-permission-modal {:type :no-orgs-change}))))))))))
 

--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -67,7 +67,7 @@
       (->> (rp/cmd! :get-teams)
            (rx/map teams-fetched)))))
 
-(defn- with-refreshed-team
+(defn with-refreshed-team
   "Fetches fresh team data from the server to ensure up-to-date org
   permissions, updates the app state, and calls f with the fresh team data.
   Returns an observable of events."

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -1513,27 +1513,11 @@
         (fn [file]
           (st/emit! (dtm/update-team-photo file)))
 
-        remove-team-from-org-fn
-        (mf/use-fn
-         (mf/deps team)
-         (fn []
-           (st/emit! (dnt/remove-team-from-org {:team-id (:id team)
-                                                :organization-id (dm/get-in team [:organization :id])
-                                                :organization-name (dm/get-in team [:organization :name])}))))
-
         on-remove-team-from-org
         (mf/use-fn
          (mf/deps team)
          (fn []
-           (let [params {:type :confirm
-                         :title (tr "modals.remove-team-org.title")
-                         :message (tr "modals.remove-team-org.text" (:name team) (dm/get-in team [:organization :name]))
-                         :hint (tr "modals.remove-team-org.info")
-                         :hint-level :default
-                         :accept-label (tr "modals.remove-team-org.accept")
-                         :on-accept remove-team-from-org-fn
-                         :accept-style :danger}]
-             (st/emit! (modal/show params)))))
+           (st/emit! (dnt/show-remove-team-from-org-modal {:team-id (:id team)}))))
 
         on-add-team-to-org
         (mf/use-fn


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26433

### Summary

Fixed the remove-team permission flow so users without move permission now get the no-permission modal instead of falling into an internal error path.

### Steps to reproduce 

Team member tries to move the team to the ghost organization (both "Never allowed" and "Only within my own organizations" configurations)

- Set “Never allowed”
   1. As User 3 open the team's Settings and click Remove team from organization (which would move it to the ghost org).
   2. → Verify a modal appears with the message: "You are not allowed to move teams that are part of [organization-name] organization. If you need more information, contact the owner."

- Set “Only within my own organizations”
   1. Repeat steps 1 to 3 with both restricted settings active and verify the result is the same.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
