### PR TITLE
:bug: Fix multiple export timeout on wasm render page

### DIFF
--- a/exporter/src/app/renderer/bitmap.cljs
+++ b/exporter/src/app/renderer/bitmap.cljs
@@ -17,7 +17,7 @@
    [promesa.core :as p]))
 
 (defn render
-  [{:keys [file-id page-id share-id token scale type objects skip-children is-wasm] :as params} on-object]
+  [{:keys [file-id page-id share-id token scale type objects skip-children] :as params} on-object]
   (letfn [(prepare-options [uri]
             #js {:screen #js {:width bw/default-viewport-width
                               :height bw/default-viewport-height}
@@ -25,7 +25,7 @@
                                 :height bw/default-viewport-height}
                  :locale "en-US"
                  :storageState #js {:cookies (bw/create-cookies uri {:token token})}
-                 :deviceScaleFactor (if is-wasm 1 scale) ;; wasm won't use deviceScaleFactor
+                 :deviceScaleFactor scale
                  :userAgent bw/default-user-agent})
 
           (render-object [page {:keys [id] :as object}]
@@ -59,9 +59,7 @@
                     :share-id share-id
                     :object-id (mapv :id objects)
                     :route "objects"
-                    :skip-children skip-children
-                    :wasm (when is-wasm "true")
-                    :scale scale}
+                    :skip-children skip-children}
             uri    (-> (cf/get-internal-uri)
                        (u/ensure-path-slash)
                        (u/join "render.html")

--- a/frontend/src/app/render.cljs
+++ b/frontend/src/app/render.cljs
@@ -136,7 +136,9 @@
               (repo/cmd! :get-page {:file-id file-id
                                     :page-id page-id
                                     :share-id share-id
-                                    :object-id object-id
+                                    :object-id (if (uuid? object-id)
+                                                 object-id
+                                                 (set object-id))
                                     :features features}))
              (rx/tap (fn [[fonts]]
                        (when (seq fonts)
@@ -155,7 +157,7 @@
    [:embed {:optional true} :boolean]
    [:skip-children {:optional true} :boolean]
    [:object-id
-    [:or [::sm/set ::sm/uuid] ::sm/uuid]]])
+    [:or [:vector ::sm/uuid] ::sm/uuid]]])
 
 (def ^:private coerce-render-objects-params
   (sm/coercer schema:render-objects))
@@ -188,7 +190,7 @@
           {:file-id file-id
            :page-id page-id
            :share-id share-id
-           :object-ids (into #{} object-id)
+           :object-ids (into [] (distinct) object-id)
            :embed embed
            :skip-children skip-children
            :wasm wasm


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Exporting several shapes as JPEG/PNG/WEBP failed with locator.waitFor: Timeout 10000ms exceeded waiting for #screenshot-<id>. SVG export of the same shapes worked.

When asking render.html with `wasm=true`, it renders one shape at a time, using the set order, and the exporter waits for them in the order it send them. So the exporter could end up waiting for a shape that was at the end. This didn't happen on SVG export because it never sets wasm=true.

Now, browser exporter never uses the wasm flag.


