### PR TITLE
:bug: Fix comment bubbles rendering above workspace dropdown menus

### DIFF
--- a/frontend/src/app/main/ui/workspace/viewport/comments.scss
+++ b/frontend/src/app/main/ui/workspace/viewport/comments.scss
@@ -4,15 +4,11 @@
 //
 // Copyright (c) KALEIDOS INC Sucursal en España SL
 
-@use "refactor/common-refactor.scss" as deprecated;
-@use "ds/z-index.scss" as *;
-
 .workspace-comments-container {
-  width: 100%;
-  height: 100%;
+  inline-size: 100%;
+  block-size: 100%;
   grid-column: 1 / span 2;
   grid-row: 1 / span 2;
-  z-index: $z-index-300;
   pointer-events: none;
   overflow: hidden;
   user-select: text;

--- a/frontend/src/app/main/ui/workspace/viewport/comments.scss
+++ b/frontend/src/app/main/ui/workspace/viewport/comments.scss
@@ -5,13 +5,14 @@
 // Copyright (c) KALEIDOS INC Sucursal en España SL
 
 @use "refactor/common-refactor.scss" as deprecated;
+@use "ds/z-index.scss" as *;
 
 .workspace-comments-container {
   width: 100%;
   height: 100%;
   grid-column: 1 / span 2;
   grid-row: 1 / span 2;
-  z-index: 1000;
+  z-index: $z-index-300;
   pointer-events: none;
   overflow: hidden;
   user-select: text;


### PR DESCRIPTION
## Problem

Closes #10283

Comment bubbles (the `.workspace-comments-container`) had a hardcoded `z-index: 1000`. The workspace dropdown menus use `--z-index-dropdown` which is **400** in the design-system z-index scale. Because 1000 > 400, comment bubbles would always paint on top of open menus, partially covering menu items.

## Fix

Replace the hardcoded `z-index: 1000` with `$z-index-300` from the DS z-index scale (`ds/z-index.scss`). This places comment bubbles:
- **Above** the viewport canvas and guides (z-index 1–200)
- **Below** dropdown menus (z-index 400)

Also adds the `@use "ds/z-index.scss" as *;` import so the variable is available in the stylesheet.

## Testing

1. Open a file in the workspace.
2. Activate the comments tool (shortcut `C`) and place a comment near the top-left of the canvas.
3. Open the main menu (three-dots button at top-left) and hover over a submenu.
4. The dropdown menu should now fully cover any comment bubble underneath it.