### PR TITLE
:bug: Fix gitch of placeholder when switching between teams on dashboard

### DIFF
--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -27,6 +27,7 @@
    [app.main.ui.dashboard.files :refer [files-section*]]
    [app.main.ui.dashboard.fonts :refer [fonts-page* font-providers-page*]]
    [app.main.ui.dashboard.import]
+   [app.main.ui.dashboard.layout-toggle :as lt]
    [app.main.ui.dashboard.libraries :refer [libraries-page*]]
    [app.main.ui.dashboard.projects :refer [projects-section*]]
    [app.main.ui.dashboard.search :refer [search-page*]]
@@ -51,7 +52,7 @@
 
 (mf/defc dashboard-content*
   {::mf/private true}
-  [{:keys [team projects project section search-term profile default-project]}]
+  [{:keys [team projects project section search-term profile default-project layout on-layout-change]}]
   (let [container       (mf/use-ref)
         content-width   (mf/use-state 0)
 
@@ -100,18 +101,18 @@
        :dashboard-recent
        (when (seq projects)
          [:*
-          [:> projects-section*
-           {:team team
-            :projects projects
-            :profile profile}]
+          [:> projects-section* {:team team
+                                 :projects projects
+                                 :profile profile
+                                 :layout layout
+                                 :on-layout-change on-layout-change}]
 
           (when ^boolean show-templates?
-            [:> templates-section*
-             {:profile profile
-              :project-id project-id
-              :team-id team-id
-              :default-project-id default-project-id
-              :content-width @content-width}])])
+            [:> templates-section* {:profile profile
+                                    :project-id project-id
+                                    :team-id team-id
+                                    :default-project-id default-project-id
+                                    :content-width @content-width}])])
 
        :dashboard-fonts
        [:> fonts-page* {:team team}]
@@ -123,14 +124,15 @@
        (when project
          [:*
           [:> files-section* {:team team
-                              :project project}]
+                              :project project
+                              :layout layout
+                              :on-layout-change on-layout-change}]
           (when ^boolean show-templates?
-            [:> templates-section*
-             {:profile profile
-              :team-id team-id
-              :project-id project-id
-              :default-project-id default-project-id
-              :content-width @content-width}])])
+            [:> templates-section* {:profile profile
+                                    :team-id team-id
+                                    :project-id project-id
+                                    :default-project-id default-project-id
+                                    :content-width @content-width}])])
 
        :dashboard-search
        [:> search-page* {:team team
@@ -155,7 +157,9 @@
        :dashboard-deleted
        [:> deleted-section* {:team team
                              :projects projects
-                             :profile profile}]
+                             :profile profile
+                             :layout layout
+                             :on-layout-change on-layout-change}]
 
        nil)]))
 
@@ -313,7 +317,15 @@
         (mf/with-memo [projects]
           (->> projects
                (filter :is-default)
-               (first)))]
+               (first)))
+
+        layout*         (hooks/use-persisted-state lt/layout-key lt/default-layout)
+        layout          (deref layout*)
+
+        on-layout-change
+        (mf/use-fn
+         (fn [value]
+           (reset! layout* (keyword value))))]
 
     (hooks/use-shortcuts ::dashboard sc/shortcuts-dashboard :dashboard)
 
