### PR TITLE
:sparkles: Persist hide resolved comments preference

### DIFF
--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -19,6 +19,7 @@
    [app.main.data.team :as dtm]
    [app.main.repo :as rp]
    [app.util.i18n :as i18n :refer [tr]]
+   [app.util.storage :as storage]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
 
@@ -531,6 +532,35 @@
     (update [_ state]
       (update state :comments-local dissoc :expanded))))
 
+(def ^:private hide-resolved-comments-storage-key
+  :app.main.data.comments/hide-resolved-comments?)
+
+(defn- load-hide-resolved-comments?
+  []
+  (= true (get @storage/user hide-resolved-comments-storage-key)))
+
+(defn- persist-hide-resolved-comments!
+  [hide?]
+  (swap! storage/user assoc hide-resolved-comments-storage-key hide?))
+
+(defn merge-persisted-filters
+  "Merge persisted hide-resolved preference into comments local state."
+  [local]
+  (let [local (or local {})]
+    (if (contains? local :show)
+      local
+      (assoc local :show (if (load-hide-resolved-comments?)
+                           :pending
+                           :all)))))
+
+(defn initialize-comments-filters
+  "Load persisted comment filter preferences into `:comments-local`."
+  []
+  (ptk/reify ::initialize-comments-filters
+    ptk/UpdateEvent
+    (update [_ state]
+      (update state :comments-local merge-persisted-filters))))
+
 (defn update-filters
   [{:keys [mode show list] :as params}]
   (ptk/reify ::update-filters
@@ -546,7 +576,12 @@
                   (assoc :show show)
 
                   (some? list)
-                  (assoc :list list)))))))
+                  (assoc :list list)))))
+
+    ptk/EffectEvent
+    (effect [_ _ _]
+      (when (some? show)
+        (persist-hide-resolved-comments! (= :pending show))))))
 
 (defn update-options
   [params]

--- a/frontend/src/app/main/data/viewer.cljs
+++ b/frontend/src/app/main/data/viewer.cljs
@@ -77,7 +77,8 @@
                     (if (nil? lstate)
                       default-local-state
                       lstate)))
-          (assoc-in [:viewer-local :share-id] share-id)))
+          (assoc-in [:viewer-local :share-id] share-id)
+          (update :comments-local dcmt/merge-persisted-filters)))
 
     ptk/WatchEvent
     (watch [_ state _]

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -345,7 +345,8 @@
           (assoc :recent-colors (:recent-colors storage/user))
           (assoc :recent-fonts (:recent-fonts storage/user))
           (assoc :current-file-id file-id)
-          (assoc :workspace-presence {})))
+          (assoc :workspace-presence {})
+          (update :comments-local dcmt/merge-persisted-filters)))
 
     ptk/WatchEvent
     (watch [_ state stream]

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -402,7 +402,8 @@
           (assoc :recent-fonts (:recent-fonts storage/user))
           (assoc :current-file-id file-id)
           (assoc :workspace-presence {})
-          (update :workspace-global dissoc :default-font)))
+          (update :workspace-global dissoc :default-font)
+          (update :comments-local dcmt/merge-persisted-filters)))
 
     ptk/WatchEvent
     (watch [_ state stream]

--- a/frontend/src/app/main/ui/viewer/comments.cljs
+++ b/frontend/src/app/main/ui/viewer/comments.cljs
@@ -95,6 +95,16 @@
           [:span {:class (stl/css :icon)}
            deprecated-icon/tick])]
 
