### PR TITLE
fix(workspace): close search and shortcuts panels with Escape key

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -331,7 +331,14 @@
         handle-find-shortcut-keydown
         (mf/use-fn
          (fn [event]
-           (when (kbd/mod? event)
+           (cond
+             (kbd/esc? event)
+             (do
+               (dom/prevent-default event)
+               (dom/stop-propagation event)
+               (st/emit! dw/close-layers-search))
+
+             (kbd/mod? event)
              (cond
                (f-key? event)
                (do

--- a/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/shortcuts.cljs
@@ -26,6 +26,7 @@
    [app.main.ui.shortcuts :as ss]
    [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
+   [app.util.keyboard :as kbd]
    [app.util.strings :refer [matches-search]]
    [clojure.set :as set]
    [rumext.v2 :as mf]))
@@ -117,6 +118,14 @@
            (reset! open-sections* [[:workspace]])
            (reset! filter-term* "")))
 
+        on-search-key-down
+        (mf/use-fn
+         (fn [event]
+           (when (kbd/esc? event)
+             (dom/prevent-default event)
+             (dom/stop-propagation event)
+             (close-fn))))
+
         go-to-edit-shortcuts
         (mf/use-fn
          #(st/emit! (rt/nav :settings-shortcuts {} {::rt/new-window true})))]
@@ -129,6 +138,7 @@
      [:div {:class (stl/css :search-field)}
       [:> search-bar* {:on-change on-search-term-change-2
                        :on-clear on-search-clear-click
+                       :on-key-down on-search-key-down
                        :value filter-term
                        :placeholder (tr "shortcuts.title")
                        :icon-id i/search


### PR DESCRIPTION
## Summary

Fixes #9540 — **Close workspace search with the Escape key**

### Problem

When the layers search panel or shortcuts panel is open, there is no keyboard way to dismiss it. Pressing Escape (the standard convention) doesn't close the panel — users must reach for the X button with the mouse.

### Fix

**Layers search** (`layers.cljs`):
- Added Escape key handling to `handle-find-shortcut-keydown` — when Escape is pressed while focus is in the search input, the search panel closes via `dw/close-layers-search`

**Shortcuts panel** (`shortcuts.cljs`):
- Added `on-search-key-down` handler that closes the shortcuts panel on Escape by calling `close-fn` (which toggles the `:shortcuts` layout flag)
- Added `app.util.keyboard` import for `kbd/esc?`

### Behavior

- Escape only fires when focus is inside the search input (per the issue spec)
- Events are stopped from propagating so Escape doesn't trigger other handlers
- The search-bar component already blurs the input on Escape — these changes add panel-closing on top of that

### Test Plan

- [ ] Open layers search (Cmd/Ctrl+F) → type something → press Escape → panel closes, focus returns to canvas
- [ ] Open shortcuts panel → focus search input → press Escape → panel closes
- [ ] With search panel open, click outside the search input → press Escape → normal Escape behavior (does not close search)
- [ ] Find-and-replace mode (Cmd/Ctrl+H) → press Escape → panel closes