@@ -347,22 +359,22 @@
      ;; team is already set so don't put the team into mf/deps.
      [:main {:class (stl/css :dashboard)
              :key (dm/str (:id team))}
-      [:> sidebar*
-       {:team team
-        :projects projects
-        :project project
-        :default-project default-project
-        :profile profile
-        :section section
-        :search-term search-term}]
-      [:> dashboard-content*
-       {:projects projects
-        :profile profile
-        :project project
-        :default-project default-project
-        :section section
-        :search-term search-term
-        :team team}]]]))
+      [:> sidebar* {:team team
+                    :projects projects
+                    :project project
+                    :default-project default-project
+                    :profile profile
+                    :section section
+                    :search-term search-term}]
+      [:> dashboard-content* {:projects projects
+                              :profile profile
+                              :project project
+                              :default-project default-project
+                              :section section
+                              :search-term search-term
+                              :team team
+                              :layout layout
+                              :on-layout-change on-layout-change}]]]))
 
 (mf/defc dashboard-page*
   {::mf/lazy-load true}

--- a/frontend/src/app/main/ui/dashboard/deleted.cljs
+++ b/frontend/src/app/main/ui/dashboard/deleted.cljs
@@ -219,16 +219,8 @@
        (tr "labels.deleted")]]]))
 
 (mf/defc deleted-section*
-  [{:keys [team projects]}]
-  (let [layout* (hooks/use-persisted-state lt/layout-key lt/default-layout)
-        layout  (deref layout*)
-
-        on-layout-change
-        (mf/use-fn
-         (fn [value]
-           (reset! layout* (keyword value))))
-
-        deleted-map
+  [{:keys [team projects layout on-layout-change]}]
+  (let [deleted-map
         (mf/deref ref:deleted-files)
 
         projects

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -147,7 +147,6 @@
                                 (sort-by :modified-at)
                                 (reverse)))
 
-
         can-edit?          (-> team :permissions :can-edit)
         project-id         (:id project)
         is-draft-proyect   (:is-default project)
@@ -155,8 +154,13 @@
         [rowref limit]     (hooks/use-dynamic-grid-item-width)
 
         file-count         (or (count files) 0)
+
+        loading?           (and (some? (:count project))
+                                (not= (:count project) file-count))
+
         empty-state-viewer (and (not can-edit?)
-                                (= 0 file-count))
+                                (= 0 file-count)
+                                (not loading?))
 
         selected-files     (mf/deref refs/selected-files)
 
@@ -208,7 +212,7 @@
                                             (tr "dashboard.empty-placeholder-drafts-subtitle")
                                             (tr "dashboard.empty-placeholder-files-subtitle"))}]
         [:> grid* {:project project
-                   :files files
+                   :files (if loading? nil files)
                    :selected-files selected-files
                    :can-edit can-edit?
                    :origin :files

--- a/frontend/src/app/main/ui/dashboard/files.cljs
+++ b/frontend/src/app/main/ui/dashboard/files.cljs
@@ -137,7 +137,7 @@
                            :on-import on-import}])]]))
 
 (mf/defc files-section*
-  [{:keys [project team]}]
+  [{:keys [project team layout on-layout-change]}]
   (let [files            (mf/deref refs/files)
         project-id       (get project :id)
 
@@ -159,14 +159,6 @@
                                 (= 0 file-count))
 
         selected-files     (mf/deref refs/selected-files)
-
-        layout*            (hooks/use-persisted-state lt/layout-key lt/default-layout)
-        layout             (deref layout*)
-
-        on-layout-change
-        (mf/use-fn
-         (fn [value]
-           (reset! layout* (keyword value))))
 
         on-file-created
         (mf/use-fn

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -109,6 +109,10 @@
         team-id    (get team :id)
 
         file-count (or (:count project) 0)
+
+        loading?   (and (pos? (:count project))
+                        (empty? files))
+
         is-draft?  (:is-default project)
         empty?     (and (not can-edit)
                         (= 0 file-count))
@@ -292,7 +296,7 @@
 
         [:> line-grid* {:project project
                         :team team
-                        :files files
+                        :files (if loading? nil files)
                         :create-fn create-file
                         :can-edit can-edit
                         :limit limit

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -313,7 +313,7 @@
   (l/derived :recent-files st/state))
 
 (mf/defc projects-section*
-  [{:keys [team projects profile]}]
+  [{:keys [team projects profile layout on-layout-change]}]
 
   (let [team-id         (get team :id)
 
@@ -333,14 +333,6 @@
         default-team?   (:is-default team)
 
         show-deleted?   (:can-edit permisions)
-
-        layout*         (hooks/use-persisted-state lt/layout-key lt/default-layout)
-        layout          (deref layout*)
-
-        on-layout-change
-        (mf/use-fn
-         (fn [value]
-           (reset! layout* (keyword value))))
 
         projects
         (mf/with-memo [projects]


### PR DESCRIPTION
### Related Ticket

Closes #10871 

### Summary

The dashboard remounts its entire subtree on team switch. Each section (`projects-section*`, `files-section*`, `deleted-section*`) independently called `hooks/use-persisted-state` which re-initialized on remount. During remount reconciliation, React briefly rendered with the default `:grid` layout before the persisted `:list` value resolved from storage.

To fix this, we lifted the `use-persisted-state` call up to `dashboard*`, which does not remount on team switch — only the children inside `<main>` do. The layout value and change handler are passed down through `dashboard-content*` to all three sections via props. This eliminates the transient `:grid` frame entirely.

We also fix a dashboard UI bug where the "no files" placeholder would flash/appear while files were still loading.