### PR TITLE
:bug: Set correct upstream Host header for internal proxy_pass locations

### DIFF
--- a/docker/images/files/nginx.conf.template
+++ b/docker/images/files/nginx.conf.template
@@ -111,6 +111,7 @@ http {
         }
 
         location /assets {
+            proxy_set_header Host $proxy_host;
             proxy_pass $PENPOT_BACKEND_URI/assets;
             recursive_error_pages on;
             proxy_intercept_errors on;
@@ -127,10 +128,12 @@ http {
         }
 
         location /api/export {
+            proxy_set_header Host $proxy_host;
             proxy_pass $PENPOT_EXPORTER_URI;
         }
 
         location /api {
+            proxy_set_header Host $proxy_host;
             proxy_pass $PENPOT_BACKEND_URI/api;
             proxy_buffering off;
         }
@@ -142,10 +145,12 @@ http {
 
         location /readyz {
             access_log off;
+            proxy_set_header Host $proxy_host;
             proxy_pass $PENPOT_BACKEND_URI$request_uri;
         }
 
         location /ws/notifications {
+            proxy_set_header Host $proxy_host;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
             proxy_pass $PENPOT_BACKEND_URI/ws/notifications;


### PR DESCRIPTION
## Description

Fixes #10835

The nginx frontend template (`nginx.conf.template`) sets a single global directive at the `http {}` level:

```nginx
proxy_set_header Host $http_host;
```

This forwards the client-facing Host header (e.g. the public domain the browser used to reach Penpot) on **every** `proxy_pass`, including the ones targeting internal services: backend (`/api`, `/assets`, `/readyz`, `/ws/notifications`) and exporter (`/api/export`).

This works fine on a plain Kubernetes Service, since routing there is purely IP/port based and the Host header is irrelevant to it. However, in a service-mesh setup with mTLS enforced (e.g. Istio with `PeerAuthentication` in `STRICT` mode), the sidecar proxy relies on the outbound request's Host/`:authority` to match it to the correct upstream cluster/service and originate mTLS accordingly. Since nginx sends the *external* Host instead of the internal service hostname, the mesh sidecar cannot match the request to a known cluster, and the connection falls back to a generic passthrough path — sent in plaintext. The backend's inbound listener, expecting strict mTLS, then rejects or hangs on that plaintext connection, resulting in random-looking `502`/`503`/connection-reset errors on `/api`, `/assets`, `/ws/notifications`, etc.

## Change

Explicitly override the `Host` header in each location that proxies to an internal service, using nginx's `$proxy_host` variable (which always reflects the host:port declared in that location's `proxy_pass`, regardless of the incoming request's Host):

```nginx
location /api {
    proxy_set_header Host $proxy_host;
    proxy_pass $PENPOT_BACKEND_URI/api;
    proxy_buffering off;
}
```

Applied to:
- `/api`
- `/assets`
- `/api/export`
- `/readyz`
- `/ws/notifications`

`/admin-console` was intentionally left untouched since it already sets its own explicit `Host` header, and `@handle_redirect` was left untouched since it proxies to external storage (S3-like), where the original Host override logic still applies.

## Why this doesn't break non-mesh deployments

`$proxy_host` simply resolves to the same value nginx would use internally to establish the upstream connection (host:port from `proxy_pass`). For plain Kubernetes/Docker-compose deployments without a service mesh, this is functionally equivalent to what the backend/exporter already expect (and is in fact closer to standard reverse-proxy best practice for internal service calls than forwarding the client's original Host).

## Testing

Reproduced and validated the fix in a Kubernetes cluster running Istio 1.30.3 with `PeerAuthentication` set to `STRICT`:
- **Before**: `curl http://localhost:8080/api/main/methods/get-profile` (through nginx) failed with `upstream connect error or disconnect/reset before headers. reset reason: connection termination`, while calling the backend service directly (bypassing nginx) succeeded.
- **After**: the same request through nginx returns `200 OK`, and Envoy logs confirm the request is now correctly routed through the mesh's outbound cluster (`outbound|6060||penpot-backend...`) instead of falling back to `PassthroughCluster`.

Also verified that WebSocket upgrade (`/ws/notifications`) and the exporter path (`/api/export`) continue to work as expected.

## Related issue

Full root-cause investigation and diagnostic steps are documented in #10835.