### PR TITLE
:bug: Fix system crash on grid element deletion of a component

### DIFF
--- a/.serena/memories/common/component-data-model.md
+++ b/.serena/memories/common/component-data-model.md
@@ -24,6 +24,12 @@ Variant masters are main instances and component roots. Their descendants may th
 
 Masters are not normally touched through `set-shape-attr`, but touched flags can appear on master shapes through cloning/duplication paths. `add-touched-from-ref-chain` in `app.common.logic.variants` unions touched flags from ancestors into the copy being processed, so upstream/master touched state can affect downstream switch behavior.
 
+## Swap slots and positional matching
+
+- A swap slot (stored via `ctk/set-swap-slot`, a `:touched` group `swap-slot-<uuid>`) marks a copy sub-head that was SWAPPED to another component; `compare-children` then pairs it to the main child by slot instead of by `shape-ref`.
+- Copy sub-heads without a slot are paired to main children by `shape-ref` (seek, not index). `find-near-match` (positional) is only a validator/repair heuristic; validity requires membership of the ref among the near-main parent's children, not index equality (`mem:common/file-change-validation-migration-subtleties`).
+- Copy child ORDER converges to the main's via the async sync (`moved` branch of `compare-children`); local code must never reorder copy children directly (guards in `:mov-objects`/`:reorder-children`).
+
 ## Cloning paths
 
 `make-component-instance` in `app.common.types.container` produces a clean component copy through `update-new-shape`, dissociating attrs such as `:touched`, `:variant-id`, and `:variant-name` on cloned shapes.

--- a/.serena/memories/common/file-change-validation-migration-subtleties.md
+++ b/.serena/memories/common/file-change-validation-migration-subtleties.md
@@ -7,6 +7,8 @@
 - `set-shape-attr` treats `:position-data` as derived and never touched. Geometry/content-path changes use approximate equality; geometry differences under about 1px can be ignored for touched purposes.
 - Width/height are excluded from the `is-geometry?` branch in `set-shape-attr`; do not assume all geometry-group attrs follow identical ignore-geometry behavior.
 - `process-touched-change` marks the owning component modified when a touched shape belongs to a main instance; component-data changes can come from shape ops through this second pass.
+- Copy structure is guarded at change application: `:mov-objects` (`is-valid-move?`) and `:reorder-children` both refuse to alter children of shapes inside component copies unless the change carries `allow-altering-copies` (sync/swap flows set it). New structural change types must follow the same rule.
+- `cls/generate-delete-shapes` propagates deletions from INSIDE a component main to the copy shapes referencing them (transitively, all pages of the file) so no dangling `shape-ref`s remain; skipped when the main root itself is deleted (copies then resolve into the deleted component) and for `allow-altering-copies` flows (swap replaces the shape; sync reconciles).
 
 ## Shape tree edits
 
@@ -19,6 +21,7 @@
 - Full referential/semantic validation currently runs only when file features contain `"components/v2"`.
 - Validation starts at root plus orphan shapes, then validates component records. `validate-file!` raises `:validation :referential-integrity` with collected details.
 - `repair-file` does not mutate data directly; it reduces validation errors into redo changes using `changes-builder`. Callers must apply or persist those changes.
+- `:missing-slot` fires only for a REAL swap: a copy sub-head whose `shape-ref` is no longer a child of the near main parent. A pure positional mismatch (ref still a sibling elsewhere) is a reorder — valid, realigned by the async component sync; do not "repair" it by assigning swap slots (a slot freezes the child out of normal sync). `fix-missing-swap-slots` (migration 0019) follows the same membership rule.
 
 ## Migrations
 

--- a/.serena/memories/common/layout-grid-subtleties.md
+++ b/.serena/memories/common/layout-grid-subtleties.md
@@ -8,6 +8,9 @@
 ## Grid assignment
 
 - Grid `assign-cells` ensures at least one column and row, skips absolute-position children, creates non-tracked rows/cols when children exceed tracked cells, and asserts that assigned cells do not overlap.
+- `position-absolute?` counts HIDDEN shapes as absolute: hiding a grid child frees its cell on the next `assign-cells`.
+- `reorder-grid-children` rewrites the parent's `:shapes` to the REVERSE of the sorted cell order, but children with no cell (hidden/absolute) keep their original index — do not "fix" this into moving them to an end; that broke copy/main positional slot alignment (referential-integrity crash).
+- The `:reorder-children` change it emits is refused on parents inside component copies unless `allow-altering-copies` (same rule as `:mov-objects`); `pcb/reorder-grid-children` also skips copy grids producer-side. Copy child order is owned by the component sync engine.
 - Grid deassignment removes cells for shapes that are no longer direct children or have become absolute-positioned.
 - Auto-positioning is not just sorting: some auto cells are converted to manual when empty/manual/span state would break the auto sequence, then auto single-span items can be compacted.
 - `fix-overlaps` is marked dev-only and removes one overlapping cell, preferring empty cells first. Avoid depending on it as normal production repair.

--- a/common/src/app/common/files/changes.cljc
+++ b/common/src/app/common/files/changes.cljc
@@ -244,6 +244,7 @@
      [:page-id {:optional true} ::sm/uuid]
      [:component-id {:optional true} ::sm/uuid]
      [:ignore-touched {:optional true} :boolean]
+     [:allow-altering-copies {:optional true} :boolean]
      [:parent-id ::sm/uuid]
      [:shapes ::sm/any]]]
 
