### PR TITLE
:whale: Remove the configuration of the mcp from Nginx if it is not enabled

### DIFF
--- a/docker/images/Dockerfile.frontend
+++ b/docker/images/Dockerfile.frontend
@@ -17,8 +17,9 @@ ARG BUNDLE_PATH="./bundle-frontend/"
 COPY $BUNDLE_PATH /var/www/app/
 COPY ./files/config.js /var/www/app/js/config.js
 COPY ./files/nginx.conf.template /tmp/nginx.conf.template
-COPY ./files/nginx-security-headers.conf /etc/nginx/nginx-security-headers.conf
 COPY ./files/nginx-resolvers.conf.template /tmp/resolvers.conf.template
+COPY ./files/nginx-mcp-locations.conf.template /tmp/nginx-mcp-locations.conf.template
+COPY ./files/nginx-security-headers.conf /etc/nginx/nginx-security-headers.conf
 COPY ./files/nginx-mime.types /etc/nginx/mime.types
 COPY ./files/nginx-external-locations.conf /etc/nginx/overrides/location.d/external-locations.conf
 COPY ./files/nginx-entrypoint.sh /entrypoint.sh

--- a/docker/images/files/nginx-entrypoint.sh
+++ b/docker/images/files/nginx-entrypoint.sh
@@ -34,15 +34,23 @@ update_flags /var/www/app/js/config.js
 export PENPOT_BACKEND_URI=${PENPOT_BACKEND_URI:-http://penpot-backend:6060}
 export PENPOT_EXPORTER_URI=${PENPOT_EXPORTER_URI:-http://penpot-exporter:6061}
 export PENPOT_NITRATE_URI=${PENPOT_NITRATE_URI:-http://penpot-nitrate:3000}
-export PENPOT_MCP_URI=${PENPOT_MCP_URI:-http://penpot-mcp:4401}
-export PENPOT_MCP_URI_WS=${PENPOT_MCP_URI_WS:-http://penpot-mcp:4402}
 export PENPOT_HTTP_SERVER_MAX_BODY_SIZE=${PENPOT_HTTP_SERVER_MAX_BODY_SIZE:-367001600} # Default to 350MiB
 export PENPOT_IPV6_LISTEN_DIRECTIVE=${PENPOT_IPV6_LISTEN_DIRECTIVE:-"listen [::]:8080 default_server;"}
 if [ "${PENPOT_DISABLE_IPV6_LISTEN}" = "true" ]; then
   export PENPOT_IPV6_LISTEN_DIRECTIVE=""
 fi
-envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI,\$PENPOT_NITRATE_URI,\$PENPOT_MCP_URI,\$PENPOT_MCP_URI_WS,\$PENPOT_HTTP_SERVER_MAX_BODY_SIZE,\$PENPOT_IPV6_LISTEN_DIRECTIVE" \
-         < /tmp/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst "\$PENPOT_BACKEND_URI,\$PENPOT_EXPORTER_URI,\$PENPOT_NITRATE_URI,\$PENPOT_HTTP_SERVER_MAX_BODY_SIZE,\$PENPOT_IPV6_LISTEN_DIRECTIVE" \
+        < /tmp/nginx.conf.template > /etc/nginx/nginx.conf
+
+if [[ $PENPOT_FLAGS == *"enable-mcp"* ]]; then
+    export PENPOT_MCP_URI=${PENPOT_MCP_URI:-http://penpot-mcp:4401}
+    export PENPOT_MCP_URI_WS=${PENPOT_MCP_URI_WS:-http://penpot-mcp:4402}
+
+    envsubst "\$PENPOT_MCP_URI,\$PENPOT_MCP_URI_WS" \
+             < /tmp/nginx-mcp-locations.conf.template > /etc/nginx/overrides/server.d/mcp-locations.conf
+else
+    rm -f /etc/nginx/overrides/server.d/mcp-locations.conf
+fi
 
 PENPOT_DEFAULT_INTERNAL_RESOLVER="$(awk 'BEGIN{ORS=" "} $1=="nameserver" { sub(/%.*$/,"",$2); print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf)"
 export PENPOT_INTERNAL_RESOLVER=${PENPOT_INTERNAL_RESOLVER:-$PENPOT_DEFAULT_INTERNAL_RESOLVER}

--- a/docker/images/files/nginx-mcp-locations.conf.template
+++ b/docker/images/files/nginx-mcp-locations.conf.template
@@ -1,0 +1,16 @@
+location /mcp/ws {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_pass $PENPOT_MCP_URI_WS;
+    proxy_http_version 1.1;
+}
+
+location /mcp/stream {
+    proxy_pass $PENPOT_MCP_URI/mcp;
+    proxy_http_version 1.1;
+}
+
+location /mcp/sse {
+    proxy_pass $PENPOT_MCP_URI/sse;
+    proxy_http_version 1.1;
+}

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -139,23 +139,6 @@ http {
             proxy_http_version 1.1;
         }
 
-        location /mcp/ws {
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_pass $PENPOT_MCP_URI_WS;
-            proxy_http_version 1.1;
-        }
-
-        location /mcp/stream {
-            proxy_pass $PENPOT_MCP_URI/mcp;
-            proxy_http_version 1.1;
-        }
-
-        location /mcp/sse {
-            proxy_pass $PENPOT_MCP_URI/sse;
-            proxy_http_version 1.1;
-        }
-
         location /readyz {
             access_log off;
             proxy_pass $PENPOT_BACKEND_URI$request_uri;


### PR DESCRIPTION
<div align="center">

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmNjbzZwY3k3Y25lMDB3aDN1a2pyNGFmOXZtM3dqcTkwYTNydWJ1YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o85xKakYquwbYc5wI/giphy.gif)

</div>

These changes are intended to prevent the penpot-frontend Nginx instance from loading the MCP configuration if the `enable-mcp` flag is not set. To do this, move the locations to a file that will be deleted at the entry point if the MCP is not enabled. 

## How to test: 

You need to build docker image for penpot-frontend first

1. With `enable-mcp`: start penpot with the default behavior and verify that:
    - the MCP is working 
    - the Nginx configuration includes the file containing the MCP locations
      ```bash
      docker compose exec penpot-frontend cat /etc/nginx/overrides/server.d/mcp-locations.conf
      ```
2. Without `enable-mcp`: Remove `enable-mcp` in the docker compose file, also remove the penpot-mcp service (and the depends-on for penpot-frontend) and verify that:
    - the Nginx configuration does not contain the file with the MCP locations.