### PR TITLE
Fix clipboard crash on insecure HTTP origins in token/MCP copy (#8496)

### DIFF
--- a/frontend/src/app/main/ui/settings/integrations.cljs
+++ b/frontend/src/app/main/ui/settings/integrations.cljs
@@ -79,13 +79,19 @@
          (mf/deps token-created)
          (fn [event]
            (dom/prevent-default event)
-           (clipboard/to-clipboard (:token token-created))
-           (st/emit! (ntf/show {:level :info
-                                :type :toast
-                                :content (if is-mcp
-                                           (tr "integrations.notification.success.mcp-key-copied")
-                                           (tr "integrations.notification.success.token-copied"))
-                                :timeout notification-timeout}))))]
+           (-> (clipboard/to-clipboard (:token token-created))
+               (.then (fn [_]
+                        (st/emit! (ntf/show {:level :info
+                                             :type :toast
+                                             :content (if is-mcp
+                                                        (tr "integrations.notification.success.mcp-key-copied")
+                                                        (tr "integrations.notification.success.token-copied"))
+                                             :timeout notification-timeout}))))
+               (.catch (fn [_]
+                         (st/emit! (ntf/show {:level :warning
+                                              :type :toast
+                                              :content (tr "errors.clipboard-api-unavailable")
+                                              :timeout notification-timeout})))))))]
 
     [:div {:class (stl/css :modal-form)}
      [:> text* {:as "h2"
@@ -466,13 +472,19 @@
          (mf/deps url)
          (fn [event]
            (dom/prevent-default event)
-           (clipboard/to-clipboard url)
-           (st/emit! (ntf/show {:level :info
-                                :type :toast
-                                :content (tr "integrations.notification.success.copied-link")
-                                :timeout notification-timeout})
-                     (ev/event {::ev/name "copy-mcp-url"
-                                ::ev/origin "integrations"}))))]
+           (-> (clipboard/to-clipboard url)
+               (.then (fn [_]
+                        (st/emit! (ntf/show {:level :info
+                                             :type :toast
+                                             :content (tr "integrations.notification.success.copied-link")
+                                             :timeout notification-timeout})
+                                  (ev/event {::ev/name "copy-mcp-url"
+                                             ::ev/origin "integrations"}))))
+               (.catch (fn [_]
+                         (st/emit! (ntf/show {:level :warning
+                                              :type :toast
+                                              :content (tr "errors.clipboard-api-unavailable")
+                                              :timeout notification-timeout})))))))]
 
     [:section {:class (stl/css :mcp-server-section)}
      [:div


### PR DESCRIPTION
## Problem

When Penpot is self-hosted over plain HTTP (non-`localhost`), browsers do not expose `navigator.clipboard`. The access token and MCP server URL copy buttons called `clipboard/to-clipboard`, which returns a rejected `Promise` in this case, without handling that rejection. The unhandled rejection propagated into React's error boundary and crashed the entire page with:

```
Hint: can't access property "writeText", navigator.clipboard is undefined
```

## Fix

Both `on-copy-to-clipboard` handlers in `integrations.cljs` now chain `.then()` / `.catch()` on the `Promise` returned by `clipboard/to-clipboard`:

- **Success path** — emits the existing success toast notification, unchanged.
- **Failure path** — emits the existing `errors.clipboard-api-unavailable` warning toast (already used in the workspace clipboard path), which tells the user to serve Penpot over HTTPS to enable clipboard access.

No new translation keys are added; the existing key added for the workspace path is reused.

Fixes #8496