### PR TITLE
:bug: Fix typo in auto-file-snapshot timeout setting

### DIFF
--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -588,7 +588,7 @@ PENPOT_FLAGS: [...] enable-auto-file-snapshot               # Enable automatic v
 
 # Backend
 PENPOT_AUTO_FILE_SNAPSHOT_EVERY: 5             # How many save operations trigger the auto-save-version?
-PENPOT_AUTO_FILE_SNAPSHOT_TIIMEOUT: "1h"       # How often is an automatic save forced even if the `every` trigger is not met?
+PENPOT_AUTO_FILE_SNAPSHOT_TIMEOUT: "1h"       # How often is an automatic save forced even if the `every` trigger is not met?
 ```
 
 Setting custom values for auto-file-snapshot does not change the behaviour for manual versions.


### PR DESCRIPTION
Corrected a typo in the configuration documentation regarding the auto-file-snapshot timeout setting.

### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
