### PR TITLE
:bug: Fix labels for teams navigation and personal files section

### DIFF
--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -371,8 +371,8 @@
       [:span {:class (stl/css :my-teams-icon)}
        [:> raw-svg* {:id penpot-logo-icon-subtle}]]
       [:span {:class (stl/css :team-text)
-              :title (tr "dashboard.my-teams")}
-       (tr "dashboard.my-teams")]
+              :title (tr "dashboard.other-teams")}
+       (tr "dashboard.other-teams")]
       (when (= default-team-id (:default-team-id organization))
         tick-icon)]
      (when (seq organizations)
@@ -438,7 +438,7 @@
       (when-not (contains? cf/flags :admin-console)
         [:span {:class (stl/css :penpot-icon)} deprecated-icon/logo-icon])
 
-      [:span {:class (stl/css :team-text)} (if (contains? cf/flags :admin-console) (tr "dashboard.my-files") (tr "dashboard.your-penpot"))]
+      [:span {:class (stl/css :team-text)} (if (contains? cf/flags :admin-console) (tr "dashboard.personal-projects") (tr "dashboard.your-penpot"))]
       (when (= default-team-id (:id team))
         tick-icon)]
 
@@ -835,7 +835,7 @@
              [:span {:class (stl/css :my-teams-icon-xxxl)}
               [:> raw-svg* {:id penpot-logo-icon-subtle}]]
              [:span {:class (stl/css :team-text)}
-              (tr "dashboard.my-teams")]]
+              (tr "dashboard.other-teams")]]
             [:*
              [:> organization-avatar* {:organization current-organization :size "xxxl"}]
              [:span {:class (stl/css :team-text)}
@@ -972,7 +972,7 @@
                                      :team-name-no-logo nitrate?)}
           (when-not nitrate?
             [:span {:class (stl/css :penpot-icon)} deprecated-icon/logo-icon])
-          [:span {:class (stl/css :team-text)} (if nitrate? (tr "dashboard.my-files") (tr "dashboard.default-team-name"))]]
+          [:span {:class (stl/css :team-text)} (if nitrate? (tr "dashboard.personal-projects") (tr "dashboard.default-team-name"))]]
 
          (and (contains? cf/flags :subscriptions)
               (not is-default?)

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -875,8 +875,8 @@ msgid "dashboard.move-to-other-team"
 msgstr "Move to other team"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:348, src/app/main/ui/dashboard/sidebar.cljs:349, src/app/main/ui/dashboard/sidebar.cljs:761
-msgid "dashboard.my-teams"
-msgstr "My Teams"
+msgid "dashboard.other-teams"
+msgstr "Other teams"
 
 #: src/app/main/ui/dashboard/files.cljs:106, src/app/main/ui/dashboard/projects.cljs:253, src/app/main/ui/dashboard/projects.cljs:254
 msgid "dashboard.new-file"
@@ -1440,8 +1440,8 @@ msgstr "Your name"
 msgid "dashboard.your-penpot"
 msgstr "Your Penpot"
 
-msgid "dashboard.my-files"
-msgstr "My Files"
+msgid "dashboard.personal-projects"
+msgstr "Personal Projects"
 
 #: src/app/main/ui/alert.cljs:36
 msgid "ds.alert-ok"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -879,8 +879,8 @@ msgid "dashboard.move-to-other-team"
 msgstr "Mover a otro equipo"
 
 #: src/app/main/ui/dashboard/sidebar.cljs:348, src/app/main/ui/dashboard/sidebar.cljs:349, src/app/main/ui/dashboard/sidebar.cljs:761
-msgid "dashboard.my-teams"
-msgstr "Mis Equipos"
+msgid "dashboard.other-teams"
+msgstr "Otros equipos"
 
 #: src/app/main/ui/dashboard/files.cljs:106, src/app/main/ui/dashboard/projects.cljs:253, src/app/main/ui/dashboard/projects.cljs:254
 msgid "dashboard.new-file"
@@ -1447,8 +1447,8 @@ msgstr "Tu nombre"
 msgid "dashboard.your-penpot"
 msgstr "Tu Penpot"
 
-msgid "dashboard.my-files"
-msgstr "Mis Archivos"
+msgid "dashboard.personal-projects"
+msgstr "Proyectos Personales"
 
 #: src/app/main/ui/alert.cljs:36
 msgid "ds.alert-ok"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26767

### Summary

Renames two dashboard labels to better reflect their purpose: "My teams" → "Other teams" (navigation) and "My Files" → "Personal Projects" (throughout the product). Updates translation keys and code references accordingly.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
