### PR TITLE
:bug: Verify read access on source file in clone-file-media-object

### DIFF
--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -272,8 +272,13 @@
   (clone-file-media-object cfg params))
 
 (defn clone-file-media-object
-  [{:keys [::db/conn]} {:keys [id file-id is-local]}]
+  [{:keys [::db/conn] :as cfg} {:keys [id file-id is-local] :as params}]
   (let [mobj (db/get-by-id conn :file-media-object id)]
+    (when-not mobj
+      (ex/raise :type :not-found
+                :code :object-not-found
+                :hint "source media object not found"))
+    (files/check-read-permissions! conn (::rpc/profile-id params) (:file-id mobj))
     (db/insert! conn :file-media-object
                 {:id (uuid/next)
                  :file-id file-id

--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -262,8 +262,13 @@
   (clone-file-media-object cfg params))
 
 (defn clone-file-media-object
-  [{:keys [::db/conn]} {:keys [id file-id is-local]}]
+  [{:keys [::db/conn] :as cfg} {:keys [id file-id is-local] :as params}]
   (let [mobj (db/get-by-id conn :file-media-object id)]
+    (when-not mobj
+      (ex/raise :type :not-found
+                :code :object-not-found
+                :hint "source media object not found"))
+    (files/check-read-permissions! conn (::rpc/profile-id params) (:file-id mobj))
     (db/insert! conn :file-media-object
                 {:id (uuid/next)
                  :file-id file-id

--- a/backend/test/backend_tests/rpc_media_test.clj
+++ b/backend/test/backend_tests/rpc_media_test.clj
@@ -734,3 +734,98 @@
         (t/is (some? (:error out)))
         (t/is (= :restriction (-> out :error ex-data :type)))
         (t/is (= :max-quote-reached (-> out :error ex-data :code)))))))
+
+;; --- Clone File Media Object BOLA tests ---
+
+(defn- create-storage-object!
+  [content content-type]
+  (let [storage (:app.storage/storage th/*system*)]
+    (sto/put-object! storage {::sto/content (sto/content content)
+                              :content-type content-type})))
+
+(t/deftest clone-file-media-object-success
+  (let [prof1  (th/create-profile* 1)
+        _      (th/create-project* 1 {:profile-id (:id prof1)
+                                      :team-id (:default-team-id prof1)})
+        file1  (th/create-file* 1 {:profile-id (:id prof1)
+                                   :project-id (:default-project-id prof1)
+                                   :is-shared false})
+        sobj   (create-storage-object! "image-content" "image/png")
+        mobj   (th/create-file-media-object* {:file-id (:id file1)
+                                              :name "test-media"
+                                              :width 100
+                                              :height 100
+                                              :mtype "image/png"
+                                              :media-id (:id sobj)})
+        file2  (th/create-file* 2 {:profile-id (:id prof1)
+                                   :project-id (:default-project-id prof1)
+                                   :is-shared false})
+        params {::th/type        :clone-file-media-object
+                ::rpc/profile-id (:id prof1)
+                :file-id         (:id file2)
+                :is-local        true
+                :id              (:id mobj)}
+        out    (th/command! params)]
+
+    (t/is (nil? (:error out)))
+    (let [result (:result out)]
+      (t/is (= (:id file2) (:file-id result)))
+      (t/is (= (:name mobj) (:name result)))
+      (t/is (= (:media-id mobj) (:media-id result)))
+      (t/is (uuid? (:id result)))
+      (t/is (not= (:id mobj) (:id result))))))
+
+(t/deftest clone-file-media-object-no-read-access
+  (let [prof1  (th/create-profile* 1)
+        _      (th/create-project* 1 {:profile-id (:id prof1)
+                                      :team-id (:default-team-id prof1)})
+        file1  (th/create-file* 1 {:profile-id (:id prof1)
+                                   :project-id (:default-project-id prof1)
+                                   :is-shared false})
+        sobj   (create-storage-object! "private-content" "image/png")
+        mobj   (th/create-file-media-object* {:file-id (:id file1)
+                                              :name "private-media"
+                                              :width 100
+                                              :height 100
+                                              :mtype "image/png"
+                                              :media-id (:id sobj)})
+
+        prof2  (th/create-profile* 2)
+        _      (th/create-project* 2 {:profile-id (:id prof2)
+                                      :team-id (:default-team-id prof2)})
+        file2  (th/create-file* 2 {:profile-id (:id prof2)
+                                   :project-id (:default-project-id prof2)
+                                   :is-shared false})
+
+        params {::th/type        :clone-file-media-object
+                ::rpc/profile-id (:id prof2)
+                :file-id         (:id file2)
+                :is-local        true
+                :id              (:id mobj)}
+        out    (th/command! params)]
+
+    (let [error      (:error out)
+          error-data (ex-data error)]
+      (t/is (th/ex-info? error))
+      (t/is (= :not-found (:type error-data)))
+      (t/is (= :object-not-found (:code error-data))))))
+
+(t/deftest clone-file-media-object-source-not-found
+  (let [prof   (th/create-profile* 1)
+        _      (th/create-project* 1 {:profile-id (:id prof)
+                                      :team-id (:default-team-id prof)})
+        file   (th/create-file* 1 {:profile-id (:id prof)
+                                   :project-id (:default-project-id prof)
+                                   :is-shared false})
+        params {::th/type        :clone-file-media-object
+                ::rpc/profile-id (:id prof)
+                :file-id         (:id file)
+                :is-local        true
+                :id              (uuid/random)}
+        out    (th/command! params)]
+
+    (let [error      (:error out)
+          error-data (ex-data error)]
+      (t/is (th/ex-info? error))
+      (t/is (= :not-found (:type error-data)))
+      (t/is (= :object-not-found (:code error-data))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- The `clone-file-media-object` RPC command now verifies that the caller has read access to the source file before allowing the clone operation
- Previously, only edit permissions on the destination file were checked; the source media object was fetched by UUID without any ownership verification
- This allowed any authenticated user with edit access to at least one of their own files to clone media objects from any other file (including private files from other teams) if they knew or guessed the source UUID

## Why

The missing source file permission check created a BOLA (Broken Object Level Authorization) vulnerability. An attacker could obtain persistent copies of media objects from files they had no legitimate access to, bypassing the intended access controls.

## How

- **Permission check:** Added `files/check-read-permissions!` on the source file's `file-id` before cloning
- **Not-found response:** When the caller lacks read access or the source object doesn't exist, the operation fails with `:not-found` / `:object-not-found` to avoid leaking information about the existence of files/media the caller cannot access
- **Tests:** Added 3 new tests covering success case, no-read-access case, and source-not-found case

Closes #11087
