### PR TITLE
:bug: Restore uppercase on shortcut section headers

### DIFF
--- a/frontend/src/app/main/ui/shortcuts.scss
+++ b/frontend/src/app/main/ui/shortcuts.scss
@@ -31,6 +31,7 @@
   cursor: pointer;
   border: none;
   background: none;
+  text-transform: uppercase;
 
   .subsection-name,
   .section-name {


### PR DESCRIPTION
## Summary

When shortcuts were refactored from `deprecated.uppercase-title-typography` to `t.use-typography("title-small")` in #10237, the `text-transform: uppercase` property was dropped from `.section-title`. This restores it.

The existing `.subsection-title { text-transform: none; }` override continues to work correctly — subsection headers remain sentence-case.

**Closes #11066**

## Changes

- Added `text-transform: uppercase` to the shared `.section-title, .subsection-title` rule in `shortcuts.scss`

## Test plan

- [ ] Open the shortcuts panel in workspace sidebar
- [ ] Verify section headers (Basics, Workspace, Dashboard, Viewer) render in UPPERCASE
- [ ] Verify subsection headers remain in normal case
- [ ] Open Settings > Shortcuts and verify the same behavior