### PR TITLE
:bug: Declare new shape attributes in schemas to match stored files

### DIFF
--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -384,7 +384,10 @@
   (->> (sg/generator schema:shape-base-attrs)
        (sg/mcat (fn [{:keys [type] :as shape}]
                   (sg/let [attrs1 (sg/generator schema:shape-generic-attrs)
-                           attrs2 (sg/generator schema:shape-geom-attrs)
+                           attrs2 (if (or (= type :path)
+                                          (= type :bool))
+                                    (sg/generator schema:nilable-geom-attrs)
+                                    (sg/generator schema:shape-geom-attrs))
                            attrs3 (case type
                                     :text    (sg/generator schema:text-attrs)
                                     :path    (sg/generator schema:path-attrs)
@@ -395,10 +398,7 @@
                                     :bool    (sg/generator schema:bool-attrs)
                                     :group   (sg/generator schema:group-attrs)
                                     :frame   (sg/generator schema:frame-attrs))]
-                    (if (or (= type :path)
-                            (= type :bool))
-                      (merge attrs1 shape attrs3)
-                      (merge attrs1 shape attrs2 attrs3)))))
+                    (merge attrs1 shape attrs2 attrs3))))
        (sg/fmap create-shape)))
 
 (def schema:shape-attrs

--- a/common/src/app/common/types/shape.cljc
+++ b/common/src/app/common/types/shape.cljc
@@ -233,7 +233,50 @@
    [:grow-type {:optional true}
     [::sm/one-of grow-types]]
    [:applied-tokens {:optional true} cto/schema:applied-tokens]
-   [:plugin-data {:optional true} ctpg/schema:plugin-data]])
+   [:plugin-data {:optional true} ctpg/schema:plugin-data]
+
+   ;; `rotation`, `flip-x` and `flip-y` are fields of the `Shape` record (see
+   ;; `cr/defrecord Shape` above) and this schema did not declare them.
+   ;; `rotation` was already named in `allowed-shape-attrs` here and in
+   ;; `app.common.types.shape.attrs/editable-attrs`, so the omission was in this
+   ;; schema and not in the model. Anything reading the model from the schema
+   ;; rather than from a live shape missed all three: the graph projection
+   ;; derives one column per entry (`app.graph.schema.projection`), so shape
+   ;; nodes carried no rotation at all, and a consumer cannot place a shape
+   ;; without it.
+   ;;
+   ;; Nilable, because `app.common.record/defrecord` cannot remove a base
+   ;; field: its `without` assocs nil and its `containsKey` answers true
+   ;; whatever the field holds, so nil is how a record field says "unset".
+   ;; `flip-x` and `flip-y` are nil on every shape `setup-shape` builds, since
+   ;; `make-minimal-shape` gives them no default.
+   ;;
+   ;; Optional as well, unlike the geometry group below, because this schema
+   ;; has a second job: `check-shape-generic-attrs` validates partial update
+   ;; payloads with it, such as the `{:blocked true}` that
+   ;; `app.main.data.workspace/update-shape` passes. A required key here would
+   ;; reject every such payload.
+   [:rotation {:optional true} [:maybe ::sm/safe-number]]
+   [:flip-x {:optional true} [:maybe :boolean]]
+   [:flip-y {:optional true} [:maybe :boolean]]
+
+   ;; Carried on circles, rects and texts too, not only on frames, so it
+   ;; belongs here rather than in `schema:frame-attrs`. Not nilable: the key
+   ;; lives outside the record, `app.common.logic.shapes` dissocs it to unset
+   ;; it, and `setup-shape` drops it when a caller passes nil.
+   [:hide-in-viewer {:optional true} :boolean]
+
+   ;; The SVG provenance an import leaves on a shape. Typed `:map` rather than
+   ;; more precisely on purpose: legacy files hold `svg-transform` as a plain
+   ;; `{:a … :f}` map rather than a `::gmt/matrix` record, and `svg-viewbox` as
+   ;; either a `::grc/rect` record or a plain map, so a tighter schema here
+   ;; would reject files that are otherwise valid. The graph *column* types are
+   ;; tightened separately, where a wrong guess costs a column rather than a
+   ;; rejected file (`app.graph.schema.contract/type-overrides`).
+   [:svg-attrs {:optional true} :map]
+   [:svg-defs {:optional true} :map]
+   [:svg-transform {:optional true} :map]
+   [:svg-viewbox {:optional true} :map]])
 
 (def schema:group-attrs
   [:map {:title "GroupAttrs"}
@@ -244,7 +287,30 @@
    [:shapes [:vector {:gen/max 10 :gen/min 1} ::sm/uuid]]
    [:hide-fill-on-export {:optional true} :boolean]
    [:show-content {:optional true} :boolean]
-   [:hide-in-viewer {:optional true} :boolean]])
+   ;; `hide-in-viewer` moved to `schema:shape-generic-attrs`: stored files carry
+   ;; it on circles, rects and texts too, not only on frames.
+   ;; `use-for-thumbnail` is a frame attribute the model has long had, since
+   ;; `app.common.files.migrations` renames `:use-for-thumbnail?` to it and
+   ;; `app.common.logic.libraries` reads it, and this schema had not declared.
+   [:use-for-thumbnail {:optional true} :boolean]])
+
+(def ^:private schema:nilable-geom-attrs
+  "`schema:shape-geom-attrs`, but nilable.
+
+  Bools and paths are the only two shape types whose geometry can be nil:
+  `make-minimal-shape` gives `x`, `y`, `width` and `height` a default for every
+  other type and skips those two, whose extent their content and `selrect`
+  imply instead. The four keys stay required, because they are `Shape` record
+  fields and `app.common.record/defrecord` keeps a base field present whatever
+  it holds. So these two branches cannot merge `schema:shape-geom-attrs`, which
+  rejects the nil, and declare the same four keys nilable instead. A
+  schema-derived reader previously saw a bool or a path as having no position or
+  size at all."
+  [:map {:title "NilableGeometryAttrs"}
+   [:x [:maybe ::sm/safe-number]]
+   [:y [:maybe ::sm/safe-number]]
+   [:width [:maybe ::sm/safe-number]]
+   [:height [:maybe ::sm/safe-number]]])
 
 (def ^:private schema:bool-attrs
   [:map {:title "BoolAttrs"}
@@ -253,10 +319,19 @@
    [:content path/schema:content]])
 
 (def ^:private schema:rect-attrs
-  [:map {:title "RectAttrs"}])
+  [:map {:title "RectAttrs"}
+   ;; Legacy radii, set by SVG import (`app.common.files.shapes-builder` parses
+   ;; `rx`/`ry` off the element) and by migration 0003, which assocs `0`.
+   ;; Superseded by `r1` to `r4`, but stored files still carry them. Not
+   ;; nilable: both keys live outside the `Shape` record, so a dissoc removes
+   ;; them, and `setup-shape` drops a nil before the merge.
+   [:rx {:optional true} ::sm/safe-number]
+   [:ry {:optional true} ::sm/safe-number]])
 
 (def ^:private schema:circle-attrs
-  [:map {:title "CircleAttrs"}])
+  [:map {:title "CircleAttrs"}
+   [:rx {:optional true} ::sm/safe-number]
+   [:ry {:optional true} ::sm/safe-number]])
 
 (def ^:private schema:svg-raw-attrs
   [:map {:title "SvgRawAttrs"}
@@ -266,7 +341,15 @@
    ;; keeps the child ids typed as uuid, so a JSON round trip (binfile
    ;; export/import) decodes them back to uuids instead of leaving
    ;; strings that no longer resolve against the objects map.
-   [:shapes {:optional true} [:vector {:gen/max 10} ::sm/uuid]]])
+   [:shapes {:optional true} [:vector {:gen/max 10} ::sm/uuid]]
+   ;; The raw SVG node an import kept.
+   ;; `app.common.files.shapes-builder/create-raw-svg` sets it and
+   ;; `allowed-svg-attrs` names it. Usually the parsed element,
+   ;; `{:tag … :attrs … :content …}`, but a bare text node arrives as the
+   ;; string itself: `<text>hi</text>` becomes one svg-raw for the element
+   ;; and another for `"hi"`. `app.common.files.shapes-builder/parse-svg-element`
+   ;; carries a FIXME about exactly that. Both forms are legal and stored.
+   [:content {:optional true} [:or :map :string]]])
 
 (def schema:image-attrs
   [:map {:title "ImageAttrs"}
@@ -347,6 +430,7 @@
      ctsl/schema:layout-child-attrs
      schema:bool-attrs
      schema:shape-generic-attrs
+     schema:nilable-geom-attrs
      schema:shape-base-attrs]]
 
    [:rect
@@ -386,6 +470,7 @@
      ctsl/schema:layout-child-attrs
      schema:path-attrs
      schema:shape-generic-attrs
+     schema:nilable-geom-attrs
      schema:shape-base-attrs]]
 
    [:text

--- a/common/test/common_tests/types/shape_decode_encode_test.cljc
+++ b/common/test/common_tests/types/shape_decode_encode_test.cljc
@@ -146,3 +146,24 @@
          ;; (app.common.pprint/pprint shape-3)
          (= shape shape-3)))
      {:num 200})))
