### PR TITLE
:bug: Fix wrong selection color on inputs

### DIFF
--- a/frontend/resources/styles/common/base.scss
+++ b/frontend/resources/styles/common/base.scss
@@ -41,6 +41,11 @@ body {
   scrollbar-width: thin;
 }
 
+::selection {
+  background: var(--color-accent-background-select);
+  color: var(--color-static-white);
+}
+
 img {
   height: auto;
   width: 100%;

--- a/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
+++ b/frontend/src/app/main/ui/ds/controls/utilities/input_field.scss
@@ -97,6 +97,7 @@
 
   &::selection {
     background: var(--color-accent-background-select);
+    color: var(--color-static-white);
   }
 
   &::placeholder {


### PR DESCRIPTION
### Related Ticket

Closes #11332 

### Summary

The custom text selection colors were no longer being applied. Instead, the app was using the operating system colors as a fallback. Ideally, we should be using a custom input component everywhere, but until then, we need a global solution.

In this PR we are moving `::selection` to a global CSS rule and setting the required colors.

#### Why this happened

The old `workspace.scss` and `dashboard.scss` used `@extend %new-scrollbar;` from `basic-rules.scss`. That placeholder contained an unscoped `::selection` rule (`basic-rules.scss`):

```scss
%new-scrollbar {
  // ...
  ::selection {                          // ← no &, applies to ALL descendants
    background: var(--text-editor-selection-background-color);
    color: var(--text-editor-selection-foreground-color);
  }
}
```

When `.workspace` and `.dashboard` extended `%new-scrollbar`, this generated `.workspace ::selection` and `.dashboard ::selection` rules that cascaded to all descendant elements, including every `<input>` inside them. That's why text selection in any input had the custom purple/mint background.

When it changed

Commit e14e7bb616 — ":recycle: Refactor and remove deprecated css (#10698)" — on July 29, 2026.

It replaced:

`@extend %new-scrollbar;`

with:

`@include custom-scrollbar($include-selection: false, $include-placeholder: false);`

The new `custom-scrollbar` mixin (`mixins.scss`) uses `&::selection` (scoped to the element itself, not descendants) and it's explicitly disabled with `$include-selection: false`. So the workspace/dashboard containers no longer provide any `::selection` styling for their descendants.