+       [:li {:class (stl/css-case
+                     :dropdown-element true
+                     :selected (= :mentions cmode))
+             :data-value "mentions"
+             :on-click update-mode}
+        [:span {:class (stl/css :label)} (tr "labels.show-mentions")]
+        (when (= :mentions cmode)
+          [:span {:class (stl/css :icon)}
+           deprecated-icon/tick])]
+
        [:li {:class (stl/css :separator)}]
 
        [:li {:class (stl/css-case

--- a/frontend/src/app/main/ui/viewer/comments.scss
+++ b/frontend/src/app/main/ui/viewer/comments.scss
@@ -4,6 +4,7 @@
 //
 // Copyright (c) KALEIDOS INC Sucursal en España SL
 
+@use "ds/_borders.scss" as *;
 @use "refactor/common-refactor.scss" as deprecated;
 
 // COMMENT DROPDOWN ON HEADER
@@ -92,7 +93,12 @@
 }
 
 .separator {
-  height: deprecated.$s-8;
+  position: relative;
+  block-size: var(--sp-xs);
+  inline-size: calc(100% + var(--sp-s));
+  border-top: $b-1 solid var(--color-background-quaternary);
+  left: calc(-1 * var(--sp-xs));
+  margin-top: var(--sp-s);
 }
 
 // FLOATING COMMENT

--- a/frontend/src/app/main/ui/viewer/comments.scss
+++ b/frontend/src/app/main/ui/viewer/comments.scss
@@ -4,6 +4,7 @@
 //
 // Copyright (c) KALEIDOS SUBSIDIARY SL
 
+@use "ds/_borders.scss" as *;
 @use "refactor/common-refactor.scss" as deprecated;
 
 // COMMENT DROPDOWN ON HEADER
@@ -92,7 +93,12 @@
 }
 
 .separator {
-  height: deprecated.$s-8;
+  position: relative;
+  block-size: var(--sp-xs);
+  inline-size: calc(100% + var(--sp-s));
+  border-top: $b-1 solid var(--color-background-quaternary);
+  left: calc(-1 * var(--sp-xs));
+  margin-top: var(--sp-s);
 }
 
 // FLOATING COMMENT

--- a/frontend/src/app/main/ui/workspace/comments.scss
+++ b/frontend/src/app/main/ui/workspace/comments.scss
@@ -5,6 +5,7 @@
 // Copyright (c) KALEIDOS INC Sucursal en España SL
 
 @use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 @use "refactor/common-refactor.scss" as deprecated;
 
 .comments-section {
@@ -112,7 +113,12 @@
 }
 
 .separator {
-  height: deprecated.$s-12;
+  position: relative;
+  block-size: var(--sp-xs);
+  inline-size: calc(100% + var(--sp-s));
+  border-top: $b-1 solid var(--color-background-quaternary);
+  left: calc(-1 * var(--sp-xs));
+  margin-top: var(--sp-s);
 }
 
 .comments-section-content {

--- a/frontend/src/app/main/ui/workspace/comments.scss
+++ b/frontend/src/app/main/ui/workspace/comments.scss
@@ -5,6 +5,7 @@
 // Copyright (c) KALEIDOS SUBSIDIARY SL
 
 @use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 @use "refactor/common-refactor.scss" as deprecated;
 
 .comments-section {
@@ -112,7 +113,12 @@
 }
 
 .separator {
-  height: deprecated.$s-12;
+  position: relative;
+  block-size: var(--sp-xs);
+  inline-size: calc(100% + var(--sp-s));
+  border-top: $b-1 solid var(--color-background-quaternary);
+  left: calc(-1 * var(--sp-xs));
+  margin-top: var(--sp-s);
 }
 
 .comments-section-content {

--- a/frontend/test/frontend_tests/data/comments_filters_test.cljs
+++ b/frontend/test/frontend_tests/data/comments_filters_test.cljs
@@ -1,0 +1,56 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns frontend-tests.data.comments-filters-test
+  (:require
+   [app.main.data.comments :as dcmt]
+   [app.util.storage :as storage]
+   [cljs.test :as t :include-macros true]
+   [potok.v2.core :as ptk]))
+
+(def ^:private storage-key
+  :app.main.data.comments/hide-resolved-comments?)
+
+(t/deftest test-merge-persisted-filters-default
+  (let [prev (get @storage/user storage-key)]
+    (try
+      (swap! storage/user dissoc storage-key)
+      (t/is (= {:show :all} (dcmt/merge-persisted-filters nil)))
+      (t/is (= {:show :all} (dcmt/merge-persisted-filters {})))
+      (finally
+        (if (some? prev)
+          (swap! storage/user assoc storage-key prev)
+          (swap! storage/user dissoc storage-key))))))
+
+(t/deftest test-merge-persisted-filters-hide-resolved
+  (let [prev (get @storage/user storage-key)]
+    (try
+      (swap! storage/user assoc storage-key true)
+      (t/is (= {:show :pending} (dcmt/merge-persisted-filters nil)))
+      (finally
+        (if (some? prev)
+          (swap! storage/user assoc storage-key prev)
+          (swap! storage/user dissoc storage-key))))))
+
+(t/deftest test-merge-persisted-filters-keeps-session-value
+  (let [prev (get @storage/user storage-key)]
+    (try
+      (swap! storage/user assoc storage-key true)
+      (t/is (= {:show :all :mode :yours}
+               (dcmt/merge-persisted-filters {:show :all :mode :yours})))
+      (finally
+        (if (some? prev)
+          (swap! storage/user assoc storage-key prev)
+          (swap! storage/user dissoc storage-key))))))
+
+(t/deftest test-update-filters-updates-show
+  (let [event (dcmt/update-filters {:show :pending})
+        state (ptk/update event {})]
+    (t/is (= :pending (get-in state [:comments-local :show])))
+
+    (let [event (dcmt/update-filters {:show :all})
+          state (ptk/update event state)]
+      (t/is (= :all (get-in state [:comments-local :show]))))))

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -8,6 +8,7 @@
    [frontend-tests.code-gen-style-test]
    [frontend-tests.composable-tests.comp.sync-test]
    [frontend-tests.copy-as-svg-test]
+   [frontend-tests.data.comments-filters-test]
    [frontend-tests.data.nitrate-test]
    [frontend-tests.data.repo-test]
    [frontend-tests.data.uploads-test]
@@ -82,6 +83,7 @@
    'frontend-tests.code-gen-style-test
    'frontend-tests.composable-tests.comp.sync-test
    'frontend-tests.copy-as-svg-test
+   'frontend-tests.data.comments-filters-test
    'frontend-tests.data.nitrate-test
    'frontend-tests.data.repo-test
    'frontend-tests.data.uploads-test

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -8,6 +8,7 @@
    [frontend-tests.code-gen-style-test]
    [frontend-tests.composable-tests.comp.sync-test]
    [frontend-tests.copy-as-svg-test]
+   [frontend-tests.data.comments-filters-test]
    [frontend-tests.data.dashboard-test]
    [frontend-tests.data.exports-assets-test]
    [frontend-tests.data.nitrate-test]
@@ -107,6 +108,7 @@
    'frontend-tests.code-gen-style-test
    'frontend-tests.composable-tests.comp.sync-test
    'frontend-tests.copy-as-svg-test
+   'frontend-tests.data.comments-filters-test
    'frontend-tests.data.dashboard-test
    'frontend-tests.data.nitrate-test
    'frontend-tests.data.profile-test


### PR DESCRIPTION
## Summary
- Persist the **Hide resolved comments** toggle in user storage (`storage/user`), consistent with canvas comment visibility from #10239
- Restore the saved preference when entering the workspace or viewer; default remains showing resolved comments
- Add the missing **Show only your mentions** option and a separator before **Hide resolved comments** in the viewer comments dropdown (workspace already had both)

Fixes #10686

## Test plan
- [ ] Open a file with open and resolved comment threads
- [ ] Enable **Hide resolved comments** and confirm resolved threads disappear from the list and canvas
- [ ] Reload the page and confirm resolved comments remain hidden
- [ ] Open a different file and confirm the same preference applies
- [ ] Disable **Hide resolved comments**, reload, and confirm resolved comments are shown again
- [ ] With a fresh user (or cleared preference), confirm resolved comments are shown by default
- [ ] In the viewer comments dropdown, confirm filter options and **Hide resolved comments** are visually separated
