### PR TITLE
:bug: Include tenant in library summary cache keys

### DIFF
--- a/backend/src/app/rpc/commands/files.clj
+++ b/backend/src/app/rpc/commands/files.clj
@@ -515,8 +515,11 @@
 (def ^:private file-summary-cache-key-ttl
   (ct/duration {:days 30}))
 
-(def file-summary-cache-key-prefix
-  "penpot.library-summary.")
+(defn file-summary-cache-key
+  "Build the redis cache key for the file library summary. The tenant is
+   included to prevent key collisions between tenants sharing a redis instance"
+  [id]
+  (str "penpot.library-summary." (cf/get :tenant) "." id))
 
 (defn- get-file-with-summary
   "Get a file without data with a summary of its local library content"
@@ -545,7 +548,7 @@
                    (rds/build-set-args {:ex file-summary-cache-key-ttl})))]
 
     (if (contains? cf/flags :redis-cache)
-      (let [cache-key (str file-summary-cache-key-prefix id)]
+      (let [cache-key (file-summary-cache-key id)]
         (or (rds/run! cfg get-from-cache cache-key)
             (let [file (calculate-from-db)]
               (rds/run! cfg persist-to-cache (:library-summary file) cache-key)

--- a/backend/src/app/rpc/commands/files_update.clj
+++ b/backend/src/app/rpc/commands/files_update.clj
@@ -322,7 +322,7 @@
 (defn- invalidate-caches!
   [cfg {:keys [id] :as file}]
   (rds/run! cfg (fn [{:keys [::rds/conn]}]
-                  (let [key (str files/file-summary-cache-key-prefix id)]
+                  (let [key (files/file-summary-cache-key id)]
                     (rds/del conn key)))))
 
 (defn- attach-snapshot


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Library summary Redis cache keys now include the tenant: `penpot.library-summary.<tenant>.<file-id>` instead of `penpot.library-summary.<file-id>`.

## Why

The library summary cache keys were the only Redis keys missing the tenant component. The rest of the shared infrastructure is tenant-scoped (rate-limit keys use `penpot.rlimit.<tenant>.*`, msgbus topics and worker queues are prefixed with the tenant), so when several Penpot instances (tenants) share the same Redis, these keys were not isolated per tenant and broke the key naming convention.

## How

- Replaced the `file-summary-cache-key-prefix` def with a `file-summary-cache-key` function that appends the configured tenant (`app.config :tenant`) to the key.
- Cache persistence (`get-file-with-summary`) and invalidation on file updates (`invalidate-caches!`) both use the new function, so they stay consistent.

Keys in the old format expire on their own with the existing 30-day TTL; no migration needed.

Closes #11407
