### PR TITLE
:bug: Fix measures panel crash on selecting image shapes

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs
@@ -66,15 +66,21 @@
 
 (defn- type->options
   [type]
+  ;; `:image` shapes carry size/position/rotation/radius like rects, so they
+  ;; map to rect-options. The trailing default keeps `case` total: any future
+  ;; or unexpected shape type degrades to the universal measure controls
+  ;; instead of throwing "No matching clause" and blanking the workspace.
   (case type
     :bool    generic-options
     :circle  generic-options
     :frame   frame-options
     :group   generic-options
+    :image   rect-options
     :path    generic-options
     :rect    rect-options
     :svg-raw generic-options
-    :text    generic-options))
+    :text    generic-options
+    generic-options))
 
 (defn select-measure-keys
   "Consider some shapes can be drawn from bottom to top or from left to right"


### PR DESCRIPTION
## What and why

Selecting a shape of type `:image` currently crashes the whole workspace with the **Internal Error** screen and the console exception:

```
Error: No matching clause: image
```

This happens for real (`:image`-type) shapes — e.g. shift-clicking a multi-select that includes a legacy image shape, or selecting an image nested inside a group. It replaces the entire editor with the error boundary, so the user loses their working view until reload.

## Root cause

`type->options` in `frontend/src/app/main/ui/workspace/sidebar/options/menus/measures.cljs` is a `case` over the shape `type` that has **no `:image` branch and no default clause**:

```clojure
(defn- type->options
  [type]
  (case type
    :bool    generic-options
    :circle  generic-options
    :frame   frame-options
    :group   generic-options
    :path    generic-options
    :rect    rect-options
    :svg-raw generic-options
    :text    generic-options))
```

When the selection resolves to an `:image` type, `case` finds no matching clause and, with no default, throws — which the workspace surfaces as the Internal Error screen.

> Note: new-style bitmaps dropped onto the canvas are `:rect` shapes with an image fill, so they take the `:rect` branch and are **not** affected. Only true `:image`-type shapes hit this path, which is why the crash can appear intermittent depending on how the image entered the document.

## Fix

- Add an `:image` branch mapping to `rect-options` — image shapes expose size / position / rotation / radius just like rects, so the rect measure controls are the correct set.
- Add a **trailing default clause** (`generic-options`) so `case` is total. This is the defensive part: any future or unexpected shape type now degrades to the universal measure controls instead of taking down the whole workspace.

```clojure
(defn- type->options
  [type]
  (case type
    :bool    generic-options
    :circle  generic-options
    :frame   frame-options
    :group   generic-options
    :image   rect-options
    :path    generic-options
    :rect    rect-options
    :svg-raw generic-options
    :text    generic-options
    generic-options))
```

## Reproduction

1. Have a document containing a true `:image`-type shape (e.g. one imported/pasted as an image shape, or grouped images).
2. Select it — or shift-click a multi-select that includes it.
3. **Before:** the workspace blanks to the Internal Error screen; console shows `Error: No matching clause: image`.
4. **After:** the measures panel renders the rect measure controls (size / position / rotation / radius) and the workspace stays interactive.

## Testing notes

- Verified against a running build carrying this patch: selecting and multi-selecting image shapes no longer crashes and shows the expected measure controls.
- Existing shape types (`:rect`, `:frame`, `:text`, `:group`, `:path`, `:circle`, `:svg-raw`, `:bool`) are unchanged — they keep their original branches; only the previously-missing `:image` case and the total-`case` default are added.

## Breaking changes

None. No schema, API, or data changes — a single pure UI dispatch function is made total.