### PR TITLE
:bug: Fix drag shapes out of frames

### DIFF
--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -3061,15 +3061,31 @@ impl RenderState {
         let moved_bounds = if self.options.is_interactive_transform() && !modifier_ids.is_empty() {
             let mut acc: Option<Rect> = None;
             for id in modifier_ids.iter() {
-                let Some(s) = tree.get(id) else { continue };
-                let r = self.get_cached_extrect(s, tree, 1.0);
-                acc = Some(match acc {
-                    None => r,
-                    Some(mut prev) => {
-                        prev.join(r);
-                        prev
-                    }
-                });
+                // Current (post-modifier) bounds
+                if let Some(s) = tree.get(id) {
+                    let r = self.get_cached_extrect(s, tree, 1.0);
+                    acc = Some(match acc {
+                        None => r,
+                        Some(mut prev) => {
+                            prev.join(r);
+                            prev
+                        }
+                    });
+                }
+
+                // Pre-modifier bounds: important so cached top-level crops that still contain the
+                // shape at its original position are considered "unsafe" even after the shape
+                // has moved away (e.g. dragging a child out of a clipped frame).
+                if let Some(raw) = tree.get_raw(id) {
+                    let r0 = self.get_cached_extrect(raw, tree, 1.0);
+                    acc = Some(match acc {
+                        None => r0,
+                        Some(mut prev) => {
+                            prev.join(r0);
+                            prev
+                        }
+                    });
+                }
             }
             acc
         } else {


### PR DESCRIPTION
### Summary

Bug: During interactive drag, the “unsafe crop” check only used post-modifier bounds. After moving a shape out of a frame, cached top-level crops at its original position were still treated as safe, leaving stale pixels. The fix unions pre-modifier (get_raw) extrects into that check.

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.
- [ ] Update the `CHANGES.md` file, referencing the related GitHub issue, if applicable.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
