### PR TITLE
fix(path): select shape after exiting path editor with Enter/Escape

### DIFF
--- a/frontend/src/app/main/data/workspace/path/edition.cljs
+++ b/frontend/src/app/main/data/workspace/path/edition.cljs
@@ -20,6 +20,7 @@
    [app.main.data.workspace.path.state :as st]
    [app.main.data.workspace.path.streams :as streams]
    [app.main.data.workspace.path.undo :as undo]
+   [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.shapes :as dwsh]
    [app.main.streams :as ms]
    [app.util.mouse :as mse]
@@ -312,8 +313,8 @@
     ptk/WatchEvent
     (watch [_ _ stream]
       (let [stopper (rx/filter #(let [type (ptk/type %)]
-                                  (= type ::dwe/clear-edition-mode)
-                                  (= type ::start-path-edit))
+                                  (or (= type ::dwe/clear-edition-mode)
+                                      (= type ::start-path-edit)))
                                stream)]
         (rx/concat
          (rx/of (undo/start-path-undo))
@@ -332,7 +333,8 @@
 
     ptk/WatchEvent
     (watch [_ _ _]
-      (rx/of (ptk/data-event :layout/update {:ids [id]})))))
+      (rx/of (dws/select-shapes (d/ordered-set id))
+             (ptk/data-event :layout/update {:ids [id]})))))
 
 (defn- split-segments
   [id {:keys [from-p to-p t]}]


### PR DESCRIPTION
## Problem

Fixes #11169 (release blocker).

After creating a path with the path tool, pressing Enter twice should select the shape — the first Enter exits the active point-drawing phase and enters the path editor, and the second Enter should exit the editor and leave the shape selected. Instead the shape was left unselected.

## Root causes

**1. `stop-path-edit` did not select the shape on exit.**

`stop-path-edit` is called whenever the path editor exits (Enter/Escape). It cleaned up the edit state and emitted only a `:layout/update` event — no shape selection — so the canvas reverted to nothing selected.

**Fix:** emit `dws/select-shapes` before the layout update in `stop-path-edit`.

**2. Stopper predicate bug in `start-path-edit`.**

The interrupt stream had a logic defect in its stopper:

```clojure
;; before: two (= type …) inside let — only the last is returned
(let [type (ptk/type %)]
  (= type ::dwe/clear-edition-mode)   ;; result silently discarded
  (= type ::start-path-edit))          ;; only this check was active

;; after: both conditions combined with or
(let [type (ptk/type %)]
  (or (= type ::dwe/clear-edition-mode)
      (= type ::start-path-edit)))
```

Without the fix, the interrupt listener inside `start-path-edit` kept running even after `clear-edition-mode` fired (because the stopper never matched), creating a dangling event subscription. Adding `or` closes the stream correctly on both stop conditions.

## Testing

1. Open the workspace.
2. Select the Path (pen) tool.
3. Click several points to create a path.
4. Press **Enter** once → path drawing ends, path editor opens.
5. Press **Enter** again → path editor closes and the path shape is now selected (bounding box visible, Design panel shows shape properties).