@@ -633,22 +634,29 @@
     (d/update-in-when data [:components component-id :objects] process-operations change)))
 
 (defn- process-children-reordering
-  [objects {:keys [parent-id shapes] :as change}]
+  [objects {:keys [parent-id shapes allow-altering-copies] :as change}]
   (if-let [old-shapes (dm/get-in objects [parent-id :shapes])]
-    (let [id->idx
-          (update-vals
-           (->> (d/enumerate shapes)
-                (group-by second))
-           (comp first first))
+    ;; The child structure of a component copy is owned by the component
+    ;; sync engine (same rule as `is-valid-move?` in :mov-objects): a local
+    ;; reorder of a copy's children would break the positional matching
+    ;; between the copy's children and the main's children.
+    (if (and (not allow-altering-copies)
+             (ctk/in-component-copy? (get objects parent-id)))
+      objects
+      (let [id->idx
+            (update-vals
+             (->> (d/enumerate shapes)
+                  (group-by second))
+             (comp first first))
 
-          new-shapes
-          (vec (sort-by #(d/nilv (id->idx %) -1) < old-shapes))]
+            new-shapes
+            (vec (sort-by #(d/nilv (id->idx %) -1) < old-shapes))]
 
-      (if (not= old-shapes new-shapes)
-        (do
-          (some-> *touched-changes* (vswap! conj change))
-          (update objects parent-id assoc :shapes new-shapes))
-        objects))
+        (if (not= old-shapes new-shapes)
+          (do
+            (some-> *touched-changes* (vswap! conj change))
+            (update objects parent-id assoc :shapes new-shapes))
+          objects)))
 
     objects))
 

--- a/common/src/app/common/files/changes_builder.cljc
+++ b/common/src/app/common/files/changes_builder.cljc
@@ -1148,6 +1148,11 @@
         (->> ids
              (map (d/getf objects))
              (filter ctl/grid-layout?)
+             ;; The structure of component copies is owned by the component
+             ;; sync engine: a local cell-driven reorder of a copy's children
+             ;; would break the positional matching between the copy's
+             ;; children and the main's children (referential integrity).
+             (remove ctk/in-component-copy?)
              (reduce reorder-grid changes))]
 
     changes))

--- a/common/src/app/common/files/comp_processors.cljc
+++ b/common/src/app/common/files/comp_processors.cljc
@@ -63,8 +63,10 @@
       file-data)))
 
 (defn fix-missing-swap-slots
-  "Locate shapes that have been swapped (i.e. their shape-ref does not point to the near match) but
-   they don't have a swap slot. In this case, add one pointing to the near match."
+  "Locate shapes that have been swapped (i.e. their shape-ref no longer points to a child of the
+   near main parent) but don't have a swap slot. In this case, add one pointing to the near match.
+   A ref shape that is still a child of the near main parent at another position is a reorder, not
+   a swap, and must NOT get a slot (a slot would freeze it out of normal synchronization)."
   [file-data libraries]
   (try
     (ctf/update-all-shapes
@@ -73,7 +75,14 @@
        (if (ctk/subcopy-head? shape)
          (let [container (:container (meta shape))
                file {:id (:id file-data) :data file-data}
-               near-match (ctf/find-near-match file container libraries shape :include-deleted? true :with-context? false)]
+               parent (get (:objects container) (:parent-id shape))
+               parent-ref-shape (when parent
+                                  (ctf/find-ref-shape file container libraries parent :include-deleted? true))
+               swapped? (and (some? parent-ref-shape)
+                             (not-any? #(= % (:shape-ref shape))
+                                       (:shapes parent-ref-shape)))
+               near-match (when swapped?
+                            (ctf/find-near-match file container libraries shape :include-deleted? true :with-context? false))]
            (if (and (some? near-match)
                     (not= (:shape-ref shape) (:id near-match))
                     (nil? (ctk/get-swap-slot shape)))

--- a/common/src/app/common/files/validate.cljc
+++ b/common/src/app/common/files/validate.cljc
@@ -438,19 +438,27 @@
                   shape file page)))
 
 (defn- check-required-swap-slot
-  "Validate that the shape has swap-slot if it's a subinstance head and the ref shape is not the
-   matching shape by position in the near main."
+  "Validate that the shape has a swap slot if it's a subinstance head that has been
+   swapped: its ref shape is no longer a child of the near main parent. A ref shape
+   that is still a child at another position is a reorder, not a swap, and needs no
+   slot (the component sync realigns positions asynchronously)."
   [shape file page libraries]
   ;; Guard first: if the shape already has a swap slot the invariant is satisfied
-  ;; and we can avoid the expensive `find-near-match` call entirely.
+  ;; and we can avoid the ref-shape lookups entirely.
   (when (nil? (ctk/get-swap-slot shape))
-    (let [near-match (ctf/find-near-match file page libraries shape :include-deleted? true :with-context? false)]
-      (when (and (some? near-match)
-                 (not= (:shape-ref shape) (:id near-match)))
-        (report-error :missing-slot
-                      "Shape has been swapped, should have swap slot"
-                      shape file page
-                      :swap-slot (or (ctk/get-swap-slot near-match) (:id near-match)))))))
+    (let [parent-shape     (ctst/get-shape page (:parent-id shape))
+          parent-ref-shape (when parent-shape
+                             (find-ref-shape* file page libraries parent-shape))
+          swapped?         (and (some? parent-ref-shape)
+                                (not-any? #(= % (:shape-ref shape))
+                                          (:shapes parent-ref-shape)))]
+      (when swapped?
+        (let [near-match (ctf/find-near-match file page libraries shape :include-deleted? true :with-context? false)]
+          (when (some? near-match)
+            (report-error :missing-slot
+                          "Shape has been swapped, should have swap slot"
+                          shape file page
+                          :swap-slot (or (ctk/get-swap-slot near-match) (:id near-match)))))))))
 
 (defn- check-valid-touched
   "Validate that the text touched flags are coherent."

--- a/common/src/app/common/logic/shapes.cljc
+++ b/common/src/app/common/logic/shapes.cljc
@@ -261,6 +261,143 @@
                  []
                  (into ids-to-delete descendants-to-delete))
 
