### PR TITLE
:recycle: Migrate editable-select to DS icon* and design tokens

### DIFF
--- a/frontend/src/app/main/ui/components/editable_select.cljs
+++ b/frontend/src/app/main/ui/components/editable_select.cljs
@@ -13,7 +13,7 @@
    [app.common.uuid :as uuid]
    [app.main.ui.components.dropdown :refer [dropdown]]
    [app.main.ui.components.numeric-input :as deprecated-input]
-   [app.main.ui.icons :as deprecated-icon]
+   [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.util.dom :as dom]
    [app.util.keyboard :as kbd]
    [app.util.timers :as timers]
@@ -182,7 +182,10 @@
 
      [:span {:class (stl/css :dropdown-button)
              :on-click toggle-dropdown}
-      deprecated-icon/arrow]
+      [:> icon* {:icon-id i/arrow-down
+                 :size "s"
+                 :aria-hidden true
+                 :class (stl/css :dropdown-icon)}]]
 
      [:& dropdown {:show (or is-open? false)
                    :on-close close-dropdown}
@@ -201,4 +204,7 @@
                :on-click select-item}
               [:span {:class (stl/css :label)} label]
               [:span {:class (stl/css :check-icon)}
-               deprecated-icon/tick]])))]]]))
+               [:> icon* {:icon-id i/tick
+                          :aria-hidden true
+                          :size "s"
+                          :class (stl/css :check-tick)}]]])))]]]))

--- a/frontend/src/app/main/ui/components/editable_select.cljs
+++ b/frontend/src/app/main/ui/components/editable_select.cljs
@@ -183,7 +183,7 @@
      [:span {:class (stl/css :dropdown-button)
              :on-click toggle-dropdown}
       [:> icon* {:icon-id i/arrow-down
-                 :size "s"
+                 :size "m"
                  :aria-hidden true
                  :class (stl/css :dropdown-icon)}]]
 
@@ -199,7 +199,7 @@
              [:li
               {:key (str element-id "-" index)
                :class (stl/css-case :dropdown-element true
-                                    :is-selected (= (dm/str value) current-value))
+                                    :is-selected (= (dm/str value) (dm/str current-value)))
                :data-value value
                :on-click select-item}
               [:span {:class (stl/css :label)} label]

--- a/frontend/src/app/main/ui/components/editable_select.scss
+++ b/frontend/src/app/main/ui/components/editable_select.scss
@@ -4,87 +4,126 @@
 //
 // Copyright (c) KALEIDOS SUBSIDIARY SL
 
-// FIXME: we need this import for %asset-element
-@use "refactor/basic-rules.scss" as deprecated;
 @use "ds/_borders.scss" as *;
 @use "ds/_sizes.scss" as *;
 @use "ds/_utils.scss" as *;
 @use "ds/spacing.scss" as *;
