### PR TITLE
:sparkles: Show a count summary on collapsed sidebar sections

### DIFF
--- a/frontend/src/app/main/ui/components/title_bar.cljs
+++ b/frontend/src/app/main/ui/components/title_bar.cljs
@@ -12,7 +12,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc title-bar*
-  [{:keys [class collapsable collapsed title children
+  [{:keys [class collapsable collapsed title children summary
            btn-icon btn-title add-icon-gap
            title-class on-collapsed on-btn-click] :rest props}]
   (let [props (mf/spread-props props {:class (stl/css :icon-text-btn)
@@ -26,7 +26,25 @@
            [:> icon* {:icon-id icon-id
                       :size "s"
                       :class (stl/css :icon)}]
-           [:div {:class (stl/css :title)} title]])]
+           [:div {:class (stl/css :title)} title]
+           ;; Compact inline representation of the section content; only
+           ;; rendered while collapsed, where the content is not visible.
+           ;; It is a purely visual hint (the content itself is reachable
+           ;; by expanding the section), so it is hidden from assistive
+           ;; technologies to keep the button label clean.
+           (when (and ^boolean collapsed (some? summary))
+             [:div {:class (stl/css :title-summary)
+                    :aria-hidden true
+                    :title (when (string? summary) summary)}
+              (cond
+                (number? summary)
+                [:span {:class (stl/css :title-summary-counter)} summary]
+
+                (string? summary)
+                [:span {:class (stl/css :title-summary-text)} summary]
+
+                :else
+                summary)])])]
 
        [:div {:class [(stl/css-case :title-only true
                                     :title-only-icon-gap add-icon-gap)

--- a/frontend/src/app/main/ui/components/title_bar.scss
+++ b/frontend/src/app/main/ui/components/title_bar.scss
@@ -55,6 +55,44 @@
   color: var(--title-foreground-color-hover);
 }
 
+.title-summary {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  gap: deprecated.$s-4;
+  min-width: 0;
+  max-width: deprecated.$s-120;
+  margin-inline-start: deprecated.$s-8;
+  overflow: hidden;
+  color: var(--color-foreground-secondary);
+}
+
+.title-summary-text {
+  @include t.use-typography("body-small");
+
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.title-summary-counter {
+  @include t.use-typography("body-small");
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: deprecated.$s-16;
+  height: deprecated.$s-16;
+  padding: 0 deprecated.$s-6;
+
+  // Half of the height, so the badge stays fully rounded (pill shaped)
+  // also when the count has more than one digit.
+  border-radius: deprecated.$s-8;
+  background-color: var(--color-background-quaternary);
+  color: var(--color-foreground-primary);
+}
+
 .icon {
   color: var(--arrow-icon-color);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -225,6 +225,12 @@
 
         toggle-content (mf/use-fn #(swap! state* update :show-content not))
 
+        summary
+        (when (seq blur-values)
+          (if mixed-state
+            (tr "settings.multiple")
+            (count blur-values)))
+
         change!
         (mf/use-fn
          (mf/deps ids)
@@ -276,6 +282,7 @@
                                         (= type :multiple) (tr "workspace.options.blur-options.title.multiple")
                                         (= type :group) (tr "workspace.options.blur-options.title.group")
                                         :else (tr "labels.blur")))
+                      :summary      summary
                       :class        (stl/css-case :title-spacing-blur (not (seq blur-values))
                                                   :long-title true)}
        (when (and (not mixed-state)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs
@@ -61,6 +61,12 @@
         (or (= :multiple exports)
             (some? (seq exports)))
 
+        summary
+        (when has-exports?
+          (if (= :multiple exports)
+            (tr "settings.multiple")
+            (count exports)))
+
         toggle-content
         (mf/use-fn #(swap! open* not))
 
@@ -208,6 +214,7 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :title        (tr (if (> (count ids) 1) "workspace.options.export-multiple" "workspace.options.export"))
+                      :summary      summary
                       :class        (stl/css-case :title-spacing-export (not has-exports?))}
        [:> icon-button* {:variant "ghost"
                          :aria-label (tr "workspace.options.export.add-export")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -314,6 +314,11 @@
         open?               (deref state*)
         has-frame-grids?    (or (= :multiple grids) (some? (seq grids)))
 
+        summary             (when has-frame-grids?
+                              (if (= :multiple grids)
+                                (tr "settings.multiple")
+                                (count grids)))
+
         toggle-content      (mf/use-fn #(swap! state* not))
 
         default-grids       (mf/deref lens:default-grids)
@@ -331,7 +336,8 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :class        (stl/css-case :title-spacing-board-grid (not has-frame-grids?))
-                      :title        (tr "workspace.options.guides.title")}
+                      :title        (tr "workspace.options.guides.title")
+                      :summary      summary}
 
        [:> icon-button* {:variant "ghost"
                          :aria-label (tr "workspace.options.guides.add-guide")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
@@ -73,6 +73,11 @@
         has-shadows?   (or (= :multiple shadows)
                            (some? (seq shadows)))
 
+        summary        (when has-shadows?
+                         (if (= :multiple shadows)
+                           (tr "settings.multiple")
+                           (count shadows)))
+
         show-content*  (mf/use-state true)
         show-content?  (deref show-content*)
 
@@ -147,6 +152,7 @@
                                       :multiple (tr "workspace.options.shadow-options.title.multiple")
                                       :group (tr "workspace.options.shadow-options.title.group")
                                       (tr "workspace.options.shadow-options.title"))
+                      :summary      summary
                       :class        (stl/css-case :shadow-title-bar (not has-shadows?))}
 
        (when-not (= :multiple shadows)


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Collapsed sections in the design sidebar now show a compact summary of what they hold, so the panel can be scanned without expanding section by section.

This first PR adds the mechanism and wires the four count-based sections — Blur, Shadow, Export and Guides — which show an item count, or `Mixed` when the selection has differing values. The color sections (Fill, Stroke, Selected colors) follow in a second PR, since they carry more design surface.

## Why

A collapsed section is a bare title: there is no way to tell an empty Fill from one with four fills, or a board without guides from one with three, other than expanding it and collapsing it again. On a busy selection that is a lot of clicking to answer a question the sidebar could just show.

## How

- **Mechanism.** An optional `summary` prop on the shared `title-bar*`, rendered next to the title only while the section is collapsed. Sections opt in by passing a summary, so every section that passes nothing renders exactly as it does today.
- **Polymorphic by design.** A number renders as a counter badge, a string as a text label, anything else is rendered as-is. Keeping that decision in one place lets the color sections pass a bullet-list element through the same slot with no extra plumbing, and keeps the call sites trivial.
- **Accessibility.** The summary is `aria-hidden` with a `title` tooltip. What it summarizes is reachable by expanding the section, and appending it to the toggle button would turn the accessible name of the Fill control into "Fill +1" — noise for a screen reader.
- **No new derivation.** Each section reuses state it already computes: Blur its `mixed-state` binding, Shadow and Export their existing `:multiple` sentinel, Guides its `has-frame-grids?`, which already folds the `:multiple` case in.
- **`Mixed` label.** Reuses `settings.multiple`, the key the rest of the sidebar already uses, rather than adding a new one (see #11148).

Relates to #11147 — closed by the follow-up PR that wires the color sections.

Thanks @filipsajdak for the prototype work and the review of the approach on the issue; several details here (notably the `:multiple` sentinel notes and the `color-bullet*` `mini` reuse landing in the follow-up) come from that discussion.

## Screenshots

Guides, collapsed, with two grids:

<img width="317" alt="Guides section collapsed showing a count badge of 2" src="https://github.com/user-attachments/assets/316d9b96-1dfc-401a-915d-a41362409d7e" />

Blur on a multi-selection with differing values:

<img width="311" alt="Blur section collapsed showing the Mixed label" src="https://github.com/user-attachments/assets/fd226c10-c686-4a4a-91ee-d37294526b14" />

The whole sidebar collapsed — Shadow, Blur and Export carry the badges added here; the Fill and Stroke bullets in the same shot come from the follow-up PR:

<img width="314" alt="Design sidebar with all sections collapsed showing count badges and color bullets" src="https://github.com/user-attachments/assets/1c9b85d6-1164-4007-9313-fc29884ac607" />

Empty sections are untouched — no badge, and the section stays non-collapsable:

<img width="313" alt="Design sidebar with every section empty and no summaries" src="https://github.com/user-attachments/assets/ecc83ddc-d86d-401f-a895-f2c05b7172ea" />
