### PR TITLE
:bug: Fix shift enter not working on text editor v2

### DIFF
--- a/frontend/text-editor/src/editor/TextEditor.js
+++ b/frontend/text-editor/src/editor/TextEditor.js
@@ -447,15 +447,20 @@ export class TextEditor extends EventTarget {
     if ((e.ctrlKey || e.metaKey) && e.key === "a") {
       e.preventDefault();
       this.selectAll();
-      return;
-    }
-
-    if ((e.ctrlKey || e.metaKey) && e.key === "Backspace") {
+    } else if ((e.ctrlKey || e.metaKey) && e.key === "Backspace") {
       e.preventDefault();
       if (this.#selectionController.isCollapsed) {
         this.#selectionController.removeWordBackward();
       } else {
         this.#selectionController.removeSelected();
+      }
+      this.#notifyLayout(LayoutType.FULL);
+    } else if (e.shiftKey && e.key === "Enter") {
+      e.preventDefault();
+      if (this.#selectionController.isCollapsed) {
+        this.#selectionController.insertParagraph();
+      } else {
+        this.#selectionController.replaceWithParagraph();
       }
       this.#notifyLayout(LayoutType.FULL);
     }


### PR DESCRIPTION
### Related Ticket

[Taiga Issue #14260](https://tree.taiga.io/project/penpot/issue/14260)
https://github.com/penpot/penpot/issues/9901

### Summary

While editing text, pressing Shift + enter should insert a line break, same as enter does.   
This is the same behavior as in PRO.

### Steps to reproduce 

1. Create a text
2. Edit the text and press Shift + Enter

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
