### PR TITLE
:bug: Fix disabled numeric input with token applied is broken

### DIFF
--- a/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
+++ b/frontend/src/app/main/ui/ds/controls/numeric_input.cljs
@@ -840,7 +840,8 @@
     (mf/with-effect [handle-unmount] handle-unmount)
 
     [:div {:class [class (stl/css-case :input-wrapper true
-                                       :resizable (not is-token-applied?))]
+                                       :resizable (and (not is-token-applied?)
+                                                       (not disabled)))]
            :ref wrapper-ref
            :on-pointer-down on-scrub-pointer-down
            :on-pointer-move on-scrub-pointer-move

--- a/frontend/src/app/main/ui/ds/controls/utilities/token_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/token_field.scss
@@ -22,9 +22,10 @@
   column-gap: var(--sp-xs);
   align-items: center;
   inline-size: 100%;
+  block-size: var(--token-field-height);
   background: var(--token-field-bg-color);
   border-radius: $br-8;
-  padding-inline-end: var(--sp-xs);
+  padding: 0 var(--input-padding-size, var(--sp-s));
   outline: $b-1 solid var(--token-field-outline-color);
   position: relative;
 


### PR DESCRIPTION
### Related Ticket

Closes #11298 

### Summary

- The height of the numeric input is now always the same, regardless of whether it is enabled or disabled.
- The internal padding is also adjusted for both states.
- When the numeric input is disabled and the user moves the mouse over the icon, the cursor no longer changes to the resize arrow.