### PR TITLE
✨ Show a color summary on collapsed sidebar sections

### DIFF
--- a/frontend/src/app/main/ui/components/color_bullet.cljs
+++ b/frontend/src/app/main/ui/components/color_bullet.cljs
@@ -7,6 +7,8 @@
 (ns app.main.ui.components.color-bullet
   (:require-macros [app.main.style :as stl])
   (:require
+   [app.common.data :as d]
+   [app.common.data.macros :as dm]
    [app.common.math :as mth]
    [app.config :as cfg]
    [app.util.color :as uc]
@@ -110,6 +112,22 @@
                    :style {:background (uc/color->background (assoc color :opacity 1))}}]
             [:div {:class (stl/css :color-bullet-right)
                    :style {:background (uc/color->background color)}}]])]))))
+
+(mf/defc color-bullet-list*
+  "Compact row of mini color bullets with an overflow counter. Used as
+  an inline summary of colors (e.g. on collapsed sidebar sections)."
+  [{:keys [colors max-colors]}]
+  (let [max-colors (d/nilv max-colors 3)
+        visible    (take max-colors colors)
+        remaining  (- (count colors) (count visible))]
+    [:div {:class (stl/css :color-bullet-list)}
+     (for [[index color] (d/enumerate visible)]
+       [:> color-bullet* {:key (dm/str "color-" index)
+                          :color color
+                          :mini true}])
+     (when (pos? remaining)
+       [:span {:class (stl/css :color-bullet-list-more)}
+        (dm/str "+" remaining)])]))
 
 (mf/defc color-name*
   [{:keys [color size on-click on-double-click origin]}]

--- a/frontend/src/app/main/ui/components/color_bullet.scss
+++ b/frontend/src/app/main/ui/components/color_bullet.scss
@@ -82,6 +82,19 @@
   border: $b-2 solid var(--color-accent-primary);
 }
 
