### PR TITLE
:bug: Cascade profile deletion in objects-gc task

### DIFF
--- a/backend/src/app/tasks/objects_gc.clj
+++ b/backend/src/app/tasks/objects_gc.clj
@@ -13,6 +13,7 @@
    [app.db :as db]
    [app.features.fdata :as fdata]
    [app.storage :as sto]
+   [app.tasks.delete-object :as dobj]
    [integrant.core :as ig]))
 
 (def ^:private sql:get-profiles
@@ -32,6 +33,11 @@
 
                  ;; Mark as deleted the storage object
                  (some->> photo-id (sto/touch-object! storage))
+
+                 ;; Cascade soft-delete to owned teams, projects, files, etc.
+                 (dobj/delete-object cfg {:object :profile
+                                          :id id
+                                          :deleted-at timestamp})
 
                  (let [affected (-> (db/delete! conn :profile {:id id})
                                     (db/get-update-count))]

--- a/backend/test/backend_tests/rpc_profile_test.clj
+++ b/backend/test/backend_tests/rpc_profile_test.clj
@@ -424,6 +424,38 @@
     (let [count-after (:count (th/db-exec-one! ["SELECT count(*) FROM http_session_v2 WHERE profile_id = ?" (:id prof)]))]
       (t/is (= 0 count-after)))))
 
+(t/deftest profile-deletion-via-gc-cascades
+  (let [prof (th/create-profile* 1)
+        file (th/create-file* 1 {:profile-id (:id prof)
+                                 :project-id (:default-project-id prof)
+                                 :is-shared false})
+        team-id (:default-team-id prof)
+        project-id (:default-project-id prof)
+        file-id (:id file)
+
+        deleted-at (ct/minus (ct/now) (ct/duration {:days 1}))]
+
+    (th/db-update! :profile
+                   {:deleted-at deleted-at}
+                   {:id (:id prof)})
+
+    (let [team-before (th/db-get :team {:id team-id} {::db/remove-deleted false})]
+      (t/is (nil? (:deleted-at team-before))))
+
+    (let [result (th/run-task! :objects-gc {:min-age 0})]
+      (t/is (pos? (:processed result))))
+
+    (let [profile-after (th/db-get :profile {:id (:id prof)} {::db/remove-deleted false})]
+      (t/is (nil? profile-after)))
+
+    (let [team-after (th/db-get :team {:id team-id} {::db/remove-deleted false})]
+      (t/is (nil? team-after)))
+
+    (let [project-after (th/db-get :project {:id project-id} {::db/remove-deleted false})]
+      (t/is (nil? project-after)))
+
+    (let [file-after (th/db-get :file {:id file-id} {::db/remove-deleted false})]
+      (t/is (nil? file-after)))))
 
 (t/deftest email-blacklist-1
   (t/is (false? (email.blacklist/enabled? th/*system*)))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Profile deletion now cascades to owned teams, projects, and files in the `objects-gc` task
- Demo users and profiles with `deleted_at` set directly are now properly cleaned up
- Prevents orphaned resources from accumulating in the database

## Why

The `objects-gc` task was performing a hard delete on profiles without first invoking the cascade logic that marks owned resources for deletion. This left teams, projects, files, and related data orphaned in the database, never to be cleaned up by subsequent GC runs.

Demo users are particularly affected because they are created with a future `deleted_at` timestamp but never trigger the cascade deletion task through the normal RPC flow.

## How

- Modified `delete-profiles!` in `objects_gc.clj` to invoke `delete-object` before the hard delete
- The cascade marks owned teams, projects, files, and related data with `deleted_at`
- Subsequent GC iterations pick up these marked resources and hard-delete them
- All operations run within the same transaction opened by `execute-proc!`, no nested transactions

Closes #11394
