### PR TITLE
:bug: Fix path node deletion removing entire shape on Delete key

### DIFF
--- a/frontend/src/app/main/data/workspace/path/shortcuts.cljs
+++ b/frontend/src/app/main/data/workspace/path/shortcuts.cljs
@@ -47,6 +47,7 @@
 
    :delete-node     {:tooltip (ds/supr)
                      :command ["del" "backspace"]
+                     :overwrite true
                      :subsections [:path-editor]
                      :section [:workspace]
                      :fn #(st/emit! (drp/remove-node))}


### PR DESCRIPTION
## Summary

Pressing **Delete** while a single node is selected in path-edit mode was removing the **entire path shape** instead of just the selected node.

**Root cause — shortcut accumulation in mousetrap:**

When path-edit mode is entered, the path shortcuts are pushed on top of the workspace shortcuts with `:merge-shortcuts :auto`. This produces a merged shortcuts map containing **both** the workspace `:delete` key (→ `delete-selected`, deletes the whole shape) and the path `:delete-node` key (→ `remove-nodes`), both bound to `["del" "backspace"]`.

Without `:overwrite true`, mousetrap **accumulates** callbacks for the same key combination instead of replacing them. On Delete, both fire in sequence:
1. `remove-node` executes (correct behaviour)
2. `delete-selected` executes (deletes the entire shape — the bug)

**Fix:** Add `:overwrite true` to the path `:delete-node` shortcut definition. Mousetrap then removes the accumulated workspace `delete-selected` callback before registering the path `remove-node` callback, so only node removal fires in path-edit mode.

**Closes #11112**

## Changes

- `frontend/src/app/main/data/workspace/path/shortcuts.cljs`: Add `:overwrite true` to `:delete-node`

## Test plan

- [ ] Create a path shape (pen tool or double-click on any shape)
- [ ] Double-click the path to enter node-edit mode
- [ ] Click a single node to select it
- [ ] Press Delete / Backspace
- [ ] Verify **only the selected node** is removed — the rest of the path remains
- [ ] Verify pressing Delete with no node selected still does nothing (no shape deletion)
- [ ] Verify Delete outside path-edit mode still removes the selected shape normally