### PR TITLE
fix(exporter): compare gradient type instead of export type in SVG renderer

### DIFF
--- a/exporter/src/app/renderer/svg.cljs
+++ b/exporter/src/app/renderer/svg.cljs
@@ -176,8 +176,9 @@
                                         "stop-opacity" (get stop-data "opacity")}}))))
 
           (data->gradient-def [id [color data]]
-            (let [id (str "gradient-" id "-" (subs color 1))]
-              (if (= type "linear")
+            (let [id (str "gradient-" id "-" (subs color 1))
+                  gradient-type (get-in data ["gradient" "type"])]
+              (if (= gradient-type "linear")
                 {"type" "element"
                  "name" "linearGradient"
                  "attributes" {"id" id "x1" "0.5" "y1" "1" "x2" "0.5" "y2" "0"}


### PR DESCRIPTION
## Summary

`data->gradient-def` in the SVG exporter was comparing the render `type` parameter (`:svg`, `:png`, `:pdf`) against `"linear"` to decide between `linearGradient` and `radialGradient` SVG elements. Since the export type is never `"linear"`, the comparison always fell through to `radialGradient`, causing **all linear gradients to be exported as radial** in SVG output.

## Changes

- `exporter/src/app/renderer/svg.cljs`: Read the gradient type from the data map (`(get-in data ["gradient" "type"])`) instead of the outer `type` binding from `render`'s parameter destructuring.

## How to test

1. Create a shape with a linear gradient fill
2. Export as SVG
3. Previously: the SVG contained a `<radialGradient>` element instead of `<linearGradient>`
4. Now: the SVG correctly contains `<linearGradient>` with the expected attributes

Fixes #5972