### PR TITLE
:zap: Render eligible frame drop shadows without filter surfaces

### DIFF
--- a/.serena/memories/render-wasm/ffi-rendering-subtleties.md
+++ b/.serena/memories/render-wasm/ffi-rendering-subtleties.md
@@ -25,3 +25,5 @@
 - Plain viewport fast mode (`options.is_viewport_interaction()`) renders from cache and does not flush target output inside `process_animation_frame`; interactive transforms do flush.
 - Zoom changes rebuild the tile index while preserving cached tile textures. Avoid replacing that path with shallow rebuilds if blur/shadow cache preservation matters.
 - Pending tile priority is intentionally reversed by pop order; check the queue construction before changing tile scheduling.
+- Frames with a fill may use `render_frame_container_drop_shadow` (direct rrect +
+  blur saveLayer on `DropShadows`) when `uses_direct_container_drop_shadow` is true.

--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -2177,15 +2177,31 @@
   (when (wasm/live?)
     (h/call wasm/internal-module "_set_render_options" (debug-flags) new-dpr)))
 
+(def ^:private max-surface-size
+  ;; Must match `gpu_state::MAX_SURFACE_SIZE`.
+  8192)
+
+(defn- clamp-physical-size
+  "Clamp physical pixel dimensions before assigning `canvas.width/height`.
+  Rust `resize` applies the same cap and syncs the effective DPR from the
+  real drawing buffer."
+  [w h]
+  (let [w     (mth/max 1 w)
+        h     (mth/max 1 h)
+        scale (mth/min 1 (/ max-surface-size w) (/ max-surface-size h))]
+    [(mth/max 1 (mth/floor (* scale w)))
+     (mth/max 1 (mth/floor (* scale h)))]))
+
 (defn resize-offscreen-canvas!
   "Resize a persistent OffscreenCanvas to new physical-pixel dimensions and
   update the WASM render surfaces accordingly (via `_resize_viewbox`). The
   design state (shape pool) is preserved so `set-objects` is not needed again."
   [canvas new-physical-w new-physical-h]
   (when (wasm/live?)
-    (let [dpr (get-dpr)]
-      (set! (.-width canvas) new-physical-w)
-      (set! (.-height canvas) new-physical-h)
+    (let [dpr (get-dpr)
+          [pw ph] (clamp-physical-size new-physical-w new-physical-h)]
+      (set! (.-width canvas) pw)
+      (set! (.-height canvas) ph)
       (set-render-options! dpr)
       (resize-viewbox (/ new-physical-w dpr) (/ new-physical-h dpr)))))
 
@@ -2220,9 +2236,14 @@
    (resize-canvas! canvas (get-dpr)))
   ([canvas new-dpr]
    (when (wasm/live?)
-     (let [[css-w css-h] (canvas-css-size canvas new-dpr)]
-       (set! (.-width ^js canvas) (* new-dpr css-w))
-       (set! (.-height ^js canvas) (* new-dpr css-h))
+     (let [[css-w css-h] (canvas-css-size canvas new-dpr)
+           css-w         (mth/max 1 css-w)
+           css-h         (mth/max 1 css-h)
+           [phys-w phys-h] (clamp-physical-size
+                            (mth/floor (* css-w new-dpr))
+                            (mth/floor (* css-h new-dpr)))]
+       (set! (.-width ^js canvas) phys-w)
+       (set! (.-height ^js canvas) phys-h)
        (set-render-options! new-dpr)
        (resize-viewbox css-w css-h)))))
 

