### PR TITLE
:bug: Add concurrency limit to import-binfile RPC handler

### DIFF
--- a/backend/resources/climit.edn
+++ b/backend/resources/climit.edn
@@ -45,4 +45,10 @@
  {:permits 4}
 
  :send-user-feedback/by-profile
- {:permits 1 :queue 3}}
+ {:permits 1 :queue 3}
+
+ :import-binfile/global
+ {:permits 4}
+
+ :import-binfile/by-profile
+ {:permits 1 :queue 2}}

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -21,6 +21,7 @@
    [app.loggers.webhooks :as-alias webhooks]
    [app.media.validation :as media.v]
    [app.rpc :as-alias rpc]
+   [app.rpc.climit :as-alias climit]
    [app.rpc.commands.files :as files]
    [app.rpc.commands.media :as media-cmd]
    [app.rpc.commands.projects :as projects]
@@ -142,7 +143,9 @@
 
    ::webhooks/event? true
    ::sse/stream? true
-   ::sm/params schema:import-binfile}
+   ::sm/params schema:import-binfile
+   ::climit/id [[:import-binfile/by-profile ::rpc/profile-id]
+                [:import-binfile/global]]}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id project-id version upload-id] :as params}]
   (projects/check-edition-permissions! pool profile-id project-id)
   (let [version (or version 3)


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Added concurrency limits to the `import-binfile` RPC handler
- Applied `climit` with 4 global permits and 1 per-profile permit (queue 2)

## Why

Each import holds a database connection for its entire duration with idle transaction timeout disabled. Without concurrency limits, unbounded concurrent imports could exhaust the connection pool (default 60 connections).

## How

- Added `::climit/id` metadata to the `import-binfile` command definition
- Configured two limit dimensions: global and per-profile
- Updated `climit.edn` configuration with the new limit definitions

Closes #11023
