### PR TITLE
:sparkles: Close search, history and shortcuts panels with Escape

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar.cljs
@@ -42,6 +42,7 @@
    [app.main.ui.workspace.tokens.sidebar :refer [tokens-sidebar-tab*]]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
+   [app.util.keyboard :as kbd]
    [rumext.v2 :as mf]))
 
 ;; --- Left Sidebar (Component)
@@ -313,7 +314,19 @@
 
         active-tokens-by-type
         (mf/with-memo [active-tokens]
-          (delay (ctob/group-by-type active-tokens)))]
+          (delay (ctob/group-by-type active-tokens)))
+
+        ;; Bound to the sidebar content instead of the document so that
+        ;; Escape only dismisses the history panel when the focus is
+        ;; already inside it.
+        on-history-key-down
+        (mf/use-fn
+         (mf/deps is-history?)
+         (fn [event]
+           (when (and ^boolean is-history? (kbd/esc? event))
+             (dom/stop-propagation event)
+             (some-> (dom/get-target event) (dom/blur!))
+             (on-close-document-history))))]
 
     [:> (mf/provider muc/sidebar) {:value :right}
      [:> (mf/provider muc/active-tokens-by-type) {:value active-tokens-by-type}
@@ -341,7 +354,8 @@
                           :layout layout
                           :page-id page-id}]
 
-       [:div {:class (stl/css :right-sidebar-content)}
+       [:div {:class (stl/css :right-sidebar-content)
+              :on-key-down on-history-key-down}
         (cond
           is-comments?
           [:> comments-sidebar* {}]

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -371,6 +371,22 @@
                (st/emit! dw/close-layers-search)
                (st/emit! (dw/open-layers-search :find {:force? true}))))))
 
+        ;; Escape is handled here, on the panel itself, rather than in the
+        ;; document listener above: it must only close the search when the
+        ;; focus is already inside the panel, and leave it untouched
+        ;; otherwise. A still open filters dropdown is dismissed first.
+        on-search-key-down
+        (mf/use-fn
+         (mf/deps show-menu? hide-menu)
+         (fn [event]
+           (when (kbd/esc? event)
+             (dom/stop-propagation event)
+             (if ^boolean show-menu?
+               (hide-menu)
+               (do
+                 (some-> (dom/get-target event) (dom/blur!))
+                 (st/emit! dw/close-layers-search))))))
+
         remove-filter
         (mf/use-fn
          (fn [event]
@@ -569,7 +585,8 @@
      #(mf/html
        (if show-search?
          [:*
-          [:div {:class (stl/css :tool-window-bar)}
+          [:div {:class (stl/css :tool-window-bar)
+                 :on-key-down on-search-key-down}
            [:> search-bar* {:input-ref search-input-ref
                             :class (stl/css :search-item)
                             :on-change update-search-text
@@ -593,7 +610,8 @@
                              :on-click toggle-search
                              :icon i/close}]]
 
-          [:div {:class (stl/css :replace-wrapper)}
+          [:div {:class (stl/css :replace-wrapper)
+                 :on-key-down on-search-key-down}
            (when ^boolean find-replace-mode?
              [:div {:class (stl/css :replace-row)}
               [:> input* {:type "text"

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -26,6 +26,7 @@
    [app.main.ui.shortcuts :as ss]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
+   [app.util.keyboard :as kbd]
    [app.util.strings :refer [matches-search]]
    [clojure.set :as set]
    [rumext.v2 :as mf]))
@@ -61,6 +62,15 @@
         filter-term                  (deref filter-term*)
 
         close-fn                     #(st/emit! (dw/toggle-layout-flag :shortcuts))
+
+        ;; Only closes when the focus is already inside the panel, so
+        ;; Escape keeps its usual meaning everywhere else.
+        on-key-down
+        (fn [event]
+          (when (kbd/esc? event)
+            (dom/stop-propagation event)
+            (some-> (dom/get-target event) (dom/blur!))
+            (close-fn)))
 
         {:keys [all-shortcuts all-sc-names all-sub-names all-section-names]}
         (ss/build-all-shortcuts workspace-shortcuts dashboard-shortcuts viewer-shortcuts)
@@ -121,7 +131,8 @@
         (mf/use-fn
          #(st/emit! (rt/nav :settings-shortcuts {} {::rt/new-window true})))]
 
-    [:div {:class (dm/str class " " (stl/css :shortcuts))}
+    [:div {:class (dm/str class " " (stl/css :shortcuts))
+           :on-key-down on-key-down}
      [:> panel-title* {:class (stl/css :shortcuts-title)
                        :text (tr "shortcuts.title")
                        :on-close close-fn}]


### PR DESCRIPTION
> **Note:** This PR was created with AI assistance as part of the Penpot MCP self-improvement initiative.

Fixes #9540.

## Approach

The key constraint from the issue is that Escape must close a panel **only when the focus is already inside it**, and behave normally otherwise.

`layers.cljs` already had an Escape handler, but it is registered on the `document`:

```clojure
(mf/with-effect []
  (let [key1 (events/listen globals/document "keydown" on-key-down)
        ...
```

A document listener cannot tell where the focus is, so closing the panel from there would have dismissed search even when the user was typing in the layers list. Instead the handler is bound to the panel itself, following the existing `versions.cljs` / `sitemap.cljs` idiom (`kbd/esc?` inside an `:on-key-down`). The event bubbles up from whichever descendant holds the focus, so "focus is inside the panel" comes for free and no containment check is needed.

| Panel | Handler bound to | Closes with |
|---|---|---|
| Search (layers / canvas) | `tool-window-bar` + `replace-wrapper` | `dw/close-layers-search` |
| Shortcuts | panel root | existing `close-fn` |
| History | `right-sidebar-content`, guarded on `is-history?` | `on-close-document-history` |

Two details:

- **Nested dismissal.** If the filters dropdown is open in the search panel, Escape closes that first and leaves the panel open, so the UI unwinds in the order the user expects.
- **Returning focus to the canvas** reuses what the existing close buttons already do — `toggle-search` blurs the focused node before emitting — rather than introducing a new focus target. `stop-propagation` then keeps the document level handler from acting on the same keypress.

Scope kept to the three panels named in the issue; the "other panels should be audited" part is deliberately left out.

## Verification

Live in the devenv (`:main` build completed, 1226 files, 0 warnings):

| Case | Expected | Result |
|---|---|---|
| Search open, focus in the Find input, Escape | panel closes, focus back to canvas | closes, `activeElement` back to `BODY` |
| Search open, **focus moved to the viewport**, Escape | panel stays open | stays open |
| Filters dropdown open, focus in panel, Escape | only the dropdown closes | dropdown closed, panel still open |
| ...then Escape again | panel closes | closes, focus back to `BODY` |
| History open, focus inside, Escape | panel closes | closes, focus back to `BODY` |
| Shortcuts open (`?`), focus inside, Escape | panel closes | closes, focus back to `BODY` |

The second row is the one that matters most: it is exactly the case the document level approach would have broken.

`clj-kondo` 0 errors / 0 warnings, `cljfmt` clean, shadow-cljs `:main` 0 warnings.

No new translation strings, and no change to the plugin API surface, so no `plugins/CHANGELOG.md` entry.
