### PR TITLE
:sparkles: Use shared org-avatar component in delete account modal

### DIFF
--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -281,18 +281,25 @@
    [:name ::sm/text]
    [:slug ::sm/text]
    [:team-count ::sm/int]
-   [:member-count ::sm/int]])
+   [:member-count ::sm/int]
+   [:avatar-bg-url {:optional true} [:maybe ::sm/uri]]
+   [:logo-id {:optional true} [:maybe ::sm/uuid]]])
 
 (defn- get-owned-orgs-summary-api
   [cfg {:keys [profile-id] :as params}]
-  (let [baseuri (cf/get :nitrate-backend-uri)]
-    (request-to-nitrate cfg :get
-                        (str baseuri
-                             "/api/users/"
-                             profile-id
-                             "/owned-organizations-summary")
-                        [:vector schema:org-summary-counts]
-                        params)))
+  (let [baseuri (cf/get :nitrate-backend-uri)
+        orgs    (request-to-nitrate cfg :get
+                                    (str baseuri
+                                         "/api/users/"
+                                         profile-id
+                                         "/owned-organizations-summary")
+                                    [:vector schema:org-summary-counts]
+                                    params)]
+    (mapv (fn [org]
+            (if-let [logo-id (:logo-id org)]
+              (assoc org :custom-photo (str (cf/get :public-uri) "/assets/by-id/" logo-id))
+              org))
+          orgs)))
 
 (defn- delete-owned-orgs-api
   [cfg {:keys [profile-id] :as params}]

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -537,7 +537,10 @@
    [:name ::sm/text]
    [:slug ::sm/text]
    [:team-count ::sm/int]
-   [:member-count ::sm/int]])
+   [:member-count ::sm/int]
+   [:avatar-bg-url {:optional true} [:maybe ::sm/uri]]
+   [:logo-id {:optional true} [:maybe ::sm/uuid]]
+   [:custom-photo {:optional true} [:maybe ::sm/text]]])
 
 (def ^:private schema:get-owned-organizations-summary-result
   [:vector schema:owned-organization-summary])

--- a/frontend/src/app/main/ui/settings/delete_account.cljs
+++ b/frontend/src/app/main/ui/settings/delete_account.cljs
@@ -13,6 +13,7 @@
    [app.main.data.profile :as du]
    [app.main.repo :as rp]
    [app.main.store :as st]
+   [app.main.ui.components.org-avatar :refer [org-avatar*]]
    [app.main.ui.ds.foundations.assets.icon :as i :refer [icon*]]
    [app.main.ui.icons :as deprecated-icon]
    [app.main.ui.notifications.context-notification :refer [context-notification]]
@@ -85,10 +86,9 @@
                                            :expanded expanded?)}]]
           (when expanded?
             [:ul {:class (stl/css :org-list)}
-             (for [{:keys [id name team-count member-count]} orgs]
+             (for [{:keys [id name team-count member-count] :as org} orgs]
                [:li {:class (stl/css :org-item) :key id}
-                [:div {:class (stl/css :org-avatar)}
-                 (when (seq name) (subs name 0 1))]
+                [:> org-avatar* {:org org :size "xxl"}]
                 [:div {:class (stl/css :org-info)}
                  [:span {:class (stl/css :org-name)} name]
                  [:div {:class (stl/css :org-counts)}

--- a/frontend/src/app/main/ui/settings/delete_account.scss
+++ b/frontend/src/app/main/ui/settings/delete_account.scss
@@ -100,20 +100,6 @@
   gap: var(--sp-s);
 }
 
-.org-avatar {
-  width: $sz-32;
-  height: $sz-32;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background-color: var(--modal-section-background-color);
-  color: var(--modal-title-foreground-color);
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
 .org-info {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Render owned organizations in the delete-account modal with the same org-avatar* component used across the dashboard, so logo and avatar background are shown consistently and initials are extracted via d/get-initials instead of a raw first-character substring.

Extends the get-owned-organizations-summary endpoint and the underlying nitrate API schema to carry :avatar-bg-url and :logo-id, deriving :custom-photo from logo-id with the public uri, matching the pattern already used by set-team-org-api.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
