### PR TITLE
Allow cubic-bezier() easing in prototype animations

### DIFF
--- a/common/src/app/common/types/shape/interactions.cljc
+++ b/common/src/app/common/types/shape/interactions.cljc
@@ -59,6 +59,31 @@
     :ease-out
     :ease-in-out})
 
+;; Design systems commonly specify motion as explicit curves rather than as one
+;; of the CSS keywords: Material 3, for instance, defines its whole motion scale
+;; with cubic-bezier() values, and three of them collapse onto `ease-out` when
+;; approximated. Easing values are stored as keywords and rendered with `name`,
+;; so a `cubic-bezier(...)` keyword travels unchanged through the viewer and the
+;; plugin API; only the schema needed widening.
+(def ^:private cubic-bezier-rx
+  #"^cubic-bezier\(\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\s*\)$")
+
+(defn cubic-bezier-easing?
+  [easing]
+  (and (keyword? easing)
+       (nil? (namespace easing))
+       (some? (re-matches cubic-bezier-rx (name easing)))))
+
+(defn valid-easing?
+  [easing]
+  (or (contains? easing-types easing)
+      (cubic-bezier-easing? easing)))
+
+(def schema:easing
+  [:or
+   [::sm/one-of easing-types]
+   [:and :keyword [:fn cubic-bezier-easing?]]])
+
 (def direction-types
   #{:right
     :left
@@ -75,7 +100,7 @@
   [:map {:title "AnimationDisolve"}
    [:animation-type [:= :dissolve]]
    [:duration ::sm/safe-int]
-   [:easing [::sm/one-of easing-types]]
+   [:easing schema:easing]
    [:way {:optional true} [::sm/one-of way-types]]
    [:offset-effect {:optional true} :boolean]
    [:direction {:optional true} [::sm/one-of direction-types]]])
@@ -84,7 +109,7 @@
   [:map {:title "AnimationSlide"}
    [:animation-type [:= :slide]]
    [:duration ::sm/safe-int]
-   [:easing [::sm/one-of easing-types]]
+   [:easing schema:easing]
    [:way [::sm/one-of way-types]]
    [:direction [::sm/one-of direction-types]]
    [:offset-effect :boolean]])
@@ -93,7 +118,7 @@
   [:map {:title "PushAnimation"}
    [:animation-type [:= :push]]
    [:duration ::sm/safe-int]
-   [:easing [::sm/one-of easing-types]]
+   [:easing schema:easing]
    [:direction [::sm/one-of direction-types]]])
 
 (def schema:animation
@@ -623,7 +648,7 @@
   [interaction easing]
 
   (assert (check-interaction interaction))
-  (assert (contains? easing-types easing)
+  (assert (valid-easing? easing)
           "expected valid easing")
   (assert (has-easing? interaction)
           "expected compatible interaction map")


### PR DESCRIPTION
Closes #11339.

### What this does

Widens the prototype animation `easing` field to accept a `cubic-bezier(...)` value alongside the five existing CSS keywords.

### Why it is one file

Easing values are stored as keywords and rendered to CSS with `(name ...)`, and the plugin bridge already runs the incoming string through `parse-keyword`. So a `cubic-bezier(0.2, 0, 0, 1)` keyword travels unchanged through `viewer/interactions.cljs` and through `plugins/parser.cljs` / `format.cljs` without any edit. Only the schema was rejecting it.

The change adds a validating predicate and a `schema:easing` union, uses it in the three animation schemas, and relaxes the `set-easing` assertion to match.

### The motivating case

Material 3 specifies its motion scale as curves. Approximated onto the keyword set, three distinct curves collapse onto `ease-out`:

| M3 token | value | nearest keyword |
|---|---|---|
| `standard` | `cubic-bezier(0.2, 0, 0, 1)` | `ease-out` |
| `emphasized-decelerate` | `cubic-bezier(0.05, 0.7, 0.1, 1)` | `ease-out` |
| `standard-accelerate` | `cubic-bezier(0.3, 0, 1, 1)` | `ease-in` |

Durations already round-trip exactly, so the rhythm survives and only the curve character is lost. The same gap shows up for anyone whose tokens carry a W3C DTCG `cubicBezier` type.

### One design question for you

Encoding the curve as a keyword is what makes the diff this small, but it produces keywords that are not reader-readable (`:cubic-bezier(0.2,0,0,1)`). Transit round-trips them fine, and nothing in the current paths reads easing back through the EDN reader — but if you would rather the field held a **string**, the alternative is to widen the schema to `[:or [::sm/one-of easing-types] :string]` and touch three more files: keep the string in `parser.cljs` instead of keywordising it, pass it through in `format.cljs`, and replace the ten `(name (:easing animation))` call sites in `viewer/interactions.cljs` with a helper. Happy to redo it that way — I went with the minimal version first so the change is easy to read.

The workspace easing dropdown is untouched, so this is reachable through the plugin API only. A "Custom" option in that select is the obvious follow-up and I would rather land the data model first.

### Testing

I have not been able to run the devenv build, so this has not been compiled or exercised against your test suite — please treat it accordingly. The reasoning is laid out above so it can be checked by reading. I can test a built branch against a Material 3 design system (45 components, 26 variant families) that already holds the token values to compare against.
