### PR TITLE
:bug: Fix nitrate advanced permissions error

### DIFF
--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -609,50 +609,56 @@
 
 (defn check-and-submit-invite-members
   "Fetches fresh team data from the server to ensure up-to-date organization
-  permissions, then submits member invitations or shows a restriction modal."
+  permissions, then submits member invitations or shows a permission error."
   [{:keys [team-id] :as params} origin do-invite-members]
   (ptk/reify ::check-and-submit-invite-members
     ptk/WatchEvent
-    (watch [_ _ _]
-      (if (contains? cf/flags :admin-console)
-        (with-refreshed-team team-id
-          (fn [team]
-            (if (not (cto/allowed? :add-anybody-to-team
-                                   {:organization-perms (:organization team)}))
-              (->> (rp/cmd! :check-organization-members {:organization-id (get-in team [:organization :id])
-                                                         :emails (vec (:emails params))})
-                   (rx/mapcat
-                    (fn [result]
-                      (let [blocked (into [] (comp (filter (fn [[_ v]] (not v)))
-                                                   (map first))
-                                          result)]
-                        (cond
-                          (empty? blocked)
-                          (do (do-invite-members params origin) (rx/empty))
+    (watch [_ state _]
+      (let [profile-id (dm/get-in state [:profile :id])]
+        (if (contains? cf/flags :admin-console)
+          (with-refreshed-team team-id
+            (fn [team]
+              (if (not (cto/can-send-invitations?
+                        {:organization (:organization team)
+                         :profile-id profile-id
+                         :team-permissions (:permissions team)}))
+                (rx/of (modal/show :no-permission-modal {:type :invite-members}))
+                (if (not (cto/allowed? :add-anybody-to-team
+                                       {:organization-perms (:organization team)}))
+                  (->> (rp/cmd! :check-organization-members {:organization-id (get-in team [:organization :id])
+                                                             :emails (vec (:emails params))})
+                       (rx/mapcat
+                        (fn [result]
+                          (let [blocked (into [] (comp (filter (fn [[_ v]] (not v)))
+                                                       (map first))
+                                              result)]
+                            (cond
+                              (empty? blocked)
+                              (do (do-invite-members params origin) (rx/empty))
 
-                          (= (count blocked) (count result))
-                          (rx/of
-                           (modal/show
-                            {:type :alert
-                             :title (tr "modals.invite-restricted-members.all-blocked-title")
-                             :message (tr "modals.invite-restricted-members.all-blocked")
-                             :accept-label (tr "labels.accept")
-                             :accept-style :primary}))
+                              (= (count blocked) (count result))
+                              (rx/of
+                               (modal/show
+                                {:type :alert
+                                 :title (tr "modals.invite-restricted-members.all-blocked-title")
+                                 :message (tr "modals.invite-restricted-members.all-blocked")
+                                 :accept-label (tr "labels.accept")
+                                 :accept-style :primary}))
 
-                          :else
-                          (rx/of
-                           (modal/show
-                            {:type :invite-restricted-members
-                             :blocked-emails blocked
-                             :on-accept (fn []
-                                          (let [valid-emails (into #{} (filter (fn [e] (get result e)))
-                                                                   (:emails params))
-                                                params'      (assoc params :emails valid-emails)]
-                                            (do-invite-members params' origin)))})))))))
-              (do (do-invite-members params origin)
-                  (rx/empty)))))
-        (do (do-invite-members params origin)
-            (rx/empty))))))
+                              :else
+                              (rx/of
+                               (modal/show
+                                {:type :invite-restricted-members
+                                 :blocked-emails blocked
+                                 :on-accept (fn []
+                                              (let [valid-emails (into #{} (filter (fn [e] (get result e)))
+                                                                       (:emails params))
+                                                    params'      (assoc params :emails valid-emails)]
+                                                (do-invite-members params' origin)))})))))))
+                  (do (do-invite-members params origin)
+                      (rx/empty))))))
+          (do (do-invite-members params origin)
+              (rx/empty)))))))
 
 (defn copy-invitation-link
   [{:keys [email team-id] :as params}]

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -233,6 +233,9 @@
                    (= :email-domain-is-not-allowed code))
               (st/emit! (ntf/error (tr "errors.email-domain-not-allowed"))
                         (modal/hide))
+              (and (= :validation type)
+                   (= :insufficient-permissions code))
+              (st/emit! (modal/show :no-permission-modal {:type :invite-members}))
 
               :else
               (st/emit! (ntf/error (tr "errors.generic"))

--- a/frontend/src/app/main/ui/dashboard/team_form.cljs
+++ b/frontend/src/app/main/ui/dashboard/team_form.cljs
@@ -152,6 +152,8 @@
                                         (tr "dashboard.no-permission-create-team.message" organization-name)]
                           :delete-team [(tr "dashboard.delete-team")
                                         (tr "dashboard.no-permission-delete-team.message" organization-name)]
+                          :invite-members [(tr "modals.invite-team-member.title")
+                                           (tr "dashboard.invitations.no-permission")]
                           :no-organizations-create [(tr "dashboard.select-organization-modal.title")
                                                     (tr "dashboard.no-organization-allows-create-team.message")]
                           :no-organizations-change [(tr "dashboard.change-organization-modal.title")


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26733

### Summary

Fixed an issue where team admins received a generic error instead of a clear permission-denied modal when attempting to send invitations after the organization owner revoked their `send-invitations` permission. The `check-and-submit-invite-members` function now re-checks `can-send-invitations?` with fresh team data before submitting, and the frontend properly handles `:insufficient-permissions` errors by displaying the `:no-permission-modal` with the appropriate `:invite-members` message.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
