### PR TITLE
:bug: Fix disabled invitation explanatory title

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -39,6 +39,7 @@
    [app.main.ui.ds.foundations.typography.heading :refer [heading*]]
    [app.main.ui.ds.foundations.typography.text :refer [text*]]
    [app.main.ui.ds.notifications.context-notification :refer [context-notification*]]
+   [app.main.ui.ds.tooltip.tooltip :refer [tooltip*]]
    [app.main.ui.forms :as fc]
    [app.main.ui.icons :as deprecated-icon]
    [app.main.ui.notifications.badge :refer [badge-notification]]
@@ -139,11 +140,26 @@
         [:a {:on-click on-nav-settings} (tr "labels.settings")]]]]
      [:div {:class (stl/css :dashboard-buttons)}
       (when (and (or invitations-section? members-section?) (not-empty invitations))
-        [:> button* {:variant "secondary"
-                     :on-click on-invite-member
-                     :disabled (not can-invite?)
-                     :data-testid "invite-member"}
-         (tr "dashboard.invite-profile")])]]))
+        (let [organization          (:organization team)
+              owners-only-invites?  (and (contains? cfg/flags :admin-console)
+                                         organization
+                                         (= (get-in organization [:permissions :send-invitations]) "owners"))
+              title-text            (if owners-only-invites?
+                                      (tr "dashboard.invite-profile-disabled.owners-only" (:name organization))
+                                      (tr "dashboard.invite-profile-disabled"))
+              invite-button         (mf/html
+                                     [:> button* {:class (stl/css :invite-button)
+                                                  :variant "secondary"
+                                                  :on-click on-invite-member
+                                                  :disabled (not can-invite?)
+                                                  :data-testid "invite-member"}
+                                      (tr "dashboard.invite-profile")])]
+          (if can-invite?
+            invite-button
+            [:> tooltip* {:content title-text
+                          :id "invite-member-disabled-tooltip"
+                          :tab-index 0}
+             invite-button])))]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; INVITATIONS MODAL

--- a/frontend/src/app/main/ui/dashboard/team.scss
+++ b/frontend/src/app/main/ui/dashboard/team.scss
@@ -1062,6 +1062,10 @@
   }
 }
 
+.invite-button:disabled {
+  --button-disabled-bg-color: var(--color-background-tertiary);
+}
+
 a {
   color: var(--modal-link-foreground-color);
 }

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -10352,3 +10352,9 @@ msgstr "Sign-in with your organization's identity provider didn't complete. The 
 
 msgid "labels.sso-error.retry"
 msgstr "Try again"
+
+msgid "dashboard.invite-profile-disabled"
+msgstr "You don't have permission to invite people to this team"
+
+msgid "dashboard.invite-profile-disabled.owners-only"
+msgstr "Only team owners can invite within %s"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -9997,3 +9997,9 @@ msgstr "El inicio de sesión con el proveedor de identidad de tu organización n
 
 msgid "labels.sso-error.retry"
 msgstr "Intentar de nuevo"
+
+msgid "dashboard.invite-profile-disabled"
+msgstr "No tienes permiso para invitar a personas a este equipo"
+
+msgid "dashboard.invite-profile-disabled.owners-only"
+msgstr "Solo los propietarios del equipo pueden invitar dentro de %s"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26745

### Summary

- The Invite button now displays a dedicated tooltip when disabled, with distinct messages depending on the reason: general lack of permission, or being part of an organization where only team owners can send invitations.
- The button's disabled state now uses a more visible background.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
