### PR TITLE
:sparkles: Close workspace search panel with Escape key

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -309,7 +309,14 @@
         (mf/use-fn
          (fn [event]
            (when (kbd/esc? event)
-             (hide-menu))))
+             (let [{:keys [show-search show-menu]} @state*]
+               (when show-search
+                 (if show-menu
+                   (hide-menu)
+                   (do
+                     (dom/stop-propagation event)
+                     (dom/prevent-default event)
+                     (st/emit! dw/close-layers-search))))))))
 
         update-search-text
         (mf/use-fn


### PR DESCRIPTION
## What and why

Pressing **Escape** while the workspace search panel (layers sidebar) is
open now closes the panel. This follows the standard keyboard convention
for dismissing panels and overlays.

**Layered dismissal:** if the filter dropdown menu is open, the first
Escape press closes just the menu; a second Escape closes the search
panel itself.

Event propagation is stopped when closing the search panel so the
workspace-level Escape handler (deselect-all) does not also fire.

Closes #9540

## Changes

- `frontend/src/app/main/ui/workspace/sidebar/layers.cljs` — modified
  the global `on-key-down` handler in `use-search` to check search
  visibility and emit `dw/close-layers-search` on Escape when the
  filter menu is not showing.

## Testing notes

1. Open a workspace, press **Cmd+F** (or **Ctrl+F**) to open layers search
2. Press **Escape** → search panel closes, canvas selection is unaffected
3. Open search again, open the filter dropdown, press **Escape** → only
   the dropdown closes; press **Escape** again → search panel closes
4. With search closed, press **Escape** → normal workspace behavior
   (deselect-all) still works