### PR TITLE
fix(modal): raise modal wrapper z-index above sticky navigation tabs

### DIFF
--- a/frontend/src/app/main/ui/modal.scss
+++ b/frontend/src/app/main/ui/modal.scss
@@ -12,4 +12,12 @@
 
 .modal-wrapper {
   @extend %new-scrollbar;
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-index-notifications);
+  pointer-events: none;
+
+  > * {
+    pointer-events: auto;
+  }
 }


### PR DESCRIPTION
## Problem

Fixes #9052.

The onboarding / release-notes modal was rendered through a React portal into a bare `<div>` appended to `document.body`. That container had no `z-index`, so sticky navigation elements in the dashboard (e.g. the Recent / Deleted tab bar, which uses `position: sticky; z-index: var(--z-index-panels)`) could paint over the modal.

## Root cause

`.modal-wrapper` had no `position` or `z-index` properties.  
Dashboard nav tabs use `position: sticky; z-index: 100` (`--z-index-panels`).  
Without a stacking context on the wrapper, those tabs appeared on top of the modal.

## Fix

- Set `position: fixed; inset: 0` on `.modal-wrapper` to establish a full-viewport stacking context.
- Assign `z-index: var(--z-index-notifications)` (500) so the wrapper always sits above navigation panels (100), dropdowns (400), and configuration modals (300).
- Add `pointer-events: none` on the wrapper with `pointer-events: auto` on direct children so the invisible overlay does not intercept clicks outside explicit modal backdrops.

## Testing

1. Navigate to the Dashboard.
2. Go to the **Deleted** section (which shows the sticky Recent / Deleted nav bar).
3. Trigger the onboarding / release-notes modal (e.g. click the version link in the sidebar).
4. Confirm the modal renders fully above the navigation tabs.
5. Confirm existing modals (confirm dialogs, color picker, etc.) still work normally.