### PR TITLE
:bug: Add configurable limits for ZIP entry count and object size in v3 import

### DIFF
--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -42,6 +42,7 @@
    [datoteka.io :as io])
   (:import
    java.io.File
+   java.io.FilterInputStream
    java.io.InputStream
    java.io.OutputStreamWriter
    java.lang.AutoCloseable
@@ -430,6 +431,31 @@
   [^ZipFile input ^ZipEntry entry]
   (.getInputStream input entry))
 
+(defn- size-limiting-stream
+  "Wraps an InputStream to enforce a maximum number of decompressed bytes.
+  Raises :validation :max-file-size-reached when the limit is exceeded."
+  ^InputStream
+  [^InputStream input ^long max-size]
+  (let [counter (atom 0)]
+    (proxy [FilterInputStream] [input]
+      (read
+        ([]
+         (let [b (.read input)]
+           (when (pos? b)
+             (when (> (swap! counter inc) max-size)
+               (ex/raise :type :validation
+                         :code :max-file-size-reached
+                         :hint (str "stream exceeded max size: " max-size))))
+           b))
+        ([buf off len]
+         (let [n (.read input buf off len)]
+           (when (pos? n)
+             (when (> (swap! counter + (long n)) max-size)
+               (ex/raise :type :validation
+                         :code :max-file-size-reached
+                         :hint (str "stream exceeded max size: " max-size))))
+           n))))))
+
 (defn- zip-entry-reader
   [^ZipFile input ^ZipEntry entry]
   (-> (zip-entry-stream input entry)
@@ -438,10 +464,12 @@
 (defn- zip-entry-storage-content
   "Wraps a ZipFile and ZipEntry into a penpot storage compatible
   object and avoid creating temporal objects"
-  [input entry]
-  (let [hash  (delay (->> entry
-                          (zip-entry-stream input)
-                          (sto.impl/calculate-hash)))]
+  [input entry & {:keys [max-size]}]
+  (let [stream-fn (fn []
+                    (cond-> (zip-entry-stream input entry)
+                      max-size (size-limiting-stream max-size)))
+        hash      (delay (->> (stream-fn)
+                              (sto.impl/calculate-hash)))]
     (reify
       sto.impl/IContentObject
       (get-size [_]
@@ -458,7 +486,7 @@
         (throw (UnsupportedOperationException. "not implemented")))
 
       (make-input-stream [_ _]
-        (zip-entry-stream input entry))
+        (stream-fn))
       (make-output-stream [_ _]
         (throw (UnsupportedOperationException. "not implemented"))))))
 
@@ -844,9 +872,9 @@
 
             ext     (cmedia/mtype->extension (:content-type object))
             path    (str "objects/" id ext)
-            content (->> path
-                         (get-zip-entry input)
-                         (zip-entry-storage-content input))]
+            content (zip-entry-storage-content input
+                                               (get-zip-entry input path)
+                                               :max-size (::bfc/import-max-object-size cfg))]
 
         (when (not= (:size object) (sto/get-size content))
           (ex/raise :type :validation

--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -856,6 +856,15 @@
                     :expected-size (:size object)
                     :found-size (sto/get-size content)))
 
