### PR TITLE
:bug: Fix default team showing up in count

### DIFF
--- a/backend/src/app/rpc/commands/nitrate.clj
+++ b/backend/src/app/rpc/commands/nitrate.clj
@@ -147,10 +147,9 @@
 
 (defn get-leave-org-summary
   [cfg default-team-id teams-to-delete teams-to-transfer-count teams-to-exit-count]
-  (let [{:keys [deletable-team-ids delete-default-team? detach-from-org-team-ids]}
+  (let [{:keys [deletable-team-ids detach-from-org-team-ids]}
         (build-leave-org-plan cfg default-team-id teams-to-delete nil)]
-    {:teams-to-delete   (+ (count deletable-team-ids)
-                           (if delete-default-team? 1 0))
+    {:teams-to-delete   (count deletable-team-ids)
      :teams-to-transfer teams-to-transfer-count
      :teams-to-exit     teams-to-exit-count
      :teams-to-detach   (count detach-from-org-team-ids)}))

--- a/backend/test/backend_tests/rpc_management_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_management_nitrate_test.clj
@@ -1025,7 +1025,7 @@
                         :organization-id          organization-id
                         :default-team-id (:id org-team)}))]
     (t/is (th/success? out))
-    (t/is (= {:teams-to-delete   1
+    (t/is (= {:teams-to-delete   0
               :teams-to-transfer 0
               :teams-to-exit     0
               :teams-to-detach   0}
@@ -1052,7 +1052,7 @@
                         :organization-id          organization-id
                         :default-team-id (:id org-team)}))]
     (t/is (th/success? out))
-    (t/is (= {:teams-to-delete   2
+    (t/is (= {:teams-to-delete   1
               :teams-to-transfer 0
               :teams-to-exit     0
               :teams-to-detach   0}
@@ -1083,7 +1083,7 @@
                         :organization-id          organization-id
                         :default-team-id (:id org-team)}))]
     (t/is (th/success? out))
-    (t/is (= {:teams-to-delete   1
+    (t/is (= {:teams-to-delete   0
               :teams-to-transfer 1
               :teams-to-exit     0
               :teams-to-detach   0}
@@ -1113,7 +1113,7 @@
                         :organization-id          organization-id
                         :default-team-id (:id org-team)}))]
     (t/is (th/success? out))
-    (t/is (= {:teams-to-delete   1
+    (t/is (= {:teams-to-delete   0
               :teams-to-transfer 0
               :teams-to-exit     1
               :teams-to-detach   0}

--- a/backend/test/backend_tests/rpc_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_nitrate_test.clj
@@ -307,7 +307,7 @@
                               :id organization-id
                               :default-team-id your-penpot-id})]
         (t/is (th/success? out))
-        (t/is (= {:teams-to-delete 1
+        (t/is (= {:teams-to-delete 0
                   :teams-to-transfer 0
                   :teams-to-exit 0
                   :teams-to-detach 0}


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26451

### Summary

Default team shouldn't show up in the count that appears when the organization owner is trying to remove a member from the organization.

### Steps to reproduce 

1. Invite an user to an organization.
2. Create a few teams inside the organization with said user.
3. As the organization owner, try to remove the user from the organization.
4. Correct number of teams should appear.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
