### PR TITLE
fix(auth,theme): default theme to "dark" on profile creation

### DIFF
--- a/backend/src/app/rpc/commands/auth.clj
+++ b/backend/src/app/rpc/commands/auth.clj
@@ -363,11 +363,12 @@
         is-demo   (:is-demo params false)
         is-muted  (:is-muted params false)
         is-active (:is-active params false)
-        theme     (:theme params nil)
+        theme     (or (:theme params) "dark")
         email     (str/lower email)
         fullname  (d/normalize-string (:fullname params))
         locale    (d/normalize-string locale)
-        theme     (d/normalize-string theme)
+        theme     (let [t (d/normalize-string theme)]
+                    (if (str/blank? t) "dark" t))
 
         photo-id  (some->> (or (:oidc/picture props)
                                (:google/picture props)

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -167,7 +167,8 @@
   (let [profile (get-profile conn profile-id ::db/for-update true)
         fullname (d/normalize-string fullname)
         lang     (d/normalize-string lang)
-        theme    (d/normalize-string theme)
+        theme    (let [t (d/normalize-string theme)]
+                   (if (str/blank? t) (:theme profile) t))
         ;; Update the profile map with direct params
         profile (-> profile
                     (assoc :fullname fullname)

--- a/frontend/src/app/main/ui/settings/options.cljs
+++ b/frontend/src/app/main/ui/settings/options.cljs
@@ -47,9 +47,10 @@
         initial (mf/with-memo [profile]
                   (-> profile
                       (update :lang #(or % ""))
-                      (update :theme #(if (= % "default")
-                                        "dark"
-                                        (or % "dark")))))
+                      (update :theme #(cond
+                                        (= % "default") "dark"
+                                        (or (nil? %) (= % "")) "dark"
+                                        :else %))))
 
         form    (fm/use-form :schema schema:options-form
                              :initial initial)]

--- a/frontend/src/app/util/theme.cljs
+++ b/frontend/src/app/util/theme.cljs
@@ -54,7 +54,8 @@
   (cond
     (= profile-theme "system") system-theme
     (= profile-theme "default") "dark"
-    :else (d/nilv profile-theme "dark")))
+    (or (nil? profile-theme) (= profile-theme "")) "dark"
+    :else profile-theme))
 
 (defn use-initialize
   [{profile-theme :theme}]


### PR DESCRIPTION
## Summary

New profiles were stored with `theme=""` (empty string) in the database because `d/normalize-string` converts `nil` → `""`. The empty string then bypassed all nil-guard defaults in the frontend, causing three symptoms:

1. **UI switching to light theme after email verification** — `resolve-theme` used `d/nilv` which only catches `nil`, not `""`; empty string fell through to `set-color-scheme ""` which applied the light CSS class
2. **Theme dropdown blank in Settings** — `(or "" "dark")` returns `""` in ClojureScript (empty string is truthy), so no option matched
3. **Workspace crash when creating files** — empty string failed theme enum validation

## Changes

**Backend** (`backend/src/app/rpc/commands/`):
- `auth.clj` / `create-profile`: default theme to `"dark"` when nil or blank after normalization
- `profile.clj` / `update-profile`: preserve existing theme when blank is submitted (instead of overwriting with `""`)

**Frontend** (`frontend/src/`):
- `app/util/theme.cljs` / `resolve-theme`: treat `""` same as `nil` → default to `"dark"`
- `app/main/ui/settings/options.cljs`: treat `""` same as `nil` → default to `"dark"` in the form initial values

## How to test

1. Create a new account
2. Verify email by clicking the link
3. Observe: UI should remain in dark theme (not switch to light)
4. Navigate to Settings > UI Theme
5. Observe: "Dark" option should be selected (not blank)
6. Create a new file in the workspace
7. Observe: no "Something went wrong" error

Fixes #11142