### PR TITLE
fix(teams): prevent admin privilege escalation via invitation role

### DIFF
--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -475,6 +475,15 @@
       (ex/raise :type :validation
                 :code :insufficient-permissions))
 
+    ;; Only owners may grant the :owner role (matches update-team-member-role behaviour).
+    (let [roles (if using-emails-format?
+                  #{role}
+                  (into #{} (map :role) (:invitations params)))]
+      (when (and (not (:is-owner perms)) (contains? roles :owner))
+        (ex/raise :type :validation
+                  :code :cant-promote-to-owner
+                  :hint "only owners can invite with the :owner role")))
+
     (when (> invitation-count max-invitations-by-request-threshold)
       (ex/raise :type :validation
                 :code :max-invitations-by-request
@@ -617,6 +626,11 @@
     (when-not (:is-admin perms)
       (ex/raise :type :validation
                 :code :insufficient-permissions))
+
+    (when (and (not (:is-owner perms)) (= role :owner))
+      (ex/raise :type :validation
+                :code :cant-promote-to-owner
+                :hint "only owners can update an invitation to the :owner role"))
 
     (db/update! conn :team-invitation
                 {:role (name role) :updated-at (ct/now)}


### PR DESCRIPTION
## Problem

Fixes #11098.

`create-team-invitations` and `update-team-invitation-role` only checked that the caller is an admin but did not prevent admins from assigning the `:owner` role to invitations. This is a privilege escalation: a team admin (a role explicitly below owner) could grant full ownership to a third party, bypassing the guard that already exists in `update-team-member-role`.

## Solution

Add the same `cant-promote-to-owner` check to both invitation methods, mirroring the protection that already exists in `update-team-member-role` (teams.clj line 895-897):

- **`create-team-invitations`**: after the `is-admin` check, collect all roles across both parameter formats and raise `:cant-promote-to-owner` if any is `:owner` and the caller is not an owner.
- **`update-team-invitation-role`**: after the `is-admin` check, raise `:cant-promote-to-owner` if `role` is `:owner` and the caller is not an owner.

## Changes

- `backend/src/app/rpc/commands/teams_invitations.clj` — two guard blocks added, one per mutation

Fixes #11098.