### PR TITLE
:bug: Increase font dropdown height and add drop shadow in token forms

### DIFF
--- a/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/fonts_combobox.scss
+++ b/frontend/src/app/main/ui/workspace/tokens/management/forms/controls/fonts_combobox.scss
@@ -5,13 +5,19 @@
 // Copyright (c) KALEIDOS INC Sucursal en España SL
 
 @use "ds/_utils.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 
 .font-select-wrapper,
 .font-select-wrapper-composite {
   position: absolute;
   width: 100%;
-  height: px2rem(115);
+  min-width: px2rem(200);
+  height: px2rem(250);
   top: px2rem(54);
+  box-shadow: 0 0 $sz-12 0 var(--color-shadow-dark);
+  border-radius: $br-8;
+  z-index: var(--z-index-dropdown);
 }
 
 .font-select-wrapper-composite {


### PR DESCRIPTION
### Related Ticket

Closes https://github.com/penpot/penpot/issues/10826

### Changes

The font-family selector popup in token typography and font-family forms had a fixed height of `px2rem(115)` (~115 px). With the font-preview feature enabled, each font row is taller than the old plain-text rows, so only 2–3 entries were visible at a time, making the picker difficult to use.

Changes to `fonts_combobox.scss`:
- Raised the wrapper height from `px2rem(115)` to `px2rem(250)` so ~7–8 font rows are comfortably visible with previews on
- Added `min-width: px2rem(200)` so the popup is never narrower than its input
- Added `box-shadow: 0 0 $sz-12 0 var(--color-shadow-dark)` to match the visual style of all other dropdowns in the design system
- Added `border-radius: $br-8` to round the popup corners consistently
- Set `z-index: var(--z-index-dropdown)` explicitly on the wrapper for correct stacking

The same wrapper class (`font-select-wrapper`) is used in both the standalone font-family token form and the composite typography token form (`font-select-wrapper-composite`), so both call-sites benefit.

### How to test

1. Open the Tokens panel in the workspace.
2. Create or edit a **Font Family** token — click the dropdown arrow next to the font input.
3. Verify the picker is taller (~250px) and has a visible drop shadow.
4. Create or edit a **Typography** token — open the font family selector there.
5. Verify the same improvements apply.
6. Compare with the current dropdown on assets typography (not changed, but noted for reference).