### PR TITLE
:bug: Fix default team and UI labels to use Personal Projects

### DIFF
--- a/backend/resources/app/email/request-file-access-yourpenpot-view/en.html
+++ b/backend/resources/app/email/request-file-access-yourpenpot-view/en.html
@@ -191,7 +191,7 @@
                           file named “{{file-name|abbreviate:25}}”.
                         </p>
                         <p>
-                          Since this file is in Personal Projects, you can provide access by sending a view-only link.
+                          Since this file is in your Personal Projects, you can provide access by sending a view-only link.
                           This will allow {{requested-by|abbreviate:25}} to view the content without making any changes.
                         </p>
                         <p>To proceed, please click the button below to generate and send the view-only link:</p>

--- a/backend/resources/app/email/request-file-access-yourpenpot-view/en.html
+++ b/backend/resources/app/email/request-file-access-yourpenpot-view/en.html
@@ -191,7 +191,7 @@
                           file named “{{file-name|abbreviate:25}}”.
                         </p>
                         <p>
-                          Since this file is in your Penpot team, you can provide access by sending a view-only link.
+                          Since this file is in Personal Projects, you can provide access by sending a view-only link.
                           This will allow {{requested-by|abbreviate:25}} to view the content without making any changes.
                         </p>
                         <p>To proceed, please click the button below to generate and send the view-only link:</p>

--- a/backend/resources/app/email/request-file-access-yourpenpot-view/en.txt
+++ b/backend/resources/app/email/request-file-access-yourpenpot-view/en.txt
@@ -2,7 +2,7 @@ Hello!
 
 {{requested-by|abbreviate:25}} ({{requested-by-email}}) wants to have view-only access to the file named “{{file-name|abbreviate:25}}”.
 
-Since this file is in Personal Projects, you can provide access by sending a view-only link. This will allow {{requested-by|abbreviate:25}} to view the content without making any changes.
+Since this file is in your Personal Projects, you can provide access by sending a view-only link. This will allow {{requested-by|abbreviate:25}} to view the content without making any changes.
 
 To proceed, please click the link below to generate and send the view-only link:
 

--- a/backend/resources/app/email/request-file-access-yourpenpot-view/en.txt
+++ b/backend/resources/app/email/request-file-access-yourpenpot-view/en.txt
@@ -2,7 +2,7 @@ Hello!
 
 {{requested-by|abbreviate:25}} ({{requested-by-email}}) wants to have view-only access to the file named “{{file-name|abbreviate:25}}”.
 
-Since this file is in your Penpot team, you can provide access by sending a view-only link. This will allow {{requested-by|abbreviate:25}} to view the content without making any changes.
+Since this file is in Personal Projects, you can provide access by sending a view-only link. This will allow {{requested-by|abbreviate:25}} to view the content without making any changes.
 
 To proceed, please click the link below to generate and send the view-only link:
 

--- a/backend/resources/app/email/request-file-access-yourpenpot/en.html
+++ b/backend/resources/app/email/request-file-access-yourpenpot/en.html
@@ -191,7 +191,7 @@
                           “{{file-name|abbreviate:25}}”.
                         </p>
                         <p>
-                          Please note that the file is currently in Your Penpot 's team, so direct access cannot be
+                          Please note that the file is currently in Personal Projects, so direct access cannot be
                           granted. However, you have two options to provide the requested access:
                         </p>
                         <ul>

--- a/backend/resources/app/email/request-file-access-yourpenpot/en.txt
+++ b/backend/resources/app/email/request-file-access-yourpenpot/en.txt
@@ -5,7 +5,7 @@ Hello!
 
 {{requested-by|abbreviate:25}} ({{requested-by-email}}) has requested access to the file named “{{file-name|abbreviate:25}}”.
 
-Please note that the file is currently in Your Penpot 's team, so direct access cannot be granted. However, you have two options to provide the requested access:
+Please note that the file is currently in Personal Projects, so direct access cannot be granted. However, you have two options to provide the requested access:
 
 - Move the File to Another Team:
 

