### PR TITLE
:bug: Prevent caching of env-generated config.js in self-hosted Docker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 
 ### :bug: Bugs fixed
 
+- Fix self-hosted Docker serving stale `/js/config.js` for up to 7 days after a `PENPOT_FLAGS`-only change and restart, by exempting it from the generic static-asset `Cache-Control: public, max-age=604800` rule in `nginx.conf.template` [Github #10556](https://github.com/penpot/penpot/issues/10556)
 - Fix LDAP provider params schema typo (`bind-passwor` → `bind-password`) introduced during the `clojure.spec` → `malli` migration; the schema slot now matches the runtime key actually read by `prepare-params` (`:password (:bind-password cfg)`) and `try-connectivity` (`(:bind-password cfg)`), so a wrong type for the password no longer slips through unvalidated
 - Fix `login-with-ldap` silently dropping its error message on the `ldap-not-initialized` restriction (typo `:hide` → `:hint`); the message `"ldap auth provider is not initialized"` now actually surfaces in logs and error responses instead of being discarded into an unread key
 - Fix `get-view-only-bundle` crashing when a share-link viewer encounters a team member whose email lacks `@` (NullPointerException in `obfuscate-email`) or whose domain has no `.` (previously produced a dangling-dot `****@****.`); now the viewer-side obfuscation is nil-safe and omits the trailing dot when the domain has no TLD

--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -163,6 +163,11 @@ http {
         location / {
             include /etc/nginx/overrides/location.d/*.conf;
 
+            location = /js/config.js {
+                include /etc/nginx/nginx-security-headers.conf;
+                add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+            }
+
             location ~* \.(js|css|jpg|png|svg|gif|ttf|woff|woff2|wasm|map)$ {
                 include /etc/nginx/nginx-security-headers.conf;
                 add_header Cache-Control "public, max-age=604800" always; # 7 days


### PR DESCRIPTION
Closes #10556

### Problem
On self-hosted Docker, `/js/config.js` is generated from `PENPOT_FLAGS` at container start (`docker/images/files/nginx-entrypoint.sh` → `update_flags /var/www/app/js/config.js`) but is served with `Cache-Control: public, max-age=604800` (7 days) by the generic `.js` rule in `docker/images/files/nginx.conf.template`. Its URL is versioned only by the build (`config.js?version=<APP_BUILD>`), so a flags-only change (edit `PENPOT_FLAGS`, restart) does not change the URL and already-cached browsers keep the pre-change `config.js` for up to 7 days. The flag change is invisible until cache expiry or a manual cache clear — e.g. enabling `enable-login-with-google` does not show the Google button for returning users, since `frontend/src/app/main/ui/auth/login.cljs` gates the SSO buttons on `cf/flags`, which is populated from the cached `config.js`.

config.js is the one shipped asset whose content changes independently of the build (it is copied plain in `docker/images/Dockerfile.frontend`, not content-hashed), so it should not be cached like the content-hashed bundles.

### Change
Add an exact-match `location = /js/config.js` in `docker/images/files/nginx.conf.template` (before the generic `.js|.css|...` rule) that sends `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`, keeping the security-headers include. One file changed, plus a one-line `CHANGES.md` note.

### Verification
Verified the behavior on a running 2.16.2 self-hosted frontend by applying an equivalent exact-match `location = /js/config.js` no-cache override: `nginx -t` passed, and `curl -I /js/config.js` flipped from `public, max-age=604800` to `no-store, no-cache, must-revalidate, max-age=0`, while other `.js` bundles kept `max-age=604800`. After that, a `PENPOT_FLAGS` change was reflected on a normal reload without clearing browser cache.

### Test plan for maintainers
1. Build the frontend image from this branch.
2. `curl -I /js/config.js` → expect `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`.
3. `curl -I /js/<any-bundle>.js` → still `public, max-age=604800`.
4. Change a `PENPOT_FLAGS` value, restart, reload without clearing cache → change is reflected.