### PR TITLE
:bug: Validate plugin UI URLs cannot target Penpot's own domain

### DIFF
--- a/plugins/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
+++ b/plugins/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
@@ -3,6 +3,7 @@ import { createPluginManager } from './plugin-manager';
 import { loadManifestCode, getValidUrl, prepareUrl } from './parse-manifest.js';
 import { PluginModalElement } from './modal/plugin-modal.js';
 import { openUIApi } from './api/openUI.api.js';
+import { validateUIUrl } from './validate-url.js';
 import type { Context, Theme } from '@penpot/plugin-types';
 import type { Manifest } from './models/manifest.model.js';
 
@@ -14,6 +15,10 @@ vi.mock('./parse-manifest.js', () => ({
 
 vi.mock('./api/openUI.api.js', () => ({
   openUIApi: vi.fn(),
+}));
+
+vi.mock('./validate-url.js', () => ({
+  validateUIUrl: vi.fn(),
 }));
 
 describe('createPluginManager', () => {
@@ -293,5 +298,39 @@ describe('createPluginManager', () => {
 
     expect(mockContext.removeListener).toHaveBeenCalled();
     expect(onCloseCallback).toHaveBeenCalled();
+  });
+
+  it('should validate the modal URL before opening', async () => {
+    const pluginManager = await createPluginManager(
+      mockContext,
+      manifest,
+      onCloseCallback,
+      onReloadModal,
+    );
+
+    pluginManager.openModal('Test Modal', '/test-url');
+
+    expect(validateUIUrl).toHaveBeenCalledWith(
+      'https://example.com/plugin',
+    );
+  });
+
+  it('should throw when URL validation fails', async () => {
+    vi.mocked(validateUIUrl).mockImplementation(() => {
+      throw new Error("Plugin UI URL must not point to Penpot's own domain");
+    });
+
+    const pluginManager = await createPluginManager(
+      mockContext,
+      manifest,
+      onCloseCallback,
+      onReloadModal,
+    );
+
+    expect(() => pluginManager.openModal('Test Modal', '/test-url')).toThrow(
+      "Plugin UI URL must not point to Penpot's own domain",
+    );
+
+    expect(openUIApi).not.toHaveBeenCalled();
   });
 });

--- a/plugins/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
+++ b/plugins/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
@@ -310,9 +310,7 @@ describe('createPluginManager', () => {
 
     pluginManager.openModal('Test Modal', '/test-url');
 
-    expect(validateUIUrl).toHaveBeenCalledWith(
-      'https://example.com/plugin',
-    );
+    expect(validateUIUrl).toHaveBeenCalledWith('https://example.com/plugin');
   });
 
   it('should throw when URL validation fails', async () => {

--- a/plugins/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
+++ b/plugins/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
@@ -310,7 +310,10 @@ describe('createPluginManager', () => {
 
     pluginManager.openModal('Test Modal', '/test-url');
 
-    expect(validateUIUrl).toHaveBeenCalledWith('https://example.com/plugin');
+    expect(validateUIUrl).toHaveBeenCalledWith(
+      'https://example.com/plugin',
+      manifest.host,
+    );
   });
 
   it('should throw when URL validation fails', async () => {

--- a/plugins/libs/plugins-runtime/src/lib/plugin-manager.ts
+++ b/plugins/libs/plugins-runtime/src/lib/plugin-manager.ts
@@ -7,6 +7,7 @@ import { openUIApi } from './api/openUI.api.js';
 import { OpenUIOptions } from './models/open-ui-options.model.js';
 import { RegisterListener } from './models/plugin.model.js';
 import { openUISchema } from './models/open-ui-options.schema.js';
+import { validateUIUrl } from './validate-url.js';
 
 export async function createPluginManager(
   context: Context,
@@ -94,6 +95,7 @@ export async function createPluginManager(
   const openModal = (name: string, url: string, options?: OpenUIOptions) => {
     const theme = context.theme as Theme;
     const modalUrl = prepareUrl(manifest, url, { theme });
+    validateUIUrl(modalUrl);
 
     if (modal?.getAttribute('iframe-src') === modalUrl) {
       return;

--- a/plugins/libs/plugins-runtime/src/lib/plugin-manager.ts
+++ b/plugins/libs/plugins-runtime/src/lib/plugin-manager.ts
@@ -95,7 +95,7 @@ export async function createPluginManager(
   const openModal = (name: string, url: string, options?: OpenUIOptions) => {
     const theme = context.theme as Theme;
     const modalUrl = prepareUrl(manifest, url, { theme });
-    validateUIUrl(modalUrl);
+    validateUIUrl(modalUrl, manifest.host);
 
     if (modal?.getAttribute('iframe-src') === modalUrl) {
       return;

--- a/plugins/libs/plugins-runtime/src/lib/validate-url.spec.ts
+++ b/plugins/libs/plugins-runtime/src/lib/validate-url.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getPenpotOrigin, validateUIUrl } from './validate-url.js';
+
+describe('validate-url', () => {
+  const originalLocation = globalThis.location;
+  const originalPenpotPublicURI = (globalThis as any).penpotPublicURI;
+
+  beforeEach(() => {
+    delete (globalThis as any).penpotPublicURI;
+  });
+
+  afterEach(() => {
+    if (originalPenpotPublicURI !== undefined) {
+      (globalThis as any).penpotPublicURI = originalPenpotPublicURI;
+    } else {
+      delete (globalThis as any).penpotPublicURI;
+    }
+  });
+
+  describe('getPenpotOrigin', () => {
+    it('should return location.origin when penpotPublicURI is not set', () => {
+      expect(getPenpotOrigin()).toBe(originalLocation.origin);
+    });
+
+    it('should return origin from penpotPublicURI when set', () => {
+      (globalThis as any).penpotPublicURI = 'https://design.penpot.com/';
+      expect(getPenpotOrigin()).toBe('https://design.penpot.com');
+    });
+
+    it('should fall back to location.origin when penpotPublicURI is invalid', () => {
+      (globalThis as any).penpotPublicURI = 'not-a-valid-url';
+      expect(getPenpotOrigin()).toBe(originalLocation.origin);
+    });
+  });
+
+  describe('validateUIUrl', () => {
+    it('should throw when URL has same origin as location.origin', () => {
+      const penpotOrigin = originalLocation.origin;
+      expect(() => validateUIUrl(`${penpotOrigin}/some/path`)).toThrow(
+        "Plugin UI URL must not point to Penpot's own domain",
+      );
+    });
+
+    it('should not throw when URL has different origin', () => {
+      expect(() =>
+        validateUIUrl('https://example.com/plugin-ui'),
+      ).not.toThrow();
+    });
+
+    it('should throw when URL matches penpotPublicURI origin', () => {
+      (globalThis as any).penpotPublicURI = 'https://design.penpot.com/';
+      expect(() =>
+        validateUIUrl('https://design.penpot.com/some/path'),
+      ).toThrow("Plugin UI URL must not point to Penpot's own domain");
+    });
+
+    it('should not throw when URL has same hostname but different port', () => {
+      const url = new URL(originalLocation.origin);
+      const differentPort = `${url.protocol}//${url.hostname}:9999`;
+      expect(() => validateUIUrl(`${differentPort}/path`)).not.toThrow();
+    });
+
+    it('should throw even when URL has different path on same origin', () => {
+      const penpotOrigin = originalLocation.origin;
+      expect(() =>
+        validateUIUrl(`${penpotOrigin}/deeply/nested/path`),
+      ).toThrow();
+    });
+  });
+});

--- a/plugins/libs/plugins-runtime/src/lib/validate-url.spec.ts
+++ b/plugins/libs/plugins-runtime/src/lib/validate-url.spec.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { getPenpotOrigin, validateUIUrl } from './validate-url.js';
+import {
+  getPenpotOrigin,
+  isPenpotOrigin,
+  validateUIUrl,
+} from './validate-url.js';
 
 describe('validate-url', () => {
   const originalLocation = globalThis.location;
   const originalPenpotPublicURI = (globalThis as any).penpotPublicURI;
+  const externalHost = 'https://example.com';
 
   beforeEach(() => {
     delete (globalThis as any).penpotPublicURI;
@@ -33,38 +38,80 @@ describe('validate-url', () => {
     });
   });
 
+  describe('isPenpotOrigin', () => {
+    it('should be true for a URL on Penpot origin', () => {
+      expect(
+        isPenpotOrigin(`${originalLocation.origin}/plugin/manifest.json`),
+      ).toBe(true);
+    });
+
+    it('should be false for a URL on another origin', () => {
+      expect(isPenpotOrigin(`${externalHost}/manifest.json`)).toBe(false);
+    });
+
+    it('should be false for an unparseable URL', () => {
+      expect(isPenpotOrigin('not-a-valid-url')).toBe(false);
+    });
+  });
+
   describe('validateUIUrl', () => {
     it('should throw when URL has same origin as location.origin', () => {
       const penpotOrigin = originalLocation.origin;
-      expect(() => validateUIUrl(`${penpotOrigin}/some/path`)).toThrow(
-        "Plugin UI URL must not point to Penpot's own domain",
-      );
+      expect(() =>
+        validateUIUrl(`${penpotOrigin}/some/path`, externalHost),
+      ).toThrow("Plugin UI URL must not point to Penpot's own domain");
     });
 
     it('should not throw when URL has different origin', () => {
       expect(() =>
-        validateUIUrl('https://example.com/plugin-ui'),
+        validateUIUrl('https://example.com/plugin-ui', externalHost),
       ).not.toThrow();
     });
 
     it('should throw when URL matches penpotPublicURI origin', () => {
       (globalThis as any).penpotPublicURI = 'https://design.penpot.com/';
       expect(() =>
-        validateUIUrl('https://design.penpot.com/some/path'),
+        validateUIUrl('https://design.penpot.com/some/path', externalHost),
       ).toThrow("Plugin UI URL must not point to Penpot's own domain");
     });
 
     it('should not throw when URL has same hostname but different port', () => {
       const url = new URL(originalLocation.origin);
       const differentPort = `${url.protocol}//${url.hostname}:9999`;
-      expect(() => validateUIUrl(`${differentPort}/path`)).not.toThrow();
+      expect(() =>
+        validateUIUrl(`${differentPort}/path`, externalHost),
+      ).not.toThrow();
     });
 
     it('should throw even when URL has different path on same origin', () => {
       const penpotOrigin = originalLocation.origin;
       expect(() =>
-        validateUIUrl(`${penpotOrigin}/deeply/nested/path`),
+        validateUIUrl(`${penpotOrigin}/deeply/nested/path`, externalHost),
       ).toThrow();
+    });
+
+    it('should not throw when the manifest is served from Penpot origin', () => {
+      const penpotOrigin = originalLocation.origin;
+      expect(() =>
+        validateUIUrl(`${penpotOrigin}/some/path`, `${penpotOrigin}/plugin`),
+      ).not.toThrow();
+    });
+
+    it('should not throw when the manifest is served from penpotPublicURI origin', () => {
+      (globalThis as any).penpotPublicURI = 'https://design.penpot.com/';
+      expect(() =>
+        validateUIUrl(
+          'https://design.penpot.com/some/path',
+          'https://design.penpot.com/plugin',
+        ),
+      ).not.toThrow();
+    });
+
+    it('should still throw when the manifest host is unparseable', () => {
+      const penpotOrigin = originalLocation.origin;
+      expect(() => validateUIUrl(`${penpotOrigin}/path`, '')).toThrow(
+        "Plugin UI URL must not point to Penpot's own domain",
+      );
     });
   });
 });

--- a/plugins/libs/plugins-runtime/src/lib/validate-url.ts
+++ b/plugins/libs/plugins-runtime/src/lib/validate-url.ts
@@ -1,0 +1,22 @@
+export function getPenpotOrigin(): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const publicUri = (globalThis as any).penpotPublicURI;
+  if (publicUri) {
+    try {
+      return new URL(publicUri).origin;
+    } catch {
+      // fall through to location.origin
+    }
+  }
+  return globalThis.location.origin;
+}
+
+export function validateUIUrl(url: string): void {
+  const penpotOrigin = getPenpotOrigin();
+  const parsed = new URL(url);
+  if (parsed.origin === penpotOrigin) {
+    throw new Error(
+      `Plugin UI URL must not point to Penpot's own domain: ${url}`,
+    );
+  }
+}

--- a/plugins/libs/plugins-runtime/src/lib/validate-url.ts
+++ b/plugins/libs/plugins-runtime/src/lib/validate-url.ts
@@ -11,10 +11,32 @@ export function getPenpotOrigin(): string {
   return globalThis.location.origin;
 }
 
-export function validateUIUrl(url: string): void {
-  const penpotOrigin = getPenpotOrigin();
+/**
+ * Whether the given URL is served from Penpot's own origin. Unparseable URLs
+ * are considered external.
+ */
+export function isPenpotOrigin(url: string): boolean {
+  try {
+    return new URL(url).origin === getPenpotOrigin();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Rejects UI URLs that resolve to Penpot's own origin, which would let the
+ * plugin iframe escape its sandbox isolation.
+ *
+ * Plugins whose manifest is itself served from Penpot's origin are part of the
+ * instance and are exempt from the check.
+ */
+export function validateUIUrl(url: string, manifestHost: string): void {
+  if (isPenpotOrigin(manifestHost)) {
+    return;
+  }
+
   const parsed = new URL(url);
-  if (parsed.origin === penpotOrigin) {
+  if (parsed.origin === getPenpotOrigin()) {
     throw new Error(
       `Plugin UI URL must not point to Penpot's own domain: ${url}`,
     );


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Plugin UI iframes could target Penpot's own domain, creating a sandbox escape risk. The iframe combines `allow-scripts` + `allow-same-origin` (necessary for plugins to use their own cookies/storage), but without URL validation, a malicious plugin could point its UI to Penpot's origin and potentially escape sandbox isolation.

## Why

The plugin runtime resolves UI URLs against the plugin's manifest host, but didn't validate that the resolved URL couldn't target Penpot's own origin. While no autonomous exploitation chain exists, this configuration violates defense-in-depth principles.

## How

- Added `validateUIUrl()` function that checks resolved URLs against Penpot's origin (from `penpotPublicURI` or `location.origin`)
- Called in `openModal()` after `prepareUrl()` resolves the URL
- Throws an error if the URL targets Penpot's domain, preventing the modal from opening

Closes #11271
