### PR TITLE
:bug: Center canvas and select layer when navigating layer search results

### DIFF
--- a/frontend/src/app/main/data/workspace.cljs
+++ b/frontend/src/app/main/data/workspace.cljs
@@ -1698,6 +1698,7 @@
 (dm/export dwgu/set-hover-guide)
 
 ;; Zoom
+(dm/export dwz/center-on-shape)
 (dm/export dwz/reset-zoom)
 (dm/export dwz/zoom-to-selected-shape)
 (dm/export dwz/start-zooming)

--- a/frontend/src/app/main/data/workspace/zoom.cljs
+++ b/frontend/src/app/main/data/workspace/zoom.cljs
@@ -135,6 +135,32 @@
     (effect [_ state _]
       (dwvw/maybe-sync-workspace-local-viewport! state))))
 
+(defn center-on-shape
+  "Pan the viewport to center on the shape with the given id without changing zoom."
+  [id]
+  (ptk/reify ::center-on-shape
+    ptk/UpdateEvent
+    (update [_ state]
+      (if (dwvw/render-context-lost? state)
+        state
+        (let [page-id (:current-page-id state)
+              objects (dsh/lookup-page-objects state page-id)
+              shape   (get objects id)
+              srect   (:selrect shape)]
+          (if (nil? srect)
+            state
+            (update state :workspace-local
+                    (fn [{:keys [vbox] :as local}]
+                      (let [cx    (+ (:x srect) (/ (:width srect) 2))
+                            cy    (+ (:y srect) (/ (:height srect) 2))
+                            new-x (- cx (/ (:width vbox) 2))
+                            new-y (- cy (/ (:height vbox) 2))]
+                        (update local :vbox assoc :x new-x :y new-y))))))))
+
+    ptk/EffectEvent
+    (effect [_ state _]
+      (dwvw/maybe-sync-workspace-local-viewport! state))))
+
 (def zoom-to-selected-shape
   (ptk/reify ::zoom-to-selected-shape
     ptk/UpdateEvent

--- a/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/layers.cljs
@@ -438,7 +438,7 @@
 
         navigate-next
         (mf/use-fn
-         (mf/deps text-match-count)
+         (mf/deps text-match-ids text-match-count)
          (fn [_]
            (when (pos? text-match-count)
              (let [ids      (mf/ref-val text-match-ids-ref)
@@ -447,11 +447,11 @@
                (mf/set-ref-val! match-idx-ref next-idx)
                (swap! state* assoc :current-match-idx next-idx)
                (st/emit! (dw/select-shape id)
-                         dw/zoom-to-selected-shape)))))
+                         (dw/center-on-shape id))))))
 
         navigate-prev
         (mf/use-fn
-         (mf/deps text-match-count)
+         (mf/deps text-match-ids text-match-count)
          (fn [_]
            (when (pos? text-match-count)
              (let [ids      (mf/ref-val text-match-ids-ref)
@@ -460,7 +460,7 @@
                (mf/set-ref-val! match-idx-ref prev-idx)
                (swap! state* assoc :current-match-idx prev-idx)
                (st/emit! (dw/select-shape id)
-                         dw/zoom-to-selected-shape)))))
+                         (dw/center-on-shape id))))))
 
         handle-replace
         (mf/use-fn


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- When navigating layer search results with the previous/next buttons in the layers panel, the canvas now centers on the matched shape and the shape is selected in the layers panel.
- Previously the internal search cursor advanced but the canvas and selection did not update, so matches were not visible to the user.
- It does not solves the main problem related on the issue

## Why

- This is a backport of the layer-search navigation fix to `staging`.
- It is an **alternative to #11157**, which targets `main` (`fix/layer-search-navigate-center-canvas`). This PR resolves the same behavior while targeting the correct `staging` branch.

## How

- **New event `center-on-shape`** (`frontend/src/app/main/data/workspace/zoom.cljs`): pans the viewport to center on the given shape id without changing the zoom level, and is exported from `frontend/src/app/main/data/workspace.cljs`.
- **Layer search navigation** (`frontend/src/app/main/ui/workspace/sidebar/layers.cljs`): `navigate-next` / `navigate-prev` now select the matched shape (`dw/select-shape`) and emit `(dw/center-on-shape id)` so the canvas follows the active match.