+         ;; --- Propagation of main-side deletions to copies ---------------
+         ;; Deleting shapes from INSIDE a component main (without deleting
+         ;; the main root itself) leaves every copy shape that references
+         ;; them dangling: it can no longer sync and fails referential
+         ;; integrity. Those copy shapes are deleted as well, transitively
+         ;; (copies of copies), across all pages of the file. Whole-main
+         ;; deletions are excluded: their copies keep working against the
+         ;; component stored as deleted.
+
+         all-deleted-ids
+         (into (set ids-to-delete) descendants-to-delete)
+
+         mutilates-main?
+         (fn [id]
+           (->> (cfh/get-parent-ids objects id)
+                (some (fn [parent-id]
+                        (let [parent (get objects parent-id)]
+                          (and (:main-instance parent)
+                               (not (contains? all-deleted-ids parent-id))))))))
+
+         pages-index
+         (when data
+           (or (:pages-index data)
+               (dm/get-in data [:data :pages-index])))
+
+         page-objects
+         (fn [page-id]
+           (if (= page-id (:id page))
+             objects
+             (dm/get-in pages-index [page-id :objects])))
+
+         ;; page-id -> [ids...] of copy shapes to delete (descendants
+         ;; leaf-first, then the referencing heads, mirroring the main
+         ;; deletion flow). Skipped for allow-altering-copies flows (like
+         ;; component swap): there the deletion is part of a replacement
+         ;; and the component sync reconciles the copies itself.
+         copy-deletions
+         (loop [dangling (if allow-altering-copies
+                           #{}
+                           (into #{} (filter mutilates-main?) all-deleted-ids))
+                seen     #{}
+                result   {}]
+           (if (or (empty? dangling) (nil? pages-index))
+             result
+             (let [hits
+                   (for [page-id (keys pages-index)
+                         :let [pobjects (page-objects page-id)]
+                         shape (vals pobjects)
+                         :when (and (contains? dangling (:shape-ref shape))
+                                    (not (contains? seen (:id shape)))
+                                    (not (contains? all-deleted-ids (:id shape))))]
+                     [page-id (:id shape)])
+
+                   descendants-of
+                   (fn [page-id id]
+                     (cfh/get-children-ids (page-objects page-id) id))]
+               (recur
+                (into #{}
+                      (mapcat (fn [[page-id id]]
+                                (cons id (descendants-of page-id id))))
+                      hits)
+                (into seen (map second) hits)
+                (reduce (fn [result [page-id id]]
+                          (update result page-id
+                                  (fnil into [])
+                                  (concat (reverse (descendants-of page-id id)) [id])))
+                        result
+                        hits)))))
+
+         ;; Parents of same-page deleted copy shapes must be resized too
+         all-parents
+         (reduce (fn [res id]
+                   (into res (cfh/get-parent-ids objects id)))
+                 all-parents
+                 (get copy-deletions (:id page)))
+
+         ;; Like `pcb/remove-objects` but for a page that is not the one
+         ;; mounted in the changes builder: redo/undo changes are built
+         ;; against that page's objects and carry its page-id.
+         remove-copy-objects-on-page
+         (fn [changes page-id ids]
+           (let [pobjects (page-objects page-id)
+
+                 add-redo-change
+                 (fn [change-set id]
+                   (conj change-set
+                         {:type :del-obj
+                          :page-id page-id
+                          :id id
+                          :ignore-touched true}))
+
+                 add-undo-change-shape
+                 (fn [change-set id]
+                   (let [shape (get pobjects id)]
+                     (cond-> change-set
+                       (some? shape)
+                       (conj {:type :add-obj
+                              :id id
+                              :page-id page-id
+                              :parent-id (:parent-id shape)
+                              :frame-id (:frame-id shape)
+                              :index (cfh/get-position-on-parent pobjects id)
+                              :obj (cond-> shape
+                                     (contains? shape :shapes)
+                                     (assoc :shapes []))}))))
+
+                 add-undo-change-parent
+                 (fn [change-set id]
+                   (let [shape (get pobjects id)
+                         prev-sibling (cfh/get-prev-sibling pobjects id)]
+                     (cond-> change-set
+                       (some? shape)
+                       (conj {:type :mov-objects
+                              :page-id page-id
+                              :parent-id (:parent-id shape)
+                              :shapes [id]
+                              :after-shape prev-sibling
+                              :index 0
+                              :ignore-touched true
+                              :allow-altering-copies true}))))]
+             (-> changes
+                 (update :redo-changes #(reduce add-redo-change % ids))
+                 (update :undo-changes #(as-> % $
+                                          (reduce add-undo-change-parent $ ids)
+                                          (reduce add-undo-change-shape $ ids))))))
+
+         generate-copy-deletions
+         (fn [changes]
+           (reduce-kv (fn [changes page-id ids]
+                        (if (= page-id (:id page))
+                          ;; current page: go through the builder so the
+                          ;; local working state stays consistent
+                          (pcb/remove-objects changes ids {:ignore-touched true})
+                          (remove-copy-objects-on-page changes page-id ids)))
+                      changes
+                      copy-deletions))
+
 
          ids-set (set ids-to-delete)
 
@@ -289,6 +426,7 @@
                      (pcb/remove-objects descendants-to-delete {:ignore-touched true})
                      (pcb/remove-objects ids-to-delete {:ignore-touched ignore-touched})
                      (pcb/remove-objects empty-parents)
+                     (generate-copy-deletions)
                      (pcb/resize-parents all-parents)
                      (pcb/update-shapes groups-to-unmask
                                         (fn [shape]

--- a/common/src/app/common/types/shape/layout.cljc
+++ b/common/src/app/common/types/shape/layout.cljc
@@ -1526,19 +1526,36 @@
       (add-children-to-cell ids objects [(:row target-cell) (:column target-cell)]))))
 
 (defn reorder-grid-children
+  "Reorder the parent's :shapes to match the visual order of the grid cells.
+  Children that do not participate in any cell (hidden or absolute positioned)
+  keep their original index: moving them would gratuitously change their
+  z-order, and for component copies it would break the positional matching
+  between a copy's children and the main's children."
   [parent]
   (let [cells (get-cells parent {:sort? true})
         child? (set (:shapes parent))
-        new-shapes
-        (into (d/ordered-set)
+        in-cell-ids
+        (into []
               (comp (keep (comp first :shapes))
-                    (filter child?))
+                    (filter child?)
+                    (distinct))
               cells)
-
-        ;; Add the children that are not in cells (absolute positioned for example)
-        new-shapes (into new-shapes (:shapes parent))]
-
-    (assoc parent :shapes (into [] (reverse new-shapes)))))
+        in-cell? (set in-cell-ids)
+        ;; target order for the in-cell children (:shapes is reversed
+        ;; relative to the visual cell order)
+        ordered (into [] (reverse in-cell-ids))]
+    (assoc parent :shapes
+           (loop [shapes  (seq (:shapes parent))
+                  ordered (seq ordered)
+                  result  (transient [])]
+             (if (nil? shapes)
+               (persistent! result)
+               (let [id (first shapes)]
+                 (if (in-cell? id)
+                   ;; slot of an in-cell child: take the next id in cell order
+                   (recur (next shapes) (next ordered) (conj! result (first ordered)))
+                   ;; cell-less child (hidden/absolute): keep it in place
+                   (recur (next shapes) ordered (conj! result id)))))))))
 
 (defn cells-by-row
   ([parent index]

--- a/common/test/common_tests/logic/comp_main_edit_breaks_copy_slots_test.cljc
+++ b/common/test/common_tests/logic/comp_main_edit_breaks_copy_slots_test.cljc
@@ -6,6 +6,7 @@
 
 (ns common-tests.logic.comp-main-edit-breaks-copy-slots-test
   (:require
+   [app.common.files.changes :as cpc]
    [app.common.files.changes-builder :as pcb]
    [app.common.logic.shapes :as cls]
    [app.common.test-helpers.components :as thc]
@@ -20,12 +21,22 @@
 ;; Regression for the referential-integrity crash (:missing-slot, "Shape has been
 ;; swapped, should have swap slot").
 ;;
-;; Root cause: changing the child STRUCTURE of a component's MAIN (reordering or
-;; deleting a nested sub-head) while copies exist. `find-near-match` matches a
-;; copy's nested sub-heads to the main's children purely BY POSITION; when the
-;; main's order changes, the copies' shape-refs no longer match their position and
-;; no swap slot is propagated to the copies -> the file fails referential-integrity
-;; validation. (The copy-SIDE edits below are handled correctly and pass.)
+;; Root cause (fixed): copy sub-heads used to be matched to the main's children
+;; purely BY POSITION (`find-near-match`), while several code paths reorder or
+;; mutilate one side only:
+;;
+;;   - reordering or deleting a nested sub-head IN THE MAIN of a component while
+;;     copies exist (this file);
+;;   - a grid reflow moving a hidden copy sub-head to the front of :shapes
+;;     (see `reorder-grid-children` tests and the :reorder-children copy guard).
+;;
+;; The fixes under test here:
+;;
+;;   - validation treats a sub-head whose ref shape is still a child of the near
+;;     main parent as a REORDER (valid, the sync realigns it), not a swap;
+;;   - deleting a sub-head in a main also deletes the corresponding copy shapes
+;;     (transitively), so no dangling refs remain;
+;;   - the :reorder-children change cannot alter the structure of copies.
 ;;
 ;; Structure built for each test:
 ;;   {:icon-main}  # [Component :icon]            (a frame + rect)
@@ -51,7 +62,7 @@
       (thc/instantiate-component :row :row-copy :children-labels [:copy-1 :copy-2 :copy-3])))
 
 ;; ---------------------------------------------------------------------------
-;; Characterization: copy-SIDE structural edits are handled correctly (pass today)
+;; Characterization: copy-SIDE structural edits are handled correctly
 ;; ---------------------------------------------------------------------------
 
 ;; Deleting a nested sub-head of a COPY only hides it (deleted-subinstance).
@@ -62,7 +73,7 @@
     (t/is (some? copy-1'))
     (t/is (true? (:hidden copy-1')))))
 
-;; Reordering a nested sub-head within a COPY assigns swap slots as needed.
+;; Reordering a nested sub-head within a COPY keeps referential integrity.
 (t/deftest reordering-a-copy-subhead-keeps-referential-integrity
   (let [file     (setup-file)
         page     (thf/current-page file)
@@ -78,11 +89,11 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Regression: main-SIDE structural edits must not break copies
-;; (these FAIL today with :missing-slot; they go green once the sync propagates
-;;  swap slots to copies on a main reorder/delete)
 ;; ---------------------------------------------------------------------------
 
-;; Reordering a sub-head IN THE MAIN must keep the copies referentially valid.
+;; Reordering a sub-head IN THE MAIN must keep the copies referentially valid:
+;; the copies' sub-heads are only reordered relative to the main (the sync
+;; realigns them), not swapped, so no swap slot is required.
 (t/deftest reordering-a-main-subhead-must-not-break-copies
   (let [file     (setup-file)
         page     (thf/current-page file)
@@ -93,27 +104,29 @@
                                             (pcb/with-page-id (:id page))
                                             (pcb/with-objects (:objects page)))
                                         (:id row-main) 2 #{(:id icon-1)})
-        ;; apply-changes validates -> throws :missing-slot today (the reproduced bug)
+        ;; apply-changes validates -> this used to throw :missing-slot
         file'    (thf/apply-changes file changes)]
     (t/is (some? (ths/get-shape file' :copy-1)))
     (t/is (some? (ths/get-shape file' :copy-2)))
     (t/is (some? (ths/get-shape file' :copy-3)))))
 
-;; Deleting a sub-head IN THE MAIN must keep the copies referentially valid.
+;; Deleting a sub-head IN THE MAIN must keep the copies referentially valid:
+;; the corresponding copy sub-head is deleted along with it, so no dangling
+;; shape-refs (and no shifted positional slots) remain.
 (t/deftest deleting-a-main-subhead-must-not-break-copies
   (let [file  (setup-file)
-        ;; deleting a main sub-head removes a slot; copies must be reconciled
         file' (tho/delete-shape file :icon-1)]
+    (t/is (nil? (ths/get-shape file' :copy-1)))
     (t/is (some? (ths/get-shape file' :copy-2)))
     (t/is (some? (ths/get-shape file' :copy-3)))))
 
 ;; ---------------------------------------------------------------------------
-;; The FULL chain (models the real crash): a main-side reorder persists a corrupt
-;; state (a file saved this way loads fine, since load does not validate), and a
-;; LATER copy-side edit is what runs validation and surfaces it as the crash.
-;; This documents the observed buggy behavior end to end.
+;; The FULL chain that used to crash: a main-side reorder persisted a corrupt
+;; state (a file saved this way loaded fine, since load does not validate), and
+;; a LATER copy-side edit ran validation and surfaced it as the crash. Now the
+;; reordered state is valid on its own and later copy edits keep working.
 ;; ---------------------------------------------------------------------------
-(t/deftest main-reorder-corrupts-copies-and-a-later-copy-edit-surfaces-it
+(t/deftest main-reorder-keeps-copies-valid-for-later-edits
   (let [file     (setup-file)
         page     (thf/current-page file)
         row-main (ths/get-shape file :row-main)
@@ -122,14 +135,40 @@
                                             (pcb/with-page-id (:id page))
                                             (pcb/with-objects (:objects page)))
                                         (:id row-main) 2 #{(:id icon-1)})
-        ;; 1) reorder a main sub-head WITHOUT validating -> the corrupt state persists
-        corrupt  (thf/apply-changes file reorder :validate? false)
-        ;; 2) the copies are now corrupt: validation reports :missing-slot
-        details  (try (thf/validate-file! corrupt) nil
-                      (catch clojure.lang.ExceptionInfo e (:details (ex-data e))))]
-    (t/is (some #(= :missing-slot (:code %)) details)
-          "main reorder must leave the copies in a :missing-slot state")
-    ;; 3) a later copy-side edit (delete) runs validation -> throws (the user's crash)
-    (t/is (thrown? clojure.lang.ExceptionInfo
-                   (tho/delete-shape corrupt :copy-2))
-          "a copy-delete on the corrupt file must trigger the validation crash")))
+        ;; 1) reorder a main sub-head WITHOUT validating (as a persisted file)
+        file'    (thf/apply-changes file reorder :validate? false)]
+    ;; 2) the file is valid nevertheless
+    (thf/validate-file! file')
+    ;; 3) a later copy-side edit (delete = hide) works instead of crashing
+    (let [file''  (tho/delete-shape file' :copy-2)
+          copy-2' (ths/get-shape file'' :copy-2)]
+      (t/is (some? copy-2'))
+      (t/is (true? (:hidden copy-2'))))))
+
+;; ---------------------------------------------------------------------------
+;; The :reorder-children change (emitted by grid reflows) must not alter the
+;; child structure of component copies: that structure is owned by the
+;; component sync engine. (A grid reflow used to move a hidden copy sub-head
+;; to the front of :shapes this way, breaking the copy/main alignment.)
+;; ---------------------------------------------------------------------------
+(t/deftest reorder-children-change-cannot-alter-copies
+  (let [file      (setup-file)
+        page      (thf/current-page file)
+        row-copy  (ths/get-shape file :row-copy)
+        scrambled (vec (reverse (:shapes row-copy)))
+        change    {:type :reorder-children
+                   :page-id (:id page)
+                   :parent-id (:id row-copy)
+                   :shapes scrambled}
+        get-order (fn [data]
+                    (get-in data [:pages-index (:id page)
+                                  :objects (:id row-copy) :shapes]))]
+    ;; without allow-altering-copies the reorder is rejected
+    (t/is (= (:shapes row-copy)
+             (get-order (cpc/process-changes (:data file) [change] false))))
+    ;; the sync engine can still restructure copies explicitly
+    (t/is (= scrambled
+             (get-order (cpc/process-changes
+                         (:data file)
+                         [(assoc change :allow-altering-copies true)]
+                         false))))))

--- a/common/test/common_tests/logic/comp_main_edit_breaks_copy_slots_test.cljc
+++ b/common/test/common_tests/logic/comp_main_edit_breaks_copy_slots_test.cljc
@@ -1,0 +1,135 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns common-tests.logic.comp-main-edit-breaks-copy-slots-test
+  (:require
+   [app.common.files.changes-builder :as pcb]
+   [app.common.logic.shapes :as cls]
+   [app.common.test-helpers.components :as thc]
+   [app.common.test-helpers.compositions :as tho]
+   [app.common.test-helpers.files :as thf]
+   [app.common.test-helpers.ids-map :as thi]
+   [app.common.test-helpers.shapes :as ths]
+   [clojure.test :as t]))
+
+(t/use-fixtures :each thi/test-fixture)
+
+;; Regression for the referential-integrity crash (:missing-slot, "Shape has been
+;; swapped, should have swap slot").
+;;
+;; Root cause: changing the child STRUCTURE of a component's MAIN (reordering or
+;; deleting a nested sub-head) while copies exist. `find-near-match` matches a
+;; copy's nested sub-heads to the main's children purely BY POSITION; when the
+;; main's order changes, the copies' shape-refs no longer match their position and
+;; no swap slot is propagated to the copies -> the file fails referential-integrity
+;; validation. (The copy-SIDE edits below are handled correctly and pass.)
+;;
+;; Structure built for each test:
+;;   {:icon-main}  # [Component :icon]            (a frame + rect)
+;;
+;;   {:row-main}   # [Component :row]             (a frame holding 3 :icon instances)
+;;       :icon-1   @--> :icon-main
+;;       :icon-2   @--> :icon-main
+;;       :icon-3   @--> :icon-main
+;;
+;;   :row-copy     #--> [Component :row] :row-main (a copy of Row)
+;;       :copy-1   @--> :icon-1
+;;       :copy-2   @--> :icon-2
+;;       :copy-3   @--> :icon-3
+(defn- setup-file
+  []
+  (-> (thf/sample-file :file1)
+      (tho/add-simple-component :icon :icon-main :icon-child)
+      (tho/add-frame :row-main :name "Row")
+      (thc/instantiate-component :icon :icon-1 :parent-label :row-main)
+      (thc/instantiate-component :icon :icon-2 :parent-label :row-main)
+      (thc/instantiate-component :icon :icon-3 :parent-label :row-main)
+      (thc/make-component :row :row-main)
+      (thc/instantiate-component :row :row-copy :children-labels [:copy-1 :copy-2 :copy-3])))
+
+;; ---------------------------------------------------------------------------
+;; Characterization: copy-SIDE structural edits are handled correctly (pass today)
+;; ---------------------------------------------------------------------------
+
+;; Deleting a nested sub-head of a COPY only hides it (deleted-subinstance).
+(t/deftest deleting-a-copy-subhead-only-hides-it
+  (let [file    (setup-file)
+        file'   (tho/delete-shape file :copy-1)
+        copy-1' (ths/get-shape file' :copy-1)]
+    (t/is (some? copy-1'))
+    (t/is (true? (:hidden copy-1')))))
+
+;; Reordering a nested sub-head within a COPY assigns swap slots as needed.
+(t/deftest reordering-a-copy-subhead-keeps-referential-integrity
+  (let [file     (setup-file)
+        page     (thf/current-page file)
+        copy-1   (ths/get-shape file :copy-1)
+        row-copy (ths/get-shape file :row-copy)
+        changes  (cls/generate-relocate (-> (pcb/empty-changes nil)
+                                            (pcb/with-page-id (:id page))
+                                            (pcb/with-objects (:objects page)))
+                                        (:id row-copy) 2 #{(:id copy-1)})
+        file'    (thf/apply-changes file changes)]
+    (t/is (some? (ths/get-shape file' :copy-2)))
+    (t/is (some? (ths/get-shape file' :copy-3)))))
+
+;; ---------------------------------------------------------------------------
+;; Regression: main-SIDE structural edits must not break copies
+;; (these FAIL today with :missing-slot; they go green once the sync propagates
+;;  swap slots to copies on a main reorder/delete)
+;; ---------------------------------------------------------------------------
+
+;; Reordering a sub-head IN THE MAIN must keep the copies referentially valid.
+(t/deftest reordering-a-main-subhead-must-not-break-copies
+  (let [file     (setup-file)
+        page     (thf/current-page file)
+        row-main (ths/get-shape file :row-main)
+        icon-1   (ths/get-shape file :icon-1)
+        ;; move the main's first sub-head to the end (index 2)
+        changes  (cls/generate-relocate (-> (pcb/empty-changes nil)
+                                            (pcb/with-page-id (:id page))
+                                            (pcb/with-objects (:objects page)))
+                                        (:id row-main) 2 #{(:id icon-1)})
+        ;; apply-changes validates -> throws :missing-slot today (the reproduced bug)
+        file'    (thf/apply-changes file changes)]
+    (t/is (some? (ths/get-shape file' :copy-1)))
+    (t/is (some? (ths/get-shape file' :copy-2)))
+    (t/is (some? (ths/get-shape file' :copy-3)))))
+
+;; Deleting a sub-head IN THE MAIN must keep the copies referentially valid.
+(t/deftest deleting-a-main-subhead-must-not-break-copies
+  (let [file  (setup-file)
+        ;; deleting a main sub-head removes a slot; copies must be reconciled
+        file' (tho/delete-shape file :icon-1)]
+    (t/is (some? (ths/get-shape file' :copy-2)))
+    (t/is (some? (ths/get-shape file' :copy-3)))))
+
+;; ---------------------------------------------------------------------------
+;; The FULL chain (models the real crash): a main-side reorder persists a corrupt
+;; state (a file saved this way loads fine, since load does not validate), and a
+;; LATER copy-side edit is what runs validation and surfaces it as the crash.
+;; This documents the observed buggy behavior end to end.
+;; ---------------------------------------------------------------------------
+(t/deftest main-reorder-corrupts-copies-and-a-later-copy-edit-surfaces-it
+  (let [file     (setup-file)
+        page     (thf/current-page file)
+        row-main (ths/get-shape file :row-main)
+        icon-1   (ths/get-shape file :icon-1)
+        reorder  (cls/generate-relocate (-> (pcb/empty-changes nil)
+                                            (pcb/with-page-id (:id page))
+                                            (pcb/with-objects (:objects page)))
+                                        (:id row-main) 2 #{(:id icon-1)})
+        ;; 1) reorder a main sub-head WITHOUT validating -> the corrupt state persists
+        corrupt  (thf/apply-changes file reorder :validate? false)
+        ;; 2) the copies are now corrupt: validation reports :missing-slot
+        details  (try (thf/validate-file! corrupt) nil
+                      (catch clojure.lang.ExceptionInfo e (:details (ex-data e))))]
+    (t/is (some #(= :missing-slot (:code %)) details)
+          "main reorder must leave the copies in a :missing-slot state")
+    ;; 3) a later copy-side edit (delete) runs validation -> throws (the user's crash)
+    (t/is (thrown? clojure.lang.ExceptionInfo
+                   (tho/delete-shape corrupt :copy-2))
+          "a copy-delete on the corrupt file must trigger the validation crash")))

--- a/common/test/common_tests/runner.cljc
+++ b/common/test/common_tests/runner.cljc
@@ -46,6 +46,7 @@
    [common-tests.logic.chained-propagation-test]
    [common-tests.logic.comp-creation-test]
    [common-tests.logic.comp-detach-with-nested-test]
+   [common-tests.logic.comp-main-edit-breaks-copy-slots-test]
    [common-tests.logic.comp-remove-swap-slots-test]
    [common-tests.logic.comp-reset-test]
    [common-tests.logic.comp-sync-test]
@@ -119,6 +120,7 @@
    'common-tests.logic.chained-propagation-test
    'common-tests.logic.comp-creation-test
    'common-tests.logic.comp-detach-with-nested-test
+   'common-tests.logic.comp-main-edit-breaks-copy-slots-test
    'common-tests.logic.comp-remove-swap-slots-test
    'common-tests.logic.comp-reset-test
    'common-tests.logic.comp-sync-test

--- a/common/test/common_tests/types/shape_layout_test.cljc
+++ b/common/test/common_tests/types/shape_layout_test.cljc
@@ -1211,7 +1211,35 @@
       ;; so shape-id-2 before shape-id-1 in new order; reorder-grid-children reverses
       (let [result (layout/reorder-grid-children parent)]
         (t/is (vector? (:shapes result)))
-        (t/is (= 2 (count (:shapes result))))))))
+        (t/is (= [shape-id-1 shape-id-2] (:shapes result)))))))
+
+(t/deftest reorder-grid-children-keeps-cell-less-children-in-place-test
+  ;; Children that participate in no cell (hidden or absolute positioned) must
+  ;; keep their original index: moving them would gratuitously change their
+  ;; z-order, and for component copies it would break the positional matching
+  ;; between the copy's children and the main's children. (A hidden copy
+  ;; sub-head used to be moved to the front of :shapes by a grid reflow,
+  ;; corrupting the file's referential integrity.)
+  (let [shape-id-1 (uuid/next)
+        shape-id-2 (uuid/next)
+        hidden-id  (uuid/next)
+        ;; cell order: shape-id-2's cell first, so the in-cell target order
+        ;; (reversed) is [shape-id-1 shape-id-2] -> the pair swaps
+        cell-a (make-cell :row 1 :column 1 :shapes [shape-id-2])
+        cell-b (make-cell :row 1 :column 2 :shapes [shape-id-1])
+        parent {:layout-grid-dir :row
+                :shapes [shape-id-2 shape-id-1 hidden-id]
+                :layout-grid-cells {(:id cell-a) cell-a
+                                    (:id cell-b) cell-b}}]
+
+    (t/testing "cell-less child at the end stays at the end"
+      (let [result (layout/reorder-grid-children parent)]
+        (t/is (= [shape-id-1 shape-id-2 hidden-id] (:shapes result)))))
+
+    (t/testing "cell-less child in the middle stays in the middle"
+      (let [parent (assoc parent :shapes [shape-id-2 hidden-id shape-id-1])
+            result (layout/reorder-grid-children parent)]
+        (t/is (= [shape-id-1 hidden-id shape-id-2] (:shapes result)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; merge-cells

--- a/plugins/apps/composable-test-suite/src/composable-tests/cases/caseCopySubheadDeletePreservesSlots.ts
+++ b/plugins/apps/composable-test-suite/src/composable-tests/cases/caseCopySubheadDeletePreservesSlots.ts
@@ -2,9 +2,12 @@ import { Board, Shape } from "@penpot/plugin-types";
 import { TestCase } from "../test-suite/TestCase.ts";
 import { Situation } from "../core/Situation";
 import { Color } from "../model/Color";
+import { ShapePropHeight } from "../model/ShapeProp.ts";
 import { OpAssert } from "../operations/OpAssert";
 import { OpSequence } from "../operations/OpSequence.ts";
+import { OpOneOf } from "../operations/OpOneOf.ts";
 import { OpOptional } from "../operations/OpOptional.ts";
+import { OpChangeProperty } from "../operations/OpChangeProperty";
 import { OpCreateNestableComponent } from "../operations/OpCreateNestableComponent";
 import { OpDeleteShape } from "../operations/OpDeleteShape";
 import { ContentCreationStrategySiblingInstances } from "../content-creation/ContentCreationStrategySiblingInstances";
@@ -13,22 +16,28 @@ import { SlotIntegrity } from "../util/SlotIntegrity";
 const BASELINE = new Color("#aaaaaa");
 const NESTED_COUNT = 3;
 const LAYOUT = "grid" as const;
+const REFLOW_HEIGHT = 500; // any size change of the grid root forces a reflow
 
 /**
- * Case D — CHARACTERIZATION: deleting a nested sub-head of a copy is well-behaved.
+ * Case D — deleting a nested sub-head of a copy is well-behaved.
  *
- * Builds a component whose main holds several nested component instances, plus a
- * copy of it, then SWEEPS whether one of the copy's nested sub-heads is deleted,
- * asserting every remaining sub-head still references its positional slot in the
- * main (see {@link SlotIntegrity}).
+ * Builds a component whose main holds several nested component instances inside
+ * a GRID layout, plus a copy of it, then sweeps: optionally delete ONE of the
+ * copy's nested sub-heads (first or last), optionally resize the copy root
+ * afterwards (which forces a grid reflow), asserting every remaining visible
+ * sub-head still references its positional slot in the main (see
+ * {@link SlotIntegrity}).
  *
- * This case PASSES for every layout (none / flex / grid): deleting a sub-head of a
- * COPY only hides it (a deleted-subinstance), so the copy stays aligned and valid.
- * We initially suspected the layout (flex, then grid) was the trigger; it is not —
- * the copy-side delete is correct. The actual :missing-slot crash comes from a
- * MAIN-side edit; see {@link ../cases/caseE} (and the clj regression test
- * `common/test/.../comp_main_edit_breaks_copy_slots_test.cljc`). This case is kept
- * as a characterization guard that copy-side deletes never corrupt the copy.
+ * Deleting a sub-head of a COPY only hides it (a deleted-subinstance), so the
+ * copy must stay aligned and valid. The sweep pins down a real crash: a grid
+ * reflow used to move the hidden (cell-less) child to the FRONT of the copy's
+ * children, shifting every sibling out of its positional slot and failing the
+ * file's referential-integrity validation (:missing-slot on every sub-head).
+ * Deleting the FIRST sub-head masked the bug (moving it to the front is a
+ * no-op) — hence the first/last sweep. The main-side counterpart of the crash
+ * is caseMainReorderKeepsCopySlots; the clj regression tests live in
+ * `common/test/.../comp_main_edit_breaks_copy_slots_test.cljc` and
+ * `common/test/.../types/shape_layout_test.cljc`.
  */
 export function createTestCaseCopySubheadDeletePreservesSlots(): TestCase {
     const foundation = new OpCreateNestableComponent(
@@ -38,22 +47,34 @@ export function createTestCaseCopySubheadDeletePreservesSlots(): TestCase {
     const outerMain = foundation.roles.mainInstance;
     const outerCopy = foundation.roles.copyInstance;
 
-    // the copy's first nested sub-head, resolved at apply-time
+    // the copy's first/last nested sub-heads, resolved at apply-time
     const firstSubhead = (s: Situation): Shape => (s.get(outerCopy).children ?? [])[0];
+    const lastSubhead = (s: Situation): Shape => {
+        const children = s.get(outerCopy).children ?? [];
+        return children[children.length - 1];
+    };
     const deleteFirstSubhead = new OpDeleteShape(firstSubhead, "first copy sub-head");
+    const deleteLastSubhead = new OpDeleteShape(lastSubhead, "last copy sub-head");
+
+    // resizing the copy root forces a grid reflow over the (possibly hidden) children
+    const reflowCopy = new OpChangeProperty(outerCopy, new ShapePropHeight(), REFLOW_HEIGHT, "copy root");
 
     return new TestCase(
         "CopySubheadDeletePreservesSlots",
-        "A component whose main holds several nested component instances is created, plus a copy " +
-            "of it. One of the copy's nested sub-heads is optionally deleted. Every remaining " +
-            "sub-head of the copy must still reference the slot at its position in the main — a " +
-            "copy-side delete must not corrupt the positional slot matching that Penpot's file " +
-            "validation enforces.",
+        "A component whose main holds several nested component instances in a grid layout is " +
+            "created, plus a copy of it. Optionally, the first or the last of the copy's nested " +
+            "sub-heads is deleted, and optionally the copy root is resized afterwards, forcing a " +
+            "grid reflow. Every remaining visible sub-head of the copy must still reference the " +
+            "slot at its position in the main — neither the copy-side delete nor the reflow may " +
+            "corrupt the positional slot matching that Penpot's file validation enforces.",
         new OpSequence(
             foundation,
             foundation.createOpInstantiate(),
-            // sweep with/without the deletion (the delete variant is the repro)
-            new OpOptional(deleteFirstSubhead),
+            // sweep which sub-head is deleted, if any (last is the crash repro:
+            // the grid reflow used to move the hidden child to the front)
+            new OpOptional(new OpOneOf(deleteFirstSubhead, deleteLastSubhead)),
+            // sweep with/without a grid reflow after the delete
+            new OpOptional(reflowCopy),
             new OpAssert("every copy sub-head still references its positional slot in the main", (s) => {
                 SlotIntegrity.assertAligned(s.get(outerCopy) as Board, s.get(outerMain) as Board);
             })

--- a/plugins/apps/composable-test-suite/src/composable-tests/cases/caseMainReorderKeepsCopySlots.ts
+++ b/plugins/apps/composable-test-suite/src/composable-tests/cases/caseMainReorderKeepsCopySlots.ts
@@ -15,26 +15,22 @@ const NESTED_COUNT = 3;
 /**
  * Case E — reordering a sub-head IN THE MAIN must not break copies.
  *
- * This is the ACTUAL cause of the referential-integrity crash (:missing-slot).
- * `find-near-match` matches a copy's nested sub-heads to the main's children BY
- * POSITION. Reordering a sub-head inside the MAIN changes that order, but the
- * copies keep their shape-refs and are NOT given swap slots — so every copy is
- * now "swapped" relative to its position without a slot -> validation fails.
+ * Regression test for the referential-integrity crash (:missing-slot).
+ * Copy sub-heads used to be matched to the main's children purely BY POSITION
+ * (`find-near-match`): reordering a sub-head inside the MAIN changed that
+ * order while the copies kept their shape-refs, so every copy sub-head was
+ * "swapped" relative to its position without a slot -> validation failed, and
+ * the reorder through the Plugin API hung the app (in the workspace UI it
+ * crashed the document). Validation now treats a ref that is still a child of
+ * the near main parent as a reorder (no slot required), and the component sync
+ * realigns the copies' order — which this case asserts end to end: after the
+ * main-side reorder settles, every copy sub-head must again reference its
+ * positional slot in the main.
  *
- * The layout is irrelevant (the equivalent clj test reproduces it with no layout);
- * the trigger is purely the main-side reorder. The copy-side edits in case D are
- * correct — it's this main-side edit that corrupts.
- *
- * ⚠ WARNING — this case reproduces the bug through the LIVE app, and the app
- * currently CHOKES on the corrupt state: reordering a main sub-head via the Plugin
- * API hangs (and in the workspace UI it crashes the document). Because the test
- * runner lives inside that same app, running this case will HANG the panel — it
- * cannot report a normal pass/fail until the underlying bug is fixed. It is
- * included as an executable, documented reproduction, NOT as a routine test; do
- * NOT include it in a "run all". The reliable, non-hanging capture of this exact
- * bug is the clj test `common/test/.../comp_main_edit_breaks_copy_slots_test.cljc`.
- * Once Penpot propagates swap slots to copies on a main reorder, this case will
- * complete and the assertion will pass.
+ * The layout is irrelevant (the equivalent clj test reproduces it with no
+ * layout); the trigger is purely the main-side reorder. The copy-side edits in
+ * case D were always correct. The clj regression tests for the same bug family
+ * live in `common/test/.../comp_main_edit_breaks_copy_slots_test.cljc`.
  */
 export function createTestCaseMainReorderKeepsCopySlots(): TestCase {
     // layout "none": the bug does not depend on the layout, only on the main reorder

--- a/plugins/apps/composable-test-suite/src/composable-tests/util/SlotIntegrity.ts
+++ b/plugins/apps/composable-test-suite/src/composable-tests/util/SlotIntegrity.ts
@@ -2,24 +2,19 @@ import { Board, Shape } from "@penpot/plugin-types";
 import { Assert } from "./Assert";
 
 /**
- * Checks the positional swap-slot invariant that Penpot's file validator enforces
- * for component copies.
+ * Checks the positional slot alignment between a component copy and its main.
  *
- * Background: in a copy of a component, each nested sub-instance head must, by
+ * Background: in a copy of a component, each nested sub-instance head should, by
  * position, reference (its `shape-ref`) the child at the SAME index in the
- * component's main. Penpot finds the "near match" purely by position
- * (`find-near-match` in `common/.../types/file.cljc`) and then requires a swap
- * slot whenever a sub-head's `shape-ref` is not that positional near match
- * (`check-required-swap-slot` in `common/.../files/validate.cljc`, error
- * `:missing-slot` — "Shape has been swapped, should have swap slot").
- *
- * When the copy's child order diverges from the main's (e.g. after deleting one
- * sub-head, which shifts the rest) while their shape-refs still point to their
- * original slots, the invariant breaks and — with no swap slot recorded — the file
- * fails referential-integrity validation, crashing the project.
- *
- * This helper replicates that positional check through the Plugin API so a test
- * can assert the invariant holds.
+ * component's main. Penpot's validator (`check-required-swap-slot` in
+ * `common/.../files/validate.cljc`) requires a swap slot only when a sub-head's
+ * `shape-ref` is no longer a child of the near main parent at all (a real swap;
+ * error `:missing-slot`); a pure positional mismatch is a reorder that the
+ * component sync realigns. Still, in the steady state (after propagation has
+ * settled) a copy that was never swapped must be POSITIONALLY aligned with its
+ * main — this helper asserts that stronger invariant through the Plugin API, so
+ * a test catches any operation that knocks a copy's child order out of sync
+ * with its main.
  */
 export class SlotIntegrity {
     /**


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/10101

### Summary

#### By Human (Mischa)

The issue was a crash due to referential integrity violation when a part of a component was deleted. It turned out that the issue is not deletion but an automatic reordering of subelements in a grid that happens when an element is hidden through the delete. Generally, due to the reordering, subelements of the master and a component instance can become out of sync and fail validation (causing the crash) before an eventual sync would fix this. So the issue is larger than just the manifestation in the linked ticket.

New regression tests were added, both in clojure and in the component testing plugin. Turns out that this issue is not  frontend related, so clojure tests were the most appropriate vehicle for reproducing and analyzing this. I am not fully confident that the new tests in the component testing plugin were catching the crash, but as regression tests they don't hurt anyway.

While this started as a story under the component testing umbrella, and therefore builds on that branch, the solution and clojure tests can be merged independently if so desired. From what I understood about the issue and the solution, it might be a bit urgent to fix this - components with subelements going out of sync with the main component could happen quite often, I imagine.

@opcode81 FYI

#### By Fable
What was going wrong

The setup. In Penpot you can turn a group of shapes into a component — a reusable master element. The original is called the main; every time
you place it somewhere, you get a copy that stays linked to the main so edits flow from main to copy. Mains can contain other components inside
them (nested instances), and copies mirror that inner structure.

The fragile assumption. A copy's inner pieces are linked to the main's inner pieces by position: "the copy's 3rd child corresponds to the main's
3rd child." That correspondence isn't stored anywhere explicit — it's implied purely by the order of the children lists. Penpot's file
validator enforces it: if a copy child at position 3 doesn't point at the main child at position 3, the validator assumes it was deliberately
swapped for something else and demands a marker recording that swap. No marker → the file is declared corrupt → the app crashes with an
"integrity" error.

The bug family. Several parts of Penpot reorder ONE side's children without the other side following, silently breaking that positional pairing:

1. Your crash: "Deleting" a child inside a copy doesn't really delete it, it just hides it (so it can be restored later). Your copy was a grid
layout (children auto-arranged in cells). On the next layout recalculation, the hidden child, having no grid cell anymore, got moved to the
front of the children list. Inserting one element at the front pushes every sibling one position over, so every child now mismatched its
counterpart in the main → crash. (Deleting the first child masked the bug, which is why existing tests missed it, moving the first child to the
front changes nothing.)
2. Related case: reordering or deleting a child inside the main left copies mismatched the same way, at least until a background sync caught up and validation could run before it did.

How it was fixed

Four complementary changes:

1. Smarter validation. The validator now distinguishes a reorder from a swap: if a copy child still points at one of the main's children (just
at a different position), that's harmless (the sync will realign it) so no crash. Only a child pointing at something genuinely foreign is
flagged.
2. Stable grid reordering. When a grid layout re-sorts its children, children without a cell (hidden ones) now stay where they were instead of jumping to the front.
3. A general safety rule. Copies' internal structure is only allowed to be changed by the component-sync machinery. The kind of change that scrambled your copy (a wholesale rewrite of a children list) is now rejected outright when aimed at a copy — closing the loophole for any code path, not just this one.
4. Delete propagation. Deleting a piece inside a main now also deletes the corresponding pieces in all its copies in the same file, immediately, so no copy is ever left pointing at something that no longer exists.

All verified: the previously failing regression tests now pass, the full test suite is green (1076 tests), and the end-to-end test that used to
hang the live app now completes and passes.


### Steps to reproduce 

See ticket
