### PR TITLE
:bug: Fix team dropdown not refreshing after organization deletion

### DIFF
--- a/frontend/src/app/main/data/team.cljs
+++ b/frontend/src/app/main/data/team.cljs
@@ -61,13 +61,18 @@
             ;; Delete old teams from state
             state    (update state :teams #(select-keys % team-ids))]
         (reduce (fn [state {:keys [id organization-id] :as team}]
-                  (let [team-updated (cond-> (merge (dm/get-in state [:teams id]) team)
-                                       (not organization-id) (dissoc :organization-id
-                                                                     :organization-name
-                                                                     :organization-slug
-                                                                     :organization-owner-id
-                                                                     :organization-avatar-bg-url
-                                                                     :organization-permissions))]
+                  (let [team-merged  (merge (dm/get-in state [:teams id]) team)
+                        has-org?     (or (some? organization-id) (some? (:organization team)))
+                        team-updated (if has-org?
+                                       team-merged
+                                       (dissoc team-merged
+                                               :organization
+                                               :organization-id
+                                               :organization-name
+                                               :organization-slug
+                                               :organization-owner-id
+                                               :organization-avatar-bg-url
+                                               :organization-permissions))]
                     (update state :teams assoc id team-updated)))
                 state
                 teams)))))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26741

### Summary

When an organization is deleted, teams moved to "My Teams" retained stale `:organization` data in the frontend state. The sidebar team dropdown filters teams by `[:organization :id]`, causing these teams to be incorrectly filtered out and invisible until a page refresh.

The `teams-fetched` handler now removes all organization-related fields when the server response doesn't include organization data, ensuring the dropdown reflects the current state without requiring a refresh.

### Steps to reproduce

1. User1 in window1 has an organization
2. User2 in window2 has a team (with files) inside said organization
3. User1 deletes the organization
4. User2 sees a toast stating that the org was removed, and is redirected to the default dashboard. In the team's dropdown, the team should be visible.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
