### PR TITLE
:sparkles: Add props to invitations and organizations events

### DIFF
--- a/backend/src/app/rpc/commands/teams_invitations.clj
+++ b/backend/src/app/rpc/commands/teams_invitations.clj
@@ -235,9 +235,8 @@
                        :organization-name (:name organization)
                        :member-email (:email-to invitation)
                        :member-id (:id member)
-                       :role role}
-                organization
-                (assoc :user-who-send-invitation (str profile-id))
+                       :role role
+                       :user-who-send-invitation (str profile-id)}
 
                 (not organization)
                 (assoc :team-belongs-to-organization (boolean team-organization-id)

--- a/backend/src/app/rpc/commands/verify_token.clj
+++ b/backend/src/app/rpc/commands/verify_token.clj
@@ -308,7 +308,9 @@
                      (assoc :name "accept-organization-invitation")
                      (assoc :props
                             (-> props
-                                (assoc :organization-id organization-id-on-add)
+                                (assoc :organization-id organization-id-on-add
+                                       :user-id (:id profile)
+                                       :user-who-send-invitation (:created-by invitation))
                                 (audit/clean-props))))))
 
               (cond-> (assoc claims :state :created)
@@ -325,6 +327,8 @@
                             (assoc :organization-id organization-id-on-add
                                    :organization-member-add-source organization-add-source
                                    :belongs-to-team-on-add (boolean team-id)
+                                   :user-id (:id profile)
+                                   :user-who-send-invitation (:created-by invitation)
                                    :organization-member-count-before
                                    organization-member-count-before)
                             (audit/clean-props))}))))))

--- a/backend/test/backend_tests/rpc_team_test.clj
+++ b/backend/test/backend_tests/rpc_team_test.clj
@@ -154,10 +154,14 @@
                                                  (get-in % [:props :member-email])))
                                         events))]
         (doseq [event [create-organization update-organization]]
+          (t/is (= (str (:id owner))
+                   (get-in event [:props :user-who-send-invitation])))
           (t/is (true? (get-in event [:props :team-belongs-to-organization])))
           (t/is (true? (get-in event [:props :adds-invitee-to-organization])))
           (t/is (true? (get-in event [:props :invitee-already-organization-member]))))
 
+        (t/is (= (str (:id owner))
+                 (get-in create-plain [:props :user-who-send-invitation])))
         (t/is (false? (get-in create-plain [:props :team-belongs-to-organization])))
         (t/is (false? (get-in create-plain [:props :adds-invitee-to-organization])))
         (t/is (false? (get-in create-plain [:props :invitee-already-organization-member])))))))
@@ -521,6 +525,9 @@
 
       (let [event (organization-event)]
         (t/is (= organization-id (get-in event [:props :organization-id])))
+        (t/is (= (:id invitee) (get-in event [:props :user-id])))
+        (t/is (= (:id inviter)
+                 (get-in event [:props :user-who-send-invitation])))
         (t/is (not (contains? (:props event) :organization-member-add-source)))
         (t/is (not (contains? (:props event) :belongs-to-team-on-add)))
         (t/is (not (contains? (:props event) :organization-member-count-before)))
@@ -530,6 +537,10 @@
                  (:origin @frontend-event)))
         (t/is (= organization-id
                  (get-in @frontend-event [:props :organization-id])))
+        (t/is (= (:id invitee)
+                 (get-in @frontend-event [:props :user-id])))
+        (t/is (= (:id inviter)
+                 (get-in @frontend-event [:props :user-who-send-invitation])))
         (t/is (= "direct-organization-invitation"
                  (get-in @frontend-event [:props :organization-member-add-source])))
         (t/is (false? (get-in @frontend-event [:props :belongs-to-team-on-add])))
@@ -570,6 +581,9 @@
         (t/is (some #(= "accept-team-invitation-from" (:name %)) events))
         (t/is (= (:id team) (get-in event [:props :team-id])))
         (t/is (= organization-id (get-in event [:props :organization-id])))
+        (t/is (= (:id invitee) (get-in event [:props :user-id])))
+        (t/is (= (:id inviter)
+                 (get-in event [:props :user-who-send-invitation])))
         (t/is (not (contains? (:props event) :organization-member-add-source)))
         (t/is (not (contains? (:props event) :belongs-to-team-on-add)))
         (t/is (not (contains? (:props event) :organization-member-count-before)))
@@ -578,6 +592,10 @@
         (t/is (= (:id team) (get-in @frontend-event [:props :team-id])))
         (t/is (= organization-id
                  (get-in @frontend-event [:props :organization-id])))
+        (t/is (= (:id invitee)
+                 (get-in @frontend-event [:props :user-id])))
+        (t/is (= (:id inviter)
+                 (get-in @frontend-event [:props :user-who-send-invitation])))
         (t/is (= "team-invitation"
                  (get-in @frontend-event [:props :organization-member-add-source])))
         (t/is (true? (get-in @frontend-event [:props :belongs-to-team-on-add])))


### PR DESCRIPTION
### Related Ticket

https://tree.taiga.io/project/penpot-nitrate/task/26570

### Summary

Improve organization invitation tracking by adding explicit user identifiers to the relevant audit events.

This props allows us to analyze how many users enter an organization through a team invitation and are later removed by an organization owner, including whether the member was removed by the same person who invited them.

### Steps to reproduce 

### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
