### PR TITLE
:bug: Fix crash when editing tokens with group nodes

### DIFF
--- a/frontend/src/app/main/data/style_dictionary.cljs
+++ b/frontend/src/app/main/data/style_dictionary.cljs
@@ -557,7 +557,8 @@
   (.. sd-token -original -name))
 
 (defn sd-token-uuid [^js sd-token]
-  (uuid (.-uuid (.. sd-token -original -id))))
+  (when-let [id (.. sd-token -original -id)]
+    (uuid (.-uuid id))))
 
 (defn- merge-name-collisions
   "Re-attach tokens that `ctob/tokens-tree` / `backtrace-tokens-tree`


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Token edit modal no longer crashes when StyleDictionary emits group nodes alongside real tokens during interactive resolution

## Why

`sd-token-uuid` unconditionally accessed `.original.id.uuid` on every StyleDictionary node. Group nodes have an `original` object but no `id` property, so `.original.id` was `undefined` and accessing `.uuid` on it threw a TypeError. The existing guard in `process-sd-tokens` (which skips nodes with no matching origin token) ran too late to protect the interactive resolution path triggered by the edit modal.

## How

- **`sd-token-uuid`** — wrapped the `.original.id` access in `when-let` so group nodes (which lack an `id`) return `nil` instead of throwing. The downstream `get` in the ids map then returns `nil`, and the existing `nil?` guard in `process-sd-tokens` correctly skips the node.

Closes #11143
