### PR TITLE
:bug: Fix nitrate's plan button size

### DIFF
--- a/frontend/src/app/main/ui/dashboard/subscription.scss
+++ b/frontend/src/app/main/ui/dashboard/subscription.scss
@@ -250,6 +250,8 @@
 
 .nitrate-bottom-button {
   width: fit-content;
+  height: fit-content;
+  padding: var(--sp-s) var(--sp-m);
 }
 
 .nitrate-current-plan {


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26457

### Summary

Fix button size when text is more than one line.

### Steps to reproduce 

1. Have no active license.
2. Check the sidebar's banner's button in spanish.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