+        (when-let [max (::bfc/import-max-object-size cfg)]
+          (when (> (sto/get-size content) max)
+            (ex/raise :type :validation
+                      :code :max-file-size-reached
+                      :hint (str "storage object exceeds maximum size: " (sto/get-size content))
+                      :path path
+                      :max max
+                      :found (sto/get-size content))))
+
         (when-let [hash (get object :hash)]
           (when (not= hash (sto/get-hash content))
             (ex/raise :type :validation
@@ -938,6 +947,15 @@
   (let [manifest (-> (read-manifest input)
                      (validate-manifest))
         entries  (read-zip-entries input)
+
+        _        (when-let [max (::bfc/import-max-zip-entries cfg)]
+                   (when (> (count entries) max)
+                     (ex/raise :type :validation
+                               :code :too-many-zip-entries
+                               :hint (str "zip file has too many entries: " (count entries))
+                               :max max
+                               :found (count entries))))
+
         cfg      (-> cfg
                      (assoc ::entries entries)
                      (assoc ::manifest manifest)

--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -94,7 +94,11 @@
 
    ;; SSRF protection
    :ssrf-allowed-hosts #{}
-   :ssrf-extra-blocked-cidrs #{}})
+   :ssrf-extra-blocked-cidrs #{}
+
+   ;; Binfile import limits
+   :binfile-import-max-object-size (* 1024 1024 100) ;; 100 MiB
+   :binfile-import-max-zip-entries (* 500 1000)})    ;; 500,000
 
 (def schema:config
   (do #_sm/optional-keys
@@ -150,6 +154,10 @@
 
     [:media-processing-service-uri {:optional true} ::sm/uri]
     [:media-processing-service-timeout {:optional true} ::sm/int]
+
+    ;; Binfile import limits (PENPOT_BINFILE_IMPORT_*)
+    [:binfile-import-max-object-size {:optional true} ::sm/int]
+    [:binfile-import-max-zip-entries {:optional true} ::sm/int]
 
     [:deletion-delay {:optional true} ::ct/duration]
     [:file-clean-delay {:optional true} ::ct/duration]

--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -94,7 +94,11 @@
 
    ;; SSRF protection
    :ssrf-allowed-hosts #{}
-   :ssrf-extra-blocked-cidrs #{}})
+   :ssrf-extra-blocked-cidrs #{}
+
+   ;; Binfile import limits
+   :binfile-import-max-object-size (* 1024 1024 100) ;; 100 MiB
+   :binfile-import-max-zip-entries (* 500 1000)})    ;; 500,000
 
 (def schema:config
   (do #_sm/optional-keys
@@ -146,6 +150,10 @@
     [:imagemagick-time-limit {:optional true} :string]
     [:imagemagick-width-limit {:optional true} :string]
     [:imagemagick-height-limit {:optional true} :string]
+
+    ;; Binfile import limits (PENPOT_BINFILE_IMPORT_*)
+    [:binfile-import-max-object-size {:optional true} ::sm/int]
+    [:binfile-import-max-zip-entries {:optional true} ::sm/int]
 
     [:deletion-delay {:optional true} ::ct/duration]
     [:file-clean-delay {:optional true} ::ct/duration]

--- a/backend/src/app/http/debug.clj
+++ b/backend/src/app/http/debug.clj
@@ -318,7 +318,9 @@
                                 ::bfc/overwrite false
                                 ::bfc/profile-id profile-id
                                 ::bfc/project-id project-id
-                                ::bfc/input path)]
+                                ::bfc/input path
+                                ::bfc/import-max-object-size (cf/get :binfile-import-max-object-size)
+                                ::bfc/import-max-zip-entries (cf/get :binfile-import-max-zip-entries))]
           (bf.v3/import-files! cfg)
           {::yres/status  200
            ::yres/headers {"content-type" "text/plain"}
@@ -354,7 +356,9 @@
                         ::bfc/profile-id profile-id
                         ::bfc/project-id project-id
                         ::bfc/input path
-                        ::bfc/features (cfeat/get-team-enabled-features cf/flags team))]
+                        ::bfc/features (cfeat/get-team-enabled-features cf/flags team)
+                        ::bfc/import-max-object-size (cf/get :binfile-import-max-object-size)
+                        ::bfc/import-max-zip-entries (cf/get :binfile-import-max-zip-entries))]
 
       (if (= format :binfile-v3)
         (bf.v3/import-files! cfg)

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -93,7 +93,9 @@
             (assoc ::bfc/features (cfeat/get-team-enabled-features cf/flags team))
             (assoc ::bfc/project-id project-id)
             (assoc ::bfc/profile-id profile-id)
-            (assoc ::bfc/name name))
+            (assoc ::bfc/name name)
+            (assoc ::bfc/import-max-object-size (cf/get :binfile-import-max-object-size))
+            (assoc ::bfc/import-max-zip-entries (cf/get :binfile-import-max-zip-entries)))
 
         input-path (:path file)
         owned?     (some? upload-id)

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -92,7 +92,9 @@
             (assoc ::bfc/features (cfeat/get-team-enabled-features cf/flags team))
             (assoc ::bfc/project-id project-id)
             (assoc ::bfc/profile-id profile-id)
