### PR TITLE
:bug: Fix wrong copy on disabled invite button tooltip

### DIFF
--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -140,23 +140,16 @@
         [:a {:on-click on-nav-settings} (tr "labels.settings")]]]]
      [:div {:class (stl/css :dashboard-buttons)}
       (when (and (or invitations-section? members-section?) (not-empty invitations))
-        (let [organization          (:organization team)
-              owners-only-invites?  (and (contains? cfg/flags :admin-console)
-                                         organization
-                                         (= (get-in organization [:permissions :send-invitations]) "owners"))
-              title-text            (if owners-only-invites?
-                                      (tr "dashboard.invite-profile-disabled.owners-only" (:name organization))
-                                      (tr "dashboard.invite-profile-disabled"))
-              invite-button         (mf/html
-                                     [:> button* {:class (stl/css :invite-button)
-                                                  :variant "secondary"
-                                                  :on-click on-invite-member
-                                                  :disabled (not can-invite?)
-                                                  :data-testid "invite-member"}
-                                      (tr "dashboard.invite-profile")])]
+        (let [invite-button (mf/html
+                             [:> button* {:class (stl/css :invite-button)
+                                          :variant "secondary"
+                                          :on-click on-invite-member
+                                          :disabled (not can-invite?)
+                                          :data-testid "invite-member"}
+                              (tr "dashboard.invite-profile")])]
           (if can-invite?
             invite-button
-            [:> tooltip* {:content title-text
+            [:> tooltip* {:content (tr "dashboard.invite-profile-disabled")
                           :id "invite-member-disabled-tooltip"
                           :tab-index 0}
              invite-button])))]]))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -10355,6 +10355,3 @@ msgstr "Try again"
 
 msgid "dashboard.invite-profile-disabled"
 msgstr "You don't have permission to invite people to this team"
-
-msgid "dashboard.invite-profile-disabled.owners-only"
-msgstr "Only team owners can invite within %s"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -10000,6 +10000,3 @@ msgstr "Intentar de nuevo"
 
 msgid "dashboard.invite-profile-disabled"
 msgstr "No tienes permiso para invitar a personas a este equipo"
-
-msgid "dashboard.invite-profile-disabled.owners-only"
-msgstr "Solo los propietarios del equipo pueden invitar dentro de %s"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26745

### Summary

Removed the distinction between "owners only" and regular disabled invite states in the team dashboard header. The `dashboard.invite-profile-disabled.owners-only translation` is no longer needed, so simplified the tooltip logic to use a single message for all disabled invite button cases.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
