### PR TITLE
fix(media): guard parse-font-weight/style against nil variant

### DIFF
--- a/common/src/app/common/media.cljc
+++ b/common/src/app/common/media.cljc
@@ -80,25 +80,27 @@
 
 (defn parse-font-weight
   [variant]
-  (cond
-    (re-seq #"(?i)(?:^|[-_\s])(hairline|thin)(?=(?:[-_\s]|$|italic\b))" variant)               100
-    (re-seq #"(?i)(?:^|[-_\s])(extra\s*light|ultra\s*light)(?=(?:[-_\s]|$|italic\b))" variant) 200
-    (re-seq #"(?i)(?:^|[-_\s])(light)(?=(?:[-_\s]|$|italic\b))" variant)                       300
-    (re-seq #"(?i)(?:^|[-_\s])(normal|regular)(?=(?:[-_\s]|$|italic\b))" variant)              400
-    (re-seq #"(?i)(?:^|[-_\s])(medium)(?=(?:[-_\s]|$|italic\b))" variant)                      500
-    (re-seq #"(?i)(?:^|[-_\s])(semi\s*bold|demi\s*bold)(?=(?:[-_\s]|$|italic\b))" variant)     600
-    (re-seq #"(?i)(?:^|[-_\s])(extra\s*bold|ultra\s*bold)(?=(?:[-_\s]|$|italic\b))" variant)   800
-    (re-seq #"(?i)(?:^|[-_\s])(bold)(?=(?:[-_\s]|$|italic\b))" variant)                        700
-    (re-seq #"(?i)(?:^|[-_\s])(extra\s*black|ultra\s*black)(?=(?:[-_\s]|$|italic\b))" variant) 950
-    (re-seq #"(?i)(?:^|[-_\s])(black|heavy|solid)(?=(?:[-_\s]|$|italic\b))" variant)           900
-    :else                                                                                      400))
+  (let [variant (or variant "")]
+    (cond
+      (re-seq #"(?i)(?:^|[-_\s])(hairline|thin)(?=(?:[-_\s]|$|italic\b))" variant)               100
+      (re-seq #"(?i)(?:^|[-_\s])(extra\s*light|ultra\s*light)(?=(?:[-_\s]|$|italic\b))" variant) 200
+      (re-seq #"(?i)(?:^|[-_\s])(light)(?=(?:[-_\s]|$|italic\b))" variant)                       300
+      (re-seq #"(?i)(?:^|[-_\s])(normal|regular)(?=(?:[-_\s]|$|italic\b))" variant)              400
+      (re-seq #"(?i)(?:^|[-_\s])(medium)(?=(?:[-_\s]|$|italic\b))" variant)                      500
+      (re-seq #"(?i)(?:^|[-_\s])(semi\s*bold|demi\s*bold)(?=(?:[-_\s]|$|italic\b))" variant)     600
+      (re-seq #"(?i)(?:^|[-_\s])(extra\s*bold|ultra\s*bold)(?=(?:[-_\s]|$|italic\b))" variant)   800
+      (re-seq #"(?i)(?:^|[-_\s])(bold)(?=(?:[-_\s]|$|italic\b))" variant)                        700
+      (re-seq #"(?i)(?:^|[-_\s])(extra\s*black|ultra\s*black)(?=(?:[-_\s]|$|italic\b))" variant) 950
+      (re-seq #"(?i)(?:^|[-_\s])(black|heavy|solid)(?=(?:[-_\s]|$|italic\b))" variant)           900
+      :else                                                                                      400)))
 
 (defn parse-font-style
   [variant]
-  (if (or (re-seq #"(?i)(?:^|[-_\s])(italic)(?:[-_\s]|$)" variant)
-          (re-seq #"(?i)italic$" variant))
-    "italic"
-    "normal"))
+  (let [variant (or variant "")]
+    (if (or (re-seq #"(?i)(?:^|[-_\s])(italic)(?:[-_\s]|$)" variant)
+            (re-seq #"(?i)italic$" variant))
+      "italic"
+      "normal")))
 
 (defn font-weight->name
   [weight]


### PR DESCRIPTION
## Summary

When uploading `.woff2` fonts that `opentype.js` cannot parse, penpot falls back to filename-based metadata extraction. If the font file has no `preferredSubfamily`/`fontSubfamily` metadata, the `variant` parameter passed to `parse-font-weight` and `parse-font-style` is `nil`, causing a `TypeError: re-seq must match against a string` error.

This PR wraps both functions with `(or variant "")` to safely default `nil` values to an empty string, which then falls through to the default weight (400) and style ("normal").

## Changes

- `common/src/app/common/media.cljc`:
  - `parse-font-weight`: wrap `variant` in `(let [variant (or variant "")] ...)` 
  - `parse-font-style`: wrap `variant` in `(let [variant (or variant "")] ...)`

## How to test

1. Upload a `.woff2` font file that `opentype.js` cannot parse (e.g., a variable font with non-standard tables)
2. Previously: `TypeError: re-seq must match against a string` at `fonts.cljs:117`
3. Now: font uploads with default weight 400 and style "normal"

Fixes #10436