+@use "ds/typography.scss" as *;
 
 .editable-select {
-  @extend %asset-element;
+  @include use-typography("body-small");
+
+  --editable-select-background-color: var(--color-background-tertiary);
 
   margin: 0;
-  border: $b-1 solid var(--input-border-color);
+  border: $b-1 solid var(--color-background-tertiary);
   position: relative;
   display: flex;
-  height: $sz-32;
-  width: 100%;
+  align-items: center;
+  inline-size: 100%;
+  block-size: $sz-32;
   padding: var(--sp-s);
   border-radius: $br-8;
   cursor: pointer;
+  background-color: var(--editable-select-background-color);
+  color: var(--color-foreground-primary);
 
-  .dropdown-button {
-    display: flex;
-    place-content: center;
+  &:hover {
+    --editable-select-background-color: var(--color-background-quaternary);
+  }
+}
 
-    svg {
-      @extend %button-icon-small;
+.dropdown-button {
+  display: flex;
+  place-content: center;
+}
 
-      transform: rotate(90deg);
-      stroke: var(--icon-foreground);
+.dropdown-icon {
+  color: var(--color-foreground-secondary);
+}
+
+.custom-select-dropdown {
+  position: absolute;
+  inset-block-start: $sz-32;
+  inset-inline-start: 0;
+  inline-size: 100%;
+  min-inline-size: px2rem(70);
+  max-block-size: px2rem(320); // TODO: when this gets addressed in the DS, use a token
+  padding: var(--sp-xxs);
+  margin: 0;
+  margin-block-start: px2rem(1);
+  border: $b-2 solid var(--color-background-quaternary);
+  border-radius: $br-8;
+  z-index: var(--z-index-dropdown);
+  overflow: hidden auto;
+  background-color: var(--color-background-tertiary);
+  color: var(--color-foreground-primary);
+  box-shadow: 0 0 $sz-12 0 var(--color-shadow-dark);
+}
+
+.separator {
+  margin: 0;
+  block-size: $sz-12;
+}
+
+.dropdown-element {
+  --dropdown-element-color: var(--color-foreground-secondary);
+  --dropdown-element-icon-color: var(--color-foreground-secondary);
+
+  display: flex;
+  align-items: center;
+  gap: var(--sp-s);
+  block-size: $sz-32;
+  padding-block: 0;
+  padding-inline: var(--sp-s);
+  border-radius: $br-6;
+  cursor: pointer;
+  color: var(--dropdown-element-color);
+
+  @include use-typography("body-small");
+
+  &.is-selected {
+    --dropdown-element-color: var(--color-foreground-primary);
+    --dropdown-element-icon-color: var(--color-foreground-primary);
+
+    .check-tick {
+      visibility: visible;
     }
   }
 
-  .custom-select-dropdown {
-    @extend %dropdown-wrapper;
+  &:hover {
+    --dropdown-element-color: var(--color-foreground-primary);
+    --dropdown-element-icon-color: var(--color-foreground-primary);
 
-    width: max-content;
-    max-height: px2rem(320); // TODO: when this gets addressed in the DS, use a token
-    .separator {
-      margin: 0;
-      height: $sz-12;
-    }
-
-    .dropdown-element {
-      @extend %dropdown-element-base;
-
-      color: var(--menu-foreground-color-rest);
-
-      .label {
-        flex-grow: 1;
-        width: 100%;
-      }
-
-      .check-icon {
-        display: flex;
-        place-content: center;
-
-        svg {
-          @extend %button-icon-small;
-
-          visibility: hidden;
-          stroke: var(--icon-foreground);
-        }
-      }
-
-      &.is-selected {
-        color: var(--menu-foreground-color);
-
-        .check-icon svg {
-          stroke: var(--menu-foreground-color);
-          visibility: visible;
-        }
-      }
-
-      &:hover {
-        background-color: var(--menu-background-color-hover);
-        color: var(--menu-foreground-color-hover);
-
-        .check-icon svg {
-          stroke: var(--menu-foreground-color-hover);
-        }
-      }
-    }
+    background-color: var(--color-background-quaternary);
   }
+}
+
+.label,
+.check-icon {
+  display: block;
+  max-inline-size: 99%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.label {
+  flex-grow: 1;
+  inline-size: 100%;
+}
+
+.check-icon {
+  display: flex;
+  place-content: center;
+}
+
+.check-tick {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  fill: none;
+  stroke-width: 1.33px;
+  visibility: hidden;
+  color: var(--dropdown-element-icon-color);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -14,10 +14,10 @@
    [app.main.store :as st]
    [app.main.ui.components.dropdown :refer [dropdown]]
    [app.main.ui.components.editable-select :refer [editable-select]]
-   [app.main.ui.components.numeric-input :as deprecated-input]
    [app.main.ui.components.select :refer [select]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
+   [app.main.ui.ds.controls.numeric-input :refer [numeric-input*]]
    [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.main.ui.workspace.sidebar.options.common :refer [advanced-options*]]
    [app.main.ui.workspace.sidebar.options.rows.color-row :refer [color-row*]]
@@ -211,11 +211,10 @@
        (if (= type :square)
          [:div {:class (stl/css :grid-size)
                 :title (tr "workspace.options.size")}
-          [:> deprecated-input/numeric-input* {:min 0.01
-                                               :value (or (:size params) "")
-                                               :no-validate true
-                                               :class (stl/css :numeric-input)
-                                               :on-change (handle-change :params :size)}]]
+          [:> numeric-input* {:min 0.01
+                              :value (or (:size params) "")
+                              :inner-class (stl/css :numeric-input)
+                              :on-change (handle-change :params :size)}]]
 
          [:div {:class (stl/css :editable-select-wrapper)}
           [:& editable-select {:value (:size params)
@@ -292,43 +291,30 @@
                    :title (if (= :row type)
                             (tr "workspace.options.grid.params.height")
                             (tr "workspace.options.grid.params.width"))}
-             [:span {:class (stl/css :icon-text)}
-              (if (= :row type)
-                "H"
-                "W")]
-             [:> deprecated-input/numeric-input* {:placeholder "Auto"
-                                                  :on-change handle-change-item-length
-                                                  :is-nillable true
-                                                  :class (stl/css :numeric-input)
-                                                  :value (or (:item-length params) "")}]]
+             [:> numeric-input* {:placeholder "Auto"
+                                 :on-change handle-change-item-length
+                                 :nillable true
+                                 :icon (if (= :row type) i/character-h i/character-w)
+                                 :inner-class (stl/css :numeric-input)
+                                 :value (or (:item-length params) "")}]]
 
             [:div {:class (stl/css :gutter)
                    :title (tr "workspace.options.grid.params.gutter")}
-             [:span {:class (stl/css-case :icon true
-                                          :rotated (= type :row))}
-              [:> icon* {:icon-id i/gap-horizontal
-                         :size "s"
-                         :aria-hidden true
-                         :class (stl/css :grid-param-icon)}]]
-             [:> deprecated-input/numeric-input* {:placeholder "0"
-                                                  :on-change (handle-change :params :gutter)
-                                                  :is-nillable true
-                                                  :class (stl/css :numeric-input)
-                                                  :value (or (:gutter params) 0)}]]
+             [:> numeric-input* {:placeholder "0"
+                                 :on-change (handle-change :params :gutter)
+                                 :nillable true
+                                 :icon (if (= type :row) i/gap-vertical i/gap-horizontal)
+                                 :inner-class (stl/css :numeric-input)
+                                 :value (or (:gutter params) 0)}]]
 
             [:div {:class (stl/css :margin)
                    :title (tr "workspace.options.grid.params.margin")}
-             [:span {:class (stl/css-case :icon true
-                                          :rotated (= type :column))}
-              [:> icon* {:icon-id i/grid-margin
-                         :size "s"
-                         :aria-hidden true
-                         :class (stl/css :grid-param-icon)}]]
-             [:> deprecated-input/numeric-input* {:placeholder "0"
-                                                  :on-change (handle-change :params :margin)
-                                                  :is-nillable true
-                                                  :class (stl/css :numeric-input)
-                                                  :value (or (:margin params) 0)}]]
+             [:> numeric-input* {:placeholder "0"
+                                 :on-change (handle-change :params :margin)
+                                 :nillable true
+                                 :icon (if (= type :column) i/margin-left-right i/margin-top-bottom)
+                                 :inner-class (stl/css :numeric-input)
+                                 :value (or (:margin params) 0)}]]
 
             [:> default-options-toggle* {:show show-more-options?
                                          :disabled is-default

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.cljs
@@ -12,16 +12,18 @@
    [app.main.data.workspace.grid :as dw]
    [app.main.refs :as refs]
    [app.main.store :as st]
+   [app.main.ui.components.dropdown :refer [dropdown]]
    [app.main.ui.components.editable-select :refer [editable-select]]
    [app.main.ui.components.numeric-input :as deprecated-input]
    [app.main.ui.components.select :refer [select]]
    [app.main.ui.components.title-bar :refer [title-bar*]]
    [app.main.ui.ds.buttons.icon-button :refer [icon-button*]]
-   [app.main.ui.ds.foundations.assets.icon :as i]
-   [app.main.ui.icons :as deprecated-icon]
+   [app.main.ui.ds.foundations.assets.icon :refer [icon*] :as i]
    [app.main.ui.workspace.sidebar.options.common :refer [advanced-options*]]
    [app.main.ui.workspace.sidebar.options.rows.color-row :refer [color-row*]]
+   [app.util.dom :as dom]
    [app.util.i18n :as i18n :refer [tr]]
+   [app.util.keyboard :as kbd]
    [okulary.core :as l]
    [rumext.v2 :as mf]))
 
@@ -32,6 +34,49 @@
   [{:value nil :label (tr "workspace.options.grid.auto")}
    :separator
    18 12 10 8 6 4 3 2])
+
+(mf/defc default-options-toggle*
+  "Toggle button that opens the reset/save-as-default menu for a grid's
+   params. Shared by the square, column and row grid-type layouts, each of
+   which places it at a different point in their own layout."
+  [{:keys [show disabled on-toggle]}]
+  [:button {:class (stl/css-case :show-more-options true
+                                 :selected show)
+            :on-click on-toggle
+            :disabled disabled}
+   [:> icon* {:icon-id i/menu
+              :size "m"
+              :aria-hidden true
+              :class (stl/css :show-options-icon)}]])
+
+(mf/defc default-options-dropdown*
+  "Dropdown menu with the reset/save-as-default options for a grid's params.
+   Shared by the square, column and row grid-type layouts, each of which
+   places it at a different point in their own layout (its `:class` controls
+   the panel's positioning, which differs per layout)."
+  [{:keys [class show on-close on-use-default on-set-as-default]}]
+  (let [handle-key-down
+        (fn [action]
+          (fn [event]
+            (when (or (kbd/enter? event) (kbd/space? event))
+              (dom/prevent-default event)
+              (action))))]
+    [:& dropdown {:show show
+                  :on-close on-close}
+     [:ul {:class class
+           :role "menu"}
+      [:li {:class (stl/css :option-btn)
+            :role "menuitem"
+            :tab-index 0
+            :on-click on-use-default
+            :on-key-down (handle-key-down on-use-default)}
+       (tr "workspace.options.grid.params.use-default")]
+      [:li {:class (stl/css :option-btn)
+            :role "menuitem"
+            :tab-index 0
+            :on-click on-set-as-default
+            :on-key-down (handle-key-down on-set-as-default)}
+       (tr "workspace.options.grid.params.set-default")]]]))
 
 (mf/defc grid-options*
   {::mf/wrap [mf/memo]}
@@ -151,7 +196,10 @@
        [:button {:class (stl/css-case :show-options true
                                       :selected open?)
                  :on-click toggle-advanced-options}
-        deprecated-icon/menu]
+        [:> icon* {:icon-id i/menu
+                   :size "m"
+                   :aria-hidden true
+                   :class (stl/css :show-options-icon)}]]
        [:div {:class (stl/css :type-select-wrapper)}
         [:& select
          {:class (stl/css :grid-type-select)
@@ -204,22 +252,14 @@
                             :origin :guides
                             :on-change handle-change-color
                             :on-detach handle-detach-color}]
-            [:button {:class (stl/css-case :show-more-options true
-                                           :selected show-more-options?)
-                      :on-click toggle-more-options}
-             deprecated-icon/menu]]
-           (when show-more-options?
-             [:div {:class (stl/css :second-row)}
-              [:button {:class (stl/css-case :btn-options true
-                                             :disabled is-default)
-                        :disabled is-default
-                        :on-click handle-use-default}
-               [:span (tr "workspace.options.grid.params.use-default")]]
-              [:button {:class (stl/css-case :btn-options true
-                                             :disabled is-default)
-                        :disabled is-default
-                        :on-click handle-set-as-default}
-               [:span (tr "workspace.options.grid.params.set-default")]]])])
+            [:> default-options-toggle* {:show show-more-options?
+                                         :disabled is-default
+                                         :on-toggle toggle-more-options}]]
+           [:> default-options-dropdown* {:class (stl/css :second-row)
+                                          :show show-more-options?
+                                          :on-close close-more-options
+                                          :on-use-default handle-use-default
+                                          :on-set-as-default handle-set-as-default}]])
 
         (when (or (= :column type) (= :row type))
           [:div {:class (stl/css :column-row)}
@@ -266,7 +306,10 @@
                    :title (tr "workspace.options.grid.params.gutter")}
              [:span {:class (stl/css-case :icon true
                                           :rotated (= type :row))}
-              deprecated-icon/gap-horizontal]
+              [:> icon* {:icon-id i/gap-horizontal
+                         :size "s"
+                         :aria-hidden true
+                         :class (stl/css :grid-param-icon)}]]
              [:> deprecated-input/numeric-input* {:placeholder "0"
                                                   :on-change (handle-change :params :gutter)
                                                   :is-nillable true
@@ -277,24 +320,24 @@
                    :title (tr "workspace.options.grid.params.margin")}
              [:span {:class (stl/css-case :icon true
                                           :rotated (= type :column))}
-              deprecated-icon/grid-margin]
+              [:> icon* {:icon-id i/grid-margin
+                         :size "s"
+                         :aria-hidden true
+                         :class (stl/css :grid-param-icon)}]]
              [:> deprecated-input/numeric-input* {:placeholder "0"
                                                   :on-change (handle-change :params :margin)
                                                   :is-nillable true
                                                   :class (stl/css :numeric-input)
                                                   :value (or (:margin params) 0)}]]
 