+.color-bullet-list {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: var(--sp-xs);
+}
+
+.color-bullet-list-more {
+  @include use-typography("body-small");
+
+  color: var(--color-foreground-secondary);
+}
+
 .color-text {
   @include two-line-text-ellipsis;
   @include use-typography("body-small");

--- a/frontend/src/app/main/ui/components/title_bar.cljs
+++ b/frontend/src/app/main/ui/components/title_bar.cljs
@@ -12,7 +12,7 @@
    [rumext.v2 :as mf]))
 
 (mf/defc title-bar*
-  [{:keys [class collapsable collapsed title children
+  [{:keys [class collapsable collapsed title children summary
            btn-icon btn-title add-icon-gap
            title-class on-collapsed on-btn-click] :rest props}]
   (let [props (mf/spread-props props {:class (stl/css :icon-text-btn)
@@ -26,7 +26,25 @@
            [:> icon* {:icon-id icon-id
                       :size "s"
                       :class (stl/css :icon)}]
-           [:div {:class (stl/css :title)} title]])]
+           [:div {:class (stl/css :title)} title]
+           ;; Compact inline representation of the section content; only
+           ;; rendered while collapsed, where the content is not visible.
+           ;; It is a purely visual hint (the content itself is reachable
+           ;; by expanding the section), so it is hidden from assistive
+           ;; technologies to keep the button label clean.
+           (when (and ^boolean collapsed (some? summary))
+             [:div {:class (stl/css :title-summary)
+                    :aria-hidden true
+                    :title (when (string? summary) summary)}
+              (cond
+                (number? summary)
+                [:span {:class (stl/css :title-summary-counter)} summary]
+
+                (string? summary)
+                [:span {:class (stl/css :title-summary-text)} summary]
+
+                :else
+                summary)])])]
 
        [:div {:class [(stl/css-case :title-only true
                                     :title-only-icon-gap add-icon-gap)

--- a/frontend/src/app/main/ui/components/title_bar.scss
+++ b/frontend/src/app/main/ui/components/title_bar.scss
@@ -55,6 +55,44 @@
   color: var(--title-foreground-color-hover);
 }
 
+.title-summary {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  gap: deprecated.$s-4;
+  min-width: 0;
+  max-width: deprecated.$s-120;
+  margin-inline-start: deprecated.$s-8;
+  overflow: hidden;
+  color: var(--color-foreground-secondary);
+}
+
+.title-summary-text {
+  @include t.use-typography("body-small");
+
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.title-summary-counter {
+  @include t.use-typography("body-small");
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: deprecated.$s-16;
+  height: deprecated.$s-16;
+  padding: 0 deprecated.$s-6;
+
+  // Half of the height, so the badge stays fully rounded (pill shaped)
+  // also when the count has more than one digit.
+  border-radius: deprecated.$s-8;
+  background-color: var(--color-background-quaternary);
+  color: var(--color-foreground-primary);
+}
+
 .icon {
   color: var(--arrow-icon-color);
 }

--- a/frontend/src/app/main/ui/inspect/styles.cljs
+++ b/frontend/src/app/main/ui/inspect/styles.cljs
@@ -9,12 +9,15 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.types.color :as ctco]
    [app.common.types.component :as ctc]
    [app.common.types.components-list :as ctkl]
+   [app.common.types.fills :as types.fills]
    [app.common.types.shape.layout :as ctl]
    [app.common.types.tokens-lib :as ctob]
    [app.main.data.style-dictionary :as sd]
    [app.main.refs :as refs]
+   [app.main.ui.components.color-bullet :refer [color-bullet-list*]]
    [app.main.ui.inspect.exports :as exports]
    [app.main.ui.inspect.styles.panels.blur :refer [blur-panel*]]
    [app.main.ui.inspect.styles.panels.fill :refer [fill-panel*]]
@@ -79,6 +82,33 @@
 
 (defn- has-shadow? [shape]
   (seq (:shadow shape)))
+
+(defn- fill-summary
+  "Compact color bullet list summarizing every fill across `shapes`."
+  [shapes]
+  (mf/html
+   [:> color-bullet-list*
+    {:colors (into [] (mapcat (fn [shape] (map types.fills/fill->color (:fills shape)))) shapes)}]))
+
+(defn- stroke-summary
+  "Compact color bullet list summarizing every stroke across `shapes`."
+  [shapes]
+  (mf/html
+   [:> color-bullet-list*
+    {:colors (into [] (mapcat (fn [shape] (map ctco/stroke->color (:strokes shape)))) shapes)}]))
+
+(defn- shadow-summary
+  "Total number of shadows across `shapes`."
+  [shapes]
+  (reduce + 0 (map (comp count :shadow) shapes)))
+
+(defn- blur-summary
+  "Total number of blur-like properties (blur, background blur) across `shapes`."
+  [shapes]
+  (reduce + 0 (map (fn [shape]
+                     (+ (if (:blur shape) 1 0)
+                        (if (:background-blur shape) 1 0)))
+                   shapes)))
 
 (defn- get-shape-type
   [shapes first-shape first-component]
@@ -208,7 +238,8 @@
            (let [shapes (filter has-fill? shapes)]
              (when (seq shapes)
                [:> style-box* {:panel :fill
-                               :shorthand (:fill shorthands)}
+                               :shorthand (:fill shorthands)
+                               :summary (fill-summary shapes)}
                 [:> fill-panel* {:color-space color-space
                                  :shapes shapes
                                  :resolved-tokens resolved-active-tokens
@@ -219,7 +250,8 @@
            (let [shapes (filter has-stroke? shapes)]
              (when (seq shapes)
                [:> style-box* {:panel :stroke
-                               :shorthand (:stroke shorthands)}
+                               :shorthand (:stroke shorthands)
+                               :summary (stroke-summary shapes)}
                 [:> stroke-panel* {:color-space color-space
                                    :shapes shapes
                                    :objects objects
@@ -245,7 +277,8 @@
            :blur
            (let [shapes (->> shapes (filter has-blur?))]
              (when (seq shapes)
-               [:> style-box* {:panel :blur}
+               [:> style-box* {:panel :blur
+                               :summary (blur-summary shapes)}
                 [:> blur-panel* {:shapes shapes}]]))
            ;; TEXT PANEL
            :text
@@ -263,7 +296,8 @@
            (let [shapes (filter has-shadow? shapes)]
              (when (seq shapes)
                [:> style-box* {:panel :shadow
-                               :shorthand (:shadow shorthands)}
+                               :shorthand (:shadow shorthands)
+                               :summary (shadow-summary shapes)}
                 [:> shadow-panel* {:shapes shapes
                                    :resolved-tokens resolved-active-tokens
                                    :color-space color-space

--- a/frontend/src/app/main/ui/inspect/styles/style_box.cljs
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.cljs
@@ -41,7 +41,7 @@
       nil)))
 
 (mf/defc style-box*
-  [{:keys [panel shorthand children]}]
+  [{:keys [panel shorthand children summary]}]
   (let [expanded* (mf/use-state true)
         expanded (deref expanded*)
 
@@ -68,7 +68,29 @@
        [:> icon* {:icon-id (if expanded "arrow-down" "arrow")
                   :class (stl/css :disclosure-icon)
                   :size "s"}]]
-      [:span {:class (stl/css :panel-title)} title]
+      ;; `.panel-title` used to carry `flex: 1` directly; moved to this
+      ;; wrapper so the title itself hugs its text and the summary sits
+      ;; right next to it (matching the design sidebar's `title-wrapper`,
+      ;; where the button — not the title alone — is the flexible element).
+      [:div {:class (stl/css :title-group)}
+       [:span {:class (stl/css :panel-title)} title]
+       ;; Compact inline representation of the panel content; only rendered
+       ;; while collapsed, mirroring the summary slot on the design
+       ;; sidebar's `title-bar*`. Purely a visual hint, so it stays out of
+       ;; the accessibility tree.
+       (when (and (not expanded) (some? summary))
+         [:div {:class (stl/css :title-summary)
+                :aria-hidden true
+                :title (when (string? summary) summary)}
+          (cond
+            (number? summary)
+            [:span {:class (stl/css :title-summary-counter)} summary]
+
+            (string? summary)
+            [:span {:class (stl/css :title-summary-text)} summary]
+
+            :else
+            summary)])]
       (when shorthand
         [:> icon-button* {:variant "ghost"
                           :tooltip-placement "top-left"

--- a/frontend/src/app/main/ui/inspect/styles/style_box.scss
+++ b/frontend/src/app/main/ui/inspect/styles/style_box.scss
@@ -4,6 +4,8 @@
 //
 // Copyright (c) KALEIDOS INC Sucursal en España SL
 
+@use "ds/_sizes.scss" as *;
+@use "ds/_borders.scss" as *;
 @use "ds/typography.scss" as *;
 
 // TODO: this must be a custom property in the design system
@@ -45,10 +47,61 @@
   border: none;
 }
 
+// Holds the title and its collapsed summary together so the summary sits
+// right next to the title text instead of being pushed to the far edge of
+// the header; this element (not `.panel-title` alone) is the flexible one.
+.title-group {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .panel-title {
   @include use-typography("headline-small");
 
-  flex: 1;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
   color: var(--title-color);
   padding-block: var(--title-padding);
+}
+
+.title-summary {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  gap: var(--sp-xs);
+  min-width: 0;
+  max-width: $sz-120;
+  margin-inline-start: var(--sp-s);
+  overflow: hidden;
+  color: var(--color-foreground-secondary);
+}
+
+.title-summary-text {
+  @include use-typography("body-small");
+
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.title-summary-counter {
+  @include use-typography("body-small");
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: $sz-16;
+  height: $sz-16;
+  padding: 0 $sz-6;
+
+  // Half of the height, so the badge stays fully rounded (pill shaped)
+  // also when the count has more than one digit.
+  border-radius: $br-8;
+  background-color: var(--color-background-quaternary);
+  color: var(--color-foreground-primary);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/blur.cljs
@@ -225,6 +225,12 @@
 
         toggle-content (mf/use-fn #(swap! state* update :show-content not))
 
+        summary
+        (when (seq blur-values)
+          (if mixed-state
+            (tr "settings.multiple")
+            (count blur-values)))
+
         change!
         (mf/use-fn
          (mf/deps ids)
@@ -276,6 +282,7 @@
                                         (= type :multiple) (tr "workspace.options.blur-options.title.multiple")
                                         (= type :group) (tr "workspace.options.blur-options.title.group")
                                         :else (tr "labels.blur")))
+                      :summary      summary
                       :class        (stl/css-case :title-spacing-blur (not (seq blur-values))
                                                   :long-title true)}
        (when (and (not mixed-state)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/color_selection.cljs
@@ -12,6 +12,7 @@
    [app.main.data.workspace.selection :as dws]
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.store :as st]
+   [app.main.ui.components.color-bullet :refer [color-bullet-list*]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.workspace.sidebar.options.rows.color-row :refer [color-row*]]
    [app.util.i18n :as i18n :refer [tr]]
@@ -98,7 +99,7 @@
 (mf/defc color-selection-menu*
   {::mf/wrap [#(mf/memo' % (mf/check-props ["shapes"]))]}
   [{:keys [shapes file-id libraries]}]
-  (let [{:keys [groups library-colors colors token-colors]}
+  (let [{:keys [groups all-colors library-colors colors token-colors]}
         (mf/with-memo [file-id shapes libraries]
           (prepare-colors shapes file-id libraries))
 
@@ -203,6 +204,9 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :title        (tr "workspace.options.selection-color")
+                      :summary      (when has-colors?
+                                      (mf/html
+                                       [:> color-bullet-list* {:colors all-colors}]))
                       :class        (stl/css-case :title-spacing-selected-colors (not has-colors?))}]]
 
      (when open?

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs
@@ -61,6 +61,12 @@
         (or (= :multiple exports)
             (some? (seq exports)))
 
+        summary
+        (when has-exports?
+          (if (= :multiple exports)
+            (tr "settings.multiple")
+            (count exports)))
+
         toggle-content
         (mf/use-fn #(swap! open* not))
 
@@ -208,6 +214,7 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :title        (tr (if (> (count ids) 1) "workspace.options.export-multiple" "workspace.options.export"))
+                      :summary      summary
                       :class        (stl/css-case :title-spacing-export (not has-exports?))}
        [:> icon-button* {:variant "ghost"
                          :aria-label (tr "workspace.options.export.add-export")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/fill.cljs
@@ -15,6 +15,7 @@
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.features :as feat]
    [app.main.store :as st]
+   [app.main.ui.components.color-bullet :refer [color-bullet-list*]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.foundations.assets.icon :as i]
@@ -100,6 +101,14 @@
           (and (not multiple?)
                (< (count fills) types.fills/MAX-FILLS))
           (not ^boolean multiple?))
+
+        summary
+        (if multiple?
+          (tr "settings.multiple")
+          (when (seq fills)
+            (mf/html
+             [:> color-bullet-list*
+              {:colors (mapv (comp :color meta) fills)}])))
 
         label
         (case type
@@ -203,6 +212,7 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :title        label
+                      :summary      summary
                       :class        (stl/css-case :fill-title-bar (not has-fills?))}
 
        (when (not (= :multiple fills))

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -314,6 +314,11 @@
         open?               (deref state*)
         has-frame-grids?    (or (= :multiple grids) (some? (seq grids)))
 
+        summary             (when has-frame-grids?
+                              (if (= :multiple grids)
+                                (tr "settings.multiple")
+                                (count grids)))
+
         toggle-content      (mf/use-fn #(swap! state* not))
 
         default-grids       (mf/deref lens:default-grids)
@@ -331,7 +336,8 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :class        (stl/css-case :title-spacing-board-grid (not has-frame-grids?))
-                      :title        (tr "workspace.options.guides.title")}
+                      :title        (tr "workspace.options.guides.title")
+                      :summary      summary}
 
        [:> icon-button* {:variant "ghost"
                          :aria-label (tr "workspace.options.guides.add-guide")

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/shadow.cljs
@@ -73,6 +73,11 @@
         has-shadows?   (or (= :multiple shadows)
                            (some? (seq shadows)))
 
+        summary        (when has-shadows?
+                         (if (= :multiple shadows)
+                           (tr "settings.multiple")
+                           (count shadows)))
+
         show-content*  (mf/use-state true)
         show-content?  (deref show-content*)
 
@@ -147,6 +152,7 @@
                                       :multiple (tr "workspace.options.shadow-options.title.multiple")
                                       :group (tr "workspace.options.shadow-options.title.group")
                                       (tr "workspace.options.shadow-options.title"))
+                      :summary      summary
                       :class        (stl/css-case :shadow-title-bar (not has-shadows?))}
 
        (when-not (= :multiple shadows)

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/stroke.cljs
@@ -9,6 +9,7 @@
   (:require
    [app.common.data :as d]
    [app.common.data.macros :as dm]
+   [app.common.types.color :as ctc]
    [app.common.types.stroke :as cts]
    [app.config :as cf]
    [app.main.data.workspace :as udw]
@@ -17,6 +18,7 @@
    [app.main.data.workspace.tokens.application :as dwta]
    [app.main.features :as features]
    [app.main.store :as st]
+   [app.main.ui.components.color-bullet :refer [color-bullet-list*]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
    [app.main.ui.ds.foundations.assets.icon :as i]
@@ -79,6 +81,13 @@
 
         strokes         (:strokes values)
         has-strokes?    (or (= :multiple strokes) (some? (seq strokes)))
+
+        summary         (when has-strokes?
+                          (if (= :multiple strokes)
+                            (tr "settings.multiple")
+                            (mf/html
+                             [:> color-bullet-list*
+                              {:colors (mapv ctc/stroke->color strokes)}])))
 
 
         on-color-change
@@ -252,6 +261,7 @@
                       :collapsed    (not open?)
                       :on-collapsed toggle-content
                       :title        label
+                      :summary      summary
                       :class        (stl/css-case :stroke-title-bar (not has-strokes?))}
        (when (not (= :multiple strokes))
          [:> icon-button* {:variant "ghost"


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Wires the three color sections of the design sidebar — Fill, Stroke and Selected colors — to the collapsed-section summary added in the previous PR. While collapsed they now show up to three color bullets plus a `+N` counter, or `Mixed` when the selection has differing values.

Completes #11147.

## Why

Follow-up to #11321, the count sections, split out because the color summaries carry the design detail (bullet size, overflow counter, placement) that the counters do not.

## How

- **Reuses `color-bullet*` with its `mini` variant** rather than a new swatch, in a small `color-bullet-list*` wrapper. This matters beyond deduplication: a naive hex swatch silently drops gradients, images and opacity, all of which the existing bullet already handles.
- **Passes color maps, not hex.** Fill uses the color from the fills metadata and Stroke uses `ctc/stroke->color`, the same conversion `stroke-row*` itself does, so the bullets match the rows the section shows when expanded.
- **Selected colors** builds its summary from `all-colors`, which includes token colors. That is wider than `has-colors?`, which counts only plain and library colors — but the summary is guarded by `has-colors?` and renders only while collapsed, so a selection with token colors alone never reaches it.
- Goes through the same polymorphic `summary` slot as the counters, so no new plumbing in `title-bar*`.

## Screenshots

Fill and Stroke collapsed, with the overflow counter on four fills:

<img width="320" alt="Fill and Stroke sections collapsed showing color bullets and a plus-one counter" src="https://github.com/user-attachments/assets/4de4f477-f170-4639-9231-5e07520c3cc5" />

Selected colors, light and dark:

<img width="312" alt="Selected colors section collapsed showing three bullets and a plus-four counter" src="https://github.com/user-attachments/assets/39199385-cf14-42d6-953f-e044f3196bcd" />

<img width="318" alt="Selected colors section collapsed in dark theme" src="https://github.com/user-attachments/assets/ecd77e8a-7985-468b-8922-abbb4c032eff" />

Fill on a multi-selection with differing values:

<img width="311" alt="Selection fill section collapsed showing the Mixed label" src="https://github.com/user-attachments/assets/96687fe5-3556-4bb9-8392-30468280b00e" />

Expanded, the sections are unchanged:

<img width="312" alt="Fill and Stroke sections expanded, identical to the current layout" src="https://github.com/user-attachments/assets/d755f99f-4ee0-4d96-b07d-b5c095743a84" />

Empty sections are untouched — no bullets, and the section stays non-collapsable:

<img width="309" alt="Design sidebar with every section empty and no summaries" src="https://github.com/user-attachments/assets/b224ebd5-0d32-4478-b70a-aca073fd5569" />

## Known trade-off

`color-bullet*` sets `role="button"` unconditionally, including when it has no `on-click`, so the summary puts elements with an interactive role inside the section's toggle `<button>`. In practice the bullets are not focusable and the whole summary is `aria-hidden`, so they never reach the accessibility tree — but dropping the role when the bullet is read-only would touch every call site of the shared component, which felt out of scope here. Happy to do it as a follow-up if you would rather have it clean.

## Note for review

Stacked on top of #11321, which is not merged yet, so its two commits still appear here. Only the last two commits belong to this PR.
