### PR TITLE
:bug: Fix keep copy untranslated to preserve token name validation

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
@@ -683,7 +683,11 @@
                                            token-id)]
             (let [tokens (vals (ctob/get-tokens tokens-lib (ctob/get-id token-set)))
                   unames (map :name tokens)     ;; TODO: add function duplicate-token in tokens-lib
-                  suffix (tr "workspace.tokens.duplicate-suffix")
+                  ;; "copy" is intentionally not translated here. Token names are validated
+                  ;; against a restricted set of allowed characters (currently English-compatible),
+                  ;; so translating this suffix could introduce invalid characters and break
+                  ;; token name validation.
+                  suffix "copy"
                   copy-name (cfh/generate-unique-name (:name token) unames :suffix suffix)
                   new-token (-> token
                                 (ctob/reid (uuid/next))


### PR DESCRIPTION
### Related Ticket
This PR closes https://github.com/penpot/penpot/issues/9875
https://tree.taiga.io/project/penpot/issue/14112
### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
