### PR TITLE
:bug: Add a missing parameter to import-files! in clone-template

### DIFF
--- a/backend/src/app/rpc/commands/management.clj
+++ b/backend/src/app/rpc/commands/management.clj
@@ -425,6 +425,7 @@
         cfg      (-> cfg
                      (assoc ::bfc/project-id project-id)
                      (assoc ::bfc/profile-id profile-id)
+                     (assoc ::bfc/team-id (:id team))
                      (assoc ::bfc/input template)
                      (assoc ::bfc/features (cfeat/get-team-enabled-features cf/flags team))
                      (assoc ::bfc/import-max-object-size (cf/get :binfile-import-max-object-size))


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/pull/11505

### Summary

A parameter was missing when calling to import-file when cloning template files.

### Steps to reproduce 

See issue.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
