### PR TITLE
:whale: Migrate media-processor images to DHI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ opencode.json
 /playwright/.cache/
 /render-wasm/target/
 /media-processor/dist/
+/media-processor/target/
 /**/node_modules
 /**/.yarn/*
 /.pnpm-store

--- a/docker/images/Dockerfile.media-processor
+++ b/docker/images/Dockerfile.media-processor
@@ -1,17 +1,16 @@
-FROM ubuntu:26.04
+# syntax=docker/dockerfile:1
+FROM dhi.io/node:24.18.0-debian13-dev
 LABEL maintainer="Penpot <docker@penpot.app>"
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    NODE_VERSION=v24.18.0 \
-    DEBIAN_FRONTEND=noninteractive \
-    PATH=/opt/node/bin:$PATH
+    DEBIAN_FRONTEND=noninteractive
 
+# passwd provides useradd, not preinstalled on the DHI base image.
 RUN set -ex; \
-    useradd -U -M -u 1001 -s /bin/false -d /opt/penpot penpot; \
-    mkdir -p /etc/resolvconf/resolv.conf.d; \
-    echo "nameserver 127.0.0.11" > /etc/resolvconf/resolv.conf.d/tail; \
     apt-get -qq update; \
+    apt-get -qqy --no-install-recommends install passwd; \
+    useradd -U -M -u 1001 -s /bin/false -d /opt/penpot penpot; \
     apt-get -qq dist-upgrade; \
     apt-get -qqy --no-install-recommends install \
       curl \
@@ -34,7 +33,7 @@ RUN set -ex; \
       \
       libgomp1 \
       libheif1 \
-      libjpeg-turbo8 \
+      libjpeg62-turbo \
       liblcms2-2 \
       libopenexr-3-1-30 \
       libopenjp2-7 \
@@ -44,34 +43,12 @@ RUN set -ex; \
       libwebp7 \
       libwebpdemux2 \
       libwebpmux3 \
-      libxml2-16 \
+      libxml2 \
       libzip5 \
       libzstd1 \
     ; \
     apt-get clean; \
-    rm -rf /var/lib/apt/lists/*;
-
-RUN set -eux; \
-    ARCH="$(dpkg --print-architecture)"; \
-    case "${ARCH}" in \
-       aarch64|arm64) \
-         BINARY_URL="https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-arm64.tar.gz"; \
-         ;; \
-       amd64|x86_64) \
-         BINARY_URL="https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz"; \
-         ;; \
-       *) \
-         echo "Unsupported arch: ${ARCH}"; \
-         exit 1; \
-         ;; \
-    esac; \
-    curl -LfsSo /tmp/nodejs.tar.gz ${BINARY_URL}; \
-    mkdir -p /opt/node; \
-    cd /opt/node; \
-    tar -xf /tmp/nodejs.tar.gz --strip-components=1; \
-    chown -R root /opt/node; \
-    rm -rf /tmp/nodejs.tar.gz; \
-    corepack enable; \
+    rm -rf /var/lib/apt/lists/*; \
     mkdir -p /opt/penpot; \
     chown -R penpot:penpot /opt/penpot;
 
@@ -79,8 +56,11 @@ ARG BUNDLE_PATH="./bundle-media-processor/"
 COPY --chown=penpot:penpot $BUNDLE_PATH /opt/penpot/media-processor/
 
 WORKDIR /opt/penpot/media-processor
-USER penpot:penpot
 
-RUN ./setup
+# Runs as root: this base image installs Node system-wide (symlinked into
+# /usr/bin), so ./setup's internal `corepack enable` needs write access there.
+RUN ./setup && chown -R penpot:penpot /opt/penpot/media-processor
+
+USER penpot:penpot
 
 CMD ["node", "dist/index.js"]

--- a/docker/images/Dockerfile.media-processor
+++ b/docker/images/Dockerfile.media-processor
@@ -1,17 +1,16 @@
-FROM ubuntu:26.04
+# syntax=docker/dockerfile:1
+FROM dhi.io/node:24.20.0-debian13-dev
 LABEL maintainer="Penpot <docker@penpot.app>"
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    NODE_VERSION=v24.20.0 \
-    DEBIAN_FRONTEND=noninteractive \
-    PATH=/opt/node/bin:$PATH
+    DEBIAN_FRONTEND=noninteractive
 
+# passwd provides useradd, not preinstalled on the DHI base image.
 RUN set -ex; \
-    useradd -U -M -u 1001 -s /bin/false -d /opt/penpot penpot; \
-    mkdir -p /etc/resolvconf/resolv.conf.d; \
-    echo "nameserver 127.0.0.11" > /etc/resolvconf/resolv.conf.d/tail; \
     apt-get -qq update; \
+    apt-get -qqy --no-install-recommends install passwd; \
+    useradd -U -M -u 1001 -s /bin/false -d /opt/penpot penpot; \
     apt-get -qq dist-upgrade; \
     apt-get -qqy --no-install-recommends install \
       curl \
@@ -34,7 +33,7 @@ RUN set -ex; \
       \
       libgomp1 \
       libheif1 \
-      libjpeg-turbo8 \
+      libjpeg62-turbo \
       liblcms2-2 \
       libopenexr-3-1-30 \
       libopenjp2-7 \
@@ -44,34 +43,12 @@ RUN set -ex; \
       libwebp7 \
       libwebpdemux2 \
       libwebpmux3 \
-      libxml2-16 \
+      libxml2 \
       libzip5 \
       libzstd1 \
     ; \
     apt-get clean; \
-    rm -rf /var/lib/apt/lists/*;
-
-RUN set -eux; \
-    ARCH="$(dpkg --print-architecture)"; \
-    case "${ARCH}" in \
-       aarch64|arm64) \
-         BINARY_URL="https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-arm64.tar.gz"; \
-         ;; \
-       amd64|x86_64) \
-         BINARY_URL="https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz"; \
-         ;; \
-       *) \
-         echo "Unsupported arch: ${ARCH}"; \
-         exit 1; \
-         ;; \
-    esac; \
-    curl -LfsSo /tmp/nodejs.tar.gz ${BINARY_URL}; \
-    mkdir -p /opt/node; \
-    cd /opt/node; \
-    tar -xf /tmp/nodejs.tar.gz --strip-components=1; \
-    chown -R root /opt/node; \
-    rm -rf /tmp/nodejs.tar.gz; \
-    corepack enable; \
+    rm -rf /var/lib/apt/lists/*; \
     mkdir -p /opt/penpot; \
     chown -R penpot:penpot /opt/penpot;
 
@@ -79,8 +56,11 @@ ARG BUNDLE_PATH="./bundle-media-processor/"
 COPY --chown=penpot:penpot $BUNDLE_PATH /opt/penpot/media-processor/
 
 WORKDIR /opt/penpot/media-processor
-USER penpot:penpot
 
-RUN ./setup
+# Runs as root: this base image installs Node system-wide (symlinked into
+# /usr/bin), so ./setup's internal `corepack enable` needs write access there.
+RUN ./setup && chown -R penpot:penpot /opt/penpot/media-processor
+
+USER penpot:penpot
 
 CMD ["node", "dist/index.js"]

--- a/manage.sh
+++ b/manage.sh
@@ -1231,6 +1231,22 @@ function build-mcp-bundle {
 }
 
 
+function build-media-processor-bundle {
+    echo ">> bundle media-processor start";
+
+    mkdir -p ./bundles
+    local version=$(print-current-version);
+    local bundle_dir="./bundles/media-processor";
+
+    build "media-processor";
+
+    rm -rf $bundle_dir;
+    mv ./media-processor/target $bundle_dir;
+    echo $version > $bundle_dir/version.txt;
+    put-license-file $bundle_dir;
+    echo ">> bundle media-processor end";
+}
+
 function build-backend-bundle {
     echo ">> bundle backend start";
 
@@ -1346,6 +1362,10 @@ function build-mcp-docker-image {
     _build-release-docker-image mcp bundle-mcp Dockerfile.mcp "$@"
 }
 
+function build-media-processor-docker-image {
+    _build-release-docker-image media-processor bundle-media-processor Dockerfile.media-processor "$@"
+}
+
 function build-storybook-docker-image {
     _build-release-docker-image storybook bundle-storybook Dockerfile.storybook "$@"
 }
@@ -1424,6 +1444,7 @@ function usage {
     echo "- build-backend-bundle             Build backend bundle."
     echo "- build-exporter-bundle            Build exporter bundle."
     echo "- build-mcp-bundle                 Build mcp bundle."
+    echo "- build-media-processor-bundle     Build media-processor bundle."
     echo "- build-storybook-bundle           Build storybook bundle."
     echo "- build-docs-bundle                Build docs bundle."
     echo ""
@@ -1435,6 +1456,7 @@ function usage {
     echo "- build-backend-docker-image [--tag TAG]    Build backend docker image."
     echo "- build-exporter-docker-image [--tag TAG]   Build exporter docker image."
     echo "- build-mcp-docker-image [--tag TAG]         Build mcp docker image."
+    echo "- build-media-processor-docker-image [--tag TAG]  Build media-processor docker image."
     echo "- build-storybook-docker-image [--tag TAG]  Build storybook docker image."
     echo "- build-imagemagick-docker-image [--tag TAG] [--push]"
     echo "                                   Build the imagemagick docker image. Local-only by default (single-"
@@ -1490,6 +1512,7 @@ case $1 in
     build-bundle)
         build-frontend-bundle;
         build-mcp-bundle;
+        build-media-processor-bundle;
         build-backend-bundle;
         build-exporter-bundle;
         build-storybook-bundle;
@@ -1501,6 +1524,10 @@ case $1 in
 
     build-mcp-bundle)
         build-mcp-bundle;
+        ;;
+
+    build-media-processor-bundle)
+        build-media-processor-bundle;
         ;;
 
     build-backend-bundle)
@@ -1524,6 +1551,7 @@ case $1 in
         build-backend-docker-image "${@:2}"
         build-exporter-docker-image "${@:2}"
         build-mcp-docker-image "${@:2}"
+        build-media-processor-docker-image "${@:2}"
         build-storybook-docker-image "${@:2}"
         ;;
 
@@ -1541,6 +1569,10 @@ case $1 in
 
     build-mcp-docker-image)
         build-mcp-docker-image "${@:2}"
+        ;;
+
+    build-media-processor-docker-image)
+        build-media-processor-docker-image "${@:2}"
         ;;
 
     build-storybook-docker-image)

--- a/mcp/scripts/build
+++ b/mcp/scripts/build
@@ -35,7 +35,7 @@ cp pnpm-lock.yaml ./dist/;
 touch ./dist/pnpm-workspace.yaml;
 
 cat <<EOF | tee ./dist/setup
-#/usr/bin/env bash
+#!/usr/bin/env bash
 set -e;
 corepack enable;
 corepack install;

--- a/media-processor/scripts/build
+++ b/media-processor/scripts/build
@@ -1,4 +1,31 @@
 #!/bin/bash
 set -e
 cd "$(dirname "$0")/.."
+
+# package.json pins pnpm via "packageManager", so the first build on a fresh
+# devenv makes corepack fetch it. Without this it asks for confirmation on
+# stdin, which hangs a CI build (and aborts an interactive one); `corepack
+# install` then fetches the pinned version explicitly.
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack install
+
 pnpm run build
+
+# Assemble the release bundle under target/, the way the other modules do.
+# esbuild leaves the runtime dependencies external (sharp, pino, pino-pretty,
+# pino-loki), so the image has to install them on build: ship the manifests
+# next to dist/ plus a setup script for Dockerfile.media-processor to run.
+rm -rf target
+mkdir -p target
+rsync -avr --delete dist/ target/dist/
+cp package.json pnpm-lock.yaml pnpm-workspace.yaml target/
+
+cat <<SETUP | tee target/setup > /dev/null
+#!/usr/bin/env bash
+set -e;
+corepack enable;
+corepack install;
+pnpm install -P;
+SETUP
+
+chmod +x target/setup


### PR DESCRIPTION
## What and why

The media-processor module had a Dockerfile but no way to build it through manage.sh, so neither its bundle nor its image could be produced. This adds both, and migrates the image to Docker Hardened Images along the way.

`scripts/build` now assembles the bundle under `target/` — following the same convention as the other modules — rather than leaving it to manage.sh. This is needed because esbuild leaves the runtime dependencies external (sharp, pino, pino-pretty, pino-loki), so the bundle has to ship package.json / pnpm-lock.yaml / pnpm-workspace.yaml next to dist/, plus a setup script for the image to run at build time. The generated setup mirrors the one mcp/scripts/build produces.

Also fixed while testing: the first bundle build on a fresh devenv hung on corepack's interactive "do you want to download pnpm?" prompt (the module pins pnpm via `packageManager`). `scripts/build` now sets
`COREPACK_ENABLE_DOWNLOAD_PROMPT=0` and calls `corepack install` explicitly, which would otherwise deadlock a CI build. Note it deliberately does *not* call `corepack enable` (unlike mcp/scripts/build): that writes shims into root-owned /opt/node/bin while manage.sh runs the build as the penpot user, and the devenv image already creates them.

**CI is intentionally untouched.** The module is still work in progress and its images are not published yet, so `build-docker.yml` gets no media-processor step — this PR only makes local builds possible.

## How to build and test it

DHI images require an authenticated pull, so log in first with a (free) Docker ID — sign up at https://app.docker.com/signup if you don't have one:

```bash
docker login dhi.io   # or docker login
```

Build the bundle and the image:

```bash
./manage.sh build-media-processor-bundle
./manage.sh build-media-processor-docker-image --tag dhi-test
```

The bundle should come out like this, with `setup` executable:

```bash
find bundles/media-processor -maxdepth 2 | sort
ls -l bundles/media-processor/setup
```

Run the image — the service listens on 6065:

```bash
docker run --rm -p 6065:6065 penpotapp/media-processor:dhi-test
```

Extra test: check that the Ubuntu → Debian base swap didn't break the processing tooling (sharp's native bindings, fontforge and woff2):

```bash
docker run --rm --entrypoint sh penpotapp/media-processor:dhi-test -c '
  node -e "
    const sharp = require(\"sharp\");
    console.log(\"sharp OK\", sharp.versions);
    sharp({create:{width:8,height:8,channels:4,background:{r:255,g:0,b:0,alpha:1}}})
      .png().toBuffer()
      .then(b => console.log(\"png encode OK\", b.length, \"bytes\"))
      .catch(e => console.log(\"FAIL\", e.message));
  "
  echo "--- fontforge ---"; fontforge --version 2>&1 | head -2
  echo "--- woff2 ---";     woff2_compress 2>&1 | head -1
'
```

### Testing notes

All of the above was run on this branch:

- Bundle produced with `dist/index.js`, the three manifests, an executable
  `setup`, `version.txt` and `LICENSE`.
- Image built cleanly and the container starts and listens on 6065.
- sharp loads and encodes a PNG (96 bytes); `fontforge --version` and
  `woff2_compress` both respond.

## Breaking changes

None. New commands, and an image that isn't built by CI yet.

