### PR TITLE
:bug: Fix missing warning  when moving a team

### DIFF
--- a/backend/src/app/rpc/commands/nitrate.clj
+++ b/backend/src/app/rpc/commands/nitrate.clj
@@ -458,13 +458,14 @@
       (let [emails (map :email (noh/get-team-invitation-emails conn team-id))]
         (if (empty? emails)
           {:allows-anybody false :external-emails []}
-          (let [emails-array    (db/create-array conn "text" (vec emails))
-                profiles        (db/exec! conn [sql:get-profiles-by-emails emails-array])
+          (let [emails-array             (db/create-array conn "text" (vec emails))
+                profiles                 (db/exec! conn [sql:get-profiles-by-emails emails-array])
                 organization-member-ids  (into #{} (nitrate/call cfg :get-organization-members {:organization-id organization-id}))
-                external-emails (->> profiles
-                                     (remove #(contains? organization-member-ids (:id %)))
-                                     (map :email)
-                                     (vec))]
+                member-emails            (->> profiles
+                                              (filter #(contains? organization-member-ids (:id %)))
+                                              (map :email)
+                                              (into #{}))
+                external-emails          (into [] (remove member-emails emails))]
             {:allows-anybody false :external-emails external-emails}))))))
 
 (def ^:private schema:add-team-to-organization

--- a/backend/test/backend_tests/rpc_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_nitrate_test.clj
@@ -1168,11 +1168,67 @@
              @set-team-params))
 
     (let [emails (->> @sent (map :to) set)]
-      (t/is (= 2 (count @sent)))
-      (t/is (= #{"member302@example.com" "external301@example.com"} emails))
+      (t/is (= 1 (count @sent)))
+      (t/is (= #{"member302@example.com"} emails))
       (doseq [email-params @sent]
         (t/is (= organization-name (:organization-name email-params)))
         (t/is (= eml/organization-setup-sso (::eml/factory email-params)))))))
+
+(t/deftest add-team-to-organization-deletes-external-invitations-for-unregistered-users
+  (let [owner      (th/create-profile* 305 {:is-active true
+                                            :fullname "Owner"
+                                            :email "owner305@example.com"})
+        member     (th/create-profile* 306 {:is-active true
+                                            :fullname "Member"
+                                            :email "member306@example.com"})
+        team       (th/create-team* 305 {:profile-id (:id owner)})
+        _          (th/create-team-role* {:team-id (:id team)
+                                          :profile-id (:id member)
+                                          :role :editor})
+        organization-id     (uuid/random)
+        organization-summary {:id organization-id
+                              :name "Test Org"
+                              :owner-id (:id owner)
+                              :teams []}
+        organization-perms  {:owner-id (:id owner)
+                             :permissions {:create-teams "any"
+                                           :move-teams "always"
+                                           :new-team-members "members"}}]
+
+    (th/db-insert! :team-invitation
+                   {:id (uuid/random)
+                    :team-id (:id team)
+                    :org-id nil
+                    :email-to "unregistered@example.com"
+                    :created-by (:id owner)
+                    :role "editor"
+                    :valid-until (ct/in-future "48h")})
+    (th/db-insert! :team-invitation
+                   {:id (uuid/random)
+                    :team-id (:id team)
+                    :org-id nil
+                    :email-to "unregistered2@example.com"
+                    :created-by (:id owner)
+                    :role "editor"
+                    :valid-until (ct/in-future "48h")})
+
+    (with-redefs [cf/flags (conj cf/flags :admin-console)
+                  nitrate/call (add-team-to-organization-nitrate-mock
+                                {:organization-id organization-id
+                                 :organization-summary organization-summary
+                                 :organization-perms organization-perms
+                                 :owner-id (:id owner)
+                                 :team-id (:id team)
+                                 :sso-active? false})
+                  teams/initialize-user-in-organization (fn [& _] nil)]
+      (let [out (th/command! {::th/type :add-team-to-organization
+                              ::rpc/profile-id (:id owner)
+                              :team-id (:id team)
+                              :organization-id organization-id})]
+        (t/is (th/success? out))))
+
+    (let [remaining (th/db-query :team-invitation {:team-id (:id team)})]
+      (t/is (empty? remaining) "Both external invitations should be deleted"))))
 
 (t/deftest create-team-in-organization-passes-association-to-nitrate
   (let [organization-id (uuid/random)


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26755

### Summary

When moving a team to an organization, pending invitations for users who haven't registered yet (no profile exists) were not being detected as external invitations. This caused two issues:

1. The warning about external invitations being canceled was not shown in the UI.
2. The invitations were not deleted after the team move.

The bug was in `get-external-invitation-info`, which derived the external email list from the `profiles` table. Unregistered invitees have no profile row, so they were silently excluded from the list.

**Fix:** Changed the logic to start from all invitation emails and subtract only those belonging to organization members (identified via their profiles). This correctly includes unregistered invitees in the external list.

Also fixed a minor issue in `notifications.cljs` where `:is-html` could be `nil` instead of a boolean, which could cause issues with the toast component schema.

### Steps to reproduce

1. Create a team and invite external users who don't have Penpot accounts yet (use email addresses that aren't registered).
2. As the team owner, try to move the team to an organization.
3. **Before fix:** No warning about external invitations is shown, and the invitations remain after the move.
4. **After fix:** Warning is correctly displayed, and invitations are deleted after the move.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