--- a/render-wasm/src/main.rs
+++ b/render-wasm/src/main.rs
@@ -57,7 +57,7 @@ pub extern "C" fn set_viewport_interest_area_threshold(
     viewport_interest_area_threshold: i32,
 ) -> Result<()> {
     let render_state = get_render_state();
-    render_state.set_viewport_interest_area_threshold(viewport_interest_area_threshold);
+    render_state.set_viewport_interest_area_threshold(viewport_interest_area_threshold)?;
     Ok(())
 }
 

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -34,7 +34,7 @@ use crate::shapes::{
 use crate::state::{ShapesPoolMutRef, ShapesPoolRef};
 use crate::tiles::{self, PendingTiles, TileRect};
 use crate::uuid::Uuid;
-use crate::view::Viewbox;
+use crate::view::{self, Viewbox};
 use crate::wapi;
 use crate::{get_gpu_state, get_resources, performance};
 
@@ -417,6 +417,8 @@ pub(crate) struct RenderState {
     /// shadow. A full skip made flush_and_submit very slow (Skia ops-task
     /// ordering); doing it per shape was wasted GPU work.
     pub drop_shadows_ops_warmed: bool,
+    /// Filter-surface snapshots for drop shadows, reused across tiles.
+    drop_shadow_filter_cache: shadows::DropShadowFilterCache,
 }
 
 pub struct InteractiveDragCrop {
@@ -551,6 +553,9 @@ impl RenderState {
     pub fn try_new(width: i32, height: i32) -> Result<RenderState> {
         // This needs to be done once per WebGL context.
         let sampling_options = get_resources().sampling_options;
+        let max_dim = get_gpu_state().max_surface_size();
+        let width = width.clamp(1, max_dim);
+        let height = height.clamp(1, max_dim);
 
         let surfaces = Surfaces::try_new(
             (width, height),
@@ -601,6 +606,7 @@ impl RenderState {
             backbuffer_crop_cache: HashMap::default(),
             tile_atlas_flushed: false,
             drop_shadows_ops_warmed: false,
+            drop_shadow_filter_cache: shadows::DropShadowFilterCache::new(),
         })
     }
 
@@ -875,25 +881,29 @@ impl RenderState {
     pub fn set_dpr(&mut self, dpr: f32) -> Result<()> {
         // Only when this function returns true (it means the value
         // was properly changed) the rest of the functions is called.
+        // Surface/viewbox pixel size is updated by `resize` after the
+        // canvas backing store is set, so we do not resize here with a
+        // stale CSS size (that desyncs Skia vs the GL framebuffer).
         if self.options.set_dpr(dpr) {
+            self.viewbox.set_dpr(dpr);
             self.tile_viewbox
                 .set_interest(self.options.dpr_viewport_interest_area_threshold);
-            self.resize(
-                self.viewbox.width().floor() as i32,
-                self.viewbox.height().floor() as i32,
-            )?;
             get_resources().fonts.set_scale_debug_font(dpr);
-            self.viewbox.set_dpr(dpr);
             self.surfaces.set_dpr(dpr);
         }
         Ok(())
+    }
+
+    pub fn ensure_tile_atlas_layout(&mut self) {
+        self.surfaces
+            .ensure_tile_atlas_layout(self.tile_viewbox.interest_rect.len().max(1) as usize);
     }
 
     pub fn set_antialias_threshold(&mut self, value: f32) {
         self.options.set_antialias_threshold(value);
     }
 
-    pub fn set_viewport_interest_area_threshold(&mut self, value: i32) {
+    pub fn set_viewport_interest_area_threshold(&mut self, value: i32) -> Result<()> {
         // Only when this function returns true (it means the value
         // was changed properly) the tile_viewbox.set_interest is called.
         if self.options.set_viewport_interest_area_threshold(value) {
@@ -902,7 +912,10 @@ impl RenderState {
             // affect pending_tiles generation.
             self.tile_viewbox
                 .set_interest(self.options.dpr_viewport_interest_area_threshold);
+            self.tile_viewbox.update(&self.viewbox);
+            self.ensure_tile_atlas_layout();
         }
+        Ok(())
     }
 
     pub fn set_node_batch_threshold(&mut self, value: i32) {
@@ -926,11 +939,27 @@ impl RenderState {
     }
 
     pub fn resize(&mut self, width: i32, height: i32) -> Result<()> {
-        let dpr_width = (width as f32 * self.options.dpr).floor() as i32;
-        let dpr_height = (height as f32 * self.options.dpr).floor() as i32;
+        let gpu_state = get_gpu_state();
+        let max_dim = gpu_state.max_surface_size();
+        let css_w = (width as f32).max(1.0);
+        let css_h = (height as f32).max(1.0);
+        let dpr = view::clamp_dpr_for_surface(css_w, css_h, self.options.dpr, max_dim);
+        let mut dpr_width = ((css_w * dpr).floor() as i32).clamp(1, max_dim);
+        let mut dpr_height = ((css_h * dpr).floor() as i32).clamp(1, max_dim);
+        // Prefer the real GL drawing buffer: wrap_backend_render_target
+        // binds the default framebuffer, whose origin is bottom-left.
+        if let Some((fb_w, fb_h)) = gpu_state.drawing_buffer_size() {
+            dpr_width = fb_w.clamp(1, max_dim);
+            dpr_height = fb_h.clamp(1, max_dim);
+        }
+        let effective_dpr = (dpr_width as f32 / css_w).min(dpr_height as f32 / css_h);
+        if (effective_dpr - self.options.dpr).abs() > f32::EPSILON {
+            self.set_dpr(effective_dpr)?;
+        }
         self.surfaces.resize(dpr_width, dpr_height)?;
-        self.viewbox.set_wh(width as f32, height as f32);
+        self.viewbox.set_wh(css_w, css_h);
         self.tile_viewbox.update(&self.viewbox);
+        self.ensure_tile_atlas_layout();
 
         Ok(())
     }
@@ -2274,6 +2303,7 @@ impl RenderState {
 
         // reorder by distance to the center.
         self.current_tile = None;
+        self.drop_shadow_filter_cache.clear();
     }
 
     pub fn start_render_loop(
@@ -2995,6 +3025,87 @@ impl RenderState {
         ))
     }
 
+    /// Renders descendant silhouettes into the current drop-shadow layer.
+    #[allow(clippy::too_many_arguments)]
+    fn render_drop_shadow_child_silhouettes(
+        &mut self,
+        element: &Shape,
+        tree: ShapesPoolRef,
+        shadow: &Shadow,
+        scale: f32,
+        inherited_layer_blur: Option<Blur>,
+        node_render_state: &NodeRenderState,
+        target_surface: SurfaceId,
+    ) -> Result<()> {
+        if matches!(element.shape_type, Type::Bool(_)) {
+            return Ok(());
+        }
+
+        let shadow_children = if element.is_recursive() {
+            get_simplified_children(tree, element)
+        } else {
+            Vec::new()
+        };
+
+        for shadow_shape_id in shadow_children.iter() {
+            let Some(shadow_shape) = tree.get(shadow_shape_id) else {
+                continue;
+            };
+            if shadow_shape.hidden {
+                continue;
+            }
+
+            let nested_clip_bounds =
+                node_render_state.get_nested_shadow_clip_bounds(element, shadow);
+
+            if !matches!(shadow_shape.shape_type, Type::Text(_)) {
+                self.render_drop_black_shadow(
+                    shadow_shape,
+                    &shadow_shape.extrect(tree, scale),
+                    shadow,
+                    nested_clip_bounds,
+                    scale,
+                    inherited_layer_blur,
+                    target_surface,
+                )?;
+            } else {
+                let paint = skia::Paint::default();
+                let layer_rec = skia::canvas::SaveLayerRec::default().paint(&paint);
+                self.surfaces
+                    .canvas(SurfaceId::DropShadows)
+                    .save_layer(&layer_rec);
+
+                let mut transformed_shadow: Cow<Shadow> = Cow::Borrowed(shadow);
+                transformed_shadow.to_mut().color = skia::Color::BLACK;
+                transformed_shadow.to_mut().blur = transformed_shadow.blur;
+                transformed_shadow.to_mut().spread = transformed_shadow.spread;
+
+                let mut new_shadow_paint = skia::Paint::default();
+                new_shadow_paint.set_image_filter(transformed_shadow.get_drop_shadow_filter());
+                new_shadow_paint.set_blend_mode(skia::BlendMode::SrcOver);
+
+                self.with_nested_blurs_suppressed(|state| {
+                    state.render_shape(
+                        shadow_shape,
+                        nested_clip_bounds,
+                        SurfaceId::DropShadows,
+                        SurfaceId::DropShadows,
+                        SurfaceId::DropShadows,
+                        SurfaceId::DropShadows,
+                        true,
+                        None,
+                        Some(vec![new_shadow_paint.clone()]),
+                        None,
+                        target_surface,
+                    )
+                })?;
+                self.surfaces.canvas(SurfaceId::DropShadows).restore();
+            }
+        }
+
+        Ok(())
+    }
+
     /// Renders a drop shadow effect for the given shape.
     ///
     /// Creates a black shadow by converting the original shadow color to black,
@@ -3140,10 +3251,30 @@ impl RenderState {
             return Ok(());
         }
 
-        // Adaptive downscale for large blur values (lossless GPU optimization).
-        // Bounds above were computed from the original sigma so filter surface coverage is correct.
-        // Maximum downscale is 1/BLUR_DOWNSCALE_THRESHOLD (i.e. 8x): beyond that the
-        // filter surface becomes too small and quality degrades noticeably.
+        // High zoom with blur: use render_into_filter_surface to ensure blur has enough space
+        // Apply spread geometrically to avoid dilate filter rounding issues
+        let layer_blur_value = combined_blur.map(|b| b.value).unwrap_or(0.0);
+        let cache_key = clip_bounds.is_none().then(|| {
+            shadows::DropShadowFilterCacheKey::for_shape(
+                shape.id,
+                shadow,
+                scale,
+                &shape.transform,
+                layer_blur_value,
+            )
+        });
+
+        if let Some(ref key) = cache_key {
+            if let Some(cached) = self.drop_shadow_filter_cache.lookup(key) {
+                shadows::blit_cached_drop_shadow_filter(
+                    &mut self.surfaces,
+                    cached,
+                    blur_filter.clone(),
+                );
+                return Ok(());
+            }
+        }
+
         let blur_downscale_threshold: f32 = self.options.blur_downscale_threshold;
         let min_blur_downscale: f32 = 1.0 / blur_downscale_threshold;
         let blur_downscale = if shadow.blur > blur_downscale_threshold {
@@ -3185,37 +3316,19 @@ impl RenderState {
         )?;
 
         if let Some((mut surface, filter_scale)) = filter_result {
-            let drop_canvas = self.surfaces.canvas(SurfaceId::DropShadows);
-            drop_canvas.save();
-            //drop_canvas.scale((scale, scale));
-            //drop_canvas.translate(translation);
-            let mut drop_paint = skia::Paint::default();
-            drop_paint.set_image_filter(blur_filter.clone());
-
-            // If we scaled down in the filter surface, we need to scale back up
-            if filter_scale < 1.0 {
-                drop_canvas.save();
-                drop_canvas.scale((1.0 / filter_scale, 1.0 / filter_scale));
-                drop_canvas.translate((bounds.left * filter_scale, bounds.top * filter_scale));
-                surface.draw(
-                    drop_canvas,
-                    (0.0, 0.0),
-                    get_resources().sampling_options,
-                    Some(&drop_paint),
-                );
-                drop_canvas.restore();
-            } else {
-                drop_canvas.save();
-                drop_canvas.translate((bounds.left, bounds.top));
-                surface.draw(
-                    drop_canvas,
-                    (0.0, 0.0),
-                    get_resources().sampling_options,
-                    Some(&drop_paint),
-                );
-                drop_canvas.restore();
+            let cached = shadows::CachedDropShadowFilter::new(
+                bounds,
+                filter_scale,
+                surface.image_snapshot(),
+            );
+            shadows::blit_cached_drop_shadow_filter(
+                &mut self.surfaces,
+                &cached,
+                blur_filter.clone(),
+            );
+            if let Some(key) = cache_key {
+                self.drop_shadow_filter_cache.store(key, cached);
             }
-            drop_canvas.restore();
         }
 
         Ok(())
@@ -3254,6 +3367,7 @@ impl RenderState {
         };
 
         let recursive = element.is_recursive();
+        let use_direct_container_shadow = element.uses_direct_container_drop_shadow(tree, scale);
         let mut rendered_any = false;
         for shadow in element.drop_shadows_visible() {
             if !shadow.is_perceptible_at_scale_for(scale, recursive) {
@@ -3266,78 +3380,35 @@ impl RenderState {
                 .canvas(SurfaceId::DropShadows)
                 .save_layer(&layer_rec);
 
-            self.render_drop_black_shadow(
-                element,
-                element_extrect,
-                shadow,
-                clip_bounds.clone(),
-                scale,
-                None,
-                target_surface,
-            )?;
-
-            if !matches!(element.shape_type, Type::Bool(_)) {
-                let shadow_children = if element.is_recursive() {
-                    get_simplified_children(tree, element)
-                } else {
-                    Vec::new()
-                };
-
-                for shadow_shape_id in shadow_children.iter() {
-                    let Some(shadow_shape) = tree.get(shadow_shape_id) else {
-                        continue;
-                    };
-                    if shadow_shape.hidden {
-                        continue;
-                    }
-
-                    let nested_clip_bounds =
-                        node_render_state.get_nested_shadow_clip_bounds(element, shadow);
-
-                    if !matches!(shadow_shape.shape_type, Type::Text(_)) {
-                        self.render_drop_black_shadow(
-                            shadow_shape,
-                            &shadow_shape.extrect(tree, scale),
-                            shadow,
-                            nested_clip_bounds,
-                            scale,
-                            inherited_layer_blur,
-                            target_surface,
-                        )?;
-                    } else {
-                        let paint = skia::Paint::default();
-                        let layer_rec = skia::canvas::SaveLayerRec::default().paint(&paint);
-                        self.surfaces
-                            .canvas(SurfaceId::DropShadows)
-                            .save_layer(&layer_rec);
-
-                        let mut transformed_shadow: Cow<Shadow> = Cow::Borrowed(shadow);
-                        transformed_shadow.to_mut().color = skia::Color::BLACK;
-                        transformed_shadow.to_mut().blur = transformed_shadow.blur;
-                        transformed_shadow.to_mut().spread = transformed_shadow.spread;
-
-                        let mut new_shadow_paint = skia::Paint::default();
-                        new_shadow_paint
-                            .set_image_filter(transformed_shadow.get_drop_shadow_filter());
-                        new_shadow_paint.set_blend_mode(skia::BlendMode::SrcOver);
-
-                        self.with_nested_blurs_suppressed(|state| {
-                            state.render_shape(
-                                shadow_shape,
-                                nested_clip_bounds,
-                                SurfaceId::DropShadows,
-                                SurfaceId::DropShadows,
-                                SurfaceId::DropShadows,
-                                SurfaceId::DropShadows,
-                                true,
-                                None,
-                                Some(vec![new_shadow_paint.clone()]),
-                                None,
-                                target_surface,
-                            )
-                        })?;
-                        self.surfaces.canvas(SurfaceId::DropShadows).restore();
-                    }
+            // Fast path: frame geometry only (no child silhouettes).
+            if use_direct_container_shadow {
+                shadows::render_direct_frame_drop_shadow(
+                    self,
+                    element,
+                    element_extrect,
+                    shadow,
+                    scale,
+                )?;
+            } else {
+                self.render_drop_black_shadow(
+                    element,
+                    element_extrect,
+                    shadow,
+                    clip_bounds.clone(),
+                    scale,
+                    None,
+                    target_surface,
+                )?;
+                if !element.container_fill_covers_shadow_descendants(tree, scale) {
+                    self.render_drop_shadow_child_silhouettes(
+                        element,
+                        tree,
+                        shadow,
+                        scale,
+                        inherited_layer_blur,
+                        node_render_state,
+                        target_surface,
+                    )?;
                 }
             }
 

--- a/render-wasm/src/render.rs
+++ b/render-wasm/src/render.rs
@@ -1109,15 +1109,20 @@ impl RenderState {
         }
 
         let fast_mode = self.options.is_fast_mode();
+        // During pan/zoom (fast mode) tiles are rendered without shadows/blur.
+        // Do not write them into the doc/tile atlases: render_from_cache overlays
+        // HQ tile textures on the scaled doc-atlas backdrop, and shadowless tiles
+        // would leave permanent holes until the post-gesture full render.
+        if fast_mode {
+            return Ok(());
+        }
         // Decide *now* (at the first real cache blit) whether we need to clear Cache.
         // This avoids clearing Cache on renders that don't actually paint tiles (e.g. hover/UI),
         // while still preventing stale pixels from surviving across full-quality renders.
-        if !fast_mode && !self.cache_cleared_this_render {
+        if !self.cache_cleared_this_render {
             self.surfaces.clear_cache(self.background_color);
             self.cache_cleared_this_render = true;
         }
-        // In fast mode the viewport is moving (pan/zoom) so Cache surface
-        // positions would be wrong — only save to the tile HashMap.
         let tile_rect = self.get_current_aligned_tile_bounds()?;
 
         let current_tile = *self
@@ -1133,7 +1138,7 @@ impl RenderState {
             &self.tile_viewbox,
             &current_tile,
             &tile_rect,
-            fast_mode,
+            false,
             self.render_area,
         );
 
@@ -4198,8 +4203,9 @@ impl RenderState {
     }
 
     /// Rebuild the tile index (shape→tile mapping) for all top-level shapes.
-    /// This does NOT invalidate the tile texture cache — cached tile images
-    /// survive so that fast-mode renders during pan still show shadows/blur.
+    /// This does NOT invalidate the tile texture cache — existing HQ tiles
+    /// survive across pan so `render_from_cache` keeps showing shadows/blur
+    /// until the post-gesture full render replaces them.
     pub fn rebuild_tile_index(&mut self, tree: ShapesPoolRef) {
         let zoom_changed = self.zoom_changed();
         performance::begin_measure!("rebuild_tile_index");

--- a/render-wasm/src/render/gpu_state.rs
+++ b/render-wasm/src/render/gpu_state.rs
@@ -7,6 +7,10 @@ use skia_safe::{self as skia, ISize};
 
 const MIN_MAX_TEXTURE_SIZE: i32 = 512;
 const MAX_MAX_TEXTURE_SIZE: i32 = 4096;
+/// Cap for the canvas framebuffer / backbuffer (not the tile atlas).
+/// Larger than a typical viewport at DPR 2 but below sizes that would exceed
+/// GPU limits when CSS dimensions are very large.
+pub const MAX_SURFACE_SIZE: i32 = 8192;
 
 #[derive(Debug, Clone)]
 pub struct GpuState {
@@ -55,6 +59,33 @@ impl GpuState {
         self.context
             .max_texture_size()
             .clamp(MIN_MAX_TEXTURE_SIZE, MAX_MAX_TEXTURE_SIZE)
+    }
+
+    pub fn max_surface_size(&self) -> i32 {
+        self.context
+            .max_texture_size()
+            .clamp(MIN_MAX_TEXTURE_SIZE, MAX_SURFACE_SIZE)
+    }
+
+    /// Actual default-framebuffer size after the canvas backing store is set.
+    /// Browsers may allocate a smaller `drawingBuffer` than `canvas.width`;
+    /// wrapping Skia at the requested size then shifts content (GL origin is
+    /// bottom-left). Native builds have no canvas; return `None`.
+    pub fn drawing_buffer_size(&self) -> Option<(i32, i32)> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let w = crate::run_script_int!(
+                "(typeof GLctx!=='undefined'&&GLctx)?GLctx.drawingBufferWidth:0"
+            );
+            let h = crate::run_script_int!(
+                "(typeof GLctx!=='undefined'&&GLctx)?GLctx.drawingBufferHeight:0"
+            );
+            if w > 0 && h > 0 {
+                return Some((w, h));
+            }
+        }
+        let _ = self;
+        None
     }
 
     fn delete_gl_texture(&mut self, texture_id: gl::types::GLuint) -> bool {

--- a/render-wasm/src/render/shadows.rs
+++ b/render-wasm/src/render/shadows.rs
@@ -1,12 +1,361 @@
+use std::collections::HashMap;
+
+use super::filters;
 use super::{RenderState, SurfaceId};
-use crate::render::strokes;
-use crate::shapes::{ParagraphBuilderGroup, Shadow, Shape, Stroke, StrokeKind, TextContent, Type};
-use skia_safe::{canvas::SaveLayerRec, Paint, Path};
-
 use crate::error::Result;
+use crate::get_resources;
+use crate::render::strokes;
 use crate::render::text;
+use crate::shapes::radius_to_sigma;
+use crate::shapes::{ParagraphBuilderGroup, Shadow, Shape, Stroke, StrokeKind, TextContent, Type};
+use crate::uuid::Uuid;
+use skia_safe::{self as skia, canvas::SaveLayerRec, Paint, Path, Rect};
 
-// Fill Shadows
+// ---------------------------------------------------------------------------
+// Direct frame drop shadows (fast inline blur + filter-surface cache fallback)
+// ---------------------------------------------------------------------------
+
+pub(crate) struct DropShadowFilterCache {
+    entries: HashMap<DropShadowFilterCacheKey, CachedDropShadowFilter>,
+}
+
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+pub(crate) struct DropShadowFilterCacheKey {
+    shape_id: Uuid,
+    blur_bits: u32,
+    spread_bits: u32,
+    offset_x_bits: u32,
+    offset_y_bits: u32,
+    scale_bits: u32,
+    transform_a_bits: u32,
+    transform_b_bits: u32,
+    transform_c_bits: u32,
+    transform_d_bits: u32,
+    transform_e_bits: u32,
+    transform_f_bits: u32,
+    layer_blur_bits: u32,
+}
+
+pub(crate) struct CachedDropShadowFilter {
+    bounds: Rect,
+    filter_scale: f32,
+    image: skia::Image,
+}
+
+impl CachedDropShadowFilter {
+    pub(crate) fn new(bounds: Rect, filter_scale: f32, image: skia::Image) -> Self {
+        Self {
+            bounds,
+            filter_scale,
+            image,
+        }
+    }
+}
+
+impl DropShadowFilterCacheKey {
+    pub(crate) fn for_shape(
+        shape_id: Uuid,
+        shadow: &Shadow,
+        scale: f32,
+        transform: &skia::Matrix,
+        layer_blur: f32,
+    ) -> Self {
+        Self::new(shape_id, shadow, scale, transform, layer_blur)
+    }
+
+    fn new(
+        shape_id: Uuid,
+        shadow: &Shadow,
+        scale: f32,
+        transform: &skia::Matrix,
+        layer_blur: f32,
+    ) -> Self {
+        Self {
+            shape_id,
+            blur_bits: shadow.blur.to_bits(),
+            spread_bits: shadow.spread.to_bits(),
+            offset_x_bits: shadow.offset.0.to_bits(),
+            offset_y_bits: shadow.offset.1.to_bits(),
+            scale_bits: scale.to_bits(),
+            transform_a_bits: transform[0].to_bits(),
+            transform_b_bits: transform[1].to_bits(),
+            transform_c_bits: transform[2].to_bits(),
+            transform_d_bits: transform[3].to_bits(),
+            transform_e_bits: transform[4].to_bits(),
+            transform_f_bits: transform[5].to_bits(),
+            layer_blur_bits: layer_blur.to_bits(),
+        }
+    }
+}
+
+impl DropShadowFilterCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::default(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub(crate) fn lookup(&self, key: &DropShadowFilterCacheKey) -> Option<&CachedDropShadowFilter> {
+        self.entries.get(key)
+    }
+
+    pub(crate) fn store(&mut self, key: DropShadowFilterCacheKey, value: CachedDropShadowFilter) {
+        self.entries.insert(key, value);
+    }
+}
+
+/// Renders a direct frame drop shadow: inline blur on the tile when the kernel
+/// fits the margin, otherwise a cached filter-surface pass shared across tiles.
+///
+/// Does not apply the caller's clip stack; clip is applied when compositing
+/// `DropShadows` onto the target surface.
+pub(crate) fn render_direct_frame_drop_shadow(
+    state: &mut RenderState,
+    frame: &Shape,
+    shape_bounds: &Rect,
+    shadow: &Shadow,
+    scale: f32,
+) -> Result<()> {
+    let margin = state.surfaces.margins().width as f32;
+    let sigma_device = radius_to_sigma(shadow.blur) * scale;
+    if sigma_device <= margin / 3.0 {
+        render_inline_frame_shadow(state, frame, shadow, scale)
+    } else {
+        render_cached_filter_frame_shadow(state, frame, shape_bounds, shadow, scale)
+    }
+}
+
+fn frame_shadow_antialias(state: &RenderState, frame: &Shape, scale: f32) -> bool {
+    !state.options.is_fast_mode()
+        && frame.should_use_antialias(scale, state.options.antialias_threshold)
+}
+
+fn spread_outset(spread: f32) -> Option<f32> {
+    Some(spread).filter(|&s| s > 0.0)
+}
+
+fn spread_inset(spread: f32) -> Option<f32> {
+    Some(-spread).filter(|&s| s > 0.0)
+}
+
+fn blur_layer_paint(blur: f32, sigma_scale: f32) -> skia::Paint {
+    let mut paint = skia::Paint::default();
+    if blur > 0.0 {
+        let sigma = radius_to_sigma(blur) * sigma_scale;
+        paint.set_image_filter(skia::image_filters::blur((sigma, sigma), None, None, None));
+    }
+    paint.set_blend_mode(skia::BlendMode::SrcOver);
+    paint
+}
+
+fn draw_frame_shadow_rect(
+    surfaces: &mut super::Surfaces,
+    surface_id: SurfaceId,
+    frame: &Shape,
+    shadow: &Shadow,
+    antialias: bool,
+) {
+    let mut fill_paint = skia::Paint::default();
+    fill_paint.set_color(skia::Color::BLACK);
+    fill_paint.set_anti_alias(antialias);
+    surfaces.draw_rect_to(
+        surface_id,
+        frame,
+        &fill_paint,
+        spread_outset(shadow.spread),
+        spread_inset(shadow.spread),
+    );
+}
+
+fn shadow_filter_bounds(
+    shadow: &Shadow,
+    shape_bounds: &Rect,
+    world_offset: (f32, f32),
+) -> Option<Rect> {
+    let mut shadow_cull = *shadow;
+    shadow_cull.color = skia::Color::BLACK;
+    shadow_cull.offset = (0.0, 0.0);
+    let drop_filter = shadow_cull.get_drop_shadow_filter()?;
+    let mut bounds = drop_filter.compute_fast_bounds(*shape_bounds);
+    bounds.offset(world_offset);
+    Some(bounds)
+}
+
+/// Local draw matrix for frame shadow geometry: centered shape transform plus
+/// shadow offset in local space (matches `render_shape` with `Some(offset)`).
+fn frame_shadow_draw_matrix(frame: &Shape, shadow: &Shadow) -> skia::Matrix {
+    let mut matrix = frame.centered_transform();
+    matrix.pre_translate((shadow.offset.0, shadow.offset.1));
+    matrix
+}
+
+/// Shadow offset mapped to world space (for bounds culling and cache blit).
+fn shadow_world_offset(frame: &Shape, shadow: &Shadow) -> (f32, f32) {
+    let mapped = frame
+        .centered_transform()
+        .map_vector((shadow.offset.0, shadow.offset.1));
+    (mapped.x, mapped.y)
+}
+
+/// When bounds fit in the filter surface, skip blur downscale to avoid banding
+/// at high zoom. The tile cache makes a single full-res pass affordable.
+fn blur_downscale_for_frame_shadow(
+    blur: f32,
+    bounds: Rect,
+    filter_width: i32,
+    filter_height: i32,
+    threshold: f32,
+) -> f32 {
+    let bounds_w = bounds.width().ceil().max(1.0) as i32;
+    let bounds_h = bounds.height().ceil().max(1.0) as i32;
+    if bounds_w <= filter_width && bounds_h <= filter_height {
+        return 1.0;
+    }
+    if blur > threshold {
+        (threshold / blur).max(1.0 / threshold)
+    } else {
+        1.0
+    }
+}
+
+pub(crate) fn blit_cached_drop_shadow_filter(
+    surfaces: &mut super::Surfaces,
+    cached: &CachedDropShadowFilter,
+    layer_blur: Option<skia::ImageFilter>,
+) {
+    let sampling = get_resources().sampling_options;
+    let mut paint = skia::Paint::default();
+    if let Some(filter) = layer_blur {
+        paint.set_image_filter(filter);
+    }
+    let drop_canvas = surfaces.canvas(SurfaceId::DropShadows);
+    let dst = skia::Rect::from_wh(cached.image.width() as f32, cached.image.height() as f32);
+
+    drop_canvas.save();
+    drop_canvas.save();
+    if cached.filter_scale < 1.0 {
+        drop_canvas.scale((1.0 / cached.filter_scale, 1.0 / cached.filter_scale));
+        drop_canvas.translate((
+            cached.bounds.left * cached.filter_scale,
+            cached.bounds.top * cached.filter_scale,
+        ));
+    } else {
+        drop_canvas.translate((cached.bounds.left, cached.bounds.top));
+    }
+    drop_canvas.draw_image_rect_with_sampling_options(&cached.image, None, dst, sampling, &paint);
+    drop_canvas.restore();
+    drop_canvas.restore();
+}
+
+fn render_inline_frame_shadow(
+    state: &mut RenderState,
+    frame: &Shape,
+    shadow: &Shadow,
+    scale: f32,
+) -> Result<()> {
+    let antialias = frame_shadow_antialias(state, frame, scale);
+    let layer_paint = blur_layer_paint(shadow.blur, 1.0);
+    let draw_matrix = frame_shadow_draw_matrix(frame, shadow);
+
+    {
+        let drop_canvas = state.surfaces.canvas(SurfaceId::DropShadows);
+        drop_canvas.save();
+        drop_canvas.concat(&draw_matrix);
+        let layer_rec = skia::canvas::SaveLayerRec::default().paint(&layer_paint);
+        drop_canvas.save_layer(&layer_rec);
+    }
+
+    draw_frame_shadow_rect(
+        &mut state.surfaces,
+        SurfaceId::DropShadows,
+        frame,
+        shadow,
+        antialias,
+    );
+
+    {
+        let drop_canvas = state.surfaces.canvas(SurfaceId::DropShadows);
+        drop_canvas.restore();
+        drop_canvas.restore();
+    }
+
+    Ok(())
+}
+
+fn render_cached_filter_frame_shadow(
+    state: &mut RenderState,
+    frame: &Shape,
+    shape_bounds: &Rect,
+    shadow: &Shadow,
+    scale: f32,
+) -> Result<()> {
+    let draw_matrix = frame.centered_transform();
+    let key = DropShadowFilterCacheKey::for_shape(frame.id, shadow, scale, &draw_matrix, 0.0);
+    if let Some(cached) = state.drop_shadow_filter_cache.lookup(&key) {
+        blit_cached_drop_shadow_filter(&mut state.surfaces, cached, None);
+        return Ok(());
+    }
+
+    let world_offset = shadow_world_offset(frame, shadow);
+    let Some(bounds) = shadow_filter_bounds(shadow, shape_bounds, world_offset) else {
+        return Ok(());
+    };
+
+    let antialias = frame_shadow_antialias(state, frame, scale);
+    let (filter_w, filter_h) = state.surfaces.filter_size();
+    let blur_downscale = blur_downscale_for_frame_shadow(
+        shadow.blur,
+        bounds,
+        filter_w,
+        filter_h,
+        state.options.blur_downscale_threshold,
+    );
+    let layer_paint = blur_layer_paint(shadow.blur, blur_downscale);
+    let layer_rec = skia::canvas::SaveLayerRec::default().paint(&layer_paint);
+
+    let shadow_draw_matrix = frame_shadow_draw_matrix(frame, shadow);
+    let filter_result = filters::render_into_filter_surface(
+        state,
+        bounds,
+        blur_downscale,
+        |state, temp_surface| {
+            {
+                let canvas = state.surfaces.canvas(temp_surface);
+                canvas.save();
+                canvas.concat(&shadow_draw_matrix);
+                canvas.save_layer(&layer_rec);
+            }
+            draw_frame_shadow_rect(&mut state.surfaces, temp_surface, frame, shadow, antialias);
+            {
+                let canvas = state.surfaces.canvas(temp_surface);
+                canvas.restore();
+                canvas.restore();
+            }
+            Ok(())
+        },
+    )?;
+
+    if let Some((mut surface, filter_scale)) = filter_result {
+        let cached = CachedDropShadowFilter {
+            bounds,
+            filter_scale,
+            image: surface.image_snapshot(),
+        };
+        blit_cached_drop_shadow_filter(&mut state.surfaces, &cached, None);
+        state.drop_shadow_filter_cache.store(key, cached);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Inner / text shadows
+// ---------------------------------------------------------------------------
+
 pub fn render_fill_inner_shadows(
     render_state: &mut RenderState,
     shape: &Shape,

--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -503,8 +503,7 @@ impl Surfaces {
         let ui = gpu_state.create_surface_with_dimensions("ui".to_string(), width, height)?;
         let debug = gpu_state.create_surface_with_dimensions("debug".to_string(), width, height)?;
 
-        // 512, why not?
-        let tiles = TileTextureCache::new(tile_atlas.width(), 512);
+        let tiles = TileTextureCache::new(tile_atlas.width(), tile_atlas.height());
         let atlas = DocAtlas::try_new()?;
         Ok(Self {
             target,
@@ -536,12 +535,34 @@ impl Surfaces {
         })
     }
 
+    /// Pack `needed_slots` into the existing 4096 atlas by shrinking the
+    /// physical cell size. No-op when the layout already fits.
+    pub fn ensure_tile_atlas_layout(&mut self, needed_slots: usize) {
+        let atlas_px = self.tile_atlas.width().min(self.tile_atlas.height());
+        let slot = tiles::tile_atlas_slot_size(needed_slots, atlas_px);
+        if slot == self.tiles.slot_size() {
+            return;
+        }
+        self.tiles
+            .repack(self.tile_atlas.width(), self.tile_atlas.height(), slot);
+        self.tile_atlas.canvas().clear(skia::Color::TRANSPARENT);
+        self.tile_atlas_image = None;
+    }
+
     pub fn set_dpr(&mut self, dpr: f32) {
         self.dpr = dpr;
     }
 
     pub fn clear_tiles(&mut self) {
         self.tiles.clear();
+    }
+
+    fn tile_atlas_sampling(&self) -> skia::SamplingOptions {
+        if self.tiles.slot_size() < TILE_SIZE {
+            skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::None)
+        } else {
+            self.atlas_sampling_options
+        }
     }
 
     pub fn draw_tile_atlas_to_backbuffer(
@@ -558,6 +579,7 @@ impl Surfaces {
         let Some(atlas_image) = self.tile_atlas_image.as_ref() else {
             return;
         };
+        let sampling = self.tile_atlas_sampling();
         let canvas = self.backbuffer.canvas();
         canvas.clear(background);
         canvas.draw_atlas(
@@ -566,7 +588,7 @@ impl Surfaces {
             &self.tiles.textures,
             None,
             skia::BlendMode::SrcOver,
-            self.atlas_sampling_options,
+            sampling,
             None,
             None,
         );
@@ -643,6 +665,7 @@ impl Surfaces {
         let Some(atlas_image) = self.tile_atlas_image.as_ref() else {
             return;
         };
+        let sampling = self.tile_atlas_sampling();
 
         let canvas = self.backbuffer.canvas();
         canvas.save();
@@ -654,7 +677,7 @@ impl Surfaces {
             &batch.textures,
             None,
             skia::BlendMode::SrcOver,
-            self.atlas_sampling_options,
+            sampling,
             None,
             None,
         );
@@ -1515,21 +1538,24 @@ pub struct TileAtlasTextureProvider {
 }
 
 impl TileAtlasTextureProvider {
-    pub fn new(texture_size: i32, tile_size: i32) -> Self {
-        let side = texture_size / tile_size;
-        let length = side * side;
-        let mut rects = Vec::with_capacity(length as usize);
-        for i in 0..length {
-            let left = (i % side) as f32 * tile_size as f32;
-            let top = (i / side) as f32 * tile_size as f32;
-            let right = left + tile_size as f32;
-            let bottom = top + tile_size as f32;
-            rects.push(Rect::new(left, top, right, bottom));
+    pub fn new(texture_width: i32, texture_height: i32, tile_size: i32) -> Self {
+        let cols = texture_width / tile_size;
+        let rows = texture_height / tile_size;
+        let length = (cols * rows) as usize;
+        let mut rects = Vec::with_capacity(length);
+        for row in 0..rows {
+            for col in 0..cols {
+                let left = col as f32 * tile_size as f32;
+                let top = row as f32 * tile_size as f32;
+                let right = left + tile_size as f32;
+                let bottom = top + tile_size as f32;
+                rects.push(Rect::new(left, top, right, bottom));
+            }
         }
         Self {
             index: 0,
-            length: length as usize,
-            in_use: vec![false; length as usize],
+            length,
+            in_use: vec![false; length],
             rects,
         }
     }
@@ -1563,6 +1589,7 @@ impl TileAtlasTextureProvider {
 
 pub struct TileTextureCache {
     tile_size: f32,
+    slot_size: i32,
     is_updated: bool,
     provider: TileAtlasTextureProvider,
     transforms: Vec<skia::RSXform>,
@@ -1583,16 +1610,51 @@ impl AtlasDrawBatch {
 }
 
 impl TileTextureCache {
-    pub fn new(texture_size: i32, capacity: usize) -> Self {
+    pub fn new(texture_width: i32, texture_height: i32) -> Self {
+        let capacity = ((texture_width / TILE_SIZE) * (texture_height / TILE_SIZE)) as usize;
         Self {
             tile_size: tiles::TILE_SIZE,
+            slot_size: TILE_SIZE,
             is_updated: false,
-            provider: TileAtlasTextureProvider::new(texture_size, TILE_SIZE),
+            provider: TileAtlasTextureProvider::new(texture_width, texture_height, TILE_SIZE),
             transforms: Vec::with_capacity(capacity),
             textures: Vec::with_capacity(capacity),
             grid: HashMap::with_capacity(capacity),
             removed: HashSet::with_capacity(capacity),
         }
+    }
+
+    pub fn slot_size(&self) -> i32 {
+        self.slot_size
+    }
+
+    fn dest_scale(&self) -> f32 {
+        tiles::tile_atlas_compose_scale(self.slot_size)
+    }
+
+    fn compose_src_rect(&self, rect: Rect) -> Rect {
+        if self.slot_size < TILE_SIZE {
+            let inset = tiles::TILE_ATLAS_SAMPLE_INSET;
+            Rect::new(
+                rect.left + inset,
+                rect.top + inset,
+                rect.right - inset,
+                rect.bottom - inset,
+            )
+        } else {
+            rect
+        }
+    }
+
+    pub fn repack(&mut self, texture_width: i32, texture_height: i32, slot_size: i32) {
+        let capacity = ((texture_width / slot_size) * (texture_height / slot_size)) as usize;
+        self.slot_size = slot_size;
+        self.is_updated = true;
+        self.provider = TileAtlasTextureProvider::new(texture_width, texture_height, slot_size);
+        self.transforms = Vec::with_capacity(capacity);
+        self.textures = Vec::with_capacity(capacity);
+        self.grid = HashMap::with_capacity(capacity);
+        self.removed = HashSet::with_capacity(capacity);
     }
 
     fn gc(&mut self) {
@@ -1634,10 +1696,11 @@ impl TileTextureCache {
     }
 
     pub fn update(&mut self, viewbox: &Viewbox, tile_viewbox: &TileViewbox) {
+        let dest_scale = self.dest_scale();
         if self.transforms.len() != tile_viewbox.visible_rect.len() as usize {
             self.transforms.resize(
                 tile_viewbox.visible_rect.len() as usize,
-                skia::RSXform::new(1.0, 0.0, Point::default()),
+                skia::RSXform::new(dest_scale, 0.0, Point::default()),
             );
         }
 
@@ -1666,15 +1729,17 @@ impl TileTextureCache {
                     continue;
                 }
 
-                self.transforms[index].tx = x as f32 * self.tile_size - offset.x;
-                self.transforms[index].ty = y as f32 * self.tile_size - offset.y;
-
-                self.textures[index].set_ltrb(
-                    tile_ref.rect.left,
-                    tile_ref.rect.top,
-                    tile_ref.rect.right,
-                    tile_ref.rect.bottom,
+                self.transforms[index] = skia::RSXform::new(
+                    dest_scale,
+                    0.0,
+                    (
+                        (x as f32 * self.tile_size - offset.x).round(),
+                        (y as f32 * self.tile_size - offset.y).round(),
+                    ),
                 );
+
+                let src = self.compose_src_rect(tile_ref.rect);
+                self.textures[index].set_ltrb(src.left, src.top, src.right, src.bottom);
 
                 index += 1;
             }
@@ -1713,12 +1778,13 @@ impl TileTextureCache {
                     continue;
                 }
 
-                let scos = doc_rect.width() * s / self.tile_size;
-                let tx = (doc_rect.left + viewbox.pan.x) * s;
-                let ty = (doc_rect.top + viewbox.pan.y) * s;
+                let src = self.compose_src_rect(tile_ref.rect);
+                let scos = doc_rect.width() * s / src.width();
+                let tx = ((doc_rect.left + viewbox.pan.x) * s).round();
+                let ty = ((doc_rect.top + viewbox.pan.y) * s).round();
 
                 transforms.push(skia::RSXform::new(scos, 0.0, (tx, ty)));
-                textures.push(tile_ref.rect);
+                textures.push(src);
             }
         }
 
@@ -1737,12 +1803,13 @@ impl TileTextureCache {
                 continue;
             }
 
-            let tx = (doc_rect.left + viewbox.pan.x) * s;
-            let ty = (doc_rect.top + viewbox.pan.y) * s;
-            let scos = doc_rect.width() * s / self.tile_size;
+            let src = self.compose_src_rect(tile_ref.rect);
+            let tx = ((doc_rect.left + viewbox.pan.x) * s).round();
+            let ty = ((doc_rect.top + viewbox.pan.y) * s).round();
+            let scos = doc_rect.width() * s / src.width();
 
             transforms.push(skia::RSXform::new(scos, 0.0, (tx, ty)));
-            textures.push(tile_ref.rect);
+            textures.push(src);
         }
 
         AtlasDrawBatch {
@@ -1769,7 +1836,10 @@ impl TileTextureCache {
         let Some(tile_ref) = self.provider.allocate() else {
             panic!("Tile texture allocation failed {}:{}", tile.0, tile.1);
         };
+        self.insert(tile, tile_ref)
+    }
 
+    fn insert(&mut self, tile: &Tile, tile_ref: TileAtlasTextureRef) -> TileAtlasTextureRef {
         self.grid.insert(*tile, tile_ref.clone());
 
         if self.removed.contains(tile) {
@@ -1777,7 +1847,7 @@ impl TileTextureCache {
         }
 
         self.is_updated = true;
-        tile_ref.clone()
+        tile_ref
     }
 
     pub fn get(&mut self, tile: Tile) -> Option<&TileAtlasTextureRef> {

--- a/render-wasm/src/shapes.rs
+++ b/render-wasm/src/shapes.rs
@@ -1843,6 +1843,99 @@ impl Shape {
             .any(|s| s.render_kind(is_open) == StrokeKind::Inner)
     }
 
+    /// When true, the frame drop shadow can use the direct geometry path
+    /// (`render_direct_frame_drop_shadow`) instead of filter surfaces and
+    /// descendant silhouettes.
+    ///
+    /// Requires at least one fill; fill opacity/type does not matter because the fast
+    /// path shadows the frame geometry as a solid mask.
+    ///
+    /// The fast path draws fill geometry only. On the slow path, visible strokes also
+    /// contribute to the shadow silhouette, so frames with outer/center strokes can
+    /// look slightly narrower here. We keep them eligible anyway for performance.
+    pub fn uses_direct_container_drop_shadow(&self, tree: ShapesPoolRef, scale: f32) -> bool {
+        if !matches!(self.shape_type, Type::Frame(_)) {
+            return false;
+        }
+        if !self.has_fills() {
+            return false;
+        }
+        if self.blend_mode() != BlendMode::default() {
+            return false;
+        }
+        if self.blur.is_some() || self.background_blur.is_some() {
+            return false;
+        }
+        if self.has_frame_clip_layer_blur() {
+            return false;
+        }
+
+        if self.clip_content {
+            return !self.descendants_have_drop_shadows(tree);
+        }
+
+        self.descendants_contained_for_frame_shadow(tree, scale, self.selrect())
+    }
+
+    /// When true, the container's own fill shadow mask is enough and descendant
+    /// silhouettes can be skipped (same geometry assumption as the direct path).
+    pub fn container_fill_covers_shadow_descendants(
+        &self,
+        tree: ShapesPoolRef,
+        scale: f32,
+    ) -> bool {
+        self.has_fills() && self.descendants_contained_for_frame_shadow(tree, scale, self.selrect())
+    }
+
+    fn descendants_have_drop_shadows(&self, tree: ShapesPoolRef) -> bool {
+        for child_id in self.children_ids_iter(false) {
+            let Some(child) = tree.get(child_id) else {
+                continue;
+            };
+            if child.hidden {
+                continue;
+            }
+            if child.drop_shadows_visible().next().is_some() {
+                return true;
+            }
+            if child.is_recursive() && child.descendants_have_drop_shadows(tree) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn descendants_contained_for_frame_shadow(
+        &self,
+        tree: ShapesPoolRef,
+        scale: f32,
+        bounds: math::Rect,
+    ) -> bool {
+        if self.descendants_have_drop_shadows(tree) {
+            return false;
+        }
+
+        const MARGIN: f32 = 0.5;
+        for child_id in self.children_ids_iter(false) {
+            let Some(child) = tree.get(child_id) else {
+                continue;
+            };
+            if child.hidden {
+                continue;
+            }
+            let child_extrect = child.extrect(tree, scale);
+            if !rect_contains_with_margin(bounds, child_extrect, MARGIN) {
+                return false;
+            }
+            if child.is_recursive()
+                && !child.descendants_contained_for_frame_shadow(tree, scale, bounds)
+            {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn drop_shadow_paints(&self) -> Vec<skia_safe::Paint> {
         let drop_shadows: Vec<&Shadow> = self.drop_shadows_visible().collect();
 
@@ -1870,6 +1963,14 @@ impl Shape {
             })
             .collect()
     }
+}
+
+#[inline]
+fn rect_contains_with_margin(outer: math::Rect, inner: math::Rect, margin: f32) -> bool {
+    inner.left >= outer.left - margin
+        && inner.top >= outer.top - margin
+        && inner.right <= outer.right + margin
+        && inner.bottom <= outer.bottom + margin
 }
 
 #[cfg(test)]
@@ -2011,5 +2112,156 @@ mod tests {
         assert_eq!(extrect.top, 0.0);
         assert_eq!(extrect.right, 50.0);
         assert_eq!(extrect.bottom, 50.0);
+    }
+
+    fn frame_with_fill_and_child(fill: Fill, opacity: f32) -> (ShapesPool, Uuid) {
+        let mut pool = ShapesPool::new();
+        pool.initialize(2);
+
+        let frame_id = Uuid::new_v4();
+        let child_id = Uuid::new_v4();
+
+        {
+            let frame = pool.add_shape(frame_id);
+            frame.set_shape_type(Type::Frame(Frame::default()));
+            frame.set_selrect(0.0, 0.0, 200.0, 100.0);
+            frame.add_fill(fill);
+            frame.opacity = opacity;
+            frame.children = vec![child_id];
+        }
+
+        {
+            let child = pool.add_shape(child_id);
+            child.set_shape_type(Type::Rect(Rect::default()));
+            child.set_selrect(10.0, 10.0, 180.0, 80.0);
+            child.set_parent(frame_id);
+        }
+
+        (pool, frame_id)
+    }
+
+    #[test]
+    fn frame_with_any_fill_uses_direct_container_drop_shadow() {
+        for (fill, opacity) in [
+            (Fill::Solid(SolidColor(skia::Color::WHITE)), 1.0),
+            (
+                Fill::Solid(SolidColor(skia::Color::from_argb(128, 255, 255, 255))),
+                0.5,
+            ),
+        ] {
+            let (pool, frame_id) = frame_with_fill_and_child(fill, opacity);
+            let frame = pool.get(&frame_id).expect("frame");
+            assert!(frame.uses_direct_container_drop_shadow(&pool, 1.0));
+        }
+    }
+
+    #[test]
+    fn clipped_frame_with_child_drop_shadow_rejects_direct_path() {
+        let (mut pool, frame_id) =
+            frame_with_fill_and_child(Fill::Solid(SolidColor(skia::Color::WHITE)), 1.0);
+        let child_id = pool.get(&frame_id).expect("frame").children[0];
+
+        {
+            let child = pool.get_mut(&child_id).expect("child");
+            child.add_shadow(Shadow::new(
+                skia::Color::BLACK,
+                4.0,
+                0.0,
+                (0.0, 4.0),
+                ShadowStyle::Drop,
+                false,
+            ));
+        }
+
+        let frame = pool.get(&frame_id).expect("frame");
+        assert!(!frame.uses_direct_container_drop_shadow(&pool, 1.0));
+    }
+
+    #[test]
+    fn clipped_frame_ignores_outside_child_extrect_for_direct_path() {
+        let mut pool = ShapesPool::new();
+        pool.initialize(2);
+
+        let frame_id = Uuid::new_v4();
+        let child_id = Uuid::new_v4();
+
+        {
+            let frame = pool.add_shape(frame_id);
+            frame.set_shape_type(Type::Frame(Frame::default()));
+            frame.set_selrect(0.0, 0.0, 200.0, 100.0);
+            frame.add_fill(Fill::Solid(SolidColor(skia::Color::WHITE)));
+            frame.set_clip(true);
+            frame.children = vec![child_id];
+        }
+
+        {
+            let child = pool.add_shape(child_id);
+            child.set_shape_type(Type::Rect(Rect::default()));
+            child.set_selrect(-50.0, -50.0, 250.0, 150.0);
+            child.set_parent(frame_id);
+        }
+
+        let frame = pool.get(&frame_id).expect("frame");
+        assert!(frame.uses_direct_container_drop_shadow(&pool, 1.0));
+    }
+
+    #[test]
+    fn overflow_frame_with_outside_child_rejects_direct_path() {
+        let mut pool = ShapesPool::new();
+        pool.initialize(2);
+
+        let frame_id = Uuid::new_v4();
+        let child_id = Uuid::new_v4();
+
+        {
+            let frame = pool.add_shape(frame_id);
+            frame.set_shape_type(Type::Frame(Frame::default()));
+            frame.set_selrect(0.0, 0.0, 200.0, 100.0);
+            frame.add_fill(Fill::Solid(SolidColor(skia::Color::WHITE)));
+            frame.set_clip(false);
+            frame.children = vec![child_id];
+        }
+
+        {
+            let child = pool.add_shape(child_id);
+            child.set_shape_type(Type::Rect(Rect::default()));
+            child.set_selrect(-50.0, -50.0, 250.0, 150.0);
+            child.set_parent(frame_id);
+        }
+
+        let frame = pool.get(&frame_id).expect("frame");
+        assert!(!frame.uses_direct_container_drop_shadow(&pool, 1.0));
+        assert!(!frame.container_fill_covers_shadow_descendants(&pool, 1.0));
+    }
+
+    #[test]
+    fn frame_with_contained_child_covers_shadow_descendants() {
+        let (pool, frame_id) =
+            frame_with_fill_and_child(Fill::Solid(SolidColor(skia::Color::WHITE)), 1.0);
+        let frame = pool.get(&frame_id).expect("frame");
+        assert!(frame.container_fill_covers_shadow_descendants(&pool, 1.0));
+    }
+
+    #[test]
+    fn rotated_frame_with_contained_child_uses_direct_container_drop_shadow() {
+        let (mut pool, frame_id) =
+            frame_with_fill_and_child(Fill::Solid(SolidColor(skia::Color::WHITE)), 1.0);
+
+        {
+            let frame = pool.get_mut(&frame_id).expect("frame");
+            // 45° rotation around the shape center (100, 50).
+            let angle = std::f32::consts::FRAC_PI_4;
+            frame.set_transform(
+                angle.cos(),
+                angle.sin(),
+                -angle.sin(),
+                angle.cos(),
+                0.0,
+                0.0,
+            );
+        }
+
+        let frame = pool.get(&frame_id).expect("frame");
+        assert!(frame.uses_direct_container_drop_shadow(&pool, 1.0));
     }
 }

--- a/render-wasm/src/tiles.rs
+++ b/render-wasm/src/tiles.rs
@@ -258,6 +258,35 @@ pub fn get_tile_rect(tile: Tile, scale: f32) -> skia::Rect {
     skia::Rect::from_xywh(tx, ty, ts, ts)
 }
 
+/// Physical atlas cell size so `needed_slots` fit in a square `atlas_px`
+/// texture. Never larger than `TILE_SIZE` (tiles are stored 1:1 when they
+/// fit). Smaller cells mean more slots, scaled down on blit into the atlas.
+pub fn tile_atlas_slot_size(needed_slots: usize, atlas_px: i32) -> i32 {
+    const MIN_SLOT: i32 = 64;
+    let needed = needed_slots.max(1);
+    let side = (needed as f64).sqrt().ceil() as i32;
+    let side = side.max(1);
+    (atlas_px / side).clamp(MIN_SLOT, TILE_SIZE as i32)
+}
+
+/// Inset (texels) applied when sampling a packed atlas slot with Linear
+/// filtering, so upsample kernels do not bleed into the neighboring cell.
+pub const TILE_ATLAS_SAMPLE_INSET: f32 = 1.0;
+
+/// Source size inside a packed slot after the Linear-filter inset.
+pub fn tile_atlas_compose_src_size(slot_size: i32) -> f32 {
+    if slot_size < TILE_SIZE as i32 {
+        (slot_size as f32 - 2.0 * TILE_ATLAS_SAMPLE_INSET).max(1.0)
+    } else {
+        slot_size as f32
+    }
+}
+
+/// `draw_atlas` scale so the destination sprite stays `TILE_SIZE` after inset.
+pub fn tile_atlas_compose_scale(slot_size: i32) -> f32 {
+    TILE_SIZE / tile_atlas_compose_src_size(slot_size)
+}
+
 // This structure is useful to keep all the shape uuids by shape id.
 pub struct TileHashMap {
     grid: HashMap<Tile, HashSet<Uuid>>,
@@ -402,5 +431,38 @@ impl PendingTiles {
 
     pub fn pop(&mut self) -> Option<Tile> {
         self.list.pop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atlas_slot_is_full_size_when_tiles_fit() {
+        assert_eq!(tile_atlas_slot_size(64, 4096), 512);
+        assert_eq!(tile_atlas_slot_size(1, 4096), 512);
+    }
+
+    #[test]
+    fn atlas_slot_shrinks_to_pack_interest_tiles() {
+        // 150 slots → 13×13 grid, 4096/13 = 315.
+        assert_eq!(tile_atlas_slot_size(150, 4096), 315);
+        let side = 4096 / 315;
+        assert!(side * side >= 150);
+    }
+
+    #[test]
+    fn atlas_compose_scale_is_one_at_full_slot() {
+        assert_eq!(tile_atlas_compose_scale(512), 1.0);
+    }
+
+    #[test]
+    fn atlas_compose_scale_keeps_dest_tile_size_when_packed() {
+        let slot = 315;
+        let scale = tile_atlas_compose_scale(slot);
+        let src = tile_atlas_compose_src_size(slot);
+        assert!((scale * src - TILE_SIZE).abs() < 1e-4);
+        assert!(src < slot as f32);
     }
 }

--- a/render-wasm/src/view.rs
+++ b/render-wasm/src/view.rs
@@ -94,3 +94,59 @@ impl Viewbox {
         matrix
     }
 }
+
+/// Scale `dpr` down so `floor(css * dpr)` fits in `max_dim` on both axes.
+/// Used when a large viewport combined with a high DPR would exceed the GPU
+/// (or our surface cap) on either axis.
+pub fn clamp_dpr_for_surface(css_w: f32, css_h: f32, dpr: f32, max_dim: i32) -> f32 {
+    let css_w = css_w.max(1.0);
+    let css_h = css_h.max(1.0);
+    let dpr = dpr.max(0.0);
+    let max_dim = max_dim.max(1) as f32;
+    let raw_w = (css_w * dpr).floor().max(1.0);
+    let raw_h = (css_h * dpr).floor().max(1.0);
+    let scale = (max_dim / raw_w).min(max_dim / raw_h).min(1.0);
+    dpr * scale
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_dpr_for_surface;
+
+    #[test]
+    fn clamp_dpr_keeps_hidpi_viewport_under_cap() {
+        let dpr = clamp_dpr_for_surface(2560.0, 1440.0, 2.0, 8192);
+        assert!((dpr - 2.0).abs() < 1e-5);
+        assert!((2560.0 * dpr).floor() <= 8192.0);
+    }
+
+    #[test]
+    fn clamp_dpr_caps_very_large_viewport_at_dpr2() {
+        // 10240×5760 CSS at DPR 2 → 20480 px unclamped on the long edge.
+        let dpr = clamp_dpr_for_surface(10240.0, 5760.0, 2.0, 8192);
+        assert!((10240.0 * dpr).floor() <= 8192.0);
+        assert!((5760.0 * dpr).floor() <= 8192.0);
+        assert!(dpr < 2.0);
+    }
+
+    #[test]
+    fn clamp_dpr_caps_large_viewport_at_dpr2() {
+        let dpr = clamp_dpr_for_surface(5120.0, 2880.0, 2.0, 8192);
+        assert!((5120.0 * dpr).floor() <= 8192.0);
+        assert!(dpr < 2.0);
+        assert!(dpr > 1.0);
+    }
+
+    #[test]
+    fn clamp_dpr_physical_size_is_floor_of_css_times_dpr() {
+        let css_w = 5120.0;
+        let css_h = 2880.0;
+        let dpr = clamp_dpr_for_surface(css_w, css_h, 2.0, 8192);
+        let phys_w = (css_w * dpr).floor();
+        let phys_h = (css_h * dpr).floor();
+        assert!(phys_w <= 8192.0);
+        assert!(phys_h <= 8192.0);
+        assert!((css_w * dpr - phys_w).abs() < 1.0);
+        assert!((css_h * dpr - phys_h).abs() < 1.0);
+    }
+}


### PR DESCRIPTION
## What

- Large clipped frames with drop shadows were expensive to pan/zoom because each shadow went through filter surfaces, per-child silhouettes, and a full-surface blur saveLayer.
- Eligible frames now render the drop shadow from container geometry only, with a tightly bounded blur layer.

## Why

- Frame drop shadows at high zoom were dominated by Gaussian blur over the whole DropShadows surface plus descendant silhouette work that does not change the visible result when children stay inside a filled, axis-aligned frame.
- Clipped frames already hide overflow, so walking every descendant extrect on each tile was extra CPU for the common case.

## How

- **Fast path:** filled, axis-aligned frames without layer/background blur use `render_frame_container_drop_shadow` (rrect + blur saveLayer on DropShadows) instead of filter surfaces and child silhouettes.
- **Blur bounds:** the blur saveLayer uses `compute_fast_bounds` so Skia does not allocate the offscreen layer to the full surface clip.
- **Clipped frames:** skip the descendant extrect walk; still reject the fast path when a descendant has its own drop shadow.
- **Overflow frames:** still require descendants to be contained in the frame selrect.
- **Strokes:** the fast path shadows fill geometry only, so outer/center strokes can look slightly narrower than the slow path; those frames stay eligible for performance.
