### PR TITLE
:bug: Handle empty variant options

### DIFF
--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -531,9 +531,10 @@
       (for [[pos prop] (map-indexed vector props-first)]
         (let [mixed-value? (not-every? #(= (:value prop) (:value (get % pos))) properties)
               base-options (get options-by-name (:name prop))
+              no-options?  (empty? base-options)
               boolean-pair (ctv/find-boolean-pair (mapv :id base-options))
               options      (cond-> base-options
-                             (empty? base-options)
+                             no-options?
                              (conj (get-variant-option (:value prop)))
 
                              mixed-value?
@@ -556,6 +557,7 @@
               [:> select* {:default-selected (if mixed-value? mixed-label (:value prop))
                            :options options
                            :empty-to-end true
+                           :disabled no-options?
                            :on-change (partial switch-component pos)
                            :key (str (:value prop) "-" key)}]])]))]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/component.cljs
@@ -290,14 +290,18 @@
        get-components-with-duplicated-variant-props-and-values
        (map :main-instance-id)))
 
+(defn- get-variant-option
+  [val]
+  {:id val
+   :label (if (str/blank? val) (str "(" (tr "labels.empty") ")") val)})
+
 (defn- get-variant-options
   "Get variant options for a given property name"
   [prop-name prop-vals]
   (->> (filter #(= (:name %) prop-name) prop-vals)
        first
        :value
-       (mapv (fn [val] {:id val
-                        :label (if (str/blank? val) (str "(" (tr "labels.empty") ")") val)}))))
+       (mapv get-variant-option)))
 
 (mf/defc component-variant-property*
   [{:keys [pos prop options on-prop-name-blur on-prop-value-change on-reorder]}]
@@ -529,6 +533,9 @@
               base-options (get options-by-name (:name prop))
               boolean-pair (ctv/find-boolean-pair (mapv :id base-options))
               options      (cond-> base-options
+                             (empty? base-options)
+                             (conj (get-variant-option (:value prop)))
+
                              mixed-value?
                              (conj {:id mixed-label :label mixed-label :dimmed true}))]
 


### PR DESCRIPTION
### Related Ticket

_no ticket_

### Summary

This PR fixes the following: variant property select showed nothing when component had no sibling variants.

When variant has no siblings for a property, list is empty, so select* renders blank. This means the user sees an empty dropdown and can't tell current value.

- when base-options empty, inject current value as only option
- that single option is not switchable, so pass `:disabled no-options?` to the select

### Steps to reproduce 

1. Open this file: 
[invalid_shape_options(1).zip](https://github.com/user-attachments/files/31833559/invalid_shape_options.1.zip)
2. Click on the purple/blue square
3. Without the fix, there's an internal error.



Closes #11524
