### PR TITLE
:bug: Restore fill on error page decorative SVGs for dark mode

### DIFF
--- a/backend/resources/rlimit.edn
+++ b/backend/resources/rlimit.edn
@@ -1,11 +1,308 @@
-;; Example rlimit.edn file
 ^{:refresh "30s"}
 {:default
  [[:default :window "200000/h"]]
 
- ;; #{:main/get-teams}
- ;; [[:burst :bucket "5/5/5s"]]
+ ;; ═══════════════════════════════════════════════
+ ;; Auth & Identity — public, unauthenticated
+ ;; ═══════════════════════════════════════════════
+ #{:main/login-with-password}
+ [[:auth-password :bucket "100/50/1m"]]
 
- ;; #{:main/get-profile}
- ;; [[:burst :bucket "60/60/1m"]]
- }
+ #{:main/login-with-ldap}
+ [[:auth-ldap :bucket "20/10/5m"]]
+
+ #{:main/register-profile}
+ [[:auth-register :bucket "20/10/15m"]]
+
+ #{:main/request-profile-recovery
+   :main/prepare-register-profile}
+ [[:auth-recovery :bucket "100/50/5m"]]
+
+ #{:main/recover-profile
+   :main/verify-token}
+ [[:auth-token :bucket "100/50/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; SSRF vectors — URL fetch endpoints
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-file-media-object-from-url}
+ [[:url-fetch :bucket "100/50/5m"]]
+
+ #{:main/create-webhook
+   :main/update-webhook}
+ [[:webhook-validation :bucket "20/10/5m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Search — full sequential scan risk
+ ;; ═══════════════════════════════════════════════
+ #{:main/search-files}
+ [[:search :bucket "60/30/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Feedback & Invitations — email-sending
+ ;; ═══════════════════════════════════════════════
+ #{:main/send-user-feedback
+   :main/create-team-invitations}
+ [[:email-send :bucket "30/15/5m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Media & File heavy ops
+ ;; ═══════════════════════════════════════════════
+ #{:main/upload-file-media-object}
+ [[:image-upload :bucket "200/100/1m"]]
+
+ #{:main/create-file-object-thumbnail
+   :main/delete-file-object-thumbnails
+   :main/get-file-object-thumbnails}
+ [[:thumbnail-ops :bucket "5000/3000/1m"]]
+
+ #{:main/get-file-data-for-thumbnail
+   :main/create-file-thumbnail}
+ [[:thumbnail-data :bucket "100/50/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; UI navigation reads — high frequency
+ ;; ═══════════════════════════════════════════════
+ #{:main/get-teams}
+ [[:get-teams :bucket "5000/2500/30s"]]
+
+ #{:main/get-team-members}
+ [[:get-team-members :bucket "4000/2000/30s"]]
+
+ #{:main/get-profile}
+ [[:get-profile :bucket "500/250/30s"]]
+
+ #{:main/get-font-variants}
+ [[:get-font-variants :bucket "250/125/30s"]]
+
+ #{:main/get-comment-threads}
+ [[:get-comment-threads :bucket "500/250/30s"]]
+
+ #{:main/get-profiles-for-file-comments}
+ [[:get-profiles-for-file-comments :bucket "300/150/30s"]]
+
+ #{:main/get-file-libraries}
+ [[:get-file-libraries :bucket "200/100/30s"]]
+
+ #{:main/get-projects}
+ [[:get-projects :bucket "120/60/30s"]]
+
+ #{:main/get-team-recent-files
+   :main/get-unread-comment-threads}
+ [[:get-team-recent :bucket "120/60/30s"]]
+
+ #{:main/get-page}
+ [[:get-page :bucket "150/75/30s"]]
+
+ #{:main/get-access-tokens
+   :main/get-subscription-usage}
+ [[:get-access-tokens :bucket "150/75/30s"]]
+
+ #{:main/get-enabled-flags}
+ [[:get-enabled-flags :bucket "250/125/30s"]]
+
+ #{:main/get-builtin-templates}
+ [[:get-builtin-templates :bucket "200/100/30s"]]
+
+ #{:main/get-project
+   :main/get-project-files}
+ [[:get-project-info :bucket "80/40/30s"]]
+
+ #{:main/get-file}
+ [[:get-file :bucket "180/90/1m"]]
+
+ #{:main/get-team-shared-files
+   :main/get-team-info
+   :main/get-team-users
+   :main/get-team-invitations
+   :main/get-team-deleted-files
+   :main/get-sso-provider}
+ [[:get-team-info :bucket "60/30/30s"]]
+
+ #{:main/get-comments
+   :main/get-file-snapshots
+   :main/get-library-usage
+   :main/has-file-libraries}
+ [[:get-misc-list :bucket "300/150/30s"]]
+
+ #{:main/get-comment-thread
+   :main/get-library-file-references}
+ [[:get-misc-single :bucket "60/30/30s"]]
+
+ #{:main/get-file-info
+   :main/get-view-only-bundle
+   :main/get-all-projects
+   :main/get-owned-teams
+   :main/get-team-stats
+   :main/get-file-summary
+   :main/get-file-stats
+   :main/get-file-fragment}
+ [[:get-light :bucket "60/30/30s"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; File mutations — editing active
+ ;; ═══════════════════════════════════════════════
+ #{:main/update-file}
+ [[:update-file :bucket "1000/500/1m"]]
+
+ #{:main/create-file
+   :main/rename-file
+   :main/duplicate-file
+   :main/move-files}
+ [[:file-create :bucket "60/30/1m"]]
+
+ #{:main/delete-file}
+ [[:file-delete :bucket "80/40/1m"]]
+
+ #{:main/set-file-shared
+   :main/update-file-library-sync-status
+   :main/ignore-file-library-sync-status
+   :main/link-file-to-library
+   :main/unlink-file-from-library
+   :main/create-file-snapshot
+   :main/restore-file-snapshot
+   :main/update-file-snapshot
+   :main/delete-file-snapshot
+   :main/lock-file-snapshot
+   :main/unlock-file-snapshot}
+ [[:file-mutations :bucket "80/40/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Project mutations
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-project}
+ [[:project-create :bucket "100/50/1m"]]
+
+ #{:main/delete-project
+   :main/rename-project
+   :main/duplicate-project
+   :main/move-project
+   :main/update-project-pin}
+ [[:project-mutations :bucket "40/20/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Team mutations
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-team
+   :main/update-team
+   :main/delete-team
+   :main/update-team-photo
+   :main/update-team-member-role
+   :main/delete-team-member
+   :main/leave-team
+   :main/create-team-with-invitations
+   :main/create-team-access-request
+   :main/permanently-delete-team-files
+   :main/restore-deleted-team-files}
+ [[:team-mutations :bucket "60/30/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Comment operations
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-comment-thread
+   :main/create-comment
+   :main/update-comment
+   :main/delete-comment
+   :main/mark-all-threads-as-read}
+ [[:comment-basic :bucket "30/15/1m"]]
+
+ #{:main/update-comment-thread
+   :main/update-comment-thread-status
+   :main/update-comment-thread-position
+   :main/update-comment-thread-frame
+   :main/delete-comment-thread}
+ [[:comment-thread :bucket "80/40/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Profile operations
+ ;; ═══════════════════════════════════════════════
+ #{:main/update-profile
+   :main/update-profile-props
+   :main/update-profile-photo
+   :main/update-profile-password
+   :main/update-profile-notifications
+   :main/delete-profile
+   :main/delete-profile-photo
+   :main/request-email-change}
+ [[:profile-mutations :bucket "30/15/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Font operations
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-font-variant
+   :main/delete-font
+   :main/delete-font-variant
+   :main/update-font
+   :main/download-font
+   :main/download-font-family}
+ [[:font-ops :bucket "100/50/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Access tokens
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-access-token
+   :main/delete-access-token}
+ [[:access-token :bucket "60/30/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Export / Import
+ ;; ═══════════════════════════════════════════════
+ #{:main/export-binfile
+   :main/import-binfile
+   :main/clone-template}
+ [[:export-import :bucket "80/40/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Upload sessions
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-upload-session
+   :main/upload-chunk
+   :main/assemble-file-media-object}
+ [[:upload-session :bucket "100/50/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Webhooks
+ ;; ═══════════════════════════════════════════════
+ #{:main/get-webhooks
+   :main/delete-webhook}
+ [[:webhook-read :bucket "20/10/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Share links
+ ;; ═══════════════════════════════════════════════
+ #{:main/create-share-link
+   :main/delete-share-link}
+ [[:share-link :bucket "10/5/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Organization operations
+ ;; ═══════════════════════════════════════════════
+ #{:main/add-team-to-organization
+   :main/remove-team-from-org
+   :main/all-org-members-in-team
+   :main/all-team-members-in-orgs
+   :main/get-owned-organizations-summary
+   :main/get-leave-org-summary
+   :main/leave-org
+   :main/check-org-members
+   :main/get-team-invitation-token
+   :main/delete-team-invitation
+   :main/check-team-external-invitations}
+ [[:org-ops :bucket "20/10/1m"]]
+
+ ;; ═══════════════════════════════════════════════
+ ;; Audit & stats
+ ;; ═══════════════════════════════════════════════
+ #{:main/push-audit-events}
+ [[:audit-events :bucket "1000/500/1m"]]
+
+ #{:main/logout
+   :main/get-error-report
+   :main/get-error-reports
+   :main/get-current-mcp-token
+   :main/get-nitrate-connectivity
+   :main/check-nitrate-sso
+   :main/redeem-nitrate-activation-code
+   :main/create-demo-profile
+   :main/get-subscription-warning}
+ [[:misc-light :bucket "100/50/1m"]]}

--- a/backend/src/app/http/middleware.clj
+++ b/backend/src/app/http/middleware.clj
@@ -24,7 +24,8 @@
   (:import
    io.undertow.server.RequestTooBigException
    java.io.InputStream
-   java.io.OutputStream))
+   java.io.OutputStream
+   java.security.MessageDigest))
 
 (set! *warn-on-reflection* true)
 
@@ -329,6 +330,11 @@
   {:name ::auth
    :compile (constantly wrap-auth)})
 
+(defn- constant-time-eq?
+  "Compare strings in constant time to prevent timing attacks."
+  [^String a ^String b]
+  (MessageDigest/isEqual (.getBytes a "UTF-8") (.getBytes b "UTF-8")))
+
 (defn- wrap-shared-key-auth
   [handler keys]
   (if (seq keys)
@@ -338,7 +344,7 @@
         (let [key-id (-> key-id str/lower keyword)]
           (if (and (string? key)
                    (contains? keys key-id)
-                   (= key (get keys key-id)))
+                   (constant-time-eq? key (get keys key-id)))
             (-> request
                 (assoc ::http/auth-key-id key-id)
                 (handler))

--- a/backend/src/app/http/session.clj
+++ b/backend/src/app/http/session.clj
@@ -226,6 +226,14 @@
     (-> (db/exec-one! cfg [sql (:profile-id session) (:id session)])
         (db/get-update-count))))
 
+(defn invalidate-all
+  "Delete all sessions for a given profile. Used when a profile is deleted
+  to ensure immediate access revocation across all devices."
+  [cfg profile-id]
+  (let [sql "delete from http_session_v2 where profile_id = ?"]
+    (-> (db/exec-one! cfg [sql profile-id])
+        (db/get-update-count))))
+
 (def ^:private sql:clear-organization-sso-sessions
   (str "UPDATE http_session_v2 "
        "SET props = props #- ARRAY['~:sso', ?]::text[] "

--- a/backend/src/app/http/websocket.clj
+++ b/backend/src/app/http/websocket.clj
@@ -7,6 +7,7 @@
 (ns app.http.websocket
   "A penpot notification service for file cooperative edition."
   (:require
+   [app.binfile.common :as bfc]
    [app.common.exceptions :as ex]
    [app.common.logging :as l]
    [app.common.pprint :as pp]
@@ -17,6 +18,8 @@
    [app.http.session :as session]
    [app.metrics :as mtx]
    [app.msgbus :as mbus]
+   [app.rpc.commands.files :as files]
+   [app.rpc.commands.teams :as teams]
    [app.util.websocket :as ws]
    [integrant.core :as ig]
    [promesa.exec.csp :as sp]
@@ -131,8 +134,9 @@
       (mbus/pub! msgbus :topic topic :message msg))))
 
 (defmethod handle-message :subscribe-team
-  [{:keys [::mbus/msgbus]} {:keys [::ws/id ::ws/state ::ws/output-ch ::session-id]} {:keys [team-id] :as params}]
+  [{:keys [::mbus/msgbus ::db/pool]} {:keys [::ws/id ::ws/state ::ws/output-ch ::session-id ::profile-id]} {:keys [team-id] :as params}]
   (l/trace :fn "handle-message" :event "subscribe-team" :team-id team-id :conn-id id)
+  (teams/check-read-permissions! pool profile-id team-id)
   (let [prev-subs (get @state ::team-subscription)
         channel   (sp/chan :buf (sp/dropping-buffer 64)
                            :xf  (remove #(= (:session-id %) session-id)))]
@@ -150,8 +154,10 @@
 
 
 (defmethod handle-message :subscribe-file
-  [{:keys [::mbus/msgbus]} {:keys [::ws/id ::ws/state ::ws/output-ch ::session-id ::profile-id]} {:keys [file-id] :as params}]
+  [{:keys [::mbus/msgbus ::db/pool]} {:keys [::ws/id ::ws/state ::ws/output-ch ::session-id ::profile-id]} {:keys [file-id] :as params}]
   (l/trace :fn "handle-message" :event "subscribe-file" :file-id file-id :conn-id id)
+  (bfc/check-file-exists pool file-id)
+  (files/check-read-permissions! pool profile-id file-id)
   (let [psub (::file-subscription @state)
         fch  (sp/chan :buf (sp/dropping-buffer 64)
                       :xf  (remove #(= (:session-id %) session-id)))]

--- a/backend/src/app/rpc/commands/files_share.clj
+++ b/backend/src/app/rpc/commands/files_share.clj
@@ -43,7 +43,7 @@
   [conn {:keys [profile-id file-id pages who-comment who-inspect]}]
   (let [pages (db/create-array conn "uuid" pages)
         slink (db/insert! conn :share-link
-                          {:id (uuid/next)
+                          {:id (uuid/random)
                            :file-id file-id
                            :who-comment who-comment
                            :who-inspect who-inspect

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -534,6 +534,10 @@
                                 :deleted-at deleted-at
                                 :id profile-id}})
 
+    ;; Invalidate all sessions for this profile to ensure immediate
+    ;; access revocation across all devices
+    (session/invalidate-all cfg profile-id)
+
     (-> (rph/wrap nil)
         (rph/with-transform (session/delete-fn cfg)))))
 

--- a/backend/src/app/rpc/rlimit.clj
+++ b/backend/src/app/rpc/rlimit.clj
@@ -190,6 +190,7 @@
              :allowed allowed?
              :remaining remaining)
     (-> limit
+        (assoc ::lresult/now now)
         (assoc ::lresult/allowed allowed?)
         (assoc ::lresult/reset (ct/plus now reset))
         (assoc ::lresult/remaining remaining))))
@@ -212,6 +213,7 @@
              :allowed allowed?
              :remaining remaining)
     (-> limit
+        (assoc ::lresult/now now)
         (assoc ::lresult/allowed allowed?)
         (assoc ::lresult/timestamp ts)
         (assoc ::lresult/remaining remaining)

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -733,7 +733,7 @@
         (t/is (= 2 (count rows)))
         (t/is (= 1 (count (remove (comp some? :deleted-at) rows))))
         (t/is (= (thc/fmt-object-id file-id page-id frame-id-1 "frame")
-                 (-> rows first :object-id))))
+                 (->> rows (remove (comp some? :deleted-at)) first :object-id))))
 
       ;; Now that file-gc have marked for deletion the object
       ;; thumbnail lets execute the objects-gc task which remove
@@ -2377,8 +2377,6 @@
     (let [edata (-> out :error ex-data)]
       (t/is (= :not-found (:type edata))))))
 
-;; --- Security Fix Tests ---
-
 (t/deftest link-file-to-library-circular-reference
   (let [profile (th/create-profile* 1)
         file1   (th/create-file* 1 {:profile-id (:id profile)
@@ -2448,3 +2446,24 @@
     (t/is (th/ex-info? (:error out)))
     (let [edata (-> out :error ex-data)]
       (t/is (= :validation (:type edata))))))
+
+(t/deftest get-file-libraries-nonexistent-file
+  (let [prof (th/create-profile* 1 {:is-active true})
+        out  (th/command! {::th/type :get-file-libraries
+                           ::rpc/profile-id (:id prof)
+                           :file-id (uuid/random)})
+        err  (:error out)]
+    (t/is (th/ex-info? err))
+    (t/is (th/ex-of-type? err :not-found))))
+
+(t/deftest get-file-libraries-no-permission
+  (let [owner (th/create-profile* 1 {:is-active true})
+        other (th/create-profile* 2 {:is-active true})
+        file  (th/create-file* 1 {:profile-id (:id owner)
+                                  :project-id (:default-project-id owner)})
+        out   (th/command! {::th/type :get-file-libraries
+                            ::rpc/profile-id (:id other)
+                            :file-id (:id file)})
+        err   (:error out)]
+    (t/is (th/ex-info? err))
+    (t/is (th/ex-of-type? err :not-found))))

--- a/backend/test/backend_tests/rpc_font_test.clj
+++ b/backend/test/backend_tests/rpc_font_test.clj
@@ -650,3 +650,24 @@
         (t/is (some? (:error out)))
         (t/is (= :not-found (-> out :error ex-data :type)))
         (t/is (= :object-not-found (-> out :error ex-data :code)))))))
+
+(t/deftest get-font-variants-nonexistent-file
+  (let [prof (th/create-profile* 1 {:is-active true})
+        out  (th/command! {::th/type :get-font-variants
+                           ::rpc/profile-id (:id prof)
+                           :file-id (uuid/random)})
+        err  (:error out)]
+    (t/is (th/ex-info? err))
+    (t/is (th/ex-of-type? err :not-found))))
+
+(t/deftest get-font-variants-no-permission
+  (let [owner (th/create-profile* 1 {:is-active true})
+        other (th/create-profile* 2 {:is-active true})
+        file  (th/create-file* 1 {:profile-id (:id owner)
+                                  :project-id (:default-project-id owner)})
+        out   (th/command! {::th/type :get-font-variants
+                            ::rpc/profile-id (:id other)
+                            :file-id (:id file)})
+        err   (:error out)]
+    (t/is (th/ex-info? err))
+    (t/is (th/ex-of-type? err :not-found))))

--- a/backend/test/backend_tests/rpc_profile_test.clj
+++ b/backend/test/backend_tests/rpc_profile_test.clj
@@ -388,6 +388,31 @@
     (let [result (th/run-task! :objects-gc {:min-age 0})]
       (t/is (= 10 (:processed result))))))
 
+(t/deftest profile-deletion-invalidates-all-sessions
+  (let [prof (th/create-profile* 1)
+
+        ;; Insert 3 sessions for this profile directly into the database
+        session-ids (doall
+                     (for [i (range 3)]
+                       (let [sid (uuid/random)]
+                         (th/db-exec-one! ["INSERT INTO http_session_v2 (id, profile_id, user_agent) VALUES (?, ?, ?)"
+                                           sid (:id prof) (str "user-agent-" i)])
+                         sid)))]
+
+    ;; Verify sessions exist
+    (let [count-before (:count (th/db-exec-one! ["SELECT count(*) FROM http_session_v2 WHERE profile_id = ?" (:id prof)]))]
+      (t/is (= 3 count-before)))
+
+    ;; Request profile to be deleted
+    (let [params {::th/type :delete-profile
+                  ::rpc/profile-id (:id prof)}
+          out    (th/command! params)]
+      (t/is (nil? (:error out))))
+
+    ;; Verify ALL sessions were invalidated (not just one)
+    (let [count-after (:count (th/db-exec-one! ["SELECT count(*) FROM http_session_v2 WHERE profile_id = ?" (:id prof)]))]
+      (t/is (= 0 count-after)))))
+
 
 (t/deftest email-blacklist-1
   (t/is (false? (email.blacklist/enabled? th/*system*)))

--- a/backend/test/backend_tests/rpc_project_test.clj
+++ b/backend/test/backend_tests/rpc_project_test.clj
@@ -241,3 +241,24 @@
             error-data (ex-data error)]
         (t/is (th/ex-info? error))
         (t/is (= (:type error-data) :not-found))))))
+
+(t/deftest get-project-nonexistent
+  (let [prof (th/create-profile* 1 {:is-active true})
+        out  (th/command! {::th/type :get-project
+                           ::rpc/profile-id (:id prof)
+                           :id (uuid/random)})
+        err  (:error out)]
+    (t/is (th/ex-info? err))
+    (t/is (th/ex-of-type? err :not-found))))
+
+(t/deftest get-project-no-permission
+  (let [owner (th/create-profile* 1 {:is-active true})
+        other (th/create-profile* 2 {:is-active true})
+        proj  (th/create-project* 1 {:profile-id (:id owner)
+                                     :team-id (:default-team-id owner)})
+        out   (th/command! {::th/type :get-project
+                            ::rpc/profile-id (:id other)
+                            :id (:id proj)})
+        err   (:error out)]
+    (t/is (th/ex-info? err))
+    (t/is (th/ex-of-type? err :not-found))))

--- a/common/src/app/common/logic/libraries.cljc
+++ b/common/src/app/common/logic/libraries.cljc
@@ -2345,7 +2345,12 @@
               updated-sync-groups (into #{}
                                         (keep #(ctk/resolve-sync-group (:type previous-shape) %))
                                         updated-attrs)
-              new-touched (set/union (or (:touched current-shape) #{}) updated-sync-groups)
+              text-sub-touched #{:text-content-text :text-content-attribute :text-content-structure}
+              new-touched (set/union (or (:touched current-shape) #{})
+                                     updated-sync-groups
+                                     (when (contains? updated-sync-groups :content-group)
+                                       (set/intersection (or (:touched previous-shape) #{})
+                                                         text-sub-touched)))
               roperations (into [{:type :set-touched :touched new-touched}] roperations)
               uoperations (into (list {:type :set-touched :touched (:touched current-shape)}) uoperations)]
           (cond-> changes

--- a/common/test/common_tests/logic/variants_switch_test.cljc
+++ b/common/test/common_tests/logic/variants_switch_test.cljc
@@ -10,6 +10,7 @@
    [app.common.files.helpers :as cfh]
    [app.common.geom.point :as gpt]
    [app.common.geom.shapes :as gsh]
+   [app.common.logic.libraries :as cll]
    [app.common.logic.shapes :as cls]
    [app.common.test-helpers.components :as thc]
    [app.common.test-helpers.compositions :as tho]
@@ -3101,3 +3102,82 @@
     (t/is (= 150 (:width rect02')))
     (t/is (= (+ (:y copy02') 70) (:y rect02')))
     (t/is (= (:y rect02') (get-in rect02' [:selrect :y])))))
+
+;; ============================================================
+;; PRESERVE TEXT SUB-TOUCHED FLAGS ACROSS VARIANT SWITCH
+;; ============================================================
+
+(t/deftest test-switch-preserves-text-sub-touched-flags
+  ;; 1. Creates a component with text "hello world" + font-size "14", variant with font-size "20"
+  ;; 2. Overrides only text on the copy → verifies :text-content-text in touched
+  ;; 3. Switches to variant → verifies text override preserved, font-size updated, :text-content-text preserved
+  ;; 4. Updates main font-size to "30" and syncs → verifies font-size synced but text override preserved
+  (let [;; ==== Setup
+        file (-> (thf/sample-file :file1)
+                 ;; c01 has text "hello world" font-size "14"
+                 ;; c02 has text "hello world" font-size "20" (same text, different font-size)
+                 (thv/add-variant-with-text
+                  :v01 :c01 :m01 :c02 :m02 :t01 :t02 "hello world" "hello world")
+                 (update-attr :t02 font-size-path-0 "20")
+                 (thc/instantiate-component :c01
+                                            :copy01
+                                            :children-labels [:copy-t01]))
+
+        ;; Override only the TEXT on the copy (not font-size)
+        file       (update-attr file :copy-t01 text-path-0 "custom text")
+        copy-t01   (ths/get-shape file :copy-t01)]
+
+    ;; Verify the copy has the text override and correct touched flags
+    (t/is (= (get-in copy-t01 text-path-0) "custom text"))
+    (t/is (= (get-in copy-t01 font-size-path-0) "14"))
+    (t/is (contains? (:touched copy-t01) :content-group))
+    (t/is (contains? (:touched copy-t01) :text-content-text))
+    (t/is (not (contains? (:touched copy-t01) :text-content-attribute)))
+    (t/is (not (contains? (:touched copy-t01) :text-content-structure)))
+
+    ;; ==== Action: Switch copy to c02 variant (same text, different font-size)
+    (let [file' (tho/swap-component-in-shape file :copy01 :c02
+                                             {:new-shape-label :copy02
+                                              :keep-touched? true})
+          page'       (thf/current-page file')
+          copy02'     (ths/get-shape file' :copy02)
+          copy-t02'   (get-in page' [:objects (-> copy02' :shapes first)])]
+
+      ;; After switch: text override preserved (same text between variants),
+      ;; font-size updated from variant, touched preserves text-content-text
+      (t/is (= (get-in copy-t02' text-path-0) "custom text"))
+      (t/is (= (get-in copy-t02' font-size-path-0) "20"))
+      (t/is (contains? (:touched copy-t02') :content-group))
+      (t/is (contains? (:touched copy-t02') :text-content-text))
+      (t/is (not (contains? (:touched copy-t02') :text-content-attribute)))
+
+      ;; ==== Now test subsequent component sync
+      ;; Modify the main component's font-size to "30" (keeping text "hello world")
+      (let [main-text  (ths/get-shape file' :t02)
+            changes1   (cls/generate-update-shapes (pcb/empty-changes nil (:id page'))
+                                                   #{(:id main-text)}
+                                                   (fn [shape]
+                                                     (assoc-in shape font-size-path-0 "30"))
+                                                   (:objects page')
+                                                   {})
+            updated-file (thf/apply-changes file' changes1)
+
+            changes2     (cll/generate-sync-file-changes (pcb/empty-changes)
+                                                         nil
+                                                         :components
+                                                         (:id updated-file)
+                                                         (thi/id :c02)
+                                                         (:id updated-file)
+                                                         {(:id updated-file) updated-file}
+                                                         (:id updated-file))
+
+            synced-file   (thf/apply-changes updated-file changes2)
+            synced-copy   (ths/get-shape synced-file :copy02)
+            synced-t      (get-in (thf/current-page synced-file)
+                                  [:objects (-> synced-copy :shapes first)])]
+
+        ;; The text override is preserved and font-size is synced
+        (t/is (= (get-in synced-t text-path-0) "custom text"))
+        (t/is (= (get-in synced-t font-size-path-0) "30"))
+        (t/is (contains? (:touched synced-t) :content-group))
+        (t/is (contains? (:touched synced-t) :text-content-text))))))

--- a/docker/images/files/nginx-mcp-locations.conf.template
+++ b/docker/images/files/nginx-mcp-locations.conf.template
@@ -1,16 +1,19 @@
 location /mcp/ws {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';
-    proxy_pass $PENPOT_MCP_URI_WS;
+    set $mcp_ws_backend $PENPOT_MCP_URI_WS;
+    proxy_pass $mcp_ws_backend;
     proxy_http_version 1.1;
 }
 
 location /mcp/stream {
-    proxy_pass $PENPOT_MCP_URI/mcp;
+    set $mcp_stream_backend $PENPOT_MCP_URI/mcp$is_args$args;
+    proxy_pass $mcp_stream_backend;
     proxy_http_version 1.1;
 }
 
 location /mcp/sse {
-    proxy_pass $PENPOT_MCP_URI/sse;
+    set $mcp_sse_backend $PENPOT_MCP_URI/sse$is_args$args;
+    proxy_pass $mcp_sse_backend;
     proxy_http_version 1.1;
 }

--- a/frontend/playwright/ui/specs/workspace-texts-typography-persist.spec.js
+++ b/frontend/playwright/ui/specs/workspace-texts-typography-persist.spec.js
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import { WasmWorkspacePage } from "../pages/WasmWorkspacePage";
+
+// ---------------------------------------------------------------------------
+// BUG 10925 - Font family typography asset must not persist across files in
+// newly created text layers.
+//
+// `save-font` writes the current font (plus the typography refs of the edited
+// shape, when it uses one) into the session-global `:workspace-global
+// :default-font`. That state is what seeds the content of brand-new text
+// shapes via `v2-default-text-content`. Because it is session-global it
+// survives a file switch, so a text created in file B could end up referencing
+// a typography asset that only exists in file A (see workspace/texts.cljs
+// save-font and workspace.cljs initialize/finalize-workspace).
+//
+// This E2E reproduces the leak faithfully in a single SPA session:
+//   1. Open file A (has a text shape linked to a typography asset).
+//   2. Change a font attribute on that shape (triggers `emit-update!` ->
+//      `save-font` with the current text-node attrs, typography refs included).
+//   3. Switch to file B (same session, fragment navigation keeps JS state).
+//   4. Create a brand-new text layer in file B.
+//   5. Assert the new text uses the DEFAULT Penpot font ("Source Sans Pro"),
+//      not the typography font-family carried over from file A.
+// ---------------------------------------------------------------------------
+
+const FILE_A = {
+  id: "1062e0a0-8fe0-80ae-8007-e70b4993f5ef",
+  pageId: "1062e0a0-8fe0-80ae-8007-e70b4993f5f0",
+  // "Text with typography asset one" carries a ref to in-file typography whose
+  // font-family is "IM Fell French Canon SC" (multiselection-typography.json).
+};
+
+const FILE_B = {
+  id: "434b0541-fa2f-802f-8006-59827d964a9b",
+  pageId: "434b0541-fa2f-802f-8006-59827d964a9c",
+  // render-wasm/get-file-text-custom-fonts.json - a mostly empty file whose
+  // only text uses the default font (no typography asset).
+};
+
+async function serveTwoFiles(page) {
+  const fileABody = await readFile(
+    "playwright/data/workspace/multiselection-typography.json",
+    "utf-8",
+  );
+  const fileBBody = await readFile(
+    "playwright/data/render-wasm/get-file-text-custom-fonts.json",
+    "utf-8",
+  );
+
+  // Dispatch on the `id` query param of the `get-file` RPC so each file gets
+  // its own fixture while keeping a single SPA session alive.
+  await page.route(/get\-file\?/, (route) => {
+    const url = new URL(route.request().url());
+    const fileId = url.searchParams.get("id");
+    const body = fileId === FILE_A.id ? fileABody : fileBBody;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/transit+json",
+      body,
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await WasmWorkspacePage.init(page);
+  // WASM_FLAGS already enables the v2 text editor / render-wasm. Add the WASM
+  // text editor on top so typography styles are read through the current text
+  // values path.
+  await WasmWorkspacePage.mockConfigFlags(page, ["enable-feature-text-editor-wasm"]);
+});
+
+test("BUG 10925 - typography font does not leak into new text in a different file", async ({ page }) => {
+  const workspace = new WasmWorkspacePage(page, { textEditor: true });
+  await workspace.setupEmptyFile();
+  await workspace.mockRPC(
+    "get-font-variants?team-id=*",
+    "render-wasm/get-font-variants-custom-fonts.json",
+  );
+
+  await serveTwoFiles(page);
+
+  // ---- File A: select the text linked to a typography and change a font ----
+  await workspace.goToWorkspace({ fileId: FILE_A.id, pageId: FILE_A.pageId });
+  await workspace.waitForFirstRender();
+  await workspace.doubleClickLeafLayer("Text with typography asset one");
+  await workspace.textEditor.startEditing();
+
+  // Changing a font attribute triggers save-font with the current text-node
+  // attrs (including the typography refs) storing them into default-font.
+  await workspace.textEditor.changeFontSize(24);
+  await workspace.textEditor.stopEditing();
+
+  // ---- File B: same SPA session, switch to a file with no typography ----
+  await workspace.goToWorkspace({ fileId: FILE_B.id, pageId: FILE_B.pageId });
+  await workspace.waitForFirstRender();
+
+  // Create a brand-new text layer in file B and query its font-family.
+  await workspace.createTextShape(100, 100, 300, 200, "hello");
+  await workspace.textEditor.stopEditing();
+  await workspace.clickLeafLayer("hello");
+  await workspace.textEditor.startEditing();
+  await workspace.page.keyboard.press("ControlOrMeta+a");
+
+  const fontFamily = workspace.rightSidebar.getByTitle("Font Family");
+  await expect(fontFamily).toContainText("Source Sans Pro");
+  // The custom typography family from file A (IM Fell French Canon SC) must NOT
+  // be carried over.
+  await expect(fontFamily).not.toContainText("IM Fell");
+});

--- a/frontend/src/app/main/data/plugins.cljs
+++ b/frontend/src/app/main/data/plugins.cljs
@@ -39,6 +39,7 @@
                     :uri plugin-url
                     :omit-default-headers true
                     :response-type :json})
+       (rx/timeout 15000)
        (rx/map :body)
        (rx/map #(preg/parse-manifest plugin-url %))))
 

--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -346,7 +346,8 @@
           (assoc :recent-colors (:recent-colors storage/user))
           (assoc :recent-fonts (:recent-fonts storage/user))
           (assoc :current-file-id file-id)
-          (assoc :workspace-presence {})))
+          (assoc :workspace-presence {})
+          (update :workspace-global dissoc :default-font)))
 
     ptk/WatchEvent
     (watch [_ state stream]
@@ -544,7 +545,7 @@
            :workspace-tokens
            :workspace-undo
            :workspace-versions)
-          (update :workspace-global dissoc :read-only?)
+          (update :workspace-global dissoc :read-only? :default-font)
           (assoc-in [:workspace-global :options-mode] :design)
           (update :files d/update-vals #(dissoc % :data))))
 

--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -831,7 +831,8 @@
       (let [multiple? (->> data vals (d/seek #(= % :multiple)))]
         (cond-> state
           (not multiple?)
-          (assoc-in [:workspace-global :default-font] data))))))
+          (assoc-in [:workspace-global :default-font]
+                    (dissoc data :typography-ref-id :typography-ref-file)))))))
 
 (defn apply-text-modifier
   [shape text-modifier]

--- a/frontend/src/app/main/ui/comments.cljs
+++ b/frontend/src/app/main/ui/comments.cljs
@@ -1063,6 +1063,14 @@
          (fn [content]
            (st/emit! (dcm/add-comment thread content))))
 
+        on-key-down
+        (mf/use-fn
+         (fn [event]
+           (when (kbd/esc? event)
+             (dom/prevent-default event)
+             (dom/stop-propagation event)
+             (st/emit! (dcm/close-thread)))))
+
         on-cancel
         (mf/use-fn #(st/emit! (dcm/close-thread)))]
 
@@ -1086,6 +1094,7 @@
               :style {:left (str pos-x "px")
                       :top (str pos-y "px")
                       "--comment-height" (str max-height "px")}
+              :on-key-down on-key-down
               :on-click dom/stop-propagation}
 
         [:div {:class (stl/css :floating-thread-header)}

--- a/frontend/src/app/main/ui/dashboard.cljs
+++ b/frontend/src/app/main/ui/dashboard.cljs
@@ -211,7 +211,7 @@
 
     (mf/with-layout-effect
       [plugin-url team-id project-id]
-      (when plugin-url
+      (when (and plugin-url project-id)
         (->> (dp/fetch-manifest plugin-url)
              (rx/subs!
               (fn [plugin]

--- a/frontend/src/app/main/ui/static.scss
+++ b/frontend/src/app/main/ui/static.scss
@@ -69,6 +69,7 @@
 // SVG inside deco-before — no class available on the raw element
 .deco-before svg {
   position: absolute;
+  fill: var(--color-foreground-secondary);
   block-size: 1537px;
   inline-size: px2rem(80);
   inset-block-end: 0;
@@ -76,6 +77,7 @@
 
 // SVG inside deco-after2 — no class available on the raw element
 .deco-after2 svg {
+  fill: var(--color-foreground-secondary);
   block-size: 1537px;
   inline-size: px2rem(80);
 }

--- a/frontend/test/frontend_tests/data/workspace_texts_test.cljs
+++ b/frontend/test/frontend_tests/data/workspace_texts_test.cljs
@@ -12,6 +12,7 @@
    [app.common.types.modifiers :as ctm]
    [app.common.types.shape :as cts]
    [app.common.types.text :as txt]
+   [app.common.uuid :as uuid]
    [app.main.data.workspace.texts :as dwt]
    [app.main.ui.workspace.shapes.text.viewport-texts-html :as vth]
    [cljs.test :as t :include-macros true]
@@ -376,6 +377,62 @@
                  "exactly one typography was added")
            (t/is (= "0.1" (:letter-spacing (first typographies)))
                  "float letter-spacing is normalised to 2-decimal string")))))))
+
+;; ---------------------------------------------------------------------------
+;; Tests: save-font must not persist typography refs into the global default font
+;;
+;; Root cause of #10925: typography assets are file-specific references, but
+;; save-font used to write :typography-ref-id / :typography-ref-file into the
+;; session-global [:workspace-global :default-font]. That state survives a file
+;; switch, and v2-default-text-content bakes it into brand-new text shapes in
+;; the other file, so they got a non-existent typography asset instead of the
+;; default Penpot font. save-font now strips those two keys.
+;; ---------------------------------------------------------------------------
+
+(t/deftest save-font-strips-typography-refs-from-default-font
+  (t/async
+    done
+    (let [file  (-> (cthf/sample-file :file1)
+                    (cths/add-sample-shape :text1
+                                           :type    :text
+                                           :x 0 :y 0
+                                           :content (txt/change-text nil "hello")))
+          store (ths/setup-store file)
+          attrs {:font-id "roboto"
+                 :font-family "Roboto"
+                 :font-variant-id "regular"
+                 :font-size "14"
+                 :typography-ref-id (uuid/next)
+                 :typography-ref-file (:id file)}]
+      (ths/run-store
+       store done [(dwt/save-font attrs)]
+       (fn [new-state]
+         (let [default-font (get-in new-state [:workspace-global :default-font])]
+           (t/is (some? default-font))
+           (t/is (= "roboto" (:font-id default-font)))
+           (t/is (nil? (:typography-ref-id default-font)))
+           (t/is (nil? (:typography-ref-file default-font)))))))))
+
+(t/deftest save-font-preserves-other-font-attrs
+  (t/async
+    done
+    (let [store (ths/setup-store (cthf/sample-file :file1))
+          attrs {:font-family "Open Sans"
+                 :font-id "opensans"
+                 :font-variant-id "regular"
+                 :font-size "18"
+                 :line-height "1.5"
+                 :letter-spacing "0"
+                 :typography-ref-id (uuid/next)
+                 :typography-ref-file (uuid/next)}]
+      (ths/run-store store done [(dwt/save-font attrs)]
+                     (fn [new-state]
+                       (let [default-font (get-in new-state [:workspace-global :default-font])]
+                         (t/is (= "Open Sans" (:font-family default-font)))
+                         (t/is (= "18" (:font-size default-font)))
+                         (t/is (= "1.5" (:line-height default-font)))
+                         (t/is (nil? (:typography-ref-id default-font)))
+                         (t/is (nil? (:typography-ref-file default-font)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tests: fix-position with degenerate selrect


### PR DESCRIPTION
### Related Ticket

Fixes https://github.com/penpot/penpot/issues/11091

### Changes

The CSS refactor in e14e7bb6 (`Refactor and remove deprecated css` #10698) split the combined `.deco-before, .deco-after` rule into separate selectors and migrated to logical properties, but dropped `fill: var(--color-foreground-secondary)` from the SVG rules.

Without an explicit `fill`, the SVG `<path>` defaults to `fill: black`, which matches the dark-mode background (`--color-background-secondary: #000`) and renders the decorative logo invisible.

This restores `fill: var(--color-foreground-secondary)` on both `.deco-before svg` and `.deco-after2 svg`.

### How to test

1. Set the UI theme to **Dark mode**.
2. Navigate to an invalid URL to trigger the 404 error page (e.g. `/#/view?file-id=nonexistent&page-id=nonexistent`).
3. Verify the decorative pencils/book SVG is visible above and below the error message.
4. Switch to **Light mode** and confirm the SVG remains visible there as well.