### PR TITLE
:bug: Stop opening Comments section from persisting display-comments

### DIFF
--- a/frontend/playwright/ui/pages/WorkspacePage.js
+++ b/frontend/playwright/ui/pages/WorkspacePage.js
@@ -600,6 +600,12 @@ export class WorkspacePage extends BaseWebSocketPage {
       .getByRole("button", { name: "Comments (C)" })
       .click(clickOptions);
   }
+
+  async toggleCommentsVisibilityFromMenu(clickOptions = {}) {
+    await this.page.getByRole("button", { name: "Main menu" }).click();
+    await this.page.getByText("view").last().click();
+    await this.page.locator("#file-menu-comments").click(clickOptions);
+  }
 }
 
 export default WorkspacePage;

--- a/frontend/playwright/ui/specs/workspace-comments.spec.js
+++ b/frontend/playwright/ui/specs/workspace-comments.spec.js
@@ -35,3 +35,64 @@ test("Group bubbles when zooming out if they overlap", async ({ page }) => {
     /unread/,
   );
 });
+
+test("Opening the Comments section only temporarily overrides a disabled global comments setting", async ({
+  page,
+}) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.setupFileWithComments();
+  await workspacePage.goToWorkspace();
+
+  const bubble = page.getByTestId("floating-thread-bubble-1");
+
+  // "Display comments" is enabled by default, so the bubble is already visible.
+  await expect(bubble).toBeVisible();
+
+  // Turn the global "Display comments" setting off from the main menu.
+  await workspacePage.toggleCommentsVisibilityFromMenu();
+  await expect(bubble).toBeHidden();
+
+  // Opening the Comments section shows comments regardless of the global setting.
+  await workspacePage.showComments();
+  await expect(bubble).toBeVisible();
+
+  // Closing the Comments section falls back to the (still disabled) global setting.
+  await workspacePage.showComments();
+  await expect(bubble).toBeHidden();
+
+  // The global setting itself must be untouched by opening/closing the section.
+  await page.getByRole("button", { name: "Main menu" }).click();
+  await page.getByText("view").last().click();
+  await expect(page.locator("#file-menu-comments")).toContainText(
+    "Show comments",
+  );
+  await page.keyboard.press("Escape");
+});
+
+test("Comments stay visible through opening and closing the Comments section when the global setting is enabled", async ({
+  page,
+}) => {
+  const workspacePage = new WasmWorkspacePage(page);
+  await workspacePage.setupEmptyFile();
+  await workspacePage.setupFileWithComments();
+  await workspacePage.goToWorkspace();
+
+  const bubble = page.getByTestId("floating-thread-bubble-1");
+
+  // "Display comments" is enabled by default.
+  await expect(bubble).toBeVisible();
+
+  await workspacePage.showComments();
+  await expect(bubble).toBeVisible();
+
+  await workspacePage.showComments();
+  await expect(bubble).toBeVisible();
+
+  await page.getByRole("button", { name: "Main menu" }).click();
+  await page.getByText("view").last().click();
+  await expect(page.locator("#file-menu-comments")).toContainText(
+    "Hide comments",
+  );
+  await page.keyboard.press("Escape");
+});

--- a/frontend/src/app/main/data/workspace/drawing.cljs
+++ b/frontend/src/app/main/data/workspace/drawing.cljs
@@ -15,7 +15,6 @@
    [app.main.data.workspace.drawing.common :as common]
    [app.main.data.workspace.drawing.curve :as curve]
    [app.main.data.workspace.drawing.line :as line]
-   [app.main.data.workspace.layout :as dwlo]
    [app.main.data.workspace.path :as path]
    [beicon.v2.core :as rx]
    [potok.v2.core :as ptk]))
@@ -46,11 +45,6 @@
       (rx/merge
        (when (= tool :path)
          (rx/of (start-drawing :path)))
-
-       ;; NOTE: comments are a special case and they manage they
-       ;; own interrupt cycle.
-       (when (= tool :comments)
-         (rx/of (dwlo/toggle-layout-flag :display-comments :force? true)))
 
        (when (and (not= tool :comments)
                   (not= tool :path))


### PR DESCRIPTION
### Related Ticket

This PR closes https://github.com/penpot/penpot/issues/11308

### Summary

Activating the comments drawing tool force-set and persisted the global `:display-comments` layout flag to localStorage every time, so closing the Comments section left comments permanently visible regardless of the user's actual preference in the main menu.

Canvas visibility already falls back correctly to `:display-comments` once the drawing tool is cleared (`show-comments?` in viewport.cljs), so removing the force-write is enough to decouple the two: opening the section shows comments only while active, closing it restores whatever the global setting was.

Adds e2e coverage asserting the global setting survives opening and closing the Comments section in both the enabled and disabled cases.

AI-assisted-by: claude-sonnet-5

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
