### PR TITLE
:bug: Unify mixed-values i18n key to settings.multiple

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
@@ -704,7 +704,7 @@
                                 :id id
                                 :class inner-class
                                 :placeholder (if is-multiple?
-                                               (tr "labels.mixed-values")
+                                               (tr "settings.multiple")
                                                placeholder)
                                 :default-value (or (mf/ref-val last-value*) (fmt/format-number value))
                                 :on-blur handle-blur

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -296,7 +296,7 @@
         (if mixed-state
           [:div  {:class (stl/css :first-row)}
            [:span {:class (stl/css :mixed-label)}
-            (tr "labels.mixed-values")]
+            (tr "settings.multiple")]
            [:> icon-button* {:variant "ghost"
                              :aria-label (tr "workspace.options.blur-options.remove-blur")
                              :on-click handle-delete-all


### PR DESCRIPTION
## Problem

The design sidebar uses two different translation keys for the same "mixed values" concept:

- Most sections (Fill, Stroke, Export, Border radius, etc.) use `settings.multiple`
- The Blur section (`blur.cljs`) and the design-system numeric input (`numeric_input.cljs`) use `labels.mixed-values`

Both read "Mixed" in English, but this inconsistency surfaces in 24 of 49 locales:
- **16 locales** where `labels.mixed-values` has no translation at all — these show the English fallback "Mixed" next to correctly-localized labels
- **8 more locales** where both keys are translated but with different wording (e.g. French: "Divers" vs "Mélangé")

## Fix

Replace `(tr "labels.mixed-values")` with `(tr "settings.multiple")` in both files, matching the key used by every other sidebar section.

## Files changed

- `frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs` — blur mixed state label
- `frontend/src/app/main/ui/ds/controls/numeric_input.cljs` — numeric input placeholder when multiple values are selected

Fixes #11148

🤖 Generated with [Claude Code](https://claude.com/claude-code)