### PR TITLE
:bug: Escape markdown in Mattermost error notifications

### DIFF
--- a/backend/src/app/loggers/mattermost.clj
+++ b/backend/src/app/loggers/mattermost.clj
@@ -7,6 +7,7 @@
 (ns app.loggers.mattermost
   "A mattermost integration for error reporting."
   (:require
+   [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.logging :as l]
    [app.common.pprint :as pp]
@@ -25,7 +26,7 @@
 (defn- send-mattermost-notification!
   [cfg {:keys [id] :as report}]
   (let [type (get report :type)
-        text (str "#" type " | " (get report :hint) "\n"
+        text (str "#" type " | " (d/escape-markdown (get report :hint)) "\n"
                   (when id
                     (str (u/join (cf/get :public-uri) "/dbg/error/" id) " "))
 
@@ -38,7 +39,7 @@
                   "- tenant: #" (:tenant report) "\n"
                   "- origin: #" (:origin report) "\n"
                   (when-let [href (get report :href)]
-                    (str "- href: `" href "`\n"))
+                    (str "- href: `" (d/escape-markdown href) "`\n"))
                   (when-let [version (get report :frontend-version)]
                     (str "- frontend-version: `" version "`\n"))
                   (when-let [version (get report :backend-version)]

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -1192,6 +1192,15 @@
         str/trim)
     ""))
 
+(defn escape-markdown
+  "Escapes Markdown special characters by prefixing them with backslash.
+  Intended for user-controlled values embedded in Markdown messages
+  (e.g. Mattermost notifications)."
+  [s]
+  (if s
+    (str/replace (str s) #"([*_~`\[\]()>#+=\-|{}.!@\\])" (fn [[_ c]] (str "\\" c)))
+    ""))
+
 (defn get-initials
   "Returns up to two uppercase initials extracted from a string.
   Non-letter prefixes in each token are ignored."

--- a/common/src/app/common/data.cljc
+++ b/common/src/app/common/data.cljc
@@ -1183,6 +1183,15 @@
         str/trim)
     ""))
 
+(defn escape-markdown
+  "Escapes Markdown special characters by prefixing them with backslash.
+  Intended for user-controlled values embedded in Markdown messages
+  (e.g. Mattermost notifications)."
+  [s]
+  (if s
+    (str/replace (str s) #"([*_~`\[\]()>#+=\-|{}.!@\\])" "\\\\$1")
+    ""))
+
 (defn get-initials
   "Returns up to two uppercase initials extracted from a string.
   Non-letter prefixes in each token are ignored."

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -54,6 +54,25 @@
   (t/is (= :keyword (d/normalize-string :keyword)))
   (t/is (= true (d/normalize-string true))))
 
+(t/deftest escape-markdown-test
+  (t/is (= "hello" (d/escape-markdown "hello")))
+  (t/is (= "" (d/escape-markdown nil)))
+  (t/is (= "" (d/escape-markdown "")))
+  (t/is (= "\\*bold\\*" (d/escape-markdown "*bold*")))
+  (t/is (= "\\_italic\\_" (d/escape-markdown "_italic_")))
+  (t/is (= "\\~strikethrough\\~" (d/escape-markdown "~strikethrough~")))
+  (t/is (= "\\`code\\`" (d/escape-markdown "`code`")))
+  (t/is (= "\\[link\\]\\(http://evil\\.com\\)" (d/escape-markdown "[link](http://evil.com)")))
+  (t/is (= "\\> quote" (d/escape-markdown "> quote")))
+  (t/is (= "\\# heading" (d/escape-markdown "# heading")))
+  (t/is (= "\\@channel" (d/escape-markdown "@channel")))
+  (t/is (= "\\!bang" (d/escape-markdown "!bang")))
+  (t/is (= "normal\\-text" (d/escape-markdown "normal-text")))
+  (t/is (= "a\\+b\\=c" (d/escape-markdown "a+b=c")))
+  (t/is (= "pipe\\|separated" (d/escape-markdown "pipe|separated")))
+  (t/is (= "curly\\{\\}braces" (d/escape-markdown "curly{}braces")))
+  (t/is (= "backslash\\\\slash" (d/escape-markdown "backslash\\slash"))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Ordered Data Structures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/common/test/common_tests/data_test.cljc
+++ b/common/test/common_tests/data_test.cljc
@@ -36,6 +36,25 @@
   (t/is (= "" (d/get-initials nil)))
   (t/is (= "" (d/get-initials "!!! ???"))))
 
+(t/deftest escape-markdown-test
+  (t/is (= "hello" (d/escape-markdown "hello")))
+  (t/is (= "" (d/escape-markdown nil)))
+  (t/is (= "" (d/escape-markdown "")))
+  (t/is (= "\\*bold\\*" (d/escape-markdown "*bold*")))
+  (t/is (= "\\_italic\\_" (d/escape-markdown "_italic_")))
+  (t/is (= "\\~strikethrough\\~" (d/escape-markdown "~strikethrough~")))
+  (t/is (= "\\`code\\`" (d/escape-markdown "`code`")))
+  (t/is (= "\\[link\\]\\(http://evil\\.com\\)" (d/escape-markdown "[link](http://evil.com)")))
+  (t/is (= "\\> quote" (d/escape-markdown "> quote")))
+  (t/is (= "\\# heading" (d/escape-markdown "# heading")))
+  (t/is (= "\\@channel" (d/escape-markdown "@channel")))
+  (t/is (= "\\!bang" (d/escape-markdown "!bang")))
+  (t/is (= "normal\\-text" (d/escape-markdown "normal-text")))
+  (t/is (= "a\\+b\\=c" (d/escape-markdown "a+b=c")))
+  (t/is (= "pipe\\|separated" (d/escape-markdown "pipe|separated")))
+  (t/is (= "curly\\{\\}braces" (d/escape-markdown "curly{}braces")))
+  (t/is (= "backslash\\\\slash" (d/escape-markdown "backslash\\slash"))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Ordered Data Structures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Added markdown escaping to user-controlled fields in Mattermost error notifications to prevent markdown injection.

## Why

The Mattermost error reporter was not escaping markdown special characters in user-controlled fields like `:hint` and `:href`, which could allow unintended formatting or injection in error notifications.

## How

- Added `escape-markdown` function to `common/data.cljc` that escapes markdown special characters (*, _, ~, `, [, ], >, #, @, etc.) by prefixing them with backslash
- Applied the escaping function to user-controlled fields (`:hint`, `:href`) in the Mattermost error reporter before constructing notification messages

Closes #11033
