### PR TITLE
fix(rpc): add input validation for upload session and binfile import

### DIFF
--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -122,7 +122,7 @@
     [:name [:or [:string {:max 250}]
             [:map-of ::sm/uuid [:string {:max 250}]]]]
     [:project-id ::sm/uuid]
-    [:version {:optional true} ::sm/int]
+    [:version {:optional true} [:enum 1 3]]
     [:file {:optional true} media.v/schema:upload]
     [:upload-id {:optional true} ::sm/uuid]]
    [:fn {:error/message "one of :file or :upload-id is required"}

--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -289,7 +289,7 @@
 
 (def ^:private schema:create-upload-session
   [:map {:title "create-upload-session"}
-   [:total-chunks ::sm/int]])
+   [:total-chunks [:int {:min 1}]]])
 
 (def ^:private schema:create-upload-session-result
   [:map {:title "create-upload-session-result"}


### PR DESCRIPTION
## Summary

Two small schema-level validation fixes.

### Fix #11103 — `create-upload-session` accepts zero/negative chunks

`total-chunks` was typed as `::sm/int` (any integer). Changed to `[:int {:min 1}]` so that sessions with 0 or negative chunk counts are rejected at the schema layer with a clean validation error.

### Fix #11105 — `import-binfile` accepts unsupported version values

`version` was typed as `::sm/int` (any integer). Changed to `[:enum 1 3]` to match the two supported binary-file format versions. Unsupported values (e.g. 2, 0, -1) now return a `:validation` error instead of falling through to an unhandled `case` exception.

## Changes

- `backend/src/app/rpc/commands/media.clj` — `total-chunks` schema: `::sm/int` → `[:int {:min 1}]`
- `backend/src/app/rpc/commands/binfile.clj` — `version` schema: `::sm/int` → `[:enum 1 3]`

Fixes #11103, fixes #11105.