### PR TITLE
:bug: Fix HTML escaping in notification pill detail section

### DIFF
--- a/frontend/src/app/main/data/workspace/tokens/errors.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/errors.cljs
@@ -6,6 +6,7 @@
 
 (ns app.main.data.workspace.tokens.errors
   (:require
+   [app.util.dom :as dom]
    [app.util.i18n :refer [tr]]
    [cuerdas.core :as str]))
 
@@ -25,12 +26,12 @@
    :error.import/invalid-token-name
    {:error/code :error.import/invalid-token-name
     :error/fn #(tr "errors.tokens.invalid-json-token-name")
-    :error/detail #(tr "errors.tokens.invalid-json-token-name-detail" %)}
+    :error/detail #(tr "errors.tokens.invalid-json-token-name-detail" (dom/escape-html %))}
 
    :error.import/style-dictionary-reference-errors
    {:error/code :error.import/style-dictionary-reference-errors
     :error/fn #(str (tr "errors.tokens.import-error") "\n\n" (first %))
-    :error/detail #(str/join "\n\n" (rest %))}
+    :error/detail #(str/join "\n\n" (map dom/escape-html (rest %)))}
 
    :error.import/style-dictionary-unknown-error
    {:error/code :error.import/style-dictionary-reference-errors

--- a/frontend/src/app/main/data/workspace/tokens/import_export.cljs
+++ b/frontend/src/app/main/data/workspace/tokens/import_export.cljs
@@ -16,6 +16,7 @@
    [app.main.data.tokenscript :as ts]
    [app.main.data.workspace.tokens.errors :as wte]
    [app.main.store :as st]
+   [app.util.dom :as dom]
    [app.util.i18n :as i18n]
    [beicon.v2.core :as rx]
    [cuerdas.core :as str]))
@@ -54,14 +55,15 @@
     (l/wrn :hint "unsupported token types found during import"
            :tokens (str/join ", " (map (fn [[path type]] (str path " (" type ")")) unknown-tokens)))
     (ntf/show {:content (i18n/tr "workspace.tokens.unknown-token-type-message")
+               :is-html true
                :detail (->> (for [[token-type token-paths] type->tokens]
                               (str (i18n/tr "workspace.tokens.unknown-token-type-section"
-                                            token-type
+                                            (dom/escape-html token-type)
                                             (i18n/tr "labels.warning-count" (i18n/c (count token-paths))))
                                    "<ul>"
                                    (->> token-paths
                                         (sort)
-                                        (map #(str "<li>" % "</li>"))
+                                        (map #(str "<li>" (dom/escape-html %) "</li>"))
                                         (str/join ""))
                                    "</ul>"))
                             (str/join ""))

--- a/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.cljs
+++ b/frontend/src/app/main/ui/ds/notifications/shared/notification_pill.cljs
@@ -59,5 +59,7 @@
      (when detail
        [:details {:class (stl/css :error-detail)}
         [:summary {:class (stl/css :error-detail-summary)} (tr "workspace.notification-pill.detail")]
-        [:div {:class (stl/css :error-detail-content)
-               :dangerouslySetInnerHTML #js {:__html detail}}]])]))
+        (if is-html
+          [:div {:class (stl/css :error-detail-content)
+                 :dangerouslySetInnerHTML #js {:__html detail}}]
+          [:div {:class (stl/css :error-detail-content)} detail])])]))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Notification pill detail section now respects the `is-html` flag (previously always rendered as raw HTML)
- Token import error messages escape HTML characters in user-provided values (token names, type names) before display

## Why

The notification pill's `detail` branch unconditionally used `dangerouslySetInnerHTML`, ignoring the component's `is-html` prop. Token import warnings interpolated raw token paths and `$type` values into HTML without escaping.

## How

- **notification_pill.cljs**: detail branch now checks `is-html` before choosing between `dangerouslySetInnerHTML` and plain text rendering
- **import_export.cljs**: `show-unknown-types-warning` escapes token paths and type names with `dom/escape-html`, adds `:is-html true` since it legitimately uses HTML structure
- **errors.cljs**: `:error/detail` functions for invalid-token-name and style-dictionary-reference-errors escape values with `dom/escape-html`



Closes #11276

