### PR TITLE
fix(media): scope assemble-chunks lookup to the requesting profile

### DIFF
--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -152,7 +152,7 @@
 
         params
         (if (some? upload-id)
-          (let [file (db/tx-run! cfg media-cmd/assemble-chunks upload-id)]
+          (let [file (db/tx-run! cfg media-cmd/assemble-chunks upload-id profile-id)]
             (assoc params :file file))
           params)
 

--- a/backend/src/app/rpc/commands/fonts.clj
+++ b/backend/src/app/rpc/commands/fonts.clj
@@ -118,10 +118,10 @@
   "Assembles each chunked-upload session in `uploads` (a `{mtype →
   session-id}` map) into a temp file, validates the media type and
   size of every entry, and returns a `{mtype → path}` data map."
-  [cfg {:keys [uploads] :as params}]
+  [cfg {:keys [uploads ::rpc/profile-id] :as params}]
   (let [data (reduce-kv
               (fn [acc mtype session-id]
-                (let [assembled (assemble-chunks cfg session-id)]
+                (let [assembled (assemble-chunks cfg session-id profile-id)]
                   (-> {:mtype mtype :size (:size assembled)}
                       (media.v/validate-media-type! cm/font-types)
                       (media.v/validate-font-size!))

--- a/backend/src/app/rpc/commands/media.clj
+++ b/backend/src/app/rpc/commands/media.clj
@@ -402,9 +402,10 @@
 
   Raises a :validation/:missing-chunks error when the number of stored
   chunks does not match `:total-chunks` recorded in the session row.
+  Raises a :not-found error when the session does not belong to `profile-id`.
   Deletes the session row from `upload_session` on success."
-  [{:keys [::db/conn] :as cfg} session-id]
-  (let [session (db/get conn :upload-session {:id session-id})
+  [{:keys [::db/conn] :as cfg} session-id profile-id]
+  (let [session (db/get conn :upload-session {:id session-id :profile-id profile-id})
         chunks  (get-upload-chunks conn session-id)]
 
     (when (not= (count chunks) (:total-chunks session))
@@ -447,7 +448,7 @@
 
   (db/tx-run! cfg
               (fn [{:keys [::db/conn] :as cfg}]
-                (let [content (assemble-chunks cfg session-id)
+                (let [content (assemble-chunks cfg session-id profile-id)
                       content (-> content
                                   (assoc :filename (str "upload:" name))
                                   (assoc :mtype mtype)


### PR DESCRIPTION
## Problem

Fixes #11011.

`assemble-chunks` looked up the upload session using only `session-id`, without verifying that the session belongs to the authenticated profile. A user could trigger assembly of another profile's upload session by supplying a foreign `session-id`.

## Solution

Add `profile-id` as a required parameter to `assemble-chunks` and scope the `upload_session` lookup with `{:id session-id :profile-id profile-id}` — the same pattern already used in `upload-chunk`.

Update all three callers:
- **`assemble-file-media-object`** (media.clj) — passes `::rpc/profile-id`
- **`prepare-font-data-from-uploads`** (fonts.clj) — extracts `::rpc/profile-id` from params
- **`import-binfile`** (binfile.clj) — passes `profile-id` via `db/tx-run!` varargs

The database lookup will now return nil for sessions that don't belong to the caller, causing an automatic `:not-found` error before any assembly takes place.

Fixes #11011.