### PR TITLE
:bug: Fix crash pressing Ctrl+D with no shape selected

### DIFF
--- a/frontend/src/app/main/data/workspace/variants.cljs
+++ b/frontend/src/app/main/data/workspace/variants.cljs
@@ -539,9 +539,10 @@
       (let [objects               (dsh/lookup-page-objects state)
             selected-ids          (dsh/lookup-selected state)
             selected-shapes       (map (d/getf objects) selected-ids)
-            add-new-variant?      (every? ctc/is-variant? selected-shapes)
+            add-new-variant?      (and (seq selected-shapes) (every? ctc/is-variant? selected-shapes))
             undo-id              (js/Symbol)]
-        (if add-new-variant?
+        (cond
+          add-new-variant?
           (rx/concat
            (rx/of
             (ev/event {::ev/name "add-new-variant" ::ev/origin "workspace:shortcut-duplicate"})
@@ -549,7 +550,12 @@
             (add-new-variant (first selected-ids) false))
            (rx/from (map #(add-new-variant % true) (rest selected-ids)))
            (rx/of (dwu/commit-undo-transaction undo-id)))
-          (rx/of (dws/duplicate-selected true)))))))
+
+          (seq selected-ids)
+          (rx/of (dws/duplicate-selected true))
+
+          :else
+          (rx/empty))))))
 
 (defn rename-variant
   "Rename the variant container and all components belonging to this variant"


### PR DESCRIPTION
### Related Ticket

This PR closes https://github.com/penpot/penpot/issues/11448

### Summary

The problem solved:
`every?` returns true on an empty collection, so with nothing selected `add-new-variant?` evaluated to true and called `add-new-variant` with a nil shape-id, tripping the `uuid?` assertion. 
Require a non-empty selection before treating it as an add-variant action, and no-op when nothing is selected instead of falling through to duplicate-selected.

AI-assisted-by: claude-sonnet-5

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
