### PR TITLE
:sparkles: Add a new nitrate endpoint to check the airgapped flag

### DIFF
--- a/backend/src/app/rpc/management/nitrate.clj
+++ b/backend/src/app/rpc/management/nitrate.clj
@@ -1045,3 +1045,18 @@ RETURNING id, deleted_at;")
                 (update acc :created conj email)))))
         {:created [] :skipped []}
         emails)))))
+
+;; ---- API: get-air-gapped
+
+(def ^:private schema:get-air-gapped-result
+  [:map
+   [:air-gapped ::sm/boolean]])
+
+(sv/defmethod ::get-air-gapped
+  "Returns whether this Penpot instance runs in air-gapped mode."
+  {::doc/added "2.18"
+   ::sm/params [:map]
+   ::sm/result schema:get-air-gapped-result
+   ::rpc/auth false}
+  [_cfg _params]
+  {:air-gapped (contains? cf/flags :air-gapped-conf)})

--- a/backend/test/backend_tests/rpc_management_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_management_nitrate_test.clj
@@ -194,6 +194,15 @@
                 (string? (get version k)))))
     (t/is (= cf/version version))))
 
+(t/deftest get-air-gapped
+  (let [out (th/management-command! {::th/type :get-air-gapped})]
+    (t/is (th/success? out))
+    (t/is (false? (-> out :result :air-gapped))))
+  (binding [cf/flags (conj cf/flags :air-gapped-conf)]
+    (let [out (th/management-command! {::th/type :get-air-gapped})]
+      (t/is (th/success? out))
+      (t/is (true? (-> out :result :air-gapped))))))
+
 (t/deftest get-teams-returns-only-owned-non-default-non-deleted
   (with-mocks [nitrate-mock {:target 'app.nitrate/call :return nil}]
     (let [profile      (th/create-profile* 1 {:is-active true})


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26770

### Summary

Add a new endpoint for nitrate that shows if an instance is airgapped

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.
