### PR TITLE
:bug: Fix enterprise modal inconsistency

### DIFF
--- a/frontend/src/app/main/ui/nitrate/nitrate_form.cljs
+++ b/frontend/src/app/main/ui/nitrate/nitrate_form.cljs
@@ -27,6 +27,7 @@
 
   (let [show-contact-sales-option (:show-contact-sales-option connectivity)
         subscription-start-origin (:subscription-start-origin connectivity)
+        base-url                  (or (:base-url connectivity) dnt/go-to-ac-url)
         online? (and (:licenses connectivity) (not show-contact-sales-option))
         profile  (mf/deref refs/profile)
         on-click
@@ -34,7 +35,7 @@
          (fn []
            (dnt/go-to-buy-nitrate-license
             "monthly"
-            dnt/go-to-ac-url
+            base-url
             dnt/go-to-subscription-url
             "dashboard:plan-confirmation-modal"
             (if (:subscription profile) "paid" "trial")

--- a/frontend/src/app/main/ui/settings/subscription.cljs
+++ b/frontend/src/app/main/ui/settings/subscription.cljs
@@ -511,10 +511,11 @@
                                 ::ev/origin "settings"}))
            (if (= subscription-type "nitrate")
              (st/emit! (dnt/show-nitrate-popup
-                        :nitrate-dialog
+                        :nitrate-form
                         {:nitrate-license nitrate-license
                          :event-origin "settings:plan-confirmation-modal"
-                         :subscription-start-origin "settings"}))
+                         :subscription-start-origin "settings"
+                         :base-url (rt/get-current-href)}))
              (st/emit!
               (modal/show :management-dialog
                           {:subscription-type subscription-type
@@ -526,7 +527,7 @@
          (mf/deps nitrate-license)
          (fn [current-subscription subscription-type & [has-billing-access?]]
            (if (= current-subscription "unlimited")
-             (st/emit! (dnt/show-nitrate-popup :nitrate-dialog {:nitrate-license nitrate-license :show-contact-sales-option true}))
+             (st/emit! (dnt/show-nitrate-popup :nitrate-form {:nitrate-license nitrate-license :show-contact-sales-option true :base-url (rt/get-current-href)}))
              (st/emit! (modal/show :nitrate-contact-sales-dialog {:subscription-type subscription-type
                                                                   :has-billing-access? has-billing-access?})))))
 
@@ -786,70 +787,6 @@
                          :show-button-cta (not nitrate-license)
                          :current-plan false
                          :inline-error nitrate-start-error-message}])]]]))
-
-(mf/defc subscribe-nitrate-dialog
-  {::mf/register modal/components
-   ::mf/register-as :nitrate-dialog}
-  [{:keys [nitrate-license show-contact-sales-option event-origin subscription-start-origin] :as connectivity}]
-  ;; TODO add translations for this texts when we have the definitive ones
-  (let [online? (:licenses connectivity)
-        handle-close-dialog
-        (mf/use-fn
-         (fn []
-           (st/emit! (ev/event {::ev/name "close-subscription-modal"
-                                ::ev/origin "nitrate:plan-confirmation-modal"
-                                :product "nitrate:enterprise"}))
-           (modal/hide!)))
-
-        on-subscribe-click
-        (mf/use-fn
-         (fn []
-           (dnt/go-to-buy-nitrate-license
-            "monthly"
-            (rt/get-current-href)
-            dnt/go-to-subscription-url
-            event-origin
-            (if nitrate-license "paid" "trial")
-            subscription-start-origin)))]
-
-    [:div {:class (stl/css :modal-overlay)}
-     [:div {:class (stl/css :modal-dialog)}
-      [:button {:class (stl/css :close-btn) :on-click handle-close-dialog}
-       [:> icon* {:icon-id "close"
-                  :size "m"}]]
-      [:div {:class (stl/css :modal-title :subscription-title :nitrate-subscription)}
-       (tr "nitrate.form.title")]
-
-      (if (and online? (not show-contact-sales-option))
-        [:div {:class (stl/css :modal-content)}
-
-         [:*
-          [:div {:class (stl/css :modal-text)} (tr "nitrate.form.enterprise-intro" ":")]
-          [:div {:class (stl/css :modal-text :price-text)}
-           [:span {:class (stl/css :price-value)} "25$"]
-           " / " (tr "subscription.settings.organization-member-month")]
-          [:div {:class (stl/css :modal-text)}
-           (tr "nitrate.form.enterprise-description")]
-
-          [:div {:class (stl/css :modal-footer)}
-           [:div {:class (stl/css :action-buttons)}
-            [:input
-             {:class (stl/css :cancel-button)
-              :type "button"
-              :value (tr "ds.confirm-cancel")
-              :on-click handle-close-dialog}]
-
-            [:input
-             {:class (stl/css :primary-button)
-              :type "button"
-              :value (if nitrate-license (tr "subscription.settings.subscribe") (tr "nitrate.form.free-trial-button"))
-              :on-click on-subscribe-click}]]]]]
-        [:div {:class (stl/css :modal-content :modal-contact-content)}
-         [:div {:class (stl/css :modal-text)}
-          (tr "nitrate.form.enterprise-intro" ".") " " (if nitrate-license (tr "nitrate.form.contact-us-upgrade") (tr "nitrate.form.contact-us-free-trial"))]
-         [:div {:class (stl/css :modal-text)}
-          [:a {:class (stl/css :cta-button) :href "mailto:sales@penpot.net"}
-           "sales@penpot.net"]]])]]))
 
 (mf/defc nitrate-contact-sales-dialog
   {::mf/register modal/components


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/issue/26778

### Summary

- The "Unlock Enterprise features" modal displayed different content depending on which page triggered it. From the Dashboard, users saw the full modal with illustration, benefits list, and activation code link. From Settings > Subscription, they saw only a short message with a mailto link.

- Unify both triggers to use the :nitrate-form modal, which provides the full experience. Add a configurable :base-url parameter to preserve the original post-checkout redirect behavior (Dashboard goes to admin console, Settings stays on subscription page).

- Remove the now-unused subscribe-nitrate-dialog component.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
