### PR TITLE
:bug: Normalize fractional rate-limit reset durations

### DIFF
--- a/backend/src/app/rpc/rlimit.clj
+++ b/backend/src/app/rpc/rlimit.clj
@@ -46,6 +46,7 @@
    [app.common.data :as d]
    [app.common.exceptions :as ex]
    [app.common.logging :as l]
+   [app.common.math :as mth]
    [app.common.schema :as sm]
    [app.common.time :as ct]
    [app.common.uri :as uri]
@@ -180,8 +181,8 @@
         result    (rds/eval rconn script)
         allowed?  (boolean (nth result 0))
         remaining (nth result 1)
-        reset     (* (/ (inst-ms interval) rate)
-                     (- capacity remaining))]
+        reset     (long (mth/ceil (double (* (/ (inst-ms interval) rate)
+                                             (- capacity remaining)))))]
     (l/trace :hint "limit processed"
              :method method
              :limit (name (::name limit))

--- a/backend/test/backend_tests/rpc_rlimit_test.clj
+++ b/backend/test/backend_tests/rpc_rlimit_test.clj
@@ -1,0 +1,28 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en Espana SL
+
+(ns backend-tests.rpc-rlimit-test
+  (:require
+   [app.common.time :as ct]
+   [app.redis :as rds]
+   [app.rpc.rlimit :as rlimit]
+   [clojure.test :as t]))
+
+(t/deftest bucket-reset-supports-fractional-milliseconds
+  (let [now   (ct/inst 0)
+        limit {::rlimit/name     :test
+               ::rlimit/strategy :bucket
+               ::rlimit/key      "test"
+               ::rlimit/method   "main.test"
+               ::rlimit/capacity 5
+               ::rlimit/rate     3
+               ::rlimit/interval (ct/duration 1000)
+               ::rlimit/params   [1 3 5]
+               ::rlimit/opts     "5/3/1s"}]
+    (with-redefs [rds/eval (fn [_ _] [true 4])]
+      (let [result (rlimit/process-limit nil "profile" now limit)]
+        (t/is (= (ct/inst 334)
+                 (:app.rpc.rlimit.result/reset result)))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Prevent RPC requests from bypassing rate limiting when bucket refill intervals produce fractional milliseconds.

## Why

- Fractional reset durations were represented as Clojure ratios and passed to duration conversion, causing rate-limit processing to fail open for the request.

## How

- Round bucket reset durations up to whole milliseconds using the shared `app.common.math/ceil` helper.
- Add regression coverage for a refill rate that produces a fractional reset duration.
- Full backend tests pass: 654 tests and 4,376 assertions.

Closes #11253