--- a/backend/src/app/email.clj
+++ b/backend/src/app/email.clj
@@ -505,13 +505,13 @@
    :schema schema:request-file-access))
 
 (def request-file-access-yourpenpot
-  "File access on Your Penpot request email."
+  "File access on Personal Projects request email."
   (template-factory
    :id ::request-file-access-yourpenpot
    :schema schema:request-file-access))
 
 (def request-file-access-yourpenpot-view
-  "File access on Your Penpot view mode request email."
+  "File access on Personal Projects view mode request email."
   (template-factory
    :id ::request-file-access-yourpenpot-view
    :schema schema:request-file-access))

--- a/backend/src/app/rpc/commands/nitrate.clj
+++ b/backend/src/app/rpc/commands/nitrate.clj
@@ -336,7 +336,7 @@
     (doseq [{:keys [id reassign-to]} teams-to-leave]
       (teams/leave-team cfg {:profile-id profile-id :id id :reassign-to reassign-to}))
 
-    ;; Process organization "Your Penpot" team: keep with prefix if needed, otherwise delete.
+    ;; Process organization "Personal Projects" team: keep with prefix if needed, otherwise delete.
     (when default-team-id
       (if keep-default-team?
         (db/exec! conn [sql:prefix-team-name-and-unset-default organization-prefix default-team-id])

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -524,7 +524,7 @@
     ;; Penpot back through two paths: ::notify-user-organizations-deletion
     ;; (during delete-owned-organizations) and ::notify-organization-deletion.
     ;; Both preserve organization teams unchanged and only prefix or delete
-    ;; imported "Your Penpot" teams according to whether they still have files.
+    ;; imported "Personal Projects" teams according to whether they still have files.
     ;; Let Nitrate clean up the data associated with the deleted Penpot user:
     ;; owned organizations, remaining memberships, and subscription cancellation.
     (when (contains? cf/flags :admin-console)

--- a/backend/src/app/rpc/commands/teams.clj
+++ b/backend/src/app/rpc/commands/teams.clj
@@ -575,7 +575,7 @@
                      (set/difference cfeat/frontend-only-features)
                      (set/difference cfeat/no-team-inheritable-features))
         params   {:profile-id profile-id
-                  :name "Your Penpot"
+                  :name "Personal Projects"
                   :features features
                   :organization-id organization-id
                   :is-default true}
@@ -829,7 +829,7 @@
                 :code :only-owner-can-delete-team))
 
     ;; Protect the user's personal default team from deletion.