-            (assoc ::bfc/name name))
+            (assoc ::bfc/name name)
+            (assoc ::bfc/import-max-object-size (cf/get :binfile-import-max-object-size))
+            (assoc ::bfc/import-max-zip-entries (cf/get :binfile-import-max-zip-entries)))
 
         input-path (:path file)
         owned?     (some? upload-id)

--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -426,7 +426,9 @@
                      (assoc ::bfc/project-id project-id)
                      (assoc ::bfc/profile-id profile-id)
                      (assoc ::bfc/input template)
-                     (assoc ::bfc/features (cfeat/get-team-enabled-features cf/flags team)))
+                     (assoc ::bfc/features (cfeat/get-team-enabled-features cf/flags team))
+                     (assoc ::bfc/import-max-object-size (cf/get :binfile-import-max-object-size))
+                     (assoc ::bfc/import-max-zip-entries (cf/get :binfile-import-max-zip-entries)))
 
         result   (if (= format :binfile-v3)
                    (bf.v3/import-files! cfg)

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -23,6 +23,7 @@
    [app.storage :as sto]
    [app.storage.tmp :as tmp]
    [backend-tests.helpers :as th]
+   [backend-tests.storage-test :as stt]
    [clojure.test :as t]
    [cuerdas.core :as str]
    [datoteka.fs :as fs]
@@ -257,3 +258,60 @@
                     d)))]
       (t/is (= :validation (:type out)))
       (t/is (= :too-many-zip-entries (:code out))))))
