### PR TITLE
:bug: Fix MCP plugin reconnect loop on duplicate connection

### DIFF
--- a/mcp/packages/plugin/src/main.ts
+++ b/mcp/packages/plugin/src/main.ts
@@ -255,6 +255,15 @@ function connectToMcpServer(baseUrl?: string, token?: string): void {
                 updateCurrentTask(null);
             }
             ws = null;
+            if (event.code === 1008) {
+                // Policy violation (e.g. duplicate connection for the same user
+                // token - another tab already holds the connection). Retrying
+                // would be refused again immediately, so stay disconnected
+                // until the user explicitly reconnects.
+                shouldReconnect = false;
+                cancelReconnect();
+                return;
+            }
             scheduleReconnect();
         };
 


### PR DESCRIPTION
Fixes #11510

**Problem**
With MCP connected in one tab, reloading a second tab triggers an endless connect/disconnect loop in the reloaded tab (~1 reconnect per second, console flood, eventually freezes the browser).

**Root cause**
- The MCP server (`mcp/packages/server/src/PluginBridge.ts:145`) rejects a second plugin connection for the same user token with `ws.close(1008, "Duplicate connection for given user token; close previous connection first.")`.
- The plugin (`mcp/packages/plugin/src/main.ts`) treats **every** close as retryable: `ws.onclose` unconditionally calls `scheduleReconnect()`, and each brief `onopen` resets the backoff via `cancelReconnect()`. So a rejected tab reconnects at ~1s intervals forever and can never win - the other tab already holds the token.
- The app-level coordination (`mcp.cljs` force-disconnect broadcast) never engages for the reloaded tab, because its connection is rejected before it can report `connected` and broadcast.

**Fix**
In the plugin's `ws.onclose`, treat close code `1008` (policy violation - used by the server for duplicate-token and missing-token rejections) as terminal: stop auto-reconnecting and stay disconnected until the user explicitly reconnects. Non-1008 closes keep the existing capped-backoff retry behavior, and the close reason is surfaced in the status label as before.

**Expected after fix**: the reloaded tab fails once, shows the duplicate-connection reason, and stays grey. No retry storm.

Note: `main.ts` is not covered by the plugin package's existing node:test suite (only ErrorUtils/PenpotUtils are); the change is a small guard in the close handler, verified by type-checking (only pre-existing build-define errors for `style.css`/`PENPOT_MCP_WEBSOCKET_URL`).

> Built by breken, your AI support engineer - breken.ai - this one's on us.