### PR TITLE
:bug: Fix text editor crash when pasting into empty text shapes

### DIFF
--- a/frontend/text-editor/src/editor/clipboard/paste.js
+++ b/frontend/text-editor/src/editor/clipboard/paste.js
@@ -83,6 +83,7 @@ export function paste(event, editor, selectionController) {
   let fragment = null;
   if (editor?.options?.allowHTMLPaste) {
     fragment = getFormattedOrPlainFragmentFromClipboardData(
+      selectionController,
       event.clipboardData,
     );
   } else {

--- a/frontend/text-editor/src/editor/commands/insertText.js
+++ b/frontend/text-editor/src/editor/commands/insertText.js
@@ -21,6 +21,8 @@ export function insertText(event, editor, selectionController) {
       return selectionController.insertText(event.data);
     } else if (selectionController.isLineBreakFocus) {
       return selectionController.replaceLineBreak(event.data);
+    } else {
+      return selectionController.insertIntoFocus(event.data);
     }
   } else {
     if (selectionController.isMultiParagraph) {

--- a/frontend/text-editor/src/editor/controllers/SelectionController.js
+++ b/frontend/text-editor/src/editor/controllers/SelectionController.js
@@ -1419,8 +1419,23 @@ export class SelectionController extends EventTarget {
         this.focusNode.replaceWith(textNode);
       }
       this.collapse(textNode, newText.length);
+    } else if (this.isParagraphFocus) {
+      const newTextNode = new Text(newText);
+      const newTextSpan = createTextSpan(newTextNode, this.#currentStyle);
+      this.focusNode.replaceChildren(newTextSpan);
+      this.collapse(newTextNode, newText.length);
+    } else if (this.isRootFocus) {
+      const newTextNode = new Text(newText);
+      const newTextSpan = createTextSpan(newTextNode, this.#currentStyle);
+      const newParagraph = createParagraph([newTextSpan], this.#currentStyle);
+      this.focusNode.replaceChildren(newParagraph);
+      this.collapse(newTextNode, newText.length);
     } else {
-      throw new Error("Unknown node type");
+      const newTextNode = new Text(newText);
+      const newTextSpan = createTextSpan(newTextNode, this.#currentStyle);
+      const newParagraph = createParagraph([newTextSpan], this.#currentStyle);
+      this.#textEditor.root.replaceChildren(newParagraph);
+      this.collapse(newTextNode, newText.length);
     }
   }
 


### PR DESCRIPTION
### Related Ticket

Closes https://github.com/penpot/penpot/issues/11149

### Summary

Three fixes for the text editor paste path:

1. **`SelectionController.insertIntoFocus()`** — handle `isParagraphFocus` and `isRootFocus` to prevent the `"Unknown node type"` crash when the caret lands on a paragraph or root element instead of a text node (common in Firefox and empty text shapes).

2. **`clipboard/paste.js`** — fix missing `selectionController` argument when calling `getFormattedOrPlainFragmentFromClipboardData` in the HTML paste path (`allowHTMLPaste`). Without it, `selectionController` receives `clipboardData` and `clipboardData` is `undefined`, causing HTML paste to always fail silently.

3. **`commands/insertText.js`** — add fallback to `insertIntoFocus()` when the selection is collapsed but focus is not on a text node or line break (paragraph/root focus). Without this, typing into an empty text shape is silently dropped.

### Steps to reproduce

1. Create a text shape
2. Double-click to enter edit mode (shape is empty)
3. Paste text (Ctrl+V / Cmd+V)
4. **Before fix:** Internal error — `Unknown node type`
5. **After fix:** Text is pasted correctly

Also reproducible in Firefox where the browser places the caret on a paragraph element rather than a text node.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue.