### PR TITLE
:bug: Guard finalize-view-interaction! against spurious pointerup events

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -1347,10 +1347,15 @@
     (or (:panning local) (:zooming local))))
 
 (defn finalize-view-interaction!
-  "Ends the view interaction and triggers a full-quality render."
+  "Ends an in-progress pan/zoom view interaction and triggers a full-quality
+   render. No-ops when no view interaction is active.
+
+   `finish-panning` runs on every pointerup, so without this guard we would
+   call `internal-render` (and WASM `reset_canvas`) on plain clicks."
   []
-  (view-interaction-end!)
-  (internal-render 0 0))
+  (when @view-interaction-active?
+    (view-interaction-end!)
+    (internal-render 0 0)))
 
 (def render-finish
   (letfn [(do-render []


### PR DESCRIPTION
Every pointerup unconditionally fires finish-panning and finish-zooming, which call finalize-view-interaction!. This triggered internal-render (and reset_canvas) on plain clicks — causing a visible white flash on large viewports or weak GPUs.

Add a guard so finalize-view-interaction! only runs when a view interaction (pan/zoom) is actually active.

Fixes #10915

### Summary

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
