### PR TITLE
:bug: Fix size-limiting-stream read arity on v3 binfile import

### DIFF
--- a/backend/src/app/binfile/v3.clj
+++ b/backend/src/app/binfile/v3.clj
@@ -436,25 +436,26 @@
   Raises :validation :max-file-size-reached when the limit is exceeded."
   ^InputStream
   [^InputStream input ^long max-size]
-  (let [counter (atom 0)]
+  (let [counter (atom 0)
+        on-read (fn [n]
+                  (when (pos? n)
+                    (when (> (swap! counter + (long n)) max-size)
+                      (ex/raise :type :validation
+                                :code :max-file-size-reached
+                                :hint (str "stream exceeded max size: " max-size))))
+                  n)]
     (proxy [FilterInputStream] [input]
       (read
         ([]
          (let [b (.read input)]
-           (when (pos? b)
-             (when (> (swap! counter inc) max-size)
-               (ex/raise :type :validation
-                         :code :max-file-size-reached
-                         :hint (str "stream exceeded max size: " max-size))))
+           (when (pos? b) (on-read 1))
            b))
-        ([buf off len]
-         (let [n (.read input buf off len)]
-           (when (pos? n)
-             (when (> (swap! counter + (long n)) max-size)
-               (ex/raise :type :validation
-                         :code :max-file-size-reached
-                         :hint (str "stream exceeded max size: " max-size))))
-           n))))))
+        ([^bytes buf]
+         (on-read (.read input buf 0 (alength buf))))
+        ([^bytes buf off]
+         (on-read (.read input buf (int off) (- (alength buf) (int off)))))
+        ([^bytes buf off len]
+         (on-read (.read input buf (int off) (int len))))))))
 
 (defn- zip-entry-reader
   [^ZipFile input ^ZipEntry entry]


### PR DESCRIPTION
## What

- v3 `.penpot` imports fail with `:server-error :unexpected` / `stream exception` on staging whenever the import processes storage objects (images, fonts, etc.).
- The backend raises `ArityException: Wrong number of args (2) passed to: app.binfile.v3/size-limiting-stream/...` while hashing ZIP entry content during `import-binfile`.

## Why

PR #11022 added `size-limiting-stream` as a `FilterInputStream` proxy to enforce decompressed byte limits, but it only overrode `read()` and `read(byte[], int, int)`.

When `calculate-hash` reads the stream, Apache Commons IO's `UnsynchronizedBufferedInputStream` calls `read(byte[])` (and Clojure interop can hit a 2-arg path). Those overloads were missing, so every import that hashes a storage object crashes with an unhandled `ArityException` instead of proceeding (or raising `:max-file-size-reached` when the limit applies).

## How

- **Proxy overloads:** implement `read(byte[])`, `read(byte[], int)`, and `read(byte[], int, int)` on the wrapper, delegating to the underlying ZIP stream.
- **Shared logic:** extract `on-read` to count bytes and raise `:validation :max-file-size-reached` consistently across all read paths.