-            [:button {:class (stl/css-case :show-more-options true
-                                           :selected show-more-options?)
-                      :on-click toggle-more-options
-                      :disabled is-default}
-             deprecated-icon/menu]
-            (when show-more-options?
-              [:div {:class (stl/css :more-options)}
-               [:button {:class (stl/css :option-btn)
-                         :on-click handle-use-default} (tr "workspace.options.grid.params.use-default")]
-               [:button {:class (stl/css :option-btn)
-                         :on-click handle-set-as-default} (tr "workspace.options.grid.params.set-default")]])]])])]))
+            [:> default-options-toggle* {:show show-more-options?
+                                         :disabled is-default
+                                         :on-toggle toggle-more-options}]
+            [:> default-options-dropdown* {:class (stl/css :more-options)
+                                           :show show-more-options?
+                                           :on-close close-more-options
+                                           :on-use-default handle-use-default
+                                           :on-set-as-default handle-set-as-default}]]])])]))
 
 (defn- check-frame-grid-props
   [old-props new-props]

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
@@ -55,206 +55,184 @@
   gap: px2rem(1);
   border-radius: $br-8;
   background-color: var(--color-background-primary);
+}
 
-  .show-options {
-    --show-options-background-color: var(--color-background-tertiary);
-    --show-options-border-color: var(--color-background-tertiary);
-    --show-options-color: var(--color-foreground-secondary);
+.show-options {
+  --show-options-background-color: var(--color-background-tertiary);
+  --show-options-border-color: var(--color-background-tertiary);
+  --show-options-color: var(--color-foreground-secondary);
 
-    // Tracks --show-options-color everywhere except :disabled — the
-    // deprecated button-secondary placeholder never re-colored its icon on
-    // disable, so the icon stayed rest-colored; preserved as-is.
-    --show-options-icon-color: var(--color-foreground-secondary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  block-size: $sz-32;
+  inline-size: $sz-28;
+  border-radius: $br-8 0 0 $br-8;
+  box-sizing: border-box;
+  border: $b-1 solid var(--show-options-border-color);
+  background-color: var(--show-options-background-color);
+  color: var(--show-options-color);
 
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    block-size: $sz-32;
-    inline-size: $sz-28;
-    border-radius: $br-8 0 0 $br-8;
-    box-sizing: border-box;
-    border: $b-1 solid var(--show-options-border-color);
-    background-color: var(--show-options-background-color);
-    color: var(--show-options-color);
-
-    &:focus-visible {
-      outline: none;
-
-      --show-options-border-color: var(--color-accent-primary);
-    }
-
-    &:hover {
-      --show-options-background-color: var(--color-background-quaternary);
-      --show-options-border-color: var(--color-background-quaternary);
-      --show-options-color: var(--color-accent-primary);
-      --show-options-icon-color: var(--color-accent-primary);
-
-      text-decoration: none;
-    }
-
-    &:active {
-      outline: none;
-
-      --show-options-background-color: var(--color-background-secondary);
-      --show-options-border-color: var(--color-background-quaternary);
-      --show-options-color: var(--color-accent-primary);
-      --show-options-icon-color: var(--color-accent-primary);
-    }
-
-    &:global(.disabled),
-    &[disabled],
-    &:disabled {
-      --show-options-background-color: var(--color-background-quaternary);
-      --show-options-border-color: var(--color-background-quaternary);
-      --show-options-color: var(--color-foreground-disabled);
-
-      cursor: unset;
-    }
-
-    // TODO: the deprecated `.selected` background/border colors diverge by
-    // theme (light theme used --color-background-primary /
-    // --color-background-secondary instead of the values below) — the
-    // design-tokens.scss alias was theme-conditional with no single DS
-    // token equivalent. Kept the default/dark values; confirm with design
-    // before relying on this in light theme.
-    &.selected {
-      outline: none;
-
-      --show-options-background-color: var(--color-background-quaternary);
-      --show-options-border-color: var(--color-background-quaternary);
-      --show-options-color: var(--color-accent-primary);
-      --show-options-icon-color: var(--color-accent-primary);
-    }
-  }
-
-  .type-select-wrapper {
-    flex-grow: 1;
-    inline-size: $sz-96;
-    padding: 0;
-    border-radius: 0;
-    block-size: $sz-32;
-
-    .grid-type-select {
-      --grid-type-select-border-color: var(--color-background-tertiary);
-
-      border-radius: 0;
-      block-size: 100%;
-      box-sizing: border-box;
-      border: $b-1 solid var(--grid-type-select-border-color);
-
-      &:hover {
-        --grid-type-select-border-color: var(--color-background-quaternary);
-      }
-    }
-  }
-
-  .editable-select-wrapper .column-select {
-    .numeric-input {
-      margin: 0;
-      padding: 0;
-    }
-  }
-
-  .grid-size {
-    @include use-typography("body-small");
-
-    display: flex;
-    align-items: center;
-    block-size: $sz-32;
-    inline-size: px2rem(60);
-    margin: 0;
-    padding: 0;
-    padding-inline-start: var(--sp-s);
-    border-radius: 0 $br-8 $br-8 0;
-    background-color: var(--color-background-tertiary);
-    color: var(--color-foreground-primary);
-
-    &:hover {
-      background-color: var(--color-background-quaternary);
-      color: var(--color-foreground-primary);
-    }
-
-    .numeric-input {
-      --input-height: #{$sz-28};
-
-      flex-grow: 1;
-    }
-  }
-
-  .editable-select-wrapper {
-    inline-size: px2rem(60);
-    margin: 0;
-    padding: 0;
-    position: relative;
-
-    .column-select {
-      block-size: $sz-32;
-      border-radius: 0 $br-8 $br-8 0;
-      box-sizing: border-box;
-      border: $b-1 solid var(--color-background-tertiary);
-    }
-  }
-
-  .editable-select-wrapper .column-select .numeric-input {
-    @include use-typography("body-small");
-
-    border: none;
-    background: none;
+  &:focus-visible {
     outline: none;
-    display: block;
-    max-inline-size: 99%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    block-size: $sz-28;
-    inline-size: 100%;
-    flex-grow: 1;
-    border-radius: $br-8;
+
+    --show-options-border-color: var(--color-accent-primary);
+  }
+
+  &:hover {
+    --show-options-background-color: var(--color-background-quaternary);
+    --show-options-border-color: var(--color-background-quaternary);
+    --show-options-color: var(--color-accent-primary);
+
+    text-decoration: none;
+  }
+
+  &:active {
+    outline: none;
+
+    --show-options-background-color: var(--color-background-secondary);
+    --show-options-border-color: var(--color-background-quaternary);
+    --show-options-color: var(--color-accent-primary);
+  }
+
+  &[disabled],
+  &:disabled {
+    --show-options-background-color: var(--color-background-quaternary);
+    --show-options-border-color: var(--color-background-quaternary);
+    --show-options-color: var(--color-foreground-disabled);
+
+    cursor: unset;
+  }
+
+  &.selected {
+    outline: none;
+
+    --show-options-background-color: var(--color-background-quaternary);
+    --show-options-border-color: var(--color-background-quaternary);
+    --show-options-color: var(--color-accent-primary);
+  }
+}
+
+.type-select-wrapper {
+  flex-grow: 1;
+  inline-size: $sz-96;
+  padding: 0;
+  border-radius: 0;
+  block-size: $sz-32;
+}
+
+.type-select-wrapper .grid-type-select {
+  --grid-type-select-border-color: var(--color-background-tertiary);
+
+  border-radius: 0;
+  block-size: 100%;
+  box-sizing: border-box;
+  border: $b-1 solid var(--grid-type-select-border-color);
+
+  &:hover {
+    --grid-type-select-border-color: var(--color-background-quaternary);
+  }
+}
+
+.grid-size {
+  @include use-typography("body-small");
+
+  display: flex;
+  align-items: center;
+  block-size: $sz-32;
+  inline-size: px2rem(60);
+  margin: 0;
+  padding: 0;
+  padding-inline-start: var(--sp-s);
+  border-radius: 0 $br-8 $br-8 0;
+  background-color: var(--color-background-tertiary);
+  color: var(--color-foreground-primary);
+
+  &:hover {
+    background-color: var(--color-background-quaternary);
     color: var(--color-foreground-primary);
-
-    &[disabled] {
-      opacity: 0.5;
-      pointer-events: none;
-    }
   }
+}
 
-  &.hidden {
-    .show-options {
-      @include hidden-control;
+.grid-size .numeric-input {
+  --input-height: #{$sz-28};
 
-      border: $b-1 solid var(--color-background-quaternary);
-    }
+  flex-grow: 1;
+}
 
-    .type-select-wrapper,
-    .editable-select-wrapper {
-      @include hidden-control;
+.editable-select-wrapper {
+  inline-size: px2rem(60);
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
 
-      .column-select,
-      .grid-type-select {
-        @include hidden-control;
+.editable-select-wrapper .column-select {
+  block-size: $sz-32;
+  border-radius: 0 $br-8 $br-8 0;
+  box-sizing: border-box;
+  border: $b-1 solid var(--color-background-tertiary);
+}
 
-        border: $b-1 solid var(--color-background-quaternary);
-      }
+.column-select .numeric-input {
+  @include use-typography("body-small");
 
-      .column-select {
-        border-radius: 0 $br-8 $br-8 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  outline: none;
+  display: block;
+  max-inline-size: 99%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  block-size: $sz-28;
+  inline-size: 100%;
+  flex-grow: 1;
+  border-radius: $br-8;
+  color: var(--color-foreground-primary);
 
-        .numeric-input {
-          @include hidden-control;
-        }
-      }
-    }
-
-    .grid-size {
-      @include hidden-control;
-
-      border: $b-1 solid var(--color-background-quaternary);
-
-      .numeric-input {
-        --input-fg-color: var(--color-foreground-secondary);
-      }
-    }
+  &[disabled] {
+    opacity: 0.5;
+    pointer-events: none;
   }
+}
+
+.hidden .show-options {
+  @include hidden-control;
+
+  border: $b-1 solid var(--color-background-quaternary);
+}
+
+.hidden .type-select-wrapper,
+.hidden .editable-select-wrapper {
+  @include hidden-control;
+}
+
+.hidden .column-select,
+.hidden .grid-type-select {
+  @include hidden-control;
+
+  border: $b-1 solid var(--color-background-quaternary);
+}
+
+.hidden .column-select {
+  border-radius: 0 $br-8 $br-8 0;
+}
+
+.hidden .column-select .numeric-input {
+  @include hidden-control;
+}
+
+.hidden .grid-size {
+  @include hidden-control;
+
+  border: $b-1 solid var(--color-background-quaternary);
+}
+
+.hidden .grid-size .numeric-input {
+  --input-fg-color: var(--color-foreground-secondary);
 }
 
 .actions {
@@ -332,7 +310,6 @@
     --show-more-options-color: var(--color-accent-primary);
   }
 
-  &:global(.disabled),
   &[disabled],
   &:disabled {
     --show-more-options-color: var(--color-foreground-disabled);
@@ -341,8 +318,6 @@
     pointer-events: none;
   }
 
-  // TODO: same theme-conditional alias caveat as .show-options.selected
-  // above — kept the default/dark values, confirm light theme.
   &.selected {
     outline: none;
 
@@ -350,10 +325,10 @@
     --show-more-options-border-color: var(--color-background-quaternary);
     --show-more-options-color: var(--color-accent-primary);
   }
+}
 
-  svg {
-    stroke: var(--show-more-options-color);
-  }
+.show-more-options svg {
+  stroke: var(--show-more-options-color);
 }
 
 .height,
@@ -373,15 +348,6 @@
   border: $b-1 solid var(--grid-param-input-border-color);
   color: var(--grid-param-input-color);
 
-  .numeric-input {
-    --input-height: #{$sz-28};
-
-    flex-grow: 1;
-    margin-block: var(--sp-xxs);
-    margin-inline: 0;
-    padding-inline-start: $sz-6;
-  }
-
   &:hover {
     --grid-param-input-color: var(--color-foreground-primary);
     --grid-param-input-background-color: var(--color-background-quaternary);
@@ -400,6 +366,17 @@
   &:focus-within {
     --grid-param-input-background-color: var(--color-background-tertiary);
   }
+}
+
+.height .numeric-input,
+.gutter .numeric-input,
+.margin .numeric-input {
+  --input-height: #{$sz-28};
+
+  flex-grow: 1;
+  margin-block: var(--sp-xxs);
+  margin-inline: 0;
+  padding-inline-start: $sz-6;
 }
 
 .more-options {

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
@@ -4,8 +4,23 @@
 //
 // Copyright (c) KALEIDOS SUBSIDIARY SL
 
-@use "refactor/common-refactor.scss" as deprecated;
+@use "ds/_borders.scss" as *;
+@use "ds/_sizes.scss" as *;
+@use "ds/_utils.scss" as *;
+@use "ds/z-index.scss" as *;
+@use "ds/spacing.scss" as *;
+@use "ds/typography.scss" as *;
 @use "../../../sidebar/common/sidebar.scss" as sidebar;
+
+// Shared by every disabled-looking control in the .hidden state below.
+@mixin hidden-control {
+  cursor: default;
+  pointer-events: none;
+  box-sizing: border-box;
+  color: var(--color-foreground-secondary);
+  stroke: var(--color-foreground-secondary);
+  background-color: transparent;
+}
 
 .element-set {
   @include sidebar.option-grid-structure;
@@ -16,15 +31,17 @@
 }
 
 .title-spacing-board-grid {
-  padding-left: deprecated.$s-2;
+  padding-inline-start: var(--sp-xxs);
   margin: 0;
 }
 
 .element-set-content {
-  @include deprecated.flex-column;
-
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
   grid-column: span 8;
-  margin: deprecated.$s-4 0 deprecated.$s-8 0;
+  margin-block: var(--sp-xs) var(--sp-s);
+  margin-inline: 0;
 }
 
 .grid-title {
@@ -35,266 +52,471 @@
   grid-column: span 6;
   display: flex;
   align-items: center;
-  gap: deprecated.$s-1;
-  border-radius: deprecated.$br-8;
-  background-color: var(--input-details-color);
+  gap: px2rem(1);
+  border-radius: $br-8;
+  background-color: var(--color-background-primary);
 
   .show-options {
-    @extend %button-secondary;
+    --show-options-background-color: var(--color-background-tertiary);
+    --show-options-border-color: var(--color-background-tertiary);
+    --show-options-color: var(--color-foreground-secondary);
 
-    height: deprecated.$s-32;
-    width: deprecated.$s-28;
-    border-radius: deprecated.$br-8 0 0 deprecated.$br-8;
+    // Tracks --show-options-color everywhere except :disabled — the
+    // deprecated button-secondary placeholder never re-colored its icon on
+    // disable, so the icon stayed rest-colored; preserved as-is.
+    --show-options-icon-color: var(--color-foreground-secondary);
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    block-size: $sz-32;
+    inline-size: $sz-28;
+    border-radius: $br-8 0 0 $br-8;
     box-sizing: border-box;
-    border: deprecated.$s-1 solid var(--input-border-color);
+    border: $b-1 solid var(--show-options-border-color);
+    background-color: var(--show-options-background-color);
+    color: var(--show-options-color);
 
-    svg {
-      @extend %button-icon;
+    &:focus-visible {
+      outline: none;
+
+      --show-options-border-color: var(--color-accent-primary);
     }
 
+    &:hover {
+      --show-options-background-color: var(--color-background-quaternary);
+      --show-options-border-color: var(--color-background-quaternary);
+      --show-options-color: var(--color-accent-primary);
+      --show-options-icon-color: var(--color-accent-primary);
+
+      text-decoration: none;
+    }
+
+    &:active {
+      outline: none;
+
+      --show-options-background-color: var(--color-background-secondary);
+      --show-options-border-color: var(--color-background-quaternary);
+      --show-options-color: var(--color-accent-primary);
+      --show-options-icon-color: var(--color-accent-primary);
+    }
+
+    &:global(.disabled),
+    &[disabled],
+    &:disabled {
+      --show-options-background-color: var(--color-background-quaternary);
+      --show-options-border-color: var(--color-background-quaternary);
+      --show-options-color: var(--color-foreground-disabled);
+
+      cursor: unset;
+    }
+
+    // TODO: the deprecated `.selected` background/border colors diverge by
+    // theme (light theme used --color-background-primary /
+    // --color-background-secondary instead of the values below) — the
+    // design-tokens.scss alias was theme-conditional with no single DS
+    // token equivalent. Kept the default/dark values; confirm with design
+    // before relying on this in light theme.
     &.selected {
-      @extend %button-icon-selected;
+      outline: none;
+
+      --show-options-background-color: var(--color-background-quaternary);
+      --show-options-border-color: var(--color-background-quaternary);
+      --show-options-color: var(--color-accent-primary);
+      --show-options-icon-color: var(--color-accent-primary);
     }
   }
 
   .type-select-wrapper {
     flex-grow: 1;
-    width: deprecated.$s-96;
+    inline-size: $sz-96;
     padding: 0;
     border-radius: 0;
-    height: deprecated.$s-32;
+    block-size: $sz-32;
 
     .grid-type-select {
+      --grid-type-select-border-color: var(--color-background-tertiary);
+
       border-radius: 0;
-      height: 100%;
+      block-size: 100%;
       box-sizing: border-box;
-      border: deprecated.$s-1 solid var(--input-border-color);
+      border: $b-1 solid var(--grid-type-select-border-color);
 
       &:hover {
-        border: deprecated.$s-1 solid var(--input-border-color-hover);
+        --grid-type-select-border-color: var(--color-background-quaternary);
       }
+    }
+  }
+
+  .grid-size,
+  .editable-select-wrapper .column-select {
+    .numeric-input {
+      margin: 0;
+      padding: 0;
     }
   }
 
   .grid-size {
-    @extend %asset-element;
+    @include use-typography("body-small");
 
-    width: deprecated.$s-60;
+    display: flex;
+    align-items: center;
+    block-size: $sz-32;
+    inline-size: px2rem(60);
     margin: 0;
     padding: 0;
-    padding-left: deprecated.$s-8;
-    border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
+    padding-inline-start: var(--sp-s);
+    border-radius: 0 $br-8 $br-8 0;
+    background-color: var(--color-background-tertiary);
+    color: var(--color-foreground-primary);
 
-    .numeric-input {
-      @extend %input-base;
-      @include deprecated.body-small-typography;
+    &:hover {
+      background-color: var(--color-background-quaternary);
+      color: var(--color-foreground-primary);
     }
   }
 
   .editable-select-wrapper {
-    @extend %asset-element;
-
-    width: deprecated.$s-60;
+    inline-size: px2rem(60);
     margin: 0;
     padding: 0;
     position: relative;
-    border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
 
+    // The editable-select component already provides its own box styling
+    // (border, background, radius) — only the docked/square-left corner
+    // treatment is overridden here, deliberately scoped under this wrapper
+    // so it reliably outranks the component's own single-class rules.
     .column-select {
-      height: deprecated.$s-32;
-      border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
+      block-size: $sz-32;
+      border-radius: 0 $br-8 $br-8 0;
       box-sizing: border-box;
-      border: deprecated.$s-1 solid var(--input-border-color);
+      border: $b-1 solid var(--color-background-tertiary);
+    }
+  }
 
-      .numeric-input {
-        @extend %input-base;
-        @include deprecated.body-small-typography;
+  .grid-size .numeric-input,
+  .editable-select-wrapper .column-select .numeric-input {
+    @include use-typography("body-small");
 
-        margin: 0;
-        padding: 0;
-      }
+    border: none;
+    background: none;
+    outline: none;
+    display: block;
+    max-inline-size: 99%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    block-size: $sz-28;
+    inline-size: 100%;
+    flex-grow: 1;
+    border-radius: $br-8;
+    color: var(--color-foreground-primary);
 
-      span {
-        @include deprecated.flex-center;
-
-        svg {
-          @extend %button-icon;
-        }
-      }
+    &[disabled] {
+      opacity: 0.5;
+      pointer-events: none;
     }
   }
 
   &.hidden {
     .show-options {
-      @include deprecated.hidden-element;
+      @include hidden-control;
 
-      border: deprecated.$s-1 solid var(--input-border-color-disabled);
+      border: $b-1 solid var(--color-background-quaternary);
     }
 
     .type-select-wrapper,
     .editable-select-wrapper {
-      @include deprecated.hidden-element;
+      @include hidden-control;
 
       .column-select,
       .grid-type-select {
-        @include deprecated.hidden-element;
+        @include hidden-control;
 
-        border: deprecated.$s-1 solid var(--input-border-color-disabled);
+        border: $b-1 solid var(--color-background-quaternary);
       }
 
       .column-select {
-        @include deprecated.hidden-element;
-
-        border-radius: 0 deprecated.$br-8 deprecated.$br-8 0;
+        border-radius: 0 $br-8 $br-8 0;
 
         .numeric-input {
-          @include deprecated.hidden-element;
+          @include hidden-control;
         }
       }
     }
 
     .grid-size {
-      @include deprecated.hidden-element;
+      @include hidden-control;
 
-      border: deprecated.$s-1 solid var(--input-border-color-disabled);
+      border: $b-1 solid var(--color-background-quaternary);
 
       .icon {
-        stroke: var(--input-foreground-color-disabled);
+        stroke: var(--color-foreground-secondary);
       }
 
       .numeric-input {
-        color: var(--input-foreground-color-disabled);
-      }
-    }
-
-    .actions {
-      .hidden-btn,
-      .lock-btn {
-        background-color: transparent;
-
-        svg {
-          stroke: var(--input-foreground-color-disabled);
-        }
+        color: var(--color-foreground-secondary);
       }
     }
   }
 }
 
 .actions {
-  @include deprecated.flex-row;
-
+  display: flex;
+  align-items: center;
+  gap: var(--sp-xs);
   grid-column: span 2;
 }
 
 .grid-advanced-options {
-  @include deprecated.flex-column;
-
-  margin-top: deprecated.$s-4;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+  margin-block-start: var(--sp-xs);
 }
 
 .column-row,
 .square-row {
-  @include deprecated.flex-column;
-
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
   position: relative;
 }
 
 .advanced-row {
   position: relative;
   display: flex;
-  gap: deprecated.$s-4;
+  gap: var(--sp-xs);
+}
 
-  .orientation-select-wrapper {
-    width: deprecated.$s-92;
-    padding: 0;
+.orientation-select-wrapper {
+  inline-size: px2rem(92);
+  padding: 0;
+}
+
+.color-wrapper {
+  inline-size: px2rem(156);
+}
+
+.show-more-options {
+  --show-more-options-background-color: transparent;
+  --show-more-options-border-color: transparent;
+  --show-more-options-color: var(--color-foreground-secondary);
+
+  background: none;
+  cursor: pointer;
+  display: grid;
+  place-content: center;
+  block-size: $sz-32;
+  inline-size: $sz-32;
+  border-radius: $br-8;
+  background-color: var(--show-more-options-background-color);
+  border: $b-2 solid var(--show-more-options-border-color);
+  color: var(--show-more-options-color);
+
+  &:focus-visible {
+    outline: none;
+
+    // Deprecated focus-type mixin hardcoded a 1px border here, narrower
+    // than this button's own 2px rest border-width — preserved as-is.
+    border: $b-1 solid var(--color-accent-primary);
+
+    --show-more-options-background-color: var(--color-background-tertiary);
+    --show-more-options-color: var(--color-foreground-primary);
   }
 
-  .color-wrapper {
-    width: deprecated.$s-156;
+  &:hover {
+    --show-more-options-background-color: var(--color-background-quaternary);
+    --show-more-options-border-color: var(--color-background-quaternary);
+    --show-more-options-color: var(--color-accent-primary);
   }
 
-  .show-more-options {
-    @extend %button-tertiary;
+  &:active {
+    outline: none;
 
-    height: deprecated.$s-32;
-    width: deprecated.$s-32;
+    --show-more-options-background-color: var(--color-background-secondary);
+    --show-more-options-border-color: transparent;
+    --show-more-options-color: var(--color-accent-primary);
+  }
 
-    svg {
-      @extend %button-icon;
+  &:global(.disabled),
+  &[disabled],
+  &:disabled {
+    --show-more-options-color: var(--color-foreground-disabled);
+
+    cursor: unset;
+    pointer-events: none;
+  }
+
+  // TODO: same theme-conditional alias caveat as .show-options.selected
+  // above — kept the default/dark values, confirm light theme.
+  &.selected {
+    outline: none;
+
+    --show-more-options-background-color: var(--color-background-quaternary);
+    --show-more-options-border-color: var(--color-background-quaternary);
+    --show-more-options-color: var(--color-accent-primary);
+  }
+
+  svg {
+    stroke: var(--show-more-options-color);
+  }
+}
+
+.height,
+.gutter,
+.margin {
+  --grid-param-input-color: var(--color-foreground-secondary);
+  --grid-param-input-background-color: var(--color-background-tertiary);
+  --grid-param-input-border-color: var(--color-background-tertiary);
+
+  @include use-typography("body-small");
+
+  display: flex;
+  align-items: center;
+  block-size: $sz-32;
+  border-radius: $br-8;
+  background-color: var(--grid-param-input-background-color);
+  border: $b-1 solid var(--grid-param-input-border-color);
+  color: var(--grid-param-input-color);
+
+  .numeric-input {
+    border: none;
+    background: none;
+    outline: none;
+    display: block;
+    max-inline-size: 99%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    block-size: $sz-28;
+    inline-size: 100%;
+    flex-grow: 1;
+    margin-block: var(--sp-xxs);
+    margin-inline: 0;
+    padding-inline-start: $sz-6;
+    border-radius: $br-8;
+    color: var(--color-foreground-primary);
+
+    &[disabled] {
+      opacity: 0.5;
+      pointer-events: none;
     }
 
-    &.selected {
-      @extend %button-icon-selected;
+    &::placeholder {
+      color: var(--color-foreground-secondary);
     }
   }
 
-  .height {
-    @extend %input-element;
-    @include deprecated.body-small-typography;
-
-    .icon-text {
-      padding-top: deprecated.$s-1;
-    }
+  // Shared base for .icon-text (height) and .icon (gutter/margin) — both
+  // are the same kind of label slot, just with different content.
+  .icon-text,
+  .icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    inline-size: px2rem(20);
+    padding-inline-start: var(--sp-s);
+    block-size: $sz-32;
+    color: var(--grid-param-input-color);
   }
 
-  .gutter,
-  .margin {
-    @extend %input-element;
-    @include deprecated.body-small-typography;
+  .grid-param-icon {
+    fill: none;
+    stroke-width: 1.33px;
 
-    .icon {
-      &.rotated svg {
-        transform: rotate(90deg);
-      }
-    }
+    // Unlike the label text and background/border colors below, the
+    // deprecated placeholder never re-colored this icon on hover/
+    // active/focus — it stayed rest-colored; preserved as-is.
+    color: var(--color-foreground-secondary);
   }
 
-  .more-options {
-    @include deprecated.menu-shadow;
-    @include deprecated.flex-column;
+  &:hover {
+    --grid-param-input-color: var(--color-foreground-primary);
+    --grid-param-input-background-color: var(--color-background-quaternary);
+    --grid-param-input-border-color: var(--color-background-quaternary);
+  }
 
-    position: absolute;
-    top: calc(deprecated.$s-2 + deprecated.$s-28);
-    right: 0;
-    width: deprecated.$s-156;
-    max-height: deprecated.$s-300;
-    padding: deprecated.$s-2;
-    margin: 0 0 deprecated.$s-40 0;
-    margin-top: deprecated.$s-4;
-    border-radius: deprecated.$br-8;
-    z-index: deprecated.$z-index-4;
-    overflow-y: auto;
-    background-color: var(--menu-background-color);
+  &:active,
+  &:focus,
+  &:focus-within {
+    --grid-param-input-color: var(--color-foreground-primary);
+    --grid-param-input-background-color: var(--color-background-primary);
+    --grid-param-input-border-color: var(--color-accent-primary);
+  }
 
-    .option-btn {
-      @include deprecated.button-style;
+  &:focus,
+  &:focus-within {
+    --grid-param-input-background-color: var(--color-background-tertiary);
+  }
+}
 
-      display: flex;
-      align-items: center;
-      height: deprecated.$s-32;
-      padding: 0 deprecated.$s-8;
-      border-radius: deprecated.$br-6;
-      color: var(--menu-foreground-color);
+.height .icon-text {
+  padding-block-start: px2rem(1);
+}
 
-      &:hover {
-        background-color: var(--menu-background-color-hover);
-        color: var(--menu-foreground-color-hover);
-      }
-    }
+.gutter,
+.margin {
+  .icon.rotated .grid-param-icon {
+    transform: rotate(90deg);
+  }
+}
+
+.more-options {
+  box-shadow: 0 0 $sz-12 0 var(--color-shadow-dark);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+  position: absolute;
+  inset-block-start: calc(var(--sp-xxs) + $sz-28);
+  inset-inline-end: 0;
+  inline-size: px2rem(156);
+  max-block-size: px2rem(300); // TODO: when this gets addressed in the DS, use a token
+  padding: var(--sp-xxs);
+  margin-block: var(--sp-xs) $sz-40;
+  margin-inline: 0;
+  border-radius: $br-8;
+  z-index: var(--z-index-dropdown);
+  overflow-y: auto;
+  background-color: var(--color-background-tertiary);
+}
+
+.option-btn {
+  @include use-typography("body-small");
+
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  block-size: $sz-32;
+  padding-inline: var(--sp-s);
+  border-radius: $br-6;
+  color: var(--color-foreground-primary);
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--color-background-quaternary);
+    color: var(--color-foreground-primary);
+  }
+
+  &:focus-visible {
+    outline: none;
   }
 }
 
 .second-row {
-  @extend %dropdown-wrapper;
-
-  left: unset;
-  right: 0;
-  width: deprecated.$s-108;
-
-  .btn-options {
-    @include deprecated.button-style;
-    @extend %dropdown-element-base;
-
-    width: 100%;
-  }
+  box-shadow: 0 0 $sz-12 0 var(--color-shadow-dark);
+  position: absolute;
+  inset-block-start: $sz-32;
+  inset-inline-start: unset;
+  inset-inline-end: 0;
+  inline-size: px2rem(108);
+  max-block-size: var(--menu-max-height, px2rem(300));
+  padding: var(--sp-xxs);
+  margin: 0;
+  margin-block-start: px2rem(1);
+  border-radius: $br-8;
+  z-index: var(--z-index-dropdown);
+  overflow: hidden auto;
+  background-color: var(--color-background-tertiary);
+  color: var(--color-foreground-primary);
 }

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/frame_grid.scss
@@ -148,7 +148,6 @@
     }
   }
 
-  .grid-size,
   .editable-select-wrapper .column-select {
     .numeric-input {
       margin: 0;
@@ -174,6 +173,12 @@
       background-color: var(--color-background-quaternary);
       color: var(--color-foreground-primary);
     }
+
+    .numeric-input {
+      --input-height: #{$sz-28};
+
+      flex-grow: 1;
+    }
   }
 
   .editable-select-wrapper {
@@ -182,10 +187,6 @@
     padding: 0;
     position: relative;
 
-    // The editable-select component already provides its own box styling
-    // (border, background, radius) — only the docked/square-left corner
-    // treatment is overridden here, deliberately scoped under this wrapper
-    // so it reliably outranks the component's own single-class rules.
     .column-select {
       block-size: $sz-32;
       border-radius: 0 $br-8 $br-8 0;
@@ -194,7 +195,6 @@
     }
   }
 
-  .grid-size .numeric-input,
   .editable-select-wrapper .column-select .numeric-input {
     @include use-typography("body-small");
 
@@ -250,12 +250,8 @@
 
       border: $b-1 solid var(--color-background-quaternary);
 
-      .icon {
-        stroke: var(--color-foreground-secondary);
-      }
-
       .numeric-input {
-        color: var(--color-foreground-secondary);
+        --input-fg-color: var(--color-foreground-secondary);
       }
     }
   }
@@ -316,9 +312,6 @@
 
   &:focus-visible {
     outline: none;
-
-    // Deprecated focus-type mixin hardcoded a 1px border here, narrower
-    // than this button's own 2px rest border-width — preserved as-is.
     border: $b-1 solid var(--color-accent-primary);
 
     --show-more-options-background-color: var(--color-background-tertiary);
@@ -381,54 +374,12 @@
   color: var(--grid-param-input-color);
 
   .numeric-input {
-    border: none;
-    background: none;
-    outline: none;
-    display: block;
-    max-inline-size: 99%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    block-size: $sz-28;
-    inline-size: 100%;
+    --input-height: #{$sz-28};
+
     flex-grow: 1;
     margin-block: var(--sp-xxs);
     margin-inline: 0;
     padding-inline-start: $sz-6;
-    border-radius: $br-8;
-    color: var(--color-foreground-primary);
-
-    &[disabled] {
-      opacity: 0.5;
-      pointer-events: none;
-    }
-
-    &::placeholder {
-      color: var(--color-foreground-secondary);
-    }
-  }
-
-  // Shared base for .icon-text (height) and .icon (gutter/margin) — both
-  // are the same kind of label slot, just with different content.
-  .icon-text,
-  .icon {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    inline-size: px2rem(20);
-    padding-inline-start: var(--sp-s);
-    block-size: $sz-32;
-    color: var(--grid-param-input-color);
-  }
-
-  .grid-param-icon {
-    fill: none;
-    stroke-width: 1.33px;
-
-    // Unlike the label text and background/border colors below, the
-    // deprecated placeholder never re-colored this icon on hover/
-    // active/focus — it stayed rest-colored; preserved as-is.
-    color: var(--color-foreground-secondary);
   }
 
   &:hover {
@@ -448,17 +399,6 @@
   &:focus,
   &:focus-within {
     --grid-param-input-background-color: var(--color-background-tertiary);
-  }
-}
-
-.height .icon-text {
-  padding-block-start: px2rem(1);
-}
-
-.gutter,
-.margin {
-  .icon.rotated .grid-param-icon {
-    transform: rotate(90deg);
   }
 }
 


### PR DESCRIPTION
### Related Ticket

This PR closes https://github.com/penpot/penpot/issues/11008

### Summary

- Fix dropdown width size
- Update CSS
- Update both icon usages with the DS icon*

AI-assisted-by: claude-sonnet-5

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
