### PR TITLE
:sparkles: Match version preview banner to History sidebar labels

### DIFF
--- a/frontend/src/app/main/data/workspace/versions.cljs
+++ b/frontend/src/app/main/data/workspace/versions.cljs
@@ -222,6 +222,15 @@
 ;; PREVIEW VERSION EVENTS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn- preview-label
+  "Return the same identifying text the History sidebar uses for a version.
+  User-created (pinned) versions use their custom label; system autosaves use
+  a localized date and time (see `snapshot-entry*` / `date*` in the sidebar)."
+  [{:keys [created-by label created-at]}]
+  (if (= "system" created-by)
+    (ct/format-inst created-at :localized-date-time)
+    (when (seq label) label)))
+
 (defn- apply-snapshot
   "Swap the file data in app state with the provided snapshot-file
   response. Used by the version preview feature to show historical
@@ -274,7 +283,7 @@
             features (features/get-enabled-features state team-id)
             snapshot (->> (dm/get-in state [:workspace-versions :data])
                           (d/seek #(= id (:id %))))
-            label    (or (:label snapshot)
+            label    (or (preview-label snapshot)
                          (tr "workspace.versions.preview.unnamed"))
             output-s (rx/subject)]
         (rx/merge


### PR DESCRIPTION
The preview banner in enter-preview used (:label snapshot) directly, which shows internal ids such as internal/snapshot/20 for system autosaves. The History sidebar instead shows a localized date and time for those entries and the custom name for user-created versions.

Add preview-label to resolve the banner text the same way: system snapshots use localized-date-time from created-at; user snapshots keep their custom label with the existing unnamed fallback.

Closes #9503

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
