### PR TITLE
:bug: Fix stale DNS caching in frontend nginx MCP proxy

### DIFF
--- a/docker/images/files/nginx-mcp-locations.conf.template
+++ b/docker/images/files/nginx-mcp-locations.conf.template
@@ -1,16 +1,19 @@
 location /mcp/ws {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';
-    proxy_pass $PENPOT_MCP_URI_WS;
+    set $mcp_ws_backend $PENPOT_MCP_URI_WS;
+    proxy_pass $mcp_ws_backend;
     proxy_http_version 1.1;
 }
 
 location /mcp/stream {
-    proxy_pass $PENPOT_MCP_URI/mcp;
+    set $mcp_stream_backend $PENPOT_MCP_URI/mcp$is_args$args;
+    proxy_pass $mcp_stream_backend;
     proxy_http_version 1.1;
 }
 
 location /mcp/sse {
-    proxy_pass $PENPOT_MCP_URI/sse;
+    set $mcp_sse_backend $PENPOT_MCP_URI/sse$is_args$args;
+    proxy_pass $mcp_sse_backend;
     proxy_http_version 1.1;
 }


### PR DESCRIPTION
## Summary

Closes #10946.

`docker/images/files/nginx-mcp-locations.conf.template` proxies each `/mcp/*` location to a plain string (`proxy_pass http://penpot-mcp:4402;` after `envsubst` bakes in the shell variable at container startup). nginx resolves a literal `proxy_pass` hostname once, at config load, and never re-checks it — so the `resolver 127.0.0.11 valid=10s;` directive already generated in `overrides/http.d/resolvers.conf` has no effect here (it only re-resolves nginx-level variables evaluated per-request).

In multi-container deployments, if `penpot-mcp` restarts/is recreated independently of `penpot-frontend` (image bump, OOM, orchestrator reschedule) and gets a new IP, `penpot-frontend`'s nginx keeps forwarding to the dead old address until the frontend container itself is restarted. Users see `wss://<host>/mcp/ws` fail to connect from the browser, with `connect() failed (111: Connection refused)` in the frontend's nginx logs.

- Route each `/mcp/ws`, `/mcp/stream`, `/mcp/sse` location's `proxy_pass` through a `set $var ...;` first, so it's a real nginx variable — this lets the pre-existing `resolver` directive re-resolve `penpot-mcp` within its 10s TTL instead of caching the address for the container's lifetime.
- No other files changed; `nginx-entrypoint.sh`'s `envsubst` call and variable names are untouched.

## Testing notes

Reproduced against a live Docker Compose deployment (`penpot-frontend`/`penpot-mcp`/`penpot-backend`/`penpot-exporter` on a shared bridge network, Penpot 2.17.0):

1. Confirmed the bug: `docker logs penpot-frontend` showed `connect() failed (111: Connection refused)` pointing at a stale `penpot-mcp` IP after the mcp container had been recreated ~5 minutes after the frontend started.
2. Applied this template change, recreated `penpot-frontend` to regenerate the config, verified with `nginx -t` that the generated config is still valid, and confirmed `docker exec penpot-frontend cat /etc/nginx/overrides/server.d/mcp-locations.conf` shows the `set`/`proxy_pass` pair with real values substituted.
3. Forced a genuine IP change on `penpot-mcp` (a throwaway container temporarily occupied its old address) **without restarting `penpot-frontend`**, and confirmed the `/mcp/ws` WebSocket upgrade kept returning `101 Switching Protocols` both immediately and after the resolver's 10s TTL window.

No UI-visible change; this only affects internal nginx→penpot-mcp proxying.