### PR TITLE
:whale: Start penpot-frontend always after penpot-mcp

### DIFF
--- a/docker/images/docker-compose.yaml
+++ b/docker/images/docker-compose.yaml
@@ -89,6 +89,7 @@ services:
     depends_on:
       - penpot-backend
       - penpot-exporter
+      - penpot-mcp
 
     networks:
       - penpot


### PR DESCRIPTION
<div align="center">

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMGJvZTE2dnh4cjY5MncwYno3Y213M2Jwd3l6ZDFnNGY4Z2g1cjhnNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gkiTqEBYtTvvyQXhni/giphy.gif)

</div>

As mentioned here (https://github.com/penpot/penpot/issues/8897#issuecomment-4467374123) nginx (penpot-frontend) may throw errors if it is started before penpot-mcp when applying the proxy-pass.

With this change, we make sure that the frontend is initialized once the MCP is up and running.