+
+(t/deftest shape-generator-key-presence
+  "The generator must produce the keys the schema declares required, even when
+  nilable. This is a targeted check for the attributes added to
+  `schema:shape-generic-attrs` and `schema:nilable-geom-attrs`."
+  (let [shapes (sg/sample (sg/generator schema:shape) {:num 200})
+        by-type (group-by :type shapes)]
+    ;; All shapes: rotation, flip-x, flip-y are base record fields, always
+    ;; present (possibly nil).
+    (doseq [shape shapes]
+      (t/is (contains? shape :rotation) "missing :rotation")
+      (t/is (contains? shape :flip-x) "missing :flip-x")
+      (t/is (contains? shape :flip-y) "missing :flip-y"))
+    ;; Bool and path: x/y/width/height are required-but-nilable in the
+    ;; schema. The generator must produce them (nil is a valid value).
+    (doseq [shape (concat (get by-type :bool [])
+                          (get by-type :path []))]
+      (t/is (contains? shape :x) "bool/path missing :x")
+      (t/is (contains? shape :y) "bool/path missing :y")
+      (t/is (contains? shape :width) "bool/path missing :width")
+      (t/is (contains? shape :height) "bool/path missing :height"))))

--- a/common/test/common_tests/types/shape_decode_encode_test.cljc
+++ b/common/test/common_tests/types/shape_decode_encode_test.cljc
@@ -151,7 +151,7 @@
   "The generator must produce the keys the schema declares required, even when
   nilable. This is a targeted check for the attributes added to
   `schema:shape-generic-attrs` and `schema:nilable-geom-attrs`."