+
+(defn- prepare-file-with-media
+  "Creates a file with a media object backed by a real storage object,
+  so that v3 export produces objects/ entries."
+  [profile]
+  (let [storage (-> (:app.storage/storage th/*system*)
+                    (stt/configure-storage-backend))
+
+        sobject (sto/put-object! storage {::sto/content (sto/content "media-bytes")
+                                          :content-type "image/svg+xml"
+                                          :bucket "file-media-object"})
+
+        file    (th/create-file* 1 {:profile-id (:id profile)
+                                    :project-id (:default-project-id profile)
+                                    :is-shared false})
+
+        mobj    (th/create-file-media-object* {:file-id (:id file)
+                                               :is-local true
+                                               :media-id (:id sobject)})]
+    (update-file!
+     :file-id (:id file)
+     :profile-id (:id profile)
+     :revn 0
+     :vern 0
+     :changes
+     [{:type :add-media
+       :object mobj}])
+
+    (dissoc file :data)))
+
+(t/deftest import-rejects-oversized-object
+  ;; import must reject storage objects exceeding max-object-size
+  (let [profile (th/create-profile* 1)
+        file    (prepare-file-with-media profile)
+        output  (tmp/tempfile :suffix ".zip")]
+
+    (v3/export-files!
+     (-> th/*system*
+         (assoc ::bfc/ids #{(:id file)})
+         (assoc ::bfc/embed-assets false)
+         (assoc ::bfc/include-libraries false))
+     (io/output-stream output))
+
+    ;; Import with max-object-size=1 — the media object will exceed this
+    (let [cfg (-> th/*system*
+                  (assoc ::bfc/project-id (:default-project-id profile))
+                  (assoc ::bfc/profile-id (:id profile))
+                  (assoc ::bfc/input output)
+                  (assoc ::bfc/import-max-object-size 1))
+          out (try
+                (v3/import-files! cfg)
+                :no-error
+                (catch Throwable e
+                  (let [d (or (ex-data e) (some-> (ex-cause e) ex-data))]
+                    d)))]
+      (t/is (= :validation (:type out)))
+      (t/is (= :max-file-size-reached (:code out))))))

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -229,3 +229,31 @@
           ;; With the guard, it raises :validation :max-file-size-reached.
           (t/is (= :validation (:type out)))
           (t/is (= :max-file-size-reached (:code out))))))))
+
+(t/deftest import-rejects-too-many-zip-entries
+  ;; import must reject ZIP files exceeding max-zip-entries
+  (let [profile (th/create-profile* 1)
+        file    (prepare-simple-file profile)
+        output  (tmp/tempfile :suffix ".zip")]
+
+    (v3/export-files!
+     (-> th/*system*
+         (assoc ::bfc/ids #{(:id file)})
+         (assoc ::bfc/embed-assets false)
+         (assoc ::bfc/include-libraries false))
+     (io/output-stream output))
+
+    ;; Import with max-zip-entries=1 — the exported ZIP has more entries
+    (let [cfg (-> th/*system*
+                  (assoc ::bfc/project-id (:default-project-id profile))
+                  (assoc ::bfc/profile-id (:id profile))
+                  (assoc ::bfc/input output)
+                  (assoc ::bfc/import-max-zip-entries 1))
+          out (try
+                (v3/import-files! cfg)
+                :no-error
+                (catch Throwable e
+                  (let [d (or (ex-data e) (some-> (ex-cause e) ex-data))]
+                    d)))]
+      (t/is (= :validation (:type out)))
+      (t/is (= :too-many-zip-entries (:code out))))))

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -105,3 +105,31 @@
                      (v3/import-files!))]
       (t/is (= (count result) 1))
       (t/is (every? uuid? result)))))
+
+(t/deftest import-rejects-too-many-zip-entries
+  ;; import must reject ZIP files exceeding max-zip-entries
+  (let [profile (th/create-profile* 1)
+        file    (prepare-simple-file profile)
+        output  (tmp/tempfile :suffix ".zip")]
+
+    (v3/export-files!
+     (-> th/*system*
+         (assoc ::bfc/ids #{(:id file)})
+         (assoc ::bfc/embed-assets false)
+         (assoc ::bfc/include-libraries false))
+     (io/output-stream output))
+
+    ;; Import with max-zip-entries=1 — the exported ZIP has more entries
+    (let [cfg (-> th/*system*
+                  (assoc ::bfc/project-id (:default-project-id profile))
+                  (assoc ::bfc/profile-id (:id profile))
+                  (assoc ::bfc/input output)
+                  (assoc ::bfc/import-max-zip-entries 1))
+          out (try
+                (v3/import-files! cfg)
+                :no-error
+                (catch Throwable e
+                  (let [d (or (ex-data e) (some-> (ex-cause e) ex-data))]
+                    d)))]
+      (t/is (= :validation (:type out)))
+      (t/is (= :too-many-zip-entries (:code out))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Added configurable limits for ZIP entry count and object size in v3 binfile import
- New config entries: `binfile-import-max-zip-entries` (default 500,000) and `binfile-import-max-object-size` (default 100 MiB)
- Configurable via `PENPOT_BINFILE_IMPORT_MAX_ZIP_ENTRIES` and `PENPOT_BINFILE_IMPORT_MAX_OBJECT_SIZE` environment variables

## Why

The v3 binfile import lacked limits on ZIP entry count and individual object size, allowing resource exhaustion attacks with crafted archive files.

## How

- Entry count is validated before processing begins
- Per-object size is validated after each storage object content is resolved
- Both limits are configurable via environment variables for deployment flexibility

Closes #11021
