### PR TITLE
Use circular indicator for mutually exclusive export options (#8083)

### DIFF
--- a/frontend/src/app/main/ui/exports/files.scss
+++ b/frontend/src/app/main/ui/exports/files.scss
@@ -223,6 +223,12 @@
   label {
     align-items: flex-start;
 
+    // Override square checkbox shape: radio options are mutually exclusive
+    // so their indicator must be circular, not square.
+    span {
+      border-radius: deprecated.$br-circle;
+    }
+
     .modal-subtitle {
       @include deprecated.body-large-typography;
 


### PR DESCRIPTION
## Problem

The \"Download as Penpot file\" export dialog presents three mutually exclusive library-handling options:

- Export shared libraries
- Include shared library assets in file libraries
- Treat shared library assets as basic objects

These are mutually exclusive (the UI already uses `<input type="radio">` under the hood), but the custom visual indicator inherited its style from the `%input-checkbox` SCSS placeholder, which has a `border-radius: 4px` — making the indicator appear square/rectangular, indistinguishable from a checkbox.

Standard UX convention (since the 1980s) is that checkboxes are square (for independent toggles) and radio buttons are circular (for mutually exclusive single-select groups).

## Fix

Override `border-radius: 50%` on the indicator `<span>` within `.export-option` so it renders as a circle, visually communicating the single-select/radio semantics.

The underlying `<input type="radio">` and all behaviour are unchanged; only the appearance of the custom indicator is corrected.

Fixes #8083