### PR TITLE
:bug: Fix session invalidation on logout to prevent token replay

### DIFF
--- a/backend/src/app/http/session.clj
+++ b/backend/src/app/http/session.clj
@@ -204,7 +204,7 @@
   [{:keys [::manager]}]
   (assert (manager? manager) "expected valid session manager")
   (fn [request response]
-    (some->> (get request ::id) (delete-session manager))
+    (some->> (get request ::session) :id (delete-session manager))
     (clear-session-cookie response)))
 
 (defn decode-token

--- a/backend/test/backend_tests/rpc_auth_test.clj
+++ b/backend/test/backend_tests/rpc_auth_test.clj
@@ -1,0 +1,106 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns backend-tests.rpc-auth-test
+  (:require
+   [app.common.uuid :as uuid]
+   [app.http.session :as session]
+   [backend-tests.helpers :as th]
+   [clojure.test :as t]
+   [yetti.response :as yres]))
+
+(t/use-fixtures :once th/state-init)
+(t/use-fixtures :each th/database-reset)
+
+(t/deftest logout-invalidates-current-session
+  (let [prof    (th/create-profile* 1)
+        manager (::session/manager th/*system*)
+        sid     (uuid/random)
+        _       (th/db-exec-one! ["INSERT INTO http_session_v2 (id, profile_id, user_agent) VALUES (?, ?, ?)"
+                                  sid (:id prof) "test-agent"])
+        session (session/read-session manager sid)]
+
+    ;; Arrange: session exists before logout
+    (t/is (some? session) "session should exist before logout")
+    (t/is (= sid (:id session)))
+
+    ;; Act: simulate Ring request as produced by wrap-authz (has ::session/session)
+    ;; delete-fn is used as response transform via rph/with-transform in auth/logout
+    (let [request  {::session/session session}
+          response {}
+          delete-fn (session/delete-fn th/*system*)
+          result    (delete-fn request response)]
+
+      ;; Assert: server-side session is deleted (CWE-613)
+      (t/is (nil? (session/read-session manager sid))
+            "session must be deleted server-side after logout (GHSA-mj9f-5cwq-7p3q)")
+
+      ;; Assert: cookie is cleared
+      (t/is (= "" (get-in result [::yres/cookies "auth-token" :value]))
+            "auth-token cookie should be cleared")
+      (t/is (= 0 (get-in result [::yres/cookies "auth-token" :max-age]))
+            "auth-token cookie max-age should be 0"))))
+
+(t/deftest logout-clears-cookie-even-when-session-missing
+  (let [manager (::session/manager th/*system*)
+        sid     (uuid/random)
+        ;; No session inserted, read should be nil
+        _       (t/is (nil? (session/read-session manager sid)))
+        request {}
+        response {}
+        delete-fn (session/delete-fn th/*system*)
+        result    (delete-fn request response)]
+
+    ;; Should still clear cookie (idempotent)
+    (t/is (= "" (get-in result [::yres/cookies "auth-token" :value])))
+    (t/is (= 0 (get-in result [::yres/cookies "auth-token" :max-age])))))
+
+(t/deftest logout-does-not-invalidate-other-sessions
+  (let [prof    (th/create-profile* 1)
+        manager (::session/manager th/*system*)
+        sid1    (uuid/random)
+        sid2    (uuid/random)
+        _       (th/db-exec-one! ["INSERT INTO http_session_v2 (id, profile_id, user_agent) VALUES (?, ?, ?)"
+                                  sid1 (:id prof) "agent-1"])
+        _       (th/db-exec-one! ["INSERT INTO http_session_v2 (id, profile_id, user_agent) VALUES (?, ?, ?)"
+                                  sid2 (:id prof) "agent-2"])
+        s1      (session/read-session manager sid1)
+        s2      (session/read-session manager sid2)]
+
+    (t/is (some? s1))
+    (t/is (some? s2))
+
+    ;; Logout only sid1
+    (let [request  {::session/session s1}
+          response {}
+          delete-fn (session/delete-fn th/*system*)]
+      (delete-fn request response))
+
+    ;; sid1 deleted, sid2 intact
+    (t/is (nil? (session/read-session manager sid1)) "current session should be deleted")
+    (t/is (some? (session/read-session manager sid2)) "other sessions should remain")))
+
+(t/deftest replay-after-logout-cannot-authenticate
+  (let [prof    (th/create-profile* 1)
+        manager (::session/manager th/*system*)
+        sid     (uuid/random)
+        _       (th/db-exec-one! ["INSERT INTO http_session_v2 (id, profile_id, user_agent) VALUES (?, ?, ?)"
+                                  sid (:id prof) "test-agent"])
+        session (session/read-session manager sid)]
+
+    (t/is (some? session) "session exists before logout")
+
+    ;; Simulate logout
+    (let [request  {::session/session session}
+          response {}
+          delete-fn (session/delete-fn th/*system*)]
+      (delete-fn request response))
+
+    ;; Replay: attempt to read session with same sid should fail (no profile attached)
+    (t/is (nil? (session/read-session manager sid))
+          "replayed token must not resolve to a valid session after logout")))
+
+


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Fixes server-side session not being invalidated on logout (CWE-613, GHSA-mj9f-5cwq-7p3q) where replayed `auth-token` cookie remained valid after logout. Closes #11316.

## Why

Regression in 363b4e3778 (#7575) removed `::session/id` association in `wrap-authz` (`backend/src/app/http/session.clj:273-276/295-298`) but `delete-fn` in `backend/src/app/http/session.clj:203` still read `(get request ::id)`, so `DELETE FROM http_session_v2` was never executed. Users on shared devices / leaked cookies kept authenticated after logout.

## How

- **Backend:** Make `delete-fn` delete via `(-> request ::session :id)` already attached by `wrap-authz` (`backend/src/app/http/session.clj:203`), removing dead `::id` read (KISS).
- **Tests:** New `backend/test/backend_tests/rpc_auth_test.clj:1` with TDD Red→Green covers invalidation, idempotency, isolation of other sessions and replay rejection (4 tests, 14 assertions). Verified with full backend suite (677 tests, 4459 assertions, 0 failures), `pnpm run lint:clj` and `pnpm run check-fmt:clj` clean.
