### PR TITLE
:bug: Align management API with payments service

### DIFF
--- a/backend/src/app/http/management.clj
+++ b/backend/src/app/http/management.clj
@@ -209,7 +209,7 @@
                  [:enum
                   "customer_service"
                   "low_quality"
-                  "missing_feature"
+                  "missing_features"
                   "other"
                   "switched_service"
                   "too_complex"

--- a/backend/src/app/nitrate.clj
+++ b/backend/src/app/nitrate.clj
@@ -245,7 +245,7 @@
                  [:enum
                   "customer_service"
                   "low_quality"
-                  "missing_feature"
+                  "missing_features"
                   "other"
                   "switched_service"
                   "too_complex"

--- a/backend/src/app/srepl/cli.clj
+++ b/backend/src/app/srepl/cli.clj
@@ -232,7 +232,7 @@
                  [:enum
                   "customer_service"
                   "low_quality"
-                  "missing_feature"
+                  "missing_features"
                   "other"
                   "switched_service"
                   "too_complex"


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/11329

### Summary
The payments service sends `missing_features` as a subscription
cancellation reason, while the backend schemas expected
`missing_feature`.

This mismatch caused schema validation to reject the request before the
cancellation could be processed. Update all relevant management schemas
to use the identifier expected by the payments service.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
