### PR TITLE
:bug: Fix move organization modal

### DIFF
--- a/frontend/src/app/main/data/nitrate.cljs
+++ b/frontend/src/app/main/data/nitrate.cljs
@@ -415,6 +415,7 @@
                                                         is-own? (= profile-id (:owner-id organization))]
                                                     (or (= perm "any") is-own?))) all-organizations)
                       team     (first (filter #(= (:id %) team-id) teams))
+                      current-organization (:organization team)
                       on-confirm (fn [organization-id]
                                    (st/emit! (add-team-to-organization {:team-id team-id
                                                                         :organization-id organization-id})))
@@ -422,11 +423,11 @@
                       (fn [organizations-allowed]
                         (let [has-filtered? (< (count organizations) (count all-organizations))
                               extra-props   (when has-filtered?
-                                              {:info-message-key "dashboard.select-organization-modal.permission-info"})]
+                                              {:info-message-key "dashboard.select-organization-modal.permission-info-add"})]
                           (modal/show :select-organization-modal
                                       (merge {:organizations organizations
                                               :organizations-allowed organizations-allowed
-                                              :current-organization-id (dm/get-in team [:organization :id])
+                                              :current-organization current-organization
                                               :on-confirm on-confirm
                                               :team-id team-id
                                               :title-key "dashboard.select-organization-modal.title"
@@ -509,11 +510,12 @@
                                    :title (tr "dashboard.change-organization-modal.title")})
                                  (modal/show :select-organization-modal
                                              (merge {:organizations           selectable-organizations
-                                                     :organizations-allowed            organizations-allowed
-                                                     :current-organization-id current-organization-id
+                                                     :organizations-allowed   organizations-allowed
+                                                     :current-organization    source-organization
                                                      :on-confirm              on-confirm
                                                      :team-id                 team-id
                                                      :title-key               "dashboard.change-organization-modal.title"
+                                                     :description-key         "dashboard.change-organization-modal.description"
                                                      :choose-key              "dashboard.change-organization-modal.choose"
                                                      :placeholder-key         "dashboard.change-organization-modal.select"
                                                      :accept-key              "dashboard.change-organization-modal.accept"

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -915,34 +915,57 @@
 (mf/defc select-organization-modal
   {::mf/register modal/components
    ::mf/register-as :select-organization-modal}
-  [{:keys [organizations organizations-allowed current-organization-id on-confirm title-key text-key choose-key placeholder-key accept-key cancel-key info-message-key team-id]}]
-  (let [valid-organizations (mf/with-memo [organizations]
-                              (remove #(= (:id %) current-organization-id) organizations))
-        options (mf/with-memo [valid-organizations organizations-allowed]
-                  (mapv (fn [organization]
-                          (let [organization-id (:id organization)
-                                ;; organizations-allowed is a map of organization-id and a boolean indicating if it is allowed
-                                enabled? (or (nil? organizations-allowed)
-                                             (true? (get organizations-allowed organization-id)))]
-                            (cond-> {:id (str organization-id)
-                                     :label (:name organization)
-                                     :disabled (not enabled?)
-                                     :dimmed (not enabled?)
-                                     :avatar {:render-fn render-organization-combobox-avatar*
-                                              :organization organization
-                                              :size "xl"}}
-                              (not enabled?)
-                              (assoc :title (tr "dashboard.team-organization.disabled-organization-tooltip")))))
-                        valid-organizations))
+  [{:keys [organizations organizations-allowed current-organization on-confirm title-key text-key choose-key placeholder-key accept-key cancel-key info-message-key description-key team-id]}]
+  (let [current-organization-id (:id current-organization)
+        has-current-org?        (some? current-organization)
+        valid-organizations     (mf/with-memo [organizations current-organization-id]
+                                  (remove #(= (:id %) current-organization-id) organizations))
+        all-organizations       (mf/with-memo [organizations current-organization]
+                                  (cond-> organizations
+                                    (and has-current-org?
+                                         (not (some #(= (:id %) current-organization-id) organizations)))
+                                    (conj current-organization)))
+        options                 (mf/with-memo [valid-organizations organizations-allowed current-organization]
+                                  (let [other-options
+                                        (mapv (fn [organization]
+                                                (let [organization-id (:id organization)
+                                                      enabled? (or (nil? organizations-allowed)
+                                                                   (true? (get organizations-allowed organization-id)))]
+                                                  (cond-> {:id (str organization-id)
+                                                           :label (:name organization)
+                                                           :disabled (not enabled?)
+                                                           :dimmed (not enabled?)
+                                                           :avatar {:render-fn render-organization-combobox-avatar*
+                                                                    :organization organization
+                                                                    :size "xl"}}
+                                                    (not enabled?)
+                                                    (assoc :title (tr "dashboard.team-organization.disabled-organization-tooltip")))))
+                                              valid-organizations)]
+                                    (if has-current-org?
+                                      (into [{:id (str current-organization-id)
+                                              :label (:name current-organization)
+                                              :avatar {:render-fn render-organization-combobox-avatar*
+                                                       :organization current-organization
+                                                       :size "xl"}}]
+                                            other-options)
+                                      other-options)))
 
-        form (fm/use-form :schema schema:organization-form :initial {})
+        initial-form            (mf/with-memo [has-current-org? current-organization-id]
+                                  (if has-current-org?
+                                    {:selected-id (str current-organization-id)}
+                                    {}))
+        form                    (fm/use-form :schema schema:organization-form :initial initial-form)
 
-        warning-info* (mf/use-state nil)
-        warning-info (deref warning-info*)
-        selected-organization (mf/with-memo [warning-info valid-organizations]
-                                (when warning-info
-                                  (d/seek #(= (:id %) (:organization-id warning-info)) valid-organizations)))
+        warning-info*           (mf/use-state nil)
+        warning-info            (deref warning-info*)
+        selected-organization   (mf/with-memo [warning-info all-organizations]
+                                  (when warning-info
+                                    (d/seek #(= (:id %) (:organization-id warning-info)) all-organizations)))
 
+        selected-id             (dm/get-in @form [:data :selected-id])
+        disabled?               (or (not (:valid @form))
+                                    (and has-current-org?
+                                         (= (str selected-id) (str current-organization-id))))
         on-change
         (mf/use-fn
          (mf/deps form team-id)
@@ -978,18 +1001,25 @@
         [:div {:class (stl/css :modal-content :modal-select-organization-text)} (tr text-key)])
 
       [:div {:class (stl/css :modal-select-organization-body)}
-       (when info-message-key
+       (when (or description-key info-message-key)
          [:div {:class (stl/css :modal-select-organization-info)}
-          (tr info-message-key)])
+          (when description-key
+            [:div {:class (stl/css :modal-select-organization-description)}
+             (tr description-key)])
+          (when info-message-key
+            [:div {:class (stl/css :modal-select-organization-info-message)}
+             (tr info-message-key)])])
        [:div {:class (stl/css :modal-select-organization-content)}
         (tr choose-key)]
        [:> combobox* {:id "selected-id"
                       :class (stl/css :team-member)
                       :options options
                       :select-only true
-                      :default-selected (or (some-> (get-in @form [:data :selected-id]) str) "")
                       :placeholder (tr placeholder-key)
-                      :on-change on-change}]
+                      :on-change on-change
+                      :default-selected (if has-current-org?
+                                          (str current-organization-id)
+                                          "")}]
 
        ;; Warning for external invitations
        (when (and warning-info
@@ -1017,7 +1047,7 @@
          {:class (stl/css :accept-btn)
           :variant "primary"
           :type "button"
-          :disabled (not (:valid @form))
+          :disabled disabled?
           :on-click on-confirm'}
          (tr accept-key)]]]]]))
 

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -1004,10 +1004,10 @@
        (when (or description-key info-message-key)
          [:div {:class (stl/css :modal-select-organization-info)}
           (when description-key
-            [:div {:class (stl/css :modal-select-organization-description)}
+            [:div
              (tr description-key)])
           (when info-message-key
-            [:div {:class (stl/css :modal-select-organization-info-message)}
+            [:div
              (tr info-message-key)])])
        [:div {:class (stl/css :modal-select-organization-content)}
         (tr choose-key)]

--- a/frontend/src/app/main/ui/dashboard/team.scss
+++ b/frontend/src/app/main/ui/dashboard/team.scss
@@ -963,7 +963,11 @@
 .modal-select-organization-info {
   @include t.use-typography("body-medium");
 
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-m);
   color: var(--color-foreground-secondary);
+  margin-block-end: var(--sp-xxl);
 }
 
 .modal-select-organization-title {

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -388,6 +388,9 @@ msgstr ""
 msgid "dashboard.change-organization-modal.title"
 msgstr "Change team's organization"
 
+msgid "dashboard.change-organization-modal.description"
+msgstr "Projects and files will remain available to team members. The team will get the configuration from the new organization."
+
 #: src/app/main/ui/dashboard/deleted.cljs:316
 msgid "dashboard.clear-trash-button"
 msgstr "Clear trash"
@@ -1111,11 +1114,11 @@ msgstr ""
 msgid "dashboard.select-organization-modal.external-invitations-will-be-canceled"
 msgstr "Pending invitations to external users will be canceled."
 
-#, unused
 msgid "dashboard.select-organization-modal.permission-info"
-msgstr ""
-"Here you find all your organizations where you are allowed to create or add "
-"teams."
+msgstr "Here you'll find the organizations you are part of where you are allowed to move the team."
+
+msgid "dashboard.select-organization-modal.permission-info-add"
+msgstr "Here you'll find the organizations you are part of where you are allowed to create or add teams."
 
 #, unused
 msgid "dashboard.select-organization-modal.select"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -395,6 +395,9 @@ msgstr ""
 msgid "dashboard.change-organization-modal.title"
 msgstr "Cambiar el equipo de organización"
 
+msgid "dashboard.change-organization-modal.description"
+msgstr "Los proyectos y archivos permanecerán disponibles para los miembros del equipo. El equipo obtendrá la configuración de la nueva organización."
+
 #: src/app/main/ui/dashboard/deleted.cljs:316
 msgid "dashboard.clear-trash-button"
 msgstr "Vaciar papelera"
@@ -1118,11 +1121,11 @@ msgstr ""
 msgid "dashboard.select-organization-modal.external-invitations-will-be-canceled"
 msgstr "Las invitaciones pendientes a usuarios externos serán canceladas."
 
-#, unused
 msgid "dashboard.select-organization-modal.permission-info"
-msgstr ""
-"Aquí encontrarás todas las organizaciones en las que tienes permiso para "
-"crear o añadir equipos."
+msgstr "Aquí encontrarás las organizaciones de las que eres parte donde tienes permiso para mover el equipo."
+
+msgid "dashboard.select-organization-modal.permission-info-add"
+msgstr "Aquí encontrarás las organizaciones de las que eres parte donde tienes permiso para crear o añadir equipos."
 
 #, unused
 msgid "dashboard.select-organization-modal.select"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26759

### Summary

Fixed the "Change team's organization" modal to match the design specification:
- **Added explanatory text**: The description text now appears above the organization selector, informing users that "Projects and files will remain available to team members. The team will get the configuration from the new organization."
- **Pre-selected current organization**: The selector now displays the current organization as the selected option with a check mark in the dropdown list, instead of showing the placeholder "Select an organization".
- **Updated info message**: Changed the permission info text to be more contextually accurate for both the "add team" and "change organization" flows.
- **Disabled accept button when unchanged**: The accept button is now disabled when the current organization is still selected, preventing unnecessary submissions.
- **Improved styling**: Added proper spacing and layout for the description and info message area.

### Steps to reproduce

1. Open a team and go to its team info
2. Under Team organization, open the "Change team's organization" modal
3. Verify the explanatory text appears above the selector
4. Open the "Move to" selector and confirm the current organization is pre-selected with a check mark
5. Verify the accept button is disabled when the current organization is still selected
6. Select a different organization and confirm the accept button becomes enabled

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
