### PR TITLE
:bug: Fix missing zip export on tempfile types

### DIFF
--- a/common/src/app/common/media.cljc
+++ b/common/src/app/common/media.cljc
@@ -23,7 +23,7 @@
     "image/svg+xml"})
 
 (def tempfile-types
-  (conj image-types "application/pdf"))
+  (conj image-types "application/pdf" "application/zip"))
 
 (defn format->extension
   [format]


### PR DESCRIPTION
### Related Ticket

### Summary

Can't export files in zip format. Seems to have been introduced [here](https://github.com/penpot/penpot/pull/11026/changes#diff-cb93ac61841dac850c925d0660974dd727fcc7e427669195e0cb0e36df31a1e8R25-R27) 

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
