### PR TITLE
:zap: Disable ReduceOpsTaskSplitting Skia flag

### DIFF
--- a/render-wasm/src/render/gpu_state.rs
+++ b/render-wasm/src/render/gpu_state.rs
@@ -22,7 +22,7 @@ impl GpuState {
 
         // We tweak some options to enhance performance.
         let mut context_options = ContextOptions::default();
-        // context_options.reduce_ops_task_splitting = Enable::Yes;
+        context_options.reduce_ops_task_splitting = Enable::No;
         context_options.skip_gl_error_checks = Enable::Yes;
         // context_options.runtime_program_cache_size = 1024;
         // context_options.allow_multiple_glyph_cache_textures = Enable::Yes;


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/11240

### Summary

Skia reorders GPU tasks at every flush to merge render passes. Since each shape draws through several surfaces (fills, strokes, shadows) before compositing into the **current** surface, and that we have multiple surface switches that trigger a new render task, this increases significantly with the number of shapes.

FYI: Flutter disabled it while ago https://github.com/flutter-team-archive/engine/pull/26067