### PR TITLE
:bug: Prevent admins from granting owner role in team invitations

### DIFF
--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -490,6 +490,13 @@
                 :code :insufficient-permissions
                 :hint "Organization policy does not allow you to send invitations"))
 
+    ;; Don't allow promote to owner to admin users.
+    (when (and (not (:is-owner perms))
+               (or (= role :owner)
+                   (some #(= :owner (:role %)) (:invitations params))))
+      (ex/raise :type :validation
+                :code :cant-promote-to-owner))
+
     (when (> invitation-count max-invitations-by-request-threshold)
       (ex/raise :type :validation
                 :code :max-invitations-by-request
@@ -632,6 +639,11 @@
     (when-not (:is-admin perms)
       (ex/raise :type :validation
                 :code :insufficient-permissions))
+
+    ;; Don't allow promote to owner to admin users.
+    (when (and (not (:is-owner perms)) (= role :owner))
+      (ex/raise :type :validation
+                :code :cant-promote-to-owner))
 
     (db/update! conn :team-invitation
                 {:role (name role) :updated-at (ct/now)}

--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -482,6 +482,13 @@
       (ex/raise :type :validation
                 :code :insufficient-permissions))
 
+    ;; Don't allow promote to owner to admin users.
+    (when (and (not (:is-owner perms))
+               (or (= role :owner)
+                   (some #(= :owner (:role %)) (:invitations params))))
+      (ex/raise :type :validation
+                :code :cant-promote-to-owner))
+
     (when (> invitation-count max-invitations-by-request-threshold)
       (ex/raise :type :validation
                 :code :max-invitations-by-request
@@ -624,6 +631,11 @@
     (when-not (:is-admin perms)
       (ex/raise :type :validation
                 :code :insufficient-permissions))
+
+    ;; Don't allow promote to owner to admin users.
+    (when (and (not (:is-owner perms)) (= role :owner))
+      (ex/raise :type :validation
+                :code :cant-promote-to-owner))
 
     (db/update! conn :team-invitation
                 {:role (name role) :updated-at (ct/now)}

--- a/backend/test/backend_tests/rpc_team_test.clj
+++ b/backend/test/backend_tests/rpc_team_test.clj
@@ -1207,3 +1207,102 @@
           (let [team (:result out)]
             (t/is (uuid? (:id team)))
             (t/is (= "Test Team" (:name team)))))))))
+
+;; --- T7-F-01: Role ceiling in team invitations ---
+
+(t/deftest admin-cannot-create-invitation-with-owner-role
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          admin   (th/create-profile* 2 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Add admin as team member with :admin role
+      (th/create-team-role* {:team-id (:id team)
+                             :profile-id (:id admin)
+                             :role :admin})
+
+      ;; Admin tries to create invitation with :owner role (emails+role format)
+      ;; This should FAIL with :cant-promote-to-owner
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id admin)
+                  :team-id (:id team)
+                  :role :owner
+                  :emails ["invitee@example.com"]}
+            out  (th/command! data)]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-type? (:error out) :validation))
+        (t/is (th/ex-of-code? (:error out) :cant-promote-to-owner))
+        (t/is (= 0 (:call-count @mock)))))))
+
+(t/deftest admin-cannot-create-invitation-with-owner-role-invitations-format
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          admin   (th/create-profile* 2 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Add admin as team member with :admin role
+      (th/create-team-role* {:team-id (:id team)
+                             :profile-id (:id admin)
+                             :role :admin})
+
+      ;; Admin tries to create invitation with :owner role (invitations format)
+      ;; This should FAIL with :cant-promote-to-owner
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id admin)
+                  :team-id (:id team)
+                  :invitations [{:email "invitee@example.com" :role :owner}]}
+            out  (th/command! data)]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-type? (:error out) :validation))
+        (t/is (th/ex-of-code? (:error out) :cant-promote-to-owner))
+        (t/is (= 0 (:call-count @mock)))))))
+
+(t/deftest admin-cannot-update-invitation-role-to-owner
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          admin   (th/create-profile* 2 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Add admin as team member with :admin role
+      (th/create-team-role* {:team-id (:id team)
+                             :profile-id (:id admin)
+                             :role :admin})
+
+      ;; Owner creates an invitation with :editor role
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id owner)
+                  :team-id (:id team)
+                  :role :editor
+                  :emails ["invitee@example.com"]}
+            out  (th/command! data)]
+        (t/is (th/success? out)))
+
+      (th/reset-mock! mock)
+
+      ;; Admin tries to update invitation role to :owner
+      ;; This should FAIL with :cant-promote-to-owner
+      (let [data {::th/type :update-team-invitation-role
+                  ::rpc/profile-id (:id admin)
+                  :team-id (:id team)
+                  :email "invitee@example.com"
+                  :role :owner}
+            out  (th/command! data)]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-type? (:error out) :validation))
+        (t/is (th/ex-of-code? (:error out) :cant-promote-to-owner))))))
+
+(t/deftest owner-can-create-invitation-with-owner-role
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Owner creates invitation with :owner role
+      ;; This should SUCCEED (owner has full privileges)
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id owner)
+                  :team-id (:id team)
+                  :role :owner
+                  :emails ["invitee@example.com"]}
+            out  (th/command! data)]
+        (t/is (th/success? out))
+        (t/is (= 1 (:call-count @mock)))))))

