### PR TITLE
:bug: Mock DNS resolution in SSRF tests for environments without public DNS

### DIFF
--- a/backend/test/backend_tests/util_ssrf_test.clj
+++ b/backend/test/backend_tests/util_ssrf_test.clj
@@ -13,11 +13,25 @@
    [clojure.test :as t]))
 
 (t/deftest validate-url-allows-public-https
-  (t/is (true? (ssrf/safe-url? "https://example.com/foo")))
-  (t/is (true? (ssrf/safe-url? "https://example.com:8080/path?q=1"))))
+  (let [original ssrf/resolve-host]
+    (with-redefs [ssrf/resolve-host
+                  (fn [hostname]
+                    (if (= hostname "example.com")
+                      (into-array java.net.InetAddress
+                                  [(java.net.InetAddress/getByName "93.184.216.34")])
+                      (original hostname)))]
+      (t/is (true? (ssrf/safe-url? "https://example.com/foo")))
+      (t/is (true? (ssrf/safe-url? "https://example.com:8080/path?q=1"))))))
 
 (t/deftest validate-url-allows-public-http
-  (t/is (true? (ssrf/safe-url? "http://example.com/foo"))))
+  (let [original ssrf/resolve-host]
+    (with-redefs [ssrf/resolve-host
+                  (fn [hostname]
+                    (if (= hostname "example.com")
+                      (into-array java.net.InetAddress
+                                  [(java.net.InetAddress/getByName "93.184.216.34")])
+                      (original hostname)))]
+      (t/is (true? (ssrf/safe-url? "http://example.com/foo"))))))
 
 (t/deftest validate-url-blocks-disallowed-schemes
   (t/is (false? (ssrf/safe-url? "file:///etc/passwd")))


### PR DESCRIPTION
## What

Mock DNS resolution in SSRF tests to work in environments without public DNS access.

## Why

The `validate-url-allows-public-{https,http}` tests relied on real DNS resolution of `example.com`, which fails in containers without public DNS access, causing test failures in isolated CI/CD environments.

## How

Mock `resolve-host` to return a known public IP, consistent with the pattern used by other tests in the same file.

Closes #11039

Note: This is a test infrastructure fix that does not affect production behavior.