### PR TITLE
:bug: Fix hide register link in viewer login modal when registration is disabled

### DIFF
--- a/frontend/src/app/main/ui/viewer/login.cljs
+++ b/frontend/src/app/main/ui/viewer/login.cljs
@@ -8,6 +8,7 @@
   (:require-macros [app.main.style :as stl])
   (:require
    [app.common.logging :as log]
+   [app.config :as cf]
    [app.main.data.modal :as modal]
    [app.main.store :as st]
    [app.main.ui.auth.login :refer [login-dialog*]]
@@ -84,13 +85,14 @@
                  :class (stl/css :recovery-link)
                  :data-value "recovery-request"}
              (tr "auth.forgot-password")]]
-           [:div {:class (stl/css :register)}
-            [:span {:class (stl/css :register-text)}
-             (tr "auth.register") " "]
-            [:a {:on-click set-section
-                 :class (stl/css :register-link)
-                 :data-value "register"}
-             (tr "auth.register-submit")]]]]
+           (when (contains? cf/flags :registration)
+             [:div {:class (stl/css :register)}
+              [:span {:class (stl/css :register-text)}
+               (tr "auth.register") " "]
+              [:a {:on-click set-section
+                   :class (stl/css :register-link)
+                   :data-value "register"}
+               (tr "auth.register-submit")]])]]
 
          :register
          [:div {:class (stl/css :form-container)}


### PR DESCRIPTION
## Problem

When `disable-registration` is set in the server flags, the main login page correctly hides the "Register" link (it is gated on `(contains? cf/flags :registration)`).

However, the "Log in or sign up" modal in the shared-prototype viewer (`frontend/src/app/main/ui/viewer/login.cljs`) always showed the Register link unconditionally — bypassing the `disable-registration` flag. This let unauthenticated users register new accounts via the shared prototype page even when the admin had disabled registration.

## Fix

Add `[app.config :as cf]` to the namespace requires of `viewer/login.cljs` and wrap the Register link in the same guard already used by the main login page:

```clojure
(when (contains? cf/flags :registration)
  [:div {:class (stl/css :register)} ...])
```

This makes the viewer modal consistent with the main login page. When registration is disabled the link is not rendered at all; when it is enabled behavior is unchanged.

Fixes #5164