--- a/backend/test/backend_tests/rpc_team_test.clj
+++ b/backend/test/backend_tests/rpc_team_test.clj
@@ -1096,3 +1096,102 @@
                 :name "My Valid Team"}
           out  (th/command! data)]
       (t/is (th/success? out)))))
+
+;; --- T7-F-01: Role ceiling in team invitations ---
+
+(t/deftest admin-cannot-create-invitation-with-owner-role
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          admin   (th/create-profile* 2 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Add admin as team member with :admin role
+      (th/create-team-role* {:team-id (:id team)
+                             :profile-id (:id admin)
+                             :role :admin})
+
+      ;; Admin tries to create invitation with :owner role (emails+role format)
+      ;; This should FAIL with :cant-promote-to-owner
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id admin)
+                  :team-id (:id team)
+                  :role :owner
+                  :emails ["invitee@example.com"]}
+            out  (th/command! data)]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-type? (:error out) :validation))
+        (t/is (th/ex-of-code? (:error out) :cant-promote-to-owner))
+        (t/is (= 0 (:call-count @mock)))))))
+
+(t/deftest admin-cannot-create-invitation-with-owner-role-invitations-format
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          admin   (th/create-profile* 2 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Add admin as team member with :admin role
+      (th/create-team-role* {:team-id (:id team)
+                             :profile-id (:id admin)
+                             :role :admin})
+
+      ;; Admin tries to create invitation with :owner role (invitations format)
+      ;; This should FAIL with :cant-promote-to-owner
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id admin)
+                  :team-id (:id team)
+                  :invitations [{:email "invitee@example.com" :role :owner}]}
+            out  (th/command! data)]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-type? (:error out) :validation))
+        (t/is (th/ex-of-code? (:error out) :cant-promote-to-owner))
+        (t/is (= 0 (:call-count @mock)))))))
+
+(t/deftest admin-cannot-update-invitation-role-to-owner
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          admin   (th/create-profile* 2 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Add admin as team member with :admin role
+      (th/create-team-role* {:team-id (:id team)
+                             :profile-id (:id admin)
+                             :role :admin})
+
+      ;; Owner creates an invitation with :editor role
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id owner)
+                  :team-id (:id team)
+                  :role :editor
+                  :emails ["invitee@example.com"]}
+            out  (th/command! data)]
+        (t/is (th/success? out)))
+
+      (th/reset-mock! mock)
+
+      ;; Admin tries to update invitation role to :owner
+      ;; This should FAIL with :cant-promote-to-owner
+      (let [data {::th/type :update-team-invitation-role
+                  ::rpc/profile-id (:id admin)
+                  :team-id (:id team)
+                  :email "invitee@example.com"
+                  :role :owner}
+            out  (th/command! data)]
+        (t/is (not (th/success? out)))
+        (t/is (th/ex-of-type? (:error out) :validation))
+        (t/is (th/ex-of-code? (:error out) :cant-promote-to-owner))))))
+
+(t/deftest owner-can-create-invitation-with-owner-role
+  (with-mocks [mock {:target 'app.email/send! :return nil}]
+    (let [owner   (th/create-profile* 1 {:is-active true})
+          team    (th/create-team* 1 {:profile-id (:id owner)})]
+
+      ;; Owner creates invitation with :owner role
+      ;; This should SUCCEED (owner has full privileges)
+      (let [data {::th/type :create-team-invitations
+                  ::rpc/profile-id (:id owner)
+                  :team-id (:id team)
+                  :role :owner
+                  :emails ["invitee@example.com"]}
+            out  (th/command! data)]
+        (t/is (th/success? out))
+        (t/is (= 1 (:call-count @mock)))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- The `create-team-invitations` and `update-team-invitation-role` RPC methods allowed team admins to grant or elevate invitations to the `:owner` role, bypassing the role-ceiling protection that exists in `update-team-member-role`
- This inconsistency allowed privilege escalation: an admin (a role explicitly below owner) could grant full ownership control to a third party

## Why

The role-ceiling check was correctly implemented in `update-team-member-role` (rejecting non-owner promotions to `:owner`), but was not replicated in the two invitation-related methods. The frontend UI never exposes the `:owner` option when inviting, but direct API calls could bypass this.

## How

- **`create-team-invitations`**: Added a check after the admin permission validation that rejects `:owner` role in both parameter formats (emails+role and invitations vector)
- **`update-team-invitation-role`**: Added the same check to prevent elevating a pending invitation to `:owner`
- Both checks use the existing `:cant-promote-to-owner` error code for consistency

Closes #11098
