### PR TITLE
Fix MCP server build failures on Windows

### DIFF
--- a/mcp/packages/server/package.json
+++ b/mcp/packages/server/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build:server": "esbuild src/index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.js --external:@modelcontextprotocol/* --external:ws --external:express --external:class-transformer --external:class-validator --external:reflect-metadata --external:pino --external:pino-pretty --external:pino-loki --external:js-yaml --external:sharp --external:nrepl-client --external:ioredis",
-    "build": "pnpm run build:server && node scripts/copy-resources.js",
+    "build:server": "pnpm exec esbuild src/index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.js --external:@modelcontextprotocol/* --external:ws --external:express --external:class-transformer --external:class-validator --external:reflect-metadata --external:pino --external:pino-pretty --external:pino-loki --external:js-yaml --external:sharp --external:nrepl-client --external:ioredis",
+    "build": "pnpm run build:server && node ./scripts/copy-resources.js",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "start": "node dist/index.js",
     "start:multi-user": "node dist/index.js --multi-user",


### PR DESCRIPTION
## Summary

- Fixes `esbuild` not-found error on Windows by invoking it via `pnpm exec esbuild` instead of bare `esbuild`, so pnpm resolves the local binary through its own PATH mechanism
- Fixes path-parsing error (`'opy-resources.js"' is not recognized`) on Windows by changing `node scripts/copy-resources.js` to `node ./scripts/copy-resources.js`

## Root Cause

`mcp/packages/server/package.json` had two Windows-hostile patterns:

1. **`esbuild src/index.ts ...`** — bare binary name fails in some Windows environments (git bash via pnpm, certain PATH configurations) where `node_modules/.bin` shims are not on the active PATH. `pnpm exec esbuild` delegates resolution to pnpm, which always locates the local binary correctly.

2. **`node scripts/copy-resources.js`** — the bare relative path `scripts/copy-resources.js` gets mis-parsed in certain Windows shell contexts (bash running inside CMD), stripping leading characters and producing `'opy-resources.js"' is not recognized`. Prefixing with `./` makes the path explicit and unambiguous across all shells.

## Test plan

- [ ] Run `pnpm run build` inside `mcp/packages/server/` on Windows — should complete without `esbuild` not-found error
- [ ] Run `pnpm run bootstrap` from `mcp/` root on Windows — should build and start without hanging or copy-resources error
- [ ] Run `pnpm run build` on macOS/Linux — should remain unaffected

Fixes #8637

🤖 Generated with [Claude Code](https://claude.com/claude-code)