### PR TITLE
:bug: Guard sd-token-uuid against group nodes without original.id

### DIFF
--- a/frontend/src/app/main/data/style_dictionary.cljs
+++ b/frontend/src/app/main/data/style_dictionary.cljs
@@ -557,7 +557,8 @@
   (.. sd-token -original -name))
 
 (defn sd-token-uuid [^js sd-token]
-  (uuid (.-uuid (.. sd-token -original -id))))
+  (when-let [id (.. sd-token -original -id)]
+    (uuid (.-uuid id))))
 
 (defn- merge-name-collisions
   "Re-attach tokens that `ctob/tokens-tree` / `backtrace-tokens-tree`


### PR DESCRIPTION
## Summary

The token edit modal crashes with `undefined is not an object (evaluating '$p1__..._SHARP_$$.original.id.uuid')` when StyleDictionary returns group nodes alongside actual tokens.

**Root cause:** `sd-token-uuid` unconditionally accesses `(.. sd-token -original -id)` and then `.-uuid`. Group nodes in StyleDictionary's `allTokens` output lack `original.id`, so the property access returns `undefined` and `.-uuid` on `undefined` throws a TypeError.

**Fix:** Wrap the access in `when-let` so `sd-token-uuid` returns `nil` for group nodes. `process-sd-tokens` already handles `nil` origin tokens by skipping them (line 491), so no further changes are needed.

**Closes #11143**

## Changes

- `frontend/src/app/main/data/style_dictionary.cljs`: Add `when-let` guard in `sd-token-uuid`

## Test plan

- [ ] Open a file with tokens in the tokens panel
- [ ] Right-click on a token and click "Edit"
- [ ] Verify the edit modal opens without crashing
- [ ] Verify token values still resolve correctly after editing