### PR TITLE
:books: Document disable-email-verification team auto-add behavior

### DIFF
--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -343,9 +343,13 @@ By default, <code class="language-bash">smtp</code> flag is disabled, the email 
 printed to the console, which means that the emails will be shown in the stdout.
 
 Note that if you plan to invite members to a team, it is recommended that you enable SMTP
-as they will need to login to their account after receiving the invite link sent an in email.
-It is currently not possible to just add someone to a team without them accepting an
-invitation email.
+as they will need to login to their account after receiving the invite link sent in an email.
+
+There is one exception: with the `disable-email-verification` flag set, inviting an email
+that already has a profile adds that user to the team directly, without sending any
+invitation email and without requiring acceptance. Emails without an existing profile
+still follow the normal invitation flow. See the
+[`disable-email-verification` flag][8] description for more detail.
 
 If you have an SMTP service, uncomment the appropriate settings section in
 <code class="language-bash">docker-compose.yml</code> and configure those
@@ -672,6 +676,13 @@ for the user:
 - <code class="language-bash">disable-login-with-password</code>: allows disable password based login form
 - <code class="language-bash">enable-prepl-server</code>: enables PREPL server, used by manage.py and other additional
   tools to communicate internally with Penpot backend. Check the [CLI section][5] to get more detail.
+- `disable-email-verification`: skips the email verification step on registration, making
+  newly registered profiles active immediately without any verification email. It also
+  changes the team invitation flow: inviting an email that already has a profile adds that
+  user to the team directly, without sending an invitation email (check the
+  [email configuration section][8] for more detail). Note that registering with an email
+  that already has an inactive profile is rejected as "email already exists" while this
+  flag is set. Not recommended for production environments.
 
 __Since version 1.13.0__
 
@@ -693,3 +704,4 @@ __Since version 2.0.0__
 [5]: /technical-guide/getting-started/docker#using-the-cli-for-administrative-tasks
 [6]: /technical-guide/integration/#webhooks
 [7]: /technical-guide/integration/#access-tokens
+[8]: /technical-guide/configuration/#email-configuration

--- a/docs/technical-guide/developer/subsystems/authentication.md
+++ b/docs/technical-guide/developer/subsystems/authentication.md
@@ -113,6 +113,13 @@ is routed, depending if the email corresponds to an existing account or not. The
 <code class="language-clojure">:register-profile</code> or <code class="language-clojure">:login</code> services are used, and the invitation token is
 attached so that the profile is linked to the team at the end.
 
+There is a shortcut when the `:email-verification` flag is disabled: if the invited email
+already corresponds to an existing profile, the `create-invitation` function (in
+`app.rpc.commands.teams-invitations`) adds the profile to the team directly, without
+creating an invitation token or sending an email, and marks the profile as active if it
+was inactive. Emails without an existing profile follow the normal invitation flow
+described above.
+
 ## Handling unfinished registrations and bouncing users
 
 All tokens have an expiration date, and when they are put in a permanent

--- a/docs/technical-guide/getting-started/docker.md
+++ b/docs/technical-guide/getting-started/docker.md
@@ -95,6 +95,10 @@ or
 docker exec -ti penpot-penpot-backend-1 python3 manage.py create-profile --skip-tutorial --skip-walkthrough
 ```
 
+**NOTE:** profiles created with this command have no verified email. If the
+`disable-email-verification` flag is set, inviting these users to a team adds them to it
+directly, without sending any invitation email, so SMTP is not required for this flow.
+Check the [Configuration][1] section for more detail.
 
 **NOTE:** the exact container name depends on your docker version and platform.
 For example it could be <code class="language-bash">penpot-penpot-backend-1</code> or <code class="language-bash">penpot_penpot-backend-1</code>.


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Replaces the incorrect claim in the self-hosting configuration docs stating that it is not possible to add someone to a team without them accepting an invitation email — with `disable-email-verification` set, existing profiles are auto-added to teams when invited.
- Adds the missing `disable-email-verification` entry to the "Other flags" reference: primary effect (skips email verification on registration), the team auto-add side effect, the "email already exists" rejection edge case, and a not-recommended-for-production warning.
- Documents in the docker getting-started guide that profiles created with `manage.py create-profile` are added to teams directly when invited, without needing SMTP.
- Describes the auto-add shortcut in the developer-facing authentication docs.

## Why

When the `:email-verification` flag is disabled, `create-invitation` in `app.rpc.commands.teams-invitations` adds profiles that already exist in the database to the team directly, with no invitation email and no acceptance step (covered by the `create-team-invitations-with-email-verification-disabled` backend test). The configuration docs claimed the opposite, and the flag itself was never defined in the current technical guide — the entry was lost during the docs migration. Reported in #11376.

## How

Docs-only change, no code modified:

- **configuration.md** — accurate exception note in the Email configuration section and a new `disable-email-verification` entry in "Other flags", cross-linked.
- **getting-started/docker.md** — NOTE after the `create-profile` commands about the auto-add behavior.
- **developer/subsystems/authentication.md** — paragraph describing the `:email-verification`-disabled shortcut in the Team invitations section.

Validated with a full docs site build (`pnpm run build`) and by checking the rendered HTML of the three pages.

Closes #11376
