### PR TITLE
fix(media): check source file read permissions in clone-file-media-object

### DIFF
--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -267,8 +267,15 @@
   {::doc/added "1.17"
    ::sm/params schema:clone-file-media-object
    ::db/transaction true}
-  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id file-id] :as params}]
+  [{:keys [::db/conn] :as cfg} {:keys [::rpc/profile-id file-id id] :as params}]
   (files/check-edition-permissions! conn profile-id file-id)
+  ;; Verify the caller can read the source media object's file before
+  ;; allowing the clone.  Return :not-found on missing/inaccessible objects
+  ;; to avoid leaking information about files the caller cannot access.
+  (let [mobj (db/get-by-id conn :file-media-object id)]
+    (when-not mobj
+      (ex/raise :type :not-found :code :object-not-found))
+    (files/check-read-permissions! conn profile-id (:file-id mobj)))
   (clone-file-media-object cfg params))
 
 (defn clone-file-media-object


### PR DESCRIPTION
## Problem

Fixes #11087.

`clone-file-media-object` verified edit permissions on the destination `file-id` but fetched the source media object by UUID without any access control. An authenticated user with edit access to any of their own files could clone the metadata (and storage reference) of a media object from a private file in any team, as long as they knew the source UUID.

## Solution

After the existing destination-file edition check, fetch the source media object and call `files/check-read-permissions!` on its owning file before executing the clone. Returns `:not-found` on missing or inaccessible objects to avoid leaking file/media existence to unauthorized callers.

## Changes

- `backend/src/app/rpc/commands/media.clj` — add source read-permission check to `::clone-file-media-object` handler

Fixes #11087.