### PR TITLE
✨ Expand token tree after importing tokens

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/library_edit.cljs
@@ -170,6 +170,23 @@
                   [:workspace-tokens :unfolded-token-types]
                   (make-unfolded-token-types-state file-id set-id #{}))))))
 
+(defn expand-all-token-types
+  "Opens all token type sections that have tokens in the given lib.
+   Used after import so the user can verify everything at a glance."
+  [lib]
+  (ptk/reify ::expand-all-token-types
+    ptk/UpdateEvent
+    (update [_ state]
+      (let [file-id   (:current-file-id state)
+            set-id    (get-in state [:workspace-tokens :selected-token-set-id])
+            all-types (->> (ctob/get-all-tokens lib)
+                           (map :type)
+                           (into #{}))]
+        (save-unfolded-token-types-in-storage file-id set-id all-types)
+        (assoc-in state
+                  [:workspace-tokens :unfolded-token-types]
+                  (make-unfolded-token-types-state file-id set-id all-types))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TOKENS TREE - Toggle tree nodes
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
+++ b/frontend/src/app/main/ui/workspace/tokens/import/modal.cljs
@@ -35,7 +35,9 @@
    tokens-lib-stream
    (fn [lib]
      (st/emit! (ev/event {::ev/name "import-tokens" :type type})
-               (dwtl/import-tokens-lib lib))
+               (dwtl/import-tokens-lib lib)
+               (dwtl/clear-tokens-paths)
+               (dwtl/expand-all-token-types lib))
      (modal/hide!))
    (fn [err]
      (st/emit! (ntf/show {:content (dwte/humanize-errors [(ex-data err)])


### PR DESCRIPTION
## Summary

Closes #9819

After importing tokens (via JSON file, directory, or ZIP), the token tree
now appears fully expanded so users can verify the import at a glance
without manually expanding each section.

### Changes

**`library_edit.cljs`** — added `expand-all-token-types` event that collects
all token types present in a given lib and opens their corresponding type
sections (persisted to localStorage).

**`import/modal.cljs`** — after emitting `import-tokens-lib`, also emits:
- `clear-tokens-paths` — expands all nested sub-folders
- `expand-all-token-types` — opens all type sections that have tokens

### Before / After

**Before:** After import, the token tree appears collapsed. Users must
expand each type section and sub-folder manually to verify the import.

**After:** After import, all type sections and sub-folders are expanded,
showing the full token tree. Users can collapse sections as they see fit.