### PR TITLE
fix(mattermost): escape markdown in user-controlled notification fields

### DIFF
--- a/backend/src/app/loggers/mattermost.clj
+++ b/backend/src/app/loggers/mattermost.clj
@@ -22,10 +22,17 @@
 
 (defonce enabled (atom true))
 
+(defn- escape-md
+  "Escapes Mattermost/Markdown special characters in user-controlled
+  strings so they cannot inject formatting into notification messages."
+  [s]
+  (when s
+    (clojure.string/replace (str s) #"[\\`*_\{\}\(\)\[\]#+\-.!|~]" #(str "\\" %))))
+
 (defn- send-mattermost-notification!
   [cfg {:keys [id] :as report}]
   (let [type (get report :type)
-        text (str "#" type " | " (get report :hint) "\n"
+        text (str "#" type " | " (escape-md (get report :hint)) "\n"
                   (when id
                     (str (u/join (cf/get :public-uri) "/dbg/error/" id) " "))
 
@@ -38,7 +45,7 @@
                   "- tenant: #" (:tenant report) "\n"
                   "- origin: #" (:origin report) "\n"
                   (when-let [href (get report :href)]
-                    (str "- href: `" href "`\n"))
+                    (str "- href: `" (escape-md href) "`\n"))
                   (when-let [version (get report :frontend-version)]
                     (str "- frontend-version: `" version "`\n"))
                   (when-let [version (get report :backend-version)]


### PR DESCRIPTION
## Problem

Fixes #11033.

`send-mattermost-notification!` inserts user-controlled fields (`:hint` from exception messages, `:href` from the request URL) directly into the notification text without escaping Markdown special characters. An error message that contains `*`, backticks, `#`, or other Markdown syntax would render with unintended formatting in Mattermost.

## Solution

Add a private `escape-md` helper that backslash-escapes Mattermost/Markdown special characters (`\`, `` ` ``, `*`, `_`, `{}`, `()`, `[]`, `#`, `+`, `-`, `.`, `!`, `|`, `~`). Apply it to:
- `:hint` — can contain user-supplied content from exception messages
- `:href` — the request URL, already quoted in backticks but could contain backticks itself

Server-controlled fields (`:type`, `:host`, `:tenant`, `:origin`) are left unescaped as they are hardcoded/config values.

## Changes

- `backend/src/app/loggers/mattermost.clj` — add `escape-md`, apply to `:hint` and `:href`

Fixes #11033.