### PR TITLE
fix(dashboard): batch unread comment profiles into a single RPC call

### DIFF
--- a/backend/src/app/rpc/commands/comments.clj
+++ b/backend/src/app/rpc/commands/comments.clj
@@ -410,6 +410,45 @@
                  (files/check-comment-permissions! cfg profile-id file-id share-id)
                  (get-file-comments-users conn file-id profile-id))))
 
+(def ^:private sql:team-comment-users
+  "WITH available_profiles AS (
+     SELECT DISTINCT c.owner_id AS id
+       FROM comment AS c
+      INNER JOIN comment_thread AS ct ON (ct.id = c.thread_id)
+      INNER JOIN file AS f ON (f.id = ct.file_id)
+      INNER JOIN project AS p ON (p.id = f.project_id)
+      WHERE p.team_id = ?
+        AND f.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+  )
+  SELECT p.id,
+         p.email,
+         p.fullname AS name,
+         p.fullname AS fullname,
+         p.photo_id,
+         p.is_active
+    FROM profile AS p
+   WHERE p.id IN (SELECT id FROM available_profiles) OR p.id=?")
+
+(defn get-team-comments-users
+  [conn team-id profile-id]
+  (db/exec! conn [sql:team-comment-users team-id profile-id]))
+
+(def ^:private
+  schema:get-profiles-for-team-comments
+  [:map {:title "get-profiles-for-team-comments"}
+   [:team-id ::sm/uuid]])
+
+(sv/defmethod ::get-profiles-for-team-comments
+  "Retrieves profiles of all participants on comment threads across an
+  entire team in a single batched query, avoiding per-file RPC calls."
+  {::doc/added "2.6"
+   ::sm/params schema:get-profiles-for-team-comments}
+  [cfg {:keys [::rpc/profile-id team-id]}]
+  (db/run! cfg (fn [{:keys [::db/conn]}]
+                 (teams/check-read-permissions! cfg profile-id team-id)
+                 (get-team-comments-users conn team-id profile-id))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; MUTATION COMMANDS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -451,16 +451,15 @@
     (watch [_ _ _]
       (let [fetched-comments #(assoc %2 :comment-threads (d/index-by :id %1))
             fetched-users #(assoc %2 :current-team-comments-users %1)]
-        (->> (rp/cmd! :get-unread-comment-threads {:team-id team-id})
-             (rx/merge-map
-              (fn [comments]
-                (rx/concat
-                 (rx/of (partial fetched-comments comments))
-
-                 (->> (rx/from (into #{} (map :file-id) comments))
-                      (rx/merge-map #(rp/cmd! :get-profiles-for-file-comments {:file-id %}))
-                      (rx/reduce #(merge %1 (d/index-by :id %2)) {})
-                      (rx/map #(partial fetched-users %))))))
+        (->> (rx/zip
+              (rp/cmd! :get-unread-comment-threads {:team-id team-id})
+              (rp/cmd! :get-profiles-for-team-comments {:team-id team-id}))
+             (rx/map
+              (fn [[comments profiles]]
+                (fn [state]
+                  (-> state
+                      (assoc :comment-threads (d/index-by :id comments))
+                      (assoc :current-team-comments-users (d/index-by :id profiles))))))
              (rx/catch #(rx/throw {:type :comment-error})))))))
 
 (defn mark-all-threads-as-read


### PR DESCRIPTION
## Problem

Fixes #10587.

When a user opens the dashboard with unread comment threads across multiple files, the frontend was firing **one `get-profiles-for-file-comments` RPC call per file**. With 20+ files this caused:

- 20+ parallel HTTP requests, each with a separate `DISTINCT owner_id` SQL query
- Backend `by-profile` concurrency limiter warnings and queue saturation
- Dashboard blocked until the slowest call returned (1.3–2.5s each)

## Solution

**Backend:** Add a new `get-profiles-for-team-comments` RPC command that fetches all commenter profiles across an entire team's files in a single SQL query using a JOIN-based `DISTINCT owner_id` scan.

**Frontend:** Replace the per-file `rx/merge-map` fan-out in `retrieve-unread-comment-threads` with a single `rx/zip` that fires two team-scoped calls in parallel (threads + profiles), reducing N+1 HTTP requests to exactly 2 regardless of file count.

## Changes

- `backend/src/app/rpc/commands/comments.clj` — new `::get-profiles-for-team-comments` command + SQL
- `frontend/src/app/main/data/comments.cljs` — replace per-file fan-out with batched call

## Testing

1. Sign in as a user with unread threads across 10+ files
2. Open the dashboard
3. Network tab should show exactly 2 comment-related requests instead of N+1