### PR TITLE
fix(auth): persist default theme during email registration

### DIFF
--- a/backend/src/app/rpc/commands/auth.clj
+++ b/backend/src/app/rpc/commands/auth.clj
@@ -367,7 +367,9 @@
         email     (str/lower email)
         fullname  (d/normalize-string (:fullname params))
         locale    (d/normalize-string locale)
-        theme     (d/normalize-string theme)
+        theme     (or (when (and (string? theme) (not (str/blank? theme)))
+                        (str/trim theme))
+                      "default")
 
         photo-id  (some->> (or (:oidc/picture props)
                                (:google/picture props)

--- a/frontend/src/app/main/ui/settings/options.cljs
+++ b/frontend/src/app/main/ui/settings/options.cljs
@@ -47,9 +47,9 @@
         initial (mf/with-memo [profile]
                   (-> profile
                       (update :lang #(or % ""))
-                      (update :theme #(if (= % "default")
-                                        "dark"
-                                        (or % "dark")))))
+                      (update :theme #(cond
+                                        (or (nil? %) (= % "") (= % "default")) "dark"
+                                        :else %))))
 
         form    (fm/use-form :schema schema:options-form
                              :initial initial)]


### PR DESCRIPTION
## Summary

Fixes #11142 — **Default theme not persisted during email verification** (release blocker, regression)

### Problem

When a user registers via email, the `theme` parameter arrives as `nil`. The backend's `d/normalize-string` converts `nil` → `""` (empty string), which gets stored in the database. On first login, the frontend's theme validation expects one of `"dark"`, `"light"`, `"system"`, or `"default"` — the empty string fails validation, causing theme selection to break.

### Root Cause

`d/normalize-string` (in `common/src/app/common/data.cljc`) converts `nil` → `""` and trims strings. In ClojureScript, `""` is truthy (unlike JavaScript), so `(or "" fallback)` never reaches the fallback.

### Fix

**Backend** (`backend/src/app/rpc/commands/auth.clj`):
- In `create-profile`, replaced `(d/normalize-string theme)` with explicit nil/blank handling that defaults to `"default"` instead of empty string

**Frontend** (`frontend/src/app/main/ui/settings/options.cljs`):
- In `options-form*`, treat empty string same as `nil`/`"default"` when normalizing theme for the settings form

### Test Plan

- [ ] Register a new account via email — theme should default to dark
- [ ] Existing users with empty string theme in DB should see dark theme on next login
- [ ] Changing theme in settings should persist correctly
- [ ] Users with existing valid theme values (dark/light/system) should be unaffected