### PR TITLE
:sparkles: Add skip-onboarding option to create-demo-profile

### DIFF
--- a/backend/src/app/rpc/commands/demo.clj
+++ b/backend/src/app/rpc/commands/demo.clj
@@ -9,6 +9,7 @@
   (:require
    [app.auth :refer [derive-password-weak]]
    [app.common.exceptions :as ex]
+   [app.common.schema :as sm]
    [app.common.uuid :as uuid]
    [app.config :as cf]
    [app.db :as db]
@@ -21,14 +22,21 @@
    [buddy.core.codecs :as bc]
    [buddy.core.nonce :as bn]))
 
+(def ^:private
+  schema:create-demo-profile
+  [:map
+   [:skip-onboarding {:optional true} ::sm/boolean]])
+
 (sv/defmethod ::create-demo-profile
   "A command that is responsible of creating a demo purpose
   profile. It only works if the `demo-users` flag is enabled in the
   configuration."
   {::rpc/auth false
    ::doc/added "1.15"
-   ::doc/changes ["1.15" "This method is migrated from mutations to commands."]}
-  [cfg _]
+   ::doc/changes [["1.15" "This method is migrated from mutations to commands."]
+                  ["2.18" "Add optional `skip-onboarding` param. When true, the profile is created with `onboarding-viewed` and `release-notes-viewed` (current version) set, skipping the onboarding flow."]]
+   ::sm/params schema:create-demo-profile}
+  [cfg {:keys [skip-onboarding]}]
 
   (when-not (contains? cf/flags :demo-users)
     (ex/raise :type :validation
@@ -48,7 +56,13 @@
                   :is-active true
                   :is-demo true
                   :password (derive-password-weak password)
-                  :props {}}
+                  :props (cond-> {}
+                           skip-onboarding (assoc :onboarding-viewed true
+                                                  ;; Redundant today: auth/create-profile
+                                                  ;; overwrites this with the current
+                                                  ;; version, kept so the skip does not
+                                                  ;; depend on that default.
+                                                  :release-notes-viewed (:main cf/version)))}
         profile  (db/tx-run! cfg (fn [cfg]
                                    (->> (auth/create-profile cfg params)
                                         (auth/create-profile-rels cfg))))]

--- a/backend/test/backend_tests/rpc_demo_test.clj
+++ b/backend/test/backend_tests/rpc_demo_test.clj
@@ -8,6 +8,7 @@
   (:require
    [app.auth :as auth]
    [app.config :as cf]
+   [app.rpc.commands.profile :as profile]
    [backend-tests.helpers :as th]
    [clojure.test :as t]))
 
@@ -38,3 +39,38 @@
   (with-redefs [cf/flags (disj cf/flags :demo-users)]
     (let [{:keys [error]} (th/command! {::th/type :create-demo-profile})]
       (t/is (th/ex-of-code? error :demo-users-not-allowed)))))
+
+(t/deftest create-demo-profile-keeps-onboarding-by-default
+  (with-redefs [cf/flags (conj cf/flags :demo-users)]
+    (let [{:keys [error result]} (th/command! {::th/type :create-demo-profile})]
+      (t/is (nil? error))
+      (let [saved   (th/db-get :profile {:email (:email result)})
+            decoded (profile/decode-row saved)]
+        (t/is (nil? (get-in decoded [:props :onboarding-viewed])))))))
+
+(t/deftest create-demo-profile-skips-onboarding-when-requested
+  (with-redefs [cf/flags (conj cf/flags :demo-users)]
+    (let [{:keys [error result]} (th/command! {::th/type :create-demo-profile
+                                               :skip-onboarding true})]
+      (t/is (nil? error))
+      (let [saved   (th/db-get :profile {:email (:email result)})
+            decoded (profile/decode-row saved)]
+        (t/is (true? (get-in decoded [:props :onboarding-viewed])))
+        (t/is (= (:main cf/version)
+                 (get-in decoded [:props :release-notes-viewed])))))))
+
+(t/deftest create-demo-profile-explicit-false-keeps-onboarding
+  (with-redefs [cf/flags (conj cf/flags :demo-users)]
+    (let [{:keys [error result]} (th/command! {::th/type :create-demo-profile
+                                               :skip-onboarding false})]
+      (t/is (nil? error))
+      (let [saved   (th/db-get :profile {:email (:email result)})
+            decoded (profile/decode-row saved)]
+        (t/is (nil? (get-in decoded [:props :onboarding-viewed])))))))
+
+(t/deftest create-demo-profile-rejects-non-boolean-skip-onboarding
+  (with-redefs [cf/flags (conj cf/flags :demo-users)]
+    (let [{:keys [error]} (th/command! {::th/type :create-demo-profile
+                                        :skip-onboarding "yes"})]
+      (t/is (th/ex-of-type? error :validation))
+      (t/is (th/ex-of-code? error :params-validation)))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- The `create-demo-profile` RPC method accepts a new optional `skip-onboarding` flag; when true, the demo profile starts with the onboarding flow already marked as viewed.
- Closes #11525.

## Why

- Demo users created for demos, manual QA, and E2E environments had to step through the full onboarding flow (questions, team-choice, and release-notes modals) before reaching the app.

## How

- **Backend:** single optional boolean param on `::create-demo-profile`; server-fixed props keep the change minimal and backwards compatible (absent/false preserves current behavior).
- **Tests:** new RPC tests cover the default path, explicit `false`, `skip-onboarding: true` (asserts persisted `onboarding-viewed` and `release-notes-viewed`), and rejection of non-boolean values.
- No breaking changes; no frontend changes. `backend-tests.rpc-demo-test`: 7 tests, 15 assertions, 0 failures; `lint:clj` and `check-fmt:clj` pass.
