### PR TITLE
Fix pressing Enter twice after path creation not selecting shape

### DIFF
--- a/frontend/src/app/main/data/workspace/path/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/path/drawing.cljs
@@ -6,7 +6,6 @@
 
 (ns app.main.data.workspace.path.drawing
   (:require
-   [app.common.data :as d]
    [app.common.data.macros :as dm]
    [app.common.geom.point :as gpt]
    [app.common.geom.shapes.flex-layout :as gsl]
@@ -385,7 +384,7 @@
     ptk/UpdateEvent
     (update [_ state]
       (if-let [id (dm/get-in state [:workspace-local :edition])]
-        (d/update-in-when state [:workspace-local :edit-path id] assoc :edit-mode mode)
+        (update-in state [:workspace-local :edit-path id] assoc :edit-mode mode)
         state))
 
     ptk/WatchEvent


### PR DESCRIPTION
## Summary

- Fixes issue where pressing Enter twice after drawing a path leaves the shape unselected
- Root cause: `change-edit-mode` used `d/update-in-when` which silently no-ops when `edit-path` has no entry for the newly created shape, preventing `start-draw-mode` from being invoked
- Fix: use `update-in` (creates the map entry if absent) so `change-edit-mode :draw` correctly initialises path edit state and transitions into draw mode

## Root Cause

In `handle-drawing-end`, after `handle-finish-drawing` adds and selects the shape, `start-edition-mode` and `change-edit-mode :draw` are called to enter path draw mode. However `change-edit-mode`'s `update` used `d/update-in-when` which is a no-op when `[:workspace-local :edit-path id]` doesn't exist (no `start-path-edit` was called for the new shape). This left the mode as `nil`, causing the `watch` to return `rx/empty` instead of calling `start-draw-mode`. Path shortcuts were never pushed, and a second Enter was handled by workspace shortcuts (`start-editing-selected`) which put the shape in path move-edit mode.

## Test plan

- [ ] Draw a path with multiple nodes using the pen tool
- [ ] Press Enter once → path drawing ends, shape is added
- [ ] Press Enter a second time → shape should be plainly selected (bounding box, no node handles), not in path edit mode
- [ ] Verify Escape after drawing also leaves shape selected
- [ ] Verify double-clicking an existing path still enters path edit mode normally

Fixes #11169

🤖 Generated with [Claude Code](https://claude.com/claude-code)