-  (let [shapes (sg/sample (sg/generator schema:shape) {:num 200})
+  (let [shapes (sg/sample (sg/generator schema:shape) {:size 200})
         by-type (group-by :type shapes)]
     ;; All shapes: rotation, flip-x, flip-y are base record fields, always
     ;; present (possibly nil).


### PR DESCRIPTION
_This work was produced with the help of language models._

### Related Ticket

None. Split out of #11101 so it can be judged on its own: it is a defect in `common/` that exists today, independently of the branch that found it.

### Summary

`app.common.types.shape/schema:shape-attrs` is the shape model as *declared*, and it has fallen behind the `Shape` record.

```clojure
(cr/defrecord Shape [id name type x y width height rotation selrect points
                     transform transform-inverse parent-id frame-id flip-x flip-y]
```

`rotation`, `flip-x` and `flip-y` are fields of that record, so they are present on **every shape that exists**, and they are declared nowhere. `rotation` is already named twice in the same namespace, in `allowed-shape-attrs`, and once in `app.common.types.shape.attrs/editable-attrs`, so the schema is the odd one out rather than the data being unusual.

Nothing complains, because the maps are open: an undeclared key validates fine. What breaks is everything reading the model *from the schema* rather than from a live value, such as the generative tests' shape generator, the generated OpenAPI surface, and any consumer reflecting over `schema:shape-attrs`.

**There are four questions for the reviewer below, each marked QUESTION.** In order: whether the optional/nilable rule is the one you meant, whether the `svg-*` group should be typed tighter, whether bool and path should stay silent about geometry, and whether a schema should serve as both read description and write contract.

### Feedback addressed: `{:optional true}` together with `[:maybe …]`

**What @niwinz said.** The first revision marked keys `{:optional true}` **and** `[:maybe …]`. That is fine for `x` and `y`, which are static props that cannot be removed from the type, but other keys are not static props, and marking those `[:maybe]` was not convincing. `rx` and `ry` on `RectAttrs` and `CircleAttrs` were the example.

**Why he is right, and mechanically so.** `app.common.record/defrecord` is not `clojure.core`'s. It cannot remove a base field:

```clojure
;; app.common.record, emit-impl-jvm and emit-impl-js agree
(without     [this key] (case key (:x :y …) (.assoc this key nil) …))
(containsKey [this key] (case key (:x :y …) true …))
```

So the two kinds of key behave differently, and each takes exactly one marker:

| kind of key | absent when unset? | nil when unset? | declaration |
|---|---|---|---|
| `Shape` base field | no, `containsKey` answers true | yes, `without` assocs nil | `[:maybe T]` |
| anything else, in the `$extmap` | yes, dissoc removes it | no, `setup-shape` drops nils through `d/without-nils` | `{:optional true} T` |

Verified in a REPL against this branch:

```clojure
(def r (cts/setup-shape {:type :rect :x 1 :y 2 :width 3 :height 4 :rx 0}))
(cts/shape? (dissoc r :x))                     ;; => true, still a Shape
[(contains? (dissoc r :x) :x)
 (:x (dissoc r :x))]                           ;; => [true nil]
(contains? (dissoc r :rx) :rx)                 ;; => false
(contains? (cts/setup-shape {… :rx nil}) :rx)  ;; => false, the nil was stripped
```

**What changed in this revision.**

| entries | first revision | now |
|---|---|---|
| `rx`, `ry`, `hide-in-viewer`, `use-for-thumbnail`, `svg-attrs`, `svg-defs`, `svg-transform`, `svg-viewbox`, svg-raw `content` | `{:optional true}` + `[:maybe T]` | `{:optional true} T`, the `[:maybe]` dropped |
| `NilableGeometryAttrs`: `x`, `y`, `width`, `height` | `{:optional true}` + `[:maybe T]` | `[:maybe T]`, the `{:optional true}` dropped |
| `rotation`, `flip-x`, `flip-y` | `{:optional true}` + `[:maybe T]` | unchanged, and the next section says why |

A census over 400 generated shapes agrees with the rule: of the nine entries that lost the `[:maybe]`, not one instance is nil, while `flip-x` is nil throughout and bool and path have nil geometry in every sample.

* **QUESTION**: is that the rule you meant? If you would rather keep `{:optional true}` everywhere for uniformity, say so and I will make the geometry group optional again; the cost is only that the schema stops saying a record field is always there.

### `schema:shape-generic-attrs` is also a write contract, which is why three keys keep both markers

`schema:shape-generic-attrs` does two jobs. Inside `schema:shape-attrs` it describes a whole stored shape. Standalone, `check-shape-generic-attrs` validates a **partial update payload**, the `{:blocked true}` that `app.main.data.workspace/update-shape` and `app.main.data.workspace.shapes/update-shape-flags` pass. Every key in it must therefore stay optional, whatever the record says, so `rotation`, `flip-x` and `flip-y` carry `{:optional true}` on top of the `[:maybe]` the record earns them.

`schema:nilable-geom-attrs` has no such second job, so it takes the required form. The general version of the problem is the last question in this description.

### What is declared, measured over a 305-shape corpus

| attribute | shapes carrying it | declared before |
|---|---:|---|
| `rotation` | 305 / 305 | no, record field |
| `flip-x`, `flip-y` | 305 / 305, value nil | no, record fields |
| `hide-in-viewer` | 197 | frames only |
| `svg-attrs`, `svg-defs`, `svg-viewbox` | 101 | no |
| `svg-transform` | 63 | no |
| `x`/`y`/`width`/`height` on bool and path | all, 10 paths hold nil | not in those two branches |

Plus `use-for-thumbnail` on frames, which `app.common.files.migrations` renames `:use-for-thumbnail?` to and `app.common.logic.libraries` reads; `rx`/`ry` on rects and circles, the legacy radii SVG import parses off the element and migration 0003 assocs as `0`; and `content` on svg-raw, which `shapes-builder/create-raw-svg` sets.

Two entries are worth a closer look.

**The `svg-*` group is typed `:map` on purpose**, not `::gmt/matrix` and `::grc/rect`. Legacy files hold `svg-transform` as a plain `{:a … :f}` map and `svg-viewbox` as either a record or a plain map, so a tighter schema would reject files that are otherwise valid. **I would probably like tighter types here**, but I do not know enough about the legacy we need to support for back-compatibility to submit that confidently.

* **QUESTION**: `:map`, or tighter types for `svg-*`?

**`content` on svg-raw is `[:or :map :string]`**, because a bare text node arrives as the string itself: `<text>hi</text>` becomes one svg-raw for the element and another for `"hi"`. `shapes-builder/parse-svg-element` carries a FIXME saying exactly that. I first typed it `:map` and the plugin API suite caught it. I am out of my depth here.

### One thing is tightened now

`schema:nilable-geom-attrs` **requires** `x`, `y`, `width` and `height` on the bool and path branches, nilable. Bool and path are the only two shape types whose geometry can be nil: `make-minimal-shape` gives the four keys a default for every other type and skips those two, whose extent their content and `selrect` imply instead. Those two branches therefore cannot merge `schema:shape-geom-attrs`, which rejects the nil.

Three things bound the risk:

1. `schema:shape` is `[:and [:fn shape?] schema:shape-attrs]`, so every value it validates is a `Shape` record, and `containsKey` answers true for all four keys by construction.
2. Every branch of `schema:shape-attrs` already requires the nine keys of `schema:shape-base-attrs`, so no partial map validated against it before this change either. `check-shape-attrs` throws unconditionally rather than under an assert flag, so a call site passing a partial map would already be failing today.
3. The other seven branches have required those same four keys all along, through `schema:shape-geom-attrs`. Bool and path were the exception, not the rule.

* **QUESTION**: would you like those two branches to stay silent about geometry? In that case I can drop `schema:nilable-geom-attrs` and keep the rest. The cost is that a schema-derived reader continues to see a bool or a path as having no position or size at all. 

### NOTE: we cannot make an analogous change to `ctf/schema:file` (for the moment)

This is mostly a note to future me. The file map carries `:backend`, `:comment-thread-seqn` and `:ignore-sync-until`, none of which `ctf/schema:file` declares. **If we declared them, we would break saving**, which I found out the hard way at 185 failures, mostly `rpc-file-test`.

Why? Because `app.binfile.common/update-file!` derives its UPDATE column list from the keys of a file map, and the `file` table has no `backend` column, since it is synthesized on read.

`check-shape-generic-attrs` above is the same conflation in `common/`, and a milder one: there the write contract only costs us the ability to require a key.

* **QUESTION: should the schema serve as both read description and write contract?** I am very curious to know how you think about this, though it is a discussion we could have separately from this pull request, which solves the current problem within the framework that exists. I can open an issue for it, if desired.

### Verifications

Adding entries changes what `shape-generator` produces, so generative tests begin exercising code paths with these attributes present. That is where a problem would surface.

| check | result |
|---|---|
| common suite, Clojure | 1142 tests, 24702 assertions, 0 failures |
| common suite, ClojureScript | 992 tests, 24017 assertions, 0 failures, 0 errors |
| `cljfmt check --parallel=true src/ test/` in `common/` | all source files formatted correctly |
| `clj-kondo --parallel --lint ../common/src/ src/` | 0 errors, 0 warnings |
| 400 generated shapes against `cts/schema:shape` | all valid |
| Plugin API test suite | passes, including the svg-raw import case |

Every test workflow carries `if: ${{ !github.event.pull_request.draft }}`, so none of them runs while this pull request is a draft. The numbers above are local runs against the pushed tree.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. *(nothing visible)*
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable. *(the generative shape tests cover it by construction)*
- [x] Refactor any modified SCSS files following the refactor guide. *(no SCSS touched)*
- [ ] Check CI passes successfully. *(skipped while draft)*

AI-assisted-by: mixed models
