### PR TITLE
:bug: Add minimum validation for total-chunks in upload session

### DIFF
--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -289,7 +289,7 @@
 
 (def ^:private schema:create-upload-session
   [:map {:title "create-upload-session"}
-   [:total-chunks ::sm/int]])
+   [:total-chunks [::sm/int {:min 1}]]])
 
 (def ^:private schema:create-upload-session-result
   [:map {:title "create-upload-session-result"}

--- a/backend/test/backend_tests/rpc_media_test.clj
+++ b/backend/test/backend_tests/rpc_media_test.clj
@@ -683,6 +683,24 @@
       (t/is (= :max-quote-reached (-> out :error ex-data :code)))
       (t/is (= "upload-chunks-per-session" (-> out :error ex-data :target))))))
 
+(t/deftest chunked-upload-invalid-total-chunks
+  ;; total-chunks must be at least 1; zero and negative values are rejected
+  ;; with a :validation error.
+  (let [prof (th/create-profile* 1)]
+    ;; zero total-chunks
+    (let [out (th/command! {::th/type        :create-upload-session
+                            ::rpc/profile-id (:id prof)
+                            :total-chunks    0})]
+      (t/is (some? (:error out)))
+      (t/is (= :validation (-> out :error ex-data :type))))
+
+    ;; negative total-chunks
+    (let [out (th/command! {::th/type        :create-upload-session
+                            ::rpc/profile-id (:id prof)
+                            :total-chunks    -1})]
+      (t/is (some? (:error out)))
+      (t/is (= :validation (-> out :error ex-data :type))))))
+
 (t/deftest chunked-upload-invalid-chunk-index
   ;; Both a negative index and an index >= total-chunks must be
   ;; rejected with a :validation / :invalid-chunk-index error.


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Add minimum validation (`{:min 1}`) for `total-chunks` parameter in `create-upload-session` RPC method
- Prevent creation of upload sessions with zero or negative chunk counts

## Why

The `total-chunks` field only validated the upper bound (max-chunks) but not the lower bound. This allowed creation of inconsistent upload session state with invalid chunk counts (0 or negative), which could lead to unexpected behavior in subsequent chunk operations.

## How

- Added `{:min 1}` constraint to the `total-chunks` schema definition in `backend/src/app/rpc/commands/media.clj`
- Added test case `chunked-upload-invalid-total-chunks` to verify rejection of zero and negative values

Closes #11103
