### PR TITLE
:bug: Apply the asset attachment disposition on the s3 backend too

### DIFF
--- a/backend/src/app/http/assets.clj
+++ b/backend/src/app/http/assets.clj
@@ -49,13 +49,21 @@
   [{:keys [::sto/storage ::signature-max-age ::cache-max-age] :as cfg} obj]
   (let [sig-max-age (or signature-max-age default-signature-max-age)
         cch-max-age (or cache-max-age default-cache-max-age)
-        {:keys [host port] :as url} (sto/get-object-url storage obj {:max-age sig-max-age})
         bucket  (-> obj meta :bucket)
+        public? (contains? public-buckets bucket)
+        ;; The disposition is also signed into the presigned url: this
+        ;; response is a redirect, so the header below applies to the
+        ;; redirect itself and not to the bytes the client then fetches
+        ;; from the object store.
+        {:keys [host port] :as url} (sto/get-object-url storage obj
+                                                        (cond-> {:max-age sig-max-age}
+                                                          (not public?)
+                                                          (assoc :content-disposition "attachment")))
         headers (cond-> {"location" (str url)
                          "x-host"   (cond-> host port (str ":" port))
                          "x-mtype"  (-> obj meta :content-type)
                          "cache-control" (str "max-age=" (inst-ms cch-max-age))}
-                  (not (contains? public-buckets bucket))
+                  (not public?)
                   (assoc "content-disposition" "attachment"))]
     {::yres/status  307
      ::yres/headers headers}))

