### PR TITLE
fix(avatar): update memo deps to track profile field changes

### DIFF
--- a/frontend/src/app/main/ui/ds/product/avatar.cljs
+++ b/frontend/src/app/main/ui/ds/product/avatar.cljs
@@ -38,7 +38,7 @@
         profile (if (object? profile)
                   (mfu/bean profile)
                   profile)
-        href    (mf/with-memo [profile]
+        href    (mf/with-memo [(:fullname profile) (:photo-id profile) (:photo-url profile)]
                   (get-url profile))
         class'  (stl/css-case :avatar true
                               :avatar-small (= variant "S")

--- a/frontend/src/app/main/ui/settings/profile.cljs
+++ b/frontend/src/app/main/ui/settings/profile.cljs
@@ -95,7 +95,7 @@
         has-photo? (some? (:photo-id profile))
 
         photo
-        (mf/with-memo [profile]
+        (mf/with-memo [(:fullname profile) (:photo-id profile)]
           (cf/resolve-profile-photo-url profile))
 
         on-image-click


### PR DESCRIPTION
## Summary

Fixes #9046 — **Profile avatar doesn't update when name changes**

### Problem

When a user changes their profile name, the default avatar (which renders the first letter of the name) doesn't update until page reload or tab switch.

### Root Cause

Both `avatar*` (in `avatar.cljs`) and `profile-photo-form*` (in `profile.cljs`) use `(mf/with-memo [profile] ...)` to memoize the avatar URL computation. `mf/with-memo` uses referential equality to decide whether to recompute. When the profile store is updated, the new profile map may be structurally different (different `:fullname`) but the memo doesn't invalidate because the object reference comparison doesn't detect the change.

### Fix

Changed memo dependencies from the full `profile` object to the specific fields that determine the avatar URL:

- **`avatar.cljs`**: `[(:fullname profile) (:photo-id profile) (:photo-url profile)]`
- **`profile.cljs`**: `[(:fullname profile) (:photo-id profile)]`

This ensures the avatar re-renders whenever the user's name or photo changes.

### Test Plan

- [ ] Change profile name → avatar letter updates immediately without reload
- [ ] Upload/delete profile photo → avatar updates correctly
- [ ] Navigate between tabs → avatar stays consistent
- [ ] No visual regressions in team member avatars or comment avatars