### PR TITLE
:bug: Raise validation error for incompatible binfile export options

### DIFF
--- a/backend/src/app/binfile/v1.clj
+++ b/backend/src/app/binfile/v1.clj
@@ -305,8 +305,9 @@
 (defn write-export!
   [{:keys [::bfc/include-libraries ::bfc/embed-assets] :as cfg}]
   (when (and include-libraries embed-assets)
-    (throw (IllegalArgumentException.
-            "the `include-libraries` and `embed-assets` are mutally excluding options")))
+    (ex/raise :type :validation
+              :code :incompatible-options
+              :hint "the `include-libraries` and `embed-assets` are mutually exclusive options"))
 
   (write-export cfg))
 

--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -221,8 +221,9 @@
   [{:keys [::bfc/embed-assets ::bfc/include-libraries] :as cfg} file-id]
 
   (when (and include-libraries embed-assets)
-    (throw (IllegalArgumentException.
-            "the `include-libraries` and `embed-assets` are mutally excluding options")))
+    (ex/raise :type :validation
+              :code :incompatible-options
+              :hint "the `include-libraries` and `embed-assets` are mutually exclusive options"))
 
   (let [detach? (and (not embed-assets) (not include-libraries))]
     (db/tx-run! cfg (fn [cfg]

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -207,6 +207,27 @@
       (t/is (= (count result) 1))
       (t/is (every? uuid? result)))))
 
+(t/deftest export-binfile-v3-rejects-incompatible-options
+  ;; Regression for #7649: requesting both `include-libraries` and
+  ;; `embed-assets` must fail with a proper `:validation` error (clear code)
+  ;; rather than a generic `:server-error`/`:unexpected` that surfaced to API
+  ;; clients as an opaque failure.
+  (let [profile (th/create-profile* 1)
+        file    (prepare-simple-file profile)
+        output  (tmp/tempfile :suffix ".zip")
+        cause   (try
+                  (v3/export-files!
+                   (-> th/*system*
+                       (assoc ::bfc/ids #{(:id file)})
+                       (assoc ::bfc/embed-assets true)
+                       (assoc ::bfc/include-libraries true))
+                   (io/output-stream output))
+                  nil
+                  (catch Throwable e e))]
+    (t/is (some? cause))
+    (t/is (= :validation (-> cause ex-data :type)))
+    (t/is (= :incompatible-options (-> cause ex-data :code)))))
+
 (t/deftest read-obj-rejects-oversized-buffer
   ;; N1-07: read-obj! must reject objects exceeding max-object-size
   ;; before attempting to allocate the buffer


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

### Related Ticket

Fixes [#7649](https://github.com/penpot/penpot/issues/7649).

### Summary

`export-binfile` (the `::export-binfile` RPC) calls into the v1/v3 binfile writers, which guard against requesting both `include-libraries` *and* `embed-assets`. That guard threw a raw `IllegalArgumentException`, so the RPC layer reported it to clients as a generic `:server-error` / `:unexpected` (HTTP 500) — the opaque failure described in #7649 (perceived as an empty/failed export when both flags were sent).

Those two options are mutually exclusive by design, i.e. it's invalid input, not a server fault. This PR:
- replaces the raw `throw (IllegalArgumentException. …)` in `backend/src/app/binfile/v3.clj` and `backend/src/app/binfile/v1.clj` with `ex/raise :type :validation :code :incompatible-options`, matching how the rest of the binfile code reports bad input;
- fixes the "mutally" → "mutually" typo in the message;
- adds a regression test.

### Steps to reproduce / verify

Reproduced and verified end-to-end on a local devenv:

```
# both options -> before: {:type :server-error :code :unexpected} (HTTP 500)
#                 after:  {:type :validation    :code :incompatible-options}
POST /api/rpc/command/export-binfile
  {"file-id": "<id>", "include-libraries": true, "embed-assets": true}

# valid single-option exports are unaffected (still produce the file):
  {"file-id": "<id>", "include-libraries": false, "embed-assets": true}  -> ok
```

Note: the original "empty zip" symptom no longer occurs for valid parameter combinations on `develop`; the remaining defect was purely the error classification for the mutually-exclusive case.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix.
- [x] Add or modify existing integration tests in case of bugs or new features.

### Notes

- Regression test `export-binfile-v3-rejects-incompatible-options` added to `backend/test/backend_tests/binfile_test.clj`; run locally via kaocha against the test DB — `1 tests, 5 assertions, 0 failures`.
- `clj-kondo` (0 errors) and `cljfmt` clean on the changed files.
- Per `CONTRIBUTING.md`, the changelog is generated at release time, so this PR does not modify `CHANGES.md`.