--- a/backend/src/app/storage/s3.clj
+++ b/backend/src/app/storage/s3.clj
@@ -346,13 +346,21 @@
   (ct/duration {:minutes 10}))
 
 (defn- get-object-url
-  [{:keys [::presigner ::bucket ::prefix]} {:keys [id]} {:keys [max-age] :or {max-age default-max-age}}]
+  [{:keys [::presigner ::bucket ::prefix]} {:keys [id]}
+   {:keys [max-age content-disposition] :or {max-age default-max-age}}]
   (assert (ct/duration? max-age) "expected valid duration instance")
 
-  (let [gor  (.. (GetObjectRequest/builder)
+  ;; The content-disposition option is signed into the presigned url, so the
+  ;; object store sets that header on the response the client fetches after
+  ;; following the redirect. It is only set when asked for, so urls for
+  ;; objects served inline stay byte identical to before.
+  (let [gorb (.. (GetObjectRequest/builder)
                  (bucket bucket)
-                 (key (dm/str prefix (impl/id->path id)))
-                 (build))
+                 (key (dm/str prefix (impl/id->path id))))
+        gorb (cond-> gorb
+               (some? content-disposition)
+               (.responseContentDisposition ^String content-disposition))
+        gor  (.build gorb)
         gopr (.. (GetObjectPresignRequest/builder)
                  (signatureDuration ^Duration max-age)
                  (getObjectRequest ^GetObjectRequest gor)

--- a/backend/test/backend_tests/http_assets_test.clj
+++ b/backend/test/backend_tests/http_assets_test.clj
@@ -270,6 +270,50 @@
     (t/is (clojure.string/includes? redirect (sto/object->relative-path object)))))
 
 ;; ----------------------------------------------------------------
+;; Tests: objects-handler — content disposition
+;; ----------------------------------------------------------------
+
+(t/deftest objects-handler-non-public-bucket-served-as-attachment
+  ;; A non-public bucket holds bytes the user uploaded and is reachable by
+  ;; direct navigation, so the response marks it as an attachment.
+  (let [storage  (-> (:app.storage/storage th/*system*)
+                     (configure-storage-backend))
+        cfg      (make-handler-cfg storage)
+        profile  (th/create-profile* 1)]
+
+    (doseq [bucket ["profile"
+                    "tempfile"
+                    "file-data"
+                    "file-thumbnail"
+                    "file-change"]]
+      (t/testing (str "bucket: " bucket)
+        (let [object   (create-storage-object! storage bucket "some data")
+              request  {:path-params {:id (str (:id object))}
+                        ::session/profile-id (:id profile)}
+              response (assets/objects-handler cfg request)]
+          (t/is (= "attachment" (get (::yres/headers response) "content-disposition"))
+                (str "bucket " bucket " should be served as an attachment")))))))
+
+(t/deftest objects-handler-public-bucket-served-inline
+  ;; Public buckets are embedded by the viewer and by outgoing mail, so they
+  ;; keep being served without a disposition.
+  (let [storage  (-> (:app.storage/storage th/*system*)
+                     (configure-storage-backend))
+        cfg      (make-handler-cfg storage)]
+
+    (doseq [bucket ["file-media-object"
+                    "file-object-thumbnail"
+                    "team-font-variant"
+                    "file-data-fragment"
+                    "organization"]]
+      (t/testing (str "bucket: " bucket)
+        (let [object   (create-storage-object! storage bucket "some data")
+              request  {:path-params {:id (str (:id object))}}
+              response (assets/objects-handler cfg request)]
+          (t/is (nil? (get (::yres/headers response) "content-disposition"))
+                (str "bucket " bucket " should stay inline")))))))
+
+;; ----------------------------------------------------------------
 ;; Tests: objects-handler — cache headers
 ;; ----------------------------------------------------------------
 


### PR DESCRIPTION
### Related Ticket

No public issue: reported privately, see References below.

### Summary

**What**

`serve-object-from-s3` and `serve-object-from-fs` (`backend/src/app/http/assets.clj:47` and `:58`) return a stored object with the content type it was uploaded with and no disposition. An uploaded SVG is therefore served as `image/svg+xml` from the application origin, and a browser that navigates to `/assets/by-id/<media-id>` parses it as an SVG document and runs the script elements it carries under that origin.

**Why**

Nothing between upload and serve keeps stored markup from becoming a document. `process-main-image` (`backend/src/app/rpc/commands/media.clj:114`) stores the raw bytes with the declared mtype, the SAX pass in `app.media` reads dimensions only, and `app.media.sanitize` documents SVG as a no-op (`backend/src/app/media/sanitize.clj:139`). `file-media-object` is one of the public buckets, so the fetch needs no session.

**How**

Both serve paths now set `content-disposition: attachment`. On the fs backend the header travels with the `x-accel-redirect` response and nginx passes it on to the client. On the s3 backend `get-object-url` takes a `:content-disposition` option that `backend/src/app/storage/s3.clj` signs into the presigned URL as `responseContentDisposition`, so S3 sets the header itself whichever client follows the 307.

`app.rpc.commands.nitrate` already reaches for the same header when it hands a generated file to the browser (`backend/src/app/rpc/commands/nitrate.clj:145`).

The header is not conditional on content type or bucket: every object these handlers serve is user supplied, and a type test would have to track each renderable type instead.

Left unchanged: the stored bytes, the upload validation, and the canvas SVG import path, which already drops scripts through `@penpot/svgo` and the tag allowlist in `common/src/app/common/svg.cljc`.

**Behaviour change**

Opening an asset URL directly in a browser tab downloads the file instead of displaying it. Subresource loads are unaffected, since `Content-Disposition` applies to navigations and not to `<img>`, CSS `@font-face` or `fetch`/XHR. The export download in `frontend/src/app/util/dom.cljs:788` already goes through an `<a download>` element, so that flow keeps working as before.

### Steps to reproduce

On a stock `docker/images/docker-compose.yaml` instance, upload an SVG to a file and request the asset without a session:

```
curl -sI http://localhost:9001/assets/by-id/<media-id>
```

Before: `content-type: image/svg+xml` and no `content-disposition`; navigating a browser to that URL renders the SVG as a document in the application origin. After: the same response carries `content-disposition: attachment` and the navigation downloads instead of committing. `/assets/by-file-media-id/<id>` behaves the same way, and an `<img src>` of the asset renders in both cases.

### Testing

Run in `penpotapp/devenv:latest` against postgres 17 and valkey 9, as `.github/workflows/tests-backend.yml` does:

- `cljfmt check --parallel=true src/ test/`: all source files formatted correctly.
- `clj-kondo --parallel --lint ../common/src/ src/`: 0 errors, 0 warnings.
- `clojure -M:dev:test --focus backend-tests.http-assets-test`: 25 tests, 70 assertions, 0 failures. Reverting the two source files and rerunning gives 8 failures in the new tests, so they cover the change.
- `clojure -M:dev:test`: 574 tests, 4200 assertions, 0 failures.

New tests in `backend/test/backend_tests/http_assets_test.clj`: `objects-handler-svg-served-as-attachment` and `objects-handler-content-disposition-on-every-bucket`.

Checked by hand against a patched `penpotapp/backend:2.16` compose stack on the fs backend, so the nginx `x-accel-redirect` hop is included:

- `/assets/by-id/<id>` and `/assets/by-file-media-id/<id>` both return `content-disposition: attachment` to the client.
- A top level navigation to an SVG asset no longer commits a document; before the change the same URL rendered as an SVG document in the application origin.
- `<img src>` of an uploaded PNG and of an uploaded SVG still render at their natural size, and `fetch` of an asset still returns 200 with the full body.
- `export-binfile` still downloads as a valid zip archive.

The s3 path was reviewed but not exercised: this setup has no S3 backend, so the presigned URL change is not covered by a test run.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. Not applicable: no UI change, the difference is a response header.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide. Not applicable: no SCSS touched.
- [ ] Check CI passes successfully. The CI fmt, lint and backend test steps were run locally in the devenv image; CI itself has not run yet.

### References

GHSA-9q54-9wm7-c4rr (reported privately, unpublished at time of writing)
