### PR TITLE
:bug: Validate version parameter in import-binfile

### DIFF
--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -105,7 +105,11 @@
         (try
           (case (int version)
             1 (bf.v1/import-files! cfg)
-            3 (bf.v3/import-files! cfg))
+            3 (bf.v3/import-files! cfg)
+            (throw (ex-info (str "Unsupported binfile version: " version)
+                            {:type :validation
+                             :code :unsupported-version
+                             :version version})))
           (finally
             (when owned?
               (fs/delete input-path))))]
@@ -123,7 +127,7 @@
     [:name [:or [:string {:max 250}]
             [:map-of ::sm/uuid [:string {:max 250}]]]]
     [:project-id ::sm/uuid]
-    [:version {:optional true} ::sm/int]
+    [:version {:optional true} [:enum 1 3]]
     [:file {:optional true} media.v/schema:upload]
     [:upload-id {:optional true} ::sm/uuid]]
    [:fn {:error/message "one of :file or :upload-id is required"}
@@ -148,21 +152,28 @@
                 [:import-binfile/global]]}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id project-id version upload-id] :as params}]
   (projects/check-edition-permissions! pool profile-id project-id)
-  (let [version (or version 3)
+  (let [params  (if (some? upload-id)
+                  (let [file (db/tx-run! cfg media-cmd/assemble-chunks profile-id upload-id)]
+                    (assoc params :file file))
+                  params)
+
+        version (or version
+                    (case (bfc/parse-file-format (-> params :file :path))
+                      :binfile-v1 1
+                      :binfile-v3 3))
+
         params  (-> params
                     (assoc :profile-id profile-id)
                     (assoc :version version))
 
-        params
-        (if (some? upload-id)
-          (let [file (db/tx-run! cfg media-cmd/assemble-chunks profile-id upload-id)]
-            (assoc params :file file))
-          params)
-
         manifest
         (case (int version)
           1 nil
-          3 (bf.v3/get-manifest (-> params :file :path)))]
+          3 (bf.v3/get-manifest (-> params :file :path))
+          (throw (ex-info (str "Unsupported binfile version: " version)
+                          {:type :validation
+                           :code :unsupported-version
+                           :version version})))]
 
     (with-meta
       (sse/response (partial import-binfile cfg params))

--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -104,7 +104,11 @@
         (try
           (case (int version)
             1 (bf.v1/import-files! cfg)
-            3 (bf.v3/import-files! cfg))
+            3 (bf.v3/import-files! cfg)
+            (throw (ex-info (str "Unsupported binfile version: " version)
+                            {:type :validation
+                             :code :unsupported-version
+                             :version version})))
           (finally
             (when owned?
               (fs/delete input-path))))]
@@ -122,7 +126,7 @@
     [:name [:or [:string {:max 250}]
             [:map-of ::sm/uuid [:string {:max 250}]]]]
     [:project-id ::sm/uuid]
-    [:version {:optional true} ::sm/int]
+    [:version {:optional true} [:enum 1 3]]
     [:file {:optional true} media.v/schema:upload]
     [:upload-id {:optional true} ::sm/uuid]]
    [:fn {:error/message "one of :file or :upload-id is required"}
@@ -145,21 +149,28 @@
    ::sm/params schema:import-binfile}
   [{:keys [::db/pool] :as cfg} {:keys [::rpc/profile-id project-id version upload-id] :as params}]
   (projects/check-edition-permissions! pool profile-id project-id)
-  (let [version (or version 3)
+  (let [params  (if (some? upload-id)
+                  (let [file (db/tx-run! cfg media-cmd/assemble-chunks upload-id)]
+                    (assoc params :file file))
+                  params)
+
+        version (or version
+                    (case (bfc/parse-file-format (-> params :file :path))
+                      :binfile-v1 1
+                      :binfile-v3 3))
+
         params  (-> params
                     (assoc :profile-id profile-id)
                     (assoc :version version))
 
-        params
-        (if (some? upload-id)
-          (let [file (db/tx-run! cfg media-cmd/assemble-chunks upload-id)]
-            (assoc params :file file))
-          params)
-
         manifest
         (case (int version)
           1 nil
-          3 (bf.v3/get-manifest (-> params :file :path)))]
+          3 (bf.v3/get-manifest (-> params :file :path))
+          (throw (ex-info (str "Unsupported binfile version: " version)
+                          {:type :validation
+                           :code :unsupported-version
+                           :version version})))]
 
     (with-meta
       (sse/response (partial import-binfile cfg params))

--- a/backend/test/backend_tests/rpc_binfile_test.clj
+++ b/backend/test/backend_tests/rpc_binfile_test.clj
@@ -11,8 +11,7 @@
    [app.rpc :as-alias rpc]
    [app.rpc.commands.binfile :as binfile]
    [backend-tests.helpers :as th]
-   [clojure.test :as t]
-   [datoteka.fs :as fs]))
+   [clojure.test :as t]))
 
 (t/use-fixtures :once th/state-init)
 (t/use-fixtures :each th/database-reset)
