### PR TITLE
:bug: Fix not quitting v3 editor with Esc + Undo transactions

### DIFF
--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -13,6 +13,7 @@
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.texts :as dwt]
+   [app.main.data.workspace.undo :as dwu]
    [app.main.refs :as refs]
    [app.main.store :as st]
    [app.main.ui.css-cursors :as cur]
@@ -542,6 +543,9 @@
     (mf/use-effect
      (mf/deps contenteditable-ref)
      (fn []
+       ;; Group the whole editing session (edits, reflow resizes, finalize) into a single
+       ;; undo entry. Nested transactions (e.g. style shortcuts) are ref-counted and fold in.
+       (st/emit! (dwu/start-undo-transaction shape-id :timeout nil))
        (when-let [node (mf/ref-val contenteditable-ref)]
          ;; Focus and select all text on mount (this will trigger on-focus)
          (.focus node)
@@ -552,6 +556,7 @@
        ;; it was not being reliable (timing issues, Firefox issues…)
        (fn []
          (on-blur)
+         (st/emit! (dwu/commit-undo-transaction shape-id))
          (text-editor/text-editor-dispose)
          (wasm.api/request-render-preserving-target "text-editor-dispose"))))
 

--- a/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
+++ b/frontend/src/app/main/ui/workspace/shapes/text/v3_editor.cljs
@@ -11,6 +11,7 @@
    [app.common.data.macros :as dm]
    [app.common.types.text :as txt]
    [app.main.data.helpers :as dsh]
+   [app.main.data.workspace :as dw]
    [app.main.data.workspace.texts :as dwt]
    [app.main.refs :as refs]
    [app.main.store :as st]
@@ -18,6 +19,7 @@
    [app.render-wasm.api :as wasm.api]
    [app.render-wasm.text-editor :as text-editor]
    [app.util.dom :as dom]
+   [app.util.keyboard :as kbd]
    [cuerdas.core :as str]
    [rumext.v2 :as mf]))
 
@@ -294,12 +296,7 @@
                          (and ctrl? (= (str/lower key) "a")))
                  (text-editor/clear-pending-caret-styles!))
                (cond
-                 ;; Escape: finalize and stop
-                 (= key "Escape")
-                 (do
-                   (dom/prevent-default event)
-                   (when-let [node (mf/ref-val contenteditable-ref)]
-                     (.blur node)))
+                 ;; NOTE: Escape is handled in a document key-up listener (see effect below).
 
                  ;; Ctrl+A: select all (key is "a" or "A" depending on platform)
                  (and ctrl? (= (str/lower key) "a"))
@@ -515,6 +512,18 @@
                    "--editor-container-width" (dm/str width "px")
                    "--editor-container-height" (dm/str height "px")
                    "--fallback-families" (if (seq fallback-families) (dm/str (str/join ", " fallback-families)) "sourcesanspro")}]
+
+    ;; Exit on Escape via a document key-up listener (like v2). On key-down the trailing
+    ;; key-up is read as a non-editing Escape and deselects the shape.
+    (mf/use-effect
+     (mf/deps)
+     (fn []
+       (let [on-key-up (fn [event]
+                         (when (kbd/esc? event)
+                           (dom/stop-propagation event)
+                           (st/emit! (dw/clear-edition-mode))))]
+         (.addEventListener js/document "keyup" on-key-up)
+         #(.removeEventListener js/document "keyup" on-key-up))))
 
     ;; Register the native `beforeinput` listener. React's synthetic
     ;; `onBeforeInput` does not expose `getTargetRanges()`, even with


### PR DESCRIPTION
- :bug: Fix Esc key not quitting editor v3
- :bug: Fix undo transactions being split in editor v3

### Related Ticket

Fixes #11258 

### Summary

This fixes v3 editor not quitting after hitting Esc. It also groups all editor activity under the same undo transaction, so doing Ctrl+Z after quitting undoes all edits done (including typing, style changes, layout recalculations, etc.

### Steps to reproduce 

1. Select a text shape
2. Type some new characters
3. Select a word and change its style
4. Hit `Esc` key
5. Hit `Ctrl+Z`

Expected behavior:

- Text editor exits
- Text shape remains selected
- The edits done in this session are undone

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] ~~Add or modify existing integration tests in case of bugs or new features, if applicable.~~
- [x] ~~Refactor any modified SCSS files following the refactor guide.~~
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
