### PR TITLE
:bug: Fix crash on composition update when pressing Esc on a IME

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -81,8 +81,10 @@
            (when-not composing?
              (reset! composing? true))
 
+           ;; IME cancel (e.g. Escape on Linux ibus-mozc) fires compositionupdate
+           ;; with an empty string; that must reach WASM to clear the preview text.
            (let [data (.-data event)]
-             (when data
+             (when (some? data)
                (text-editor/text-editor-composition-update data)
                (sync-wasm-text-editor-content!)
                (wasm.api/request-render "text-composition"))
@@ -93,13 +95,12 @@
         (mf/use-fn
          (fn [^js event]
            (reset! composing? false)
-           (let [data (.-data event)]
-             (when data
-               (text-editor/text-editor-composition-end data)
-               (sync-wasm-text-editor-content!)
-               (wasm.api/request-render "text-composition"))
-             (when-let [node (mf/ref-val contenteditable-ref)]
-               (set! (.-textContent node) "")))))
+           (let [data (or (.-data event) "")]
+             (text-editor/text-editor-composition-end data)
+             (sync-wasm-text-editor-content!)
+             (wasm.api/request-render "text-composition"))
+           (when-let [node (mf/ref-val contenteditable-ref)]
+             (set! (.-textContent node) ""))))
 
         on-paste
         (mf/use-fn

--- a/render-wasm/src/wasm/text_editor.rs
+++ b/render-wasm/src/wasm/text_editor.rs
@@ -324,7 +324,7 @@ pub extern "C" fn text_editor_composition_start() -> Result<()> {
 #[no_mangle]
 #[wasm_error]
 pub extern "C" fn text_editor_composition_end() -> Result<()> {
-    let bytes = crate::mem::bytes();
+    let bytes = crate::mem::bytes_or_empty();
     let text = match String::from_utf8(bytes) {
         Ok(text) => text,
         Err(_) => return Ok(()),
@@ -380,7 +380,7 @@ pub extern "C" fn text_editor_composition_end() -> Result<()> {
 #[no_mangle]
 #[wasm_error]
 pub extern "C" fn text_editor_composition_update() -> Result<()> {
-    let bytes = crate::mem::bytes();
+    let bytes = crate::mem::bytes_or_empty();
     let text = match String::from_utf8(bytes) {
         Ok(text) => text,
         Err(_) => return Ok(()),


### PR DESCRIPTION
### Related Ticket

Fixes #10469 

### Summary

This fixes an error triggered by `compositionupdate` event after the IME returns an empty string (for instance, when canceling input by pressing Esc).

### Steps to reproduce 

_These steps work on Linux + mozc IME_.

1. Ensure the v3 editor is enabled.
2. Switch to Japanese input (mozc) at OS level.
3. Create a text shape and type some text in Japanese.
4. Press Esc to cancel an input in the IME.

Actual results (before this fix): an error is logged into the console (see #10469) and a toast is shown.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