-    ;; Organization-scoped default teams ("Your Penpot") are allowed to be deleted when they have no files.
+    ;; Organization-scoped default teams ("Personal Projects") are allowed to be deleted when they have no files.
     (when (and (:is-default team) (not in-organization?))
       (ex/raise :type :validation
                 :code :non-deletable-team

--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -318,7 +318,7 @@ RETURNING id, deleted_at;")
 
 (defn manage-deleted-organization-teams
   "For a deleted organization, preserve organization teams unchanged and only prefix or
-  delete member Your Penpot teams depending on whether they still contain files."
+  delete member Personal Projects teams depending on whether they still contain files."
   [cfg {:keys [organization-id organization-name teams]}]
   (let [all-team-ids (->> teams
                           (map :id)
@@ -347,13 +347,13 @@ RETURNING id, deleted_at;")
                  teams-to-delete  (->> your-penpot-team-ids (remove teams-with-files) (into []))]
 
              ;; Organization teams move to the fallback organization unchanged. Only imported
-             ;; Your Penpot teams keep the organization prefix when they still have files.
+             ;; Personal Projects teams keep the organization prefix when they still have files.
              (when (seq teams-to-prefix)
                (db/exec! conn [sql:prefix-teams-name-and-unset-default
                                organization-prefix
                                (db/create-array conn "uuid" teams-to-prefix)]))
 
-             ;; Empty imported Your Penpot teams disappear entirely.
+             ;; Empty imported Personal Projects teams disappear entirely.
              (soft-delete-teams! cfg teams-to-delete)
 
              (notifications/notify-organization-deletion cfg organization-id organization-name all-team-ids teams-to-delete)
@@ -362,7 +362,7 @@ RETURNING id, deleted_at;")
 
 (sv/defmethod ::notify-organization-deletion
   "For a deleted organization, preserve organization teams and only prefix or delete
-   imported Your Penpot teams before notifying connected users."
+   imported Personal Projects before notifying connected users."
   {::doc/added "2.18"
    ::sm/params schema:notify-organization-deletion
    ::rpc/auth false}
@@ -382,7 +382,7 @@ RETURNING id, deleted_at;")
 
 (sv/defmethod ::notify-user-organizations-deletion
   "For a given user, find all owned organizations and apply the deleted-organization
-   transfer rules to their imported Your Penpot teams."
+   transfer rules to their imported Personal Projects teams."
   {::doc/added "2.18"
    ::sm/params schema:notify-user-organizations-deletion
    ::nitrate/sso false}

--- a/backend/test/backend_tests/rpc_management_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_management_nitrate_test.clj
@@ -268,7 +268,7 @@
           new-team     (th/db-get :team {:id new-team-id})]
       (t/is (th/success? out))
       (t/is (= 1 (count (set/difference after-teams before-teams))))
-      (t/is (= "Your Penpot" (:name new-team)))
+      (t/is (= "Personal Projects" (:name new-team)))
       (t/is (true? (:is-default new-team))))))
 
 (t/deftest get-managed-profiles-returns-unique-members-for-owned-teams

--- a/frontend/playwright/ui/pages/DashboardPage.js
+++ b/frontend/playwright/ui/pages/DashboardPage.js
@@ -86,7 +86,7 @@ export class DashboardPage extends BaseWebSocketPage {
     this.searchInput = page.getByPlaceholder("Search…");
 
     this.teamDropdown = this.sidebar.getByRole("button", {
-      name: "Your Penpot",
+      name: "Personal Projects",
     });
     this.userAccount = this.sidebar.getByRole("button", {
       name: /Princesa Leia/,

--- a/frontend/playwright/ui/pages/OnboardingPage.js
+++ b/frontend/playwright/ui/pages/OnboardingPage.js
@@ -7,7 +7,7 @@ export class OnboardingPage extends BaseWebSocketPage {
   }
 
   async fillOnboardingInputsStep1() {
-    await this.page.getByText("Personal").click();
+    await this.page.getByText("Personal", { exact: true }).click();
     await this.page.getByText("Select option").click();
     await this.page.getByText("Product Management").click();
 

--- a/frontend/src/app/main/ui/dashboard/file_menu.cljs
+++ b/frontend/src/app/main/ui/dashboard/file_menu.cljs
@@ -37,7 +37,7 @@
 (defn- get-team-name
   [team]
   (if (:is-default team)
-    (tr "dashboard.your-penpot")
+    (tr "dashboard.personal-projects")
     (:name team)))
 
 (defn- group-by-team

--- a/frontend/src/app/main/ui/dashboard/fonts.cljs
+++ b/frontend/src/app/main/ui/dashboard/fonts.cljs
@@ -43,7 +43,7 @@
   (mf/with-effect [team]
     (when team
       (let [tname (if (:is-default team)
-                    (tr "dashboard.your-penpot")
+                    (tr "dashboard.personal-projects")
                     (:name team))]
         (case section
           :fonts (dom/set-html-title (tr "title.dashboard.fonts" tname))

--- a/frontend/src/app/main/ui/dashboard/libraries.cljs
+++ b/frontend/src/app/main/ui/dashboard/libraries.cljs
@@ -52,7 +52,7 @@
 
     (mf/with-effect [team]
       (let [tname (if (:is-default team)
-                    (tr "dashboard.your-penpot")
+                    (tr "dashboard.personal-projects")
                     (:name team))]
         (dom/set-html-title (tr "title.dashboard.shared-libraries" tname))))
 

--- a/frontend/src/app/main/ui/dashboard/projects.cljs
+++ b/frontend/src/app/main/ui/dashboard/projects.cljs
@@ -357,7 +357,7 @@
 
     (mf/with-effect [team]
       (let [tname (if (:is-default team)
-                    (tr "dashboard.your-penpot")
+                    (tr "dashboard.personal-projects")
                     (:name team))]
         (dom/set-html-title (tr "title.dashboard.projects" tname))))
 

--- a/frontend/src/app/main/ui/dashboard/search.cljs
+++ b/frontend/src/app/main/ui/dashboard/search.cljs
@@ -44,7 +44,7 @@
     (mf/with-effect [team]
       (when team
         (let [tname (if (:is-default team)
-                      (tr "dashboard.your-penpot")
+                      (tr "dashboard.personal-projects")
                       (:name team))]
           (dom/set-html-title (tr "title.dashboard.search" tname)))))
 

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -438,7 +438,7 @@
       (when-not (contains? cf/flags :admin-console)
         [:span {:class (stl/css :penpot-icon)} deprecated-icon/logo-icon])
 
-      [:span {:class (stl/css :team-text)} (if (contains? cf/flags :admin-console) (tr "dashboard.personal-projects") (tr "dashboard.your-penpot"))]
+      [:span {:class (stl/css :team-text)} (tr "dashboard.personal-projects")]
       (when (= default-team-id (:id team))
         tick-icon)]
 
@@ -725,7 +725,7 @@
 
         current-organization (dtm/team->organization team)
 
-        ;; Find the "your-penpot" teams, and transform them in organizations. When
+        ;; Find the "personal-projects" teams, and transform them in organizations. When
         ;; the selected team is directly accessible but not listed in
         ;; membership teams, include only its organization so the organization selector can
         ;; show the current selection without leaking the team into the

--- a/frontend/src/app/main/ui/dashboard/sidebar.cljs
+++ b/frontend/src/app/main/ui/dashboard/sidebar.cljs
@@ -972,7 +972,7 @@
                                      :team-name-no-logo nitrate?)}
           (when-not nitrate?
             [:span {:class (stl/css :penpot-icon)} deprecated-icon/logo-icon])
-          [:span {:class (stl/css :team-text)} (if nitrate? (tr "dashboard.personal-projects") (tr "dashboard.default-team-name"))]]
+          [:span {:class (stl/css :team-text)} (tr "dashboard.personal-projects")]]
 
          (and (contains? cf/flags :subscriptions)
               (not is-default?)

--- a/frontend/src/app/main/ui/dashboard/team.cljs
+++ b/frontend/src/app/main/ui/dashboard/team.cljs
@@ -644,7 +644,7 @@
     (dom/set-html-title
      (tr "title.team-members"
          (if (:is-default team)
-           (tr "dashboard.your-penpot")
+           (tr "dashboard.personal-projects")
            (:name team)))))
 
   (mf/with-effect [(:id team)]
@@ -1248,7 +1248,7 @@
     (dom/set-html-title
      (tr "title.team-invitations"
          (if (:is-default team)
-           (tr "dashboard.your-penpot")
+           (tr "dashboard.personal-projects")
            (:name team)))))
 
   (mf/with-effect [(:id team)]
@@ -1528,7 +1528,7 @@
       (dom/set-html-title
        (tr "title.team-webhooks"
            (if (:is-default team)
-             (tr "dashboard.your-penpot")
+             (tr "dashboard.personal-projects")
              (:name team)))))
 
     (mf/with-effect []
@@ -1635,7 +1635,7 @@
     (mf/with-effect [team]
       (dom/set-html-title (tr "title.team-settings"
                               (if (:is-default team)
-                                (tr "dashboard.your-penpot")
+                                (tr "dashboard.personal-projects")
                                 (:name team)))))
 
     (mf/with-effect []

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -1440,9 +1440,6 @@ msgstr "Your name"
 msgid "dashboard.personal-projects"
 msgstr "Personal Projects"
 
-msgid "dashboard.personal-projects"
-msgstr "Personal Projects"
-
 #: src/app/main/ui/alert.cljs:36
 msgid "ds.alert-ok"
 msgstr "Ok"

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -413,7 +413,7 @@ msgstr "Pin this version"
 
 #: src/app/main/ui/components/context_menu_a11y.cljs:300, src/app/main/ui/dashboard/sidebar.cljs:882
 msgid "dashboard.default-team-name"
-msgstr "Your Penpot"
+msgstr "Personal Projects"
 
 #: src/app/main/ui/dashboard/deleted.cljs:265
 msgid "dashboard.delete-all-forever-confirmation.description"
@@ -1437,8 +1437,8 @@ msgid "dashboard.your-name"
 msgstr "Your name"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:40, src/app/main/ui/dashboard/fonts.cljs:46, src/app/main/ui/dashboard/libraries.cljs:55, src/app/main/ui/dashboard/projects.cljs:352, src/app/main/ui/dashboard/search.cljs:47, src/app/main/ui/dashboard/sidebar.cljs:411, src/app/main/ui/dashboard/team.cljs:616, src/app/main/ui/dashboard/team.cljs:1191, src/app/main/ui/dashboard/team.cljs:1471, src/app/main/ui/dashboard/team.cljs:1577
-msgid "dashboard.your-penpot"
-msgstr "Your Penpot"
+msgid "dashboard.personal-projects"
+msgstr "Personal Projects"
 
 msgid "dashboard.personal-projects"
 msgstr "Personal Projects"
@@ -4631,7 +4631,7 @@ msgstr "You don't have access to this file."
 
 #: src/app/main/ui/static.cljs:62, src/app/main/ui/static.cljs:265, src/app/main/ui/static.cljs:271, src/app/main/ui/static.cljs:277, src/app/main/ui/static.cljs:283, src/app/main/ui/static.cljs:292, src/app/main/ui/static.cljs:301
 msgid "not-found.no-permission.go-dashboard"
-msgstr "Go to your Penpot"
+msgstr "Go to Personal Projects"
 
 #: src/app/main/ui/static.cljs:289, src/app/main/ui/static.cljs:298
 msgid "not-found.no-permission.if-approves"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -1447,9 +1447,6 @@ msgstr "Tu nombre"
 msgid "dashboard.personal-projects"
 msgstr "Proyectos Personales"
 
-msgid "dashboard.personal-projects"
-msgstr "Proyectos Personales"
-
 #: src/app/main/ui/alert.cljs:36
 msgid "ds.alert-ok"
 msgstr "Ok"

--- a/frontend/translations/es.po
+++ b/frontend/translations/es.po
@@ -420,7 +420,7 @@ msgstr "Guardar esta versión"
 
 #: src/app/main/ui/components/context_menu_a11y.cljs:300, src/app/main/ui/dashboard/sidebar.cljs:882
 msgid "dashboard.default-team-name"
-msgstr "Tu Penpot"
+msgstr "Proyectos Personales"
 
 #: src/app/main/ui/dashboard/deleted.cljs:265
 msgid "dashboard.delete-all-forever-confirmation.description"
@@ -1444,8 +1444,8 @@ msgid "dashboard.your-name"
 msgstr "Tu nombre"
 
 #: src/app/main/ui/dashboard/file_menu.cljs:40, src/app/main/ui/dashboard/fonts.cljs:46, src/app/main/ui/dashboard/libraries.cljs:55, src/app/main/ui/dashboard/projects.cljs:352, src/app/main/ui/dashboard/search.cljs:47, src/app/main/ui/dashboard/sidebar.cljs:411, src/app/main/ui/dashboard/team.cljs:616, src/app/main/ui/dashboard/team.cljs:1191, src/app/main/ui/dashboard/team.cljs:1471, src/app/main/ui/dashboard/team.cljs:1577
-msgid "dashboard.your-penpot"
-msgstr "Tu Penpot"
+msgid "dashboard.personal-projects"
+msgstr "Proyectos Personales"
 
 msgid "dashboard.personal-projects"
 msgstr "Proyectos Personales"
@@ -4503,7 +4503,7 @@ msgstr "No tienes permiso para acceder a este archivo."
 
 #: src/app/main/ui/static.cljs:62, src/app/main/ui/static.cljs:265, src/app/main/ui/static.cljs:271, src/app/main/ui/static.cljs:277, src/app/main/ui/static.cljs:283, src/app/main/ui/static.cljs:292, src/app/main/ui/static.cljs:301
 msgid "not-found.no-permission.go-dashboard"
-msgstr "Ir a tu Penpot"
+msgstr "Ir a tus Proyectos Personales"
 
 #: src/app/main/ui/static.cljs:289, src/app/main/ui/static.cljs:298
 msgid "not-found.no-permission.if-approves"


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26764

### Summary

Renames "Your Penpot" to "Personal Projects" across all user-facing surfaces: UI labels, translation keys (en/es), default team name on org join, email template text, and the org-deletion prefix logic. Internal identifiers (:is-your-penpot, variable names, email template directory names, test data files) are intentionally left unchanged in this phase.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
