### PR TITLE
:bug: Preserve public URI subpath in asset download URLs

### DIFF
--- a/backend/src/app/rpc/commands/binfile.clj
+++ b/backend/src/app/rpc/commands/binfile.clj
@@ -62,7 +62,8 @@
                                      :bucket "tempfile"})]
 
         (-> (cf/get :public-uri)
-            (u/join "/assets/by-id/")
+            (u/ensure-path-slash)
+            (u/join "assets/by-id/")
             (u/join (str (:id object)))))
 
       (finally

--- a/backend/src/app/rpc/management/exporter.clj
+++ b/backend/src/app/rpc/management/exporter.clj
@@ -45,5 +45,6 @@
         object (sto/put-object! storage content)]
     {:id (:id object)
      :uri (-> (cf/get :public-uri)
-              (u/join "/assets/by-id/")
+              (u/ensure-path-slash)
+              (u/join "assets/by-id/")
               (u/join (str (:id object))))}))

--- a/backend/test/backend_tests/binfile_test.clj
+++ b/backend/test/backend_tests/binfile_test.clj
@@ -16,10 +16,12 @@
    [app.common.thumbnails :as thc]
    [app.common.types.shape :as cts]
    [app.common.uuid :as uuid]
+   [app.config :as cf]
    [app.db :as db]
    [app.db.sql :as sql]
    [app.http :as http]
    [app.rpc :as-alias rpc]
+   [app.rpc.commands.binfile :as binfile]
    [app.storage :as sto]
    [app.storage.tmp :as tmp]
    [backend-tests.helpers :as th]
@@ -206,6 +208,18 @@
                      (v3/import-files!))]
       (t/is (= (count result) 1))
       (t/is (every? uuid? result)))))
+
+(t/deftest export-binfile-preserves-public-uri-subpath
+  (let [profile (th/create-profile* 1)
+        file    (prepare-simple-file profile)
+        config  (assoc cf/config :public-uri "https://example.com/penpot")
+        params  {:file-id (:id file)
+                 :include-libraries false
+                 :embed-assets false}
+        uri     (binding [cf/config config]
+                  (#'binfile/export-binfile th/*system* params))]
+    (t/is (str/starts-with? (str uri)
+                            "https://example.com/penpot/assets/by-id/"))))
 
 (t/deftest read-obj-rejects-oversized-buffer
   ;; N1-07: read-obj! must reject objects exceeding max-object-size

--- a/backend/test/backend_tests/rpc_management_test.clj
+++ b/backend/test/backend_tests/rpc_management_test.clj
@@ -11,6 +11,7 @@
    [app.common.pprint :as pp]
    [app.common.types.shape :as cts]
    [app.common.uuid :as uuid]
+   [app.config :as cf]
    [app.db :as db]
    [app.http :as http]
    [app.rpc :as-alias rpc]
@@ -19,6 +20,7 @@
    [backend-tests.storage-test :refer [configure-storage-backend]]
    [buddy.core.bytes :as b]
    [clojure.test :as t]
+   [cuerdas.core :as str]
    [datoteka.fs :as fs]
    [datoteka.io :as io]))
 
@@ -50,10 +52,15 @@
                            :path path
                            :mtype "image/png"
                            :size 7}}
-        out1    (th/management-command! params)
-        out2    (th/management-command! params)]
+        config  (assoc cf/config :public-uri "https://example.com/penpot")
+        out1    (binding [cf/config config]
+                  (th/management-command! params))
+        out2    (binding [cf/config config]
+                  (th/management-command! params))]
     (t/is (nil? (:error out1)))
     (t/is (nil? (:error out2)))
+    (t/is (str/starts-with? (str (get-in out1 [:result :uri]))
+                            "https://example.com/penpot/assets/by-id/"))
     (t/is (not= (get-in out1 [:result :id])
                 (get-in out2 [:result :id])))))
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Preserve the configured public URI subpath in temporary export download URLs.
- Apply the same behavior to binary `.penpot` file downloads.
- Add regression coverage for both URL generation paths.

## Why

Asset download paths were joined using an absolute `/assets/by-id/` path. This replaced the path component of `PENPOT_PUBLIC_URI`, causing installations hosted under a subpath such as `https://example.com/penpot` to return `https://example.com/assets/by-id/{id}` instead of `https://example.com/penpot/assets/by-id/{id}`.

## How

- Ensure the configured public URI ends with a slash.
- Join `assets/by-id/` as a relative path so the configured subpath is retained.
- Verify both temporary exporter assets and binary file exports with subpath-based public URIs.