@@ -32,3 +31,35 @@
 
     (t/is (not (contains? (sm/keys (second schema)) :file-id))
           "file-id should not be a declared parameter")))
+
+(t/deftest import-binfile-schema-rejects-unsupported-version
+  ;; T1-N2-03: version parameter should be restricted to supported values (1 or 3)
+  (let [schema @#'binfile/schema:import-binfile
+        validator (sm/lazy-validator schema)
+        base-params {:name "test"
+                     :project-id (uuid/random)
+                     :upload-id (uuid/random)}]
+
+    ;; Version 1 should be accepted
+    (t/is (true? (validator (assoc base-params :version 1)))
+          "version 1 should be valid")
+
+    ;; Version 3 should be accepted
+    (t/is (true? (validator (assoc base-params :version 3)))
+          "version 3 should be valid")
+
+    ;; Version 2 should be rejected
+    (t/is (false? (validator (assoc base-params :version 2)))
+          "version 2 should be rejected")
+
+    ;; Version 0 should be rejected
+    (t/is (false? (validator (assoc base-params :version 0)))
+          "version 0 should be rejected")
+
+    ;; Negative version should be rejected
+    (t/is (false? (validator (assoc base-params :version -1)))
+          "negative version should be rejected")
+
+    ;; Version 4 should be rejected
+    (t/is (false? (validator (assoc base-params :version 4)))
+          "version 4 should be rejected")))

--- a/backend/test/backend_tests/rpc_binfile_test.clj
+++ b/backend/test/backend_tests/rpc_binfile_test.clj
@@ -40,3 +40,35 @@
     ;; (Currently this will fail because file-id is still in schema)
     (t/is (false? (validator params-with-file-id))
           "params with file-id should be rejected")))
+
+(t/deftest import-binfile-schema-rejects-unsupported-version
+  ;; T1-N2-03: version parameter should be restricted to supported values (1 or 3)
+  (let [schema @#'binfile/schema:import-binfile
+        validator (sm/lazy-validator schema)
+        base-params {:name "test"
+                     :project-id (uuid/random)
+                     :upload-id (uuid/random)}]
+
+    ;; Version 1 should be accepted
+    (t/is (true? (validator (assoc base-params :version 1)))
+          "version 1 should be valid")
+
+    ;; Version 3 should be accepted
+    (t/is (true? (validator (assoc base-params :version 3)))
+          "version 3 should be valid")
+
+    ;; Version 2 should be rejected
+    (t/is (false? (validator (assoc base-params :version 2)))
+          "version 2 should be rejected")
+
+    ;; Version 0 should be rejected
+    (t/is (false? (validator (assoc base-params :version 0)))
+          "version 0 should be rejected")
+
+    ;; Negative version should be rejected
+    (t/is (false? (validator (assoc base-params :version -1)))
+          "negative version should be rejected")
+
+    ;; Version 4 should be rejected
+    (t/is (false? (validator (assoc base-params :version 4)))
+          "version 4 should be rejected")))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Restrict `version` parameter in `import-binfile` to supported values (1 or 3) via schema validation
- Add content-based format detection using `bfc/parse-file-format` when `version` is not provided
- Add explicit default clause to `case` statements that throws a clean `:validation` error with code `:unsupported-version`

## Why

The `import-binfile` RPC method accepted any integer for the `version` parameter. Unsupported values (e.g., 2, 0, -1) caused unhandled exceptions from the `case` statements instead of returning a clean validation error. Additionally, when `version` was omitted, the system defaulted to version 3 without inspecting the actual file content, even though the code already had `bfc/parse-file-format` for content detection.

## How

- **Schema**: Changed `[:version {:optional true} ::sm/int]` to `[:version {:optional true} [:enum 1 3]]`
- **Content detection**: When `version` is not provided, use `bfc/parse-file-format` to detect format from file magic bytes (ZIP PK\x03\x04 → v3, otherwise → v1)
- **Default clause**: Added explicit default to both `case` statements that throws `ex-info` with `:type :validation, :code :unsupported-version`

Closes #11105
