### PR TITLE
:bug: Center canvas and select layer when navigating layer search results

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1620,6 +1620,7 @@
 (dm/export dwgu/set-hover-guide)
 
 ;; Zoom
+(dm/export dwz/center-on-shape)
 (dm/export dwz/reset-zoom)
 (dm/export dwz/zoom-to-selected-shape)
 (dm/export dwz/start-zooming)

--- a/frontend/src/app/main/data/workspace/zoom.cljs
+++ b/frontend/src/app/main/data/workspace/zoom.cljs
@@ -135,6 +135,32 @@
     (effect [_ state _]
       (dwvw/maybe-sync-workspace-local-viewport! state))))
 
+(defn center-on-shape
+  "Pan the viewport to center on the shape with the given id without changing zoom."
+  [id]
+  (ptk/reify ::center-on-shape
+    ptk/UpdateEvent
+    (update [_ state]
+      (if (dwvw/render-context-lost? state)
+        state
+        (let [page-id (:current-page-id state)
+              objects (dsh/lookup-page-objects state page-id)
+              shape   (get objects id)
+              srect   (:selrect shape)]
+          (if (nil? srect)
+            state
+            (update state :workspace-local
+                    (fn [{:keys [vbox] :as local}]
+                      (let [cx    (+ (:x srect) (/ (:width srect) 2))
+                            cy    (+ (:y srect) (/ (:height srect) 2))
+                            new-x (- cx (/ (:width vbox) 2))
+                            new-y (- cy (/ (:height vbox) 2))]
+                        (update local :vbox assoc :x new-x :y new-y))))))))
+
+    ptk/EffectEvent
+    (effect [_ state _]
+      (dwvw/maybe-sync-workspace-local-viewport! state))))
+
 (def zoom-to-selected-shape
   (ptk/reify ::zoom-to-selected-shape
     ptk/UpdateEvent

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -433,21 +433,27 @@
 
         navigate-next
         (mf/use-fn
-         (mf/deps text-match-count)
+         (mf/deps text-match-ids text-match-count)
          (fn [_]
            (when (pos? text-match-count)
-             (swap! state* update :current-match-idx
-                    (fn [idx]
-                      (mod (inc idx) text-match-count))))))
+             (let [new-state (swap! state* update :current-match-idx
+                                    (fn [idx] (mod (inc idx) text-match-count)))
+                   new-idx   (mod (:current-match-idx new-state) text-match-count)
+                   id        (nth text-match-ids new-idx)]
+               (st/emit! (dw/select-shape id)
+                         (dw/center-on-shape id))))))
 
         navigate-prev
         (mf/use-fn
-         (mf/deps text-match-count)
+         (mf/deps text-match-ids text-match-count)
          (fn [_]
            (when (pos? text-match-count)
-             (swap! state* update :current-match-idx
-                    (fn [idx]
-                      (mod (+ (dec idx) text-match-count) text-match-count))))))
+             (let [new-state (swap! state* update :current-match-idx
+                                    (fn [idx] (mod (+ (dec idx) text-match-count) text-match-count)))
+                   new-idx   (mod (:current-match-idx new-state) text-match-count)
+                   id        (nth text-match-ids new-idx)]
+               (st/emit! (dw/select-shape id)
+                         (dw/center-on-shape id))))))
 
         handle-replace
         (mf/use-fn


### PR DESCRIPTION
Closes #10422

## Problem

When using the previous/next buttons to navigate through layer search results, neither the canvas nor the layers panel updated correctly:

- The layer was not selected in the layers panel
- The layers panel did not scroll to bring the matching layer into view
- The canvas did not center on the selected layer

## Solution

- Added `center-on-shape` event to `workspace/zoom.cljs` that pans the viewport to center on a shape without changing zoom level
- Updated `navigate-next` and `navigate-prev` in the layers sidebar to:
  1. Select the matching shape
  2. Center the canvas on it

The `select-shape` event already triggers the layers panel to scroll the item into view (via the existing scroll-into-view-if-needed logic in `layer_item.cljs`).

## Changes

- `frontend/src/app/main/data/workspace/zoom.cljs` — new `center-on-shape` event
- `frontend/src/app/main/data/workspace.cljs` — export `center-on-shape`
- `frontend/src/app/main/ui/workspace/sidebar/layers.cljs` — emit select + center on navigate-next/navigate-prev