### PR TITLE
:bug: Fix shared library deletion with storage-backed file data

### DIFF
--- a/backend/src/app/main.clj
+++ b/backend/src/app/main.clj
@@ -437,7 +437,8 @@
     ::sto/storage (ig/ref ::sto/storage)}
 
    :app.tasks.delete-object/handler
-   {::db/pool (ig/ref ::db/pool)}
+   {::db/pool     (ig/ref ::db/pool)
+    ::sto/storage (ig/ref ::sto/storage)}
 
    :app.tasks.demo-purge/handler
    {::db/pool (ig/ref ::db/pool)}

--- a/backend/src/app/tasks/delete_object.clj
+++ b/backend/src/app/tasks/delete_object.clj
@@ -13,6 +13,7 @@
    [app.db.sql :as-alias sql]
    [app.rpc.commands.files :as files]
    [app.rpc.commands.profile :as profile]
+   [app.storage :as sto]
    [integrant.core :as ig]))
 
 (def ^:dynamic *team-deletion* false)
@@ -149,7 +150,8 @@
 
 (defmethod ig/assert-key ::handler
   [_ params]
-  (assert (db/pool? (::db/pool params)) "expected a valid database pool"))
+  (assert (db/pool? (::db/pool params)) "expected a valid database pool")
+  (assert (sto/valid-storage? (::sto/storage params)) "expected valid storage to be provided"))
 
 (defmethod ig/init-key ::handler
   [_ cfg]

--- a/backend/test/backend_tests/rpc_file_test.clj
+++ b/backend/test/backend_tests/rpc_file_test.clj
@@ -2087,6 +2087,39 @@
       (t/is (= (:id file-2) (:file-id (get rows 0))))
       (t/is (nil? (:deleted-at (get rows 0)))))))
 
+(t/deftest delete-shared-library-with-storage-file-data
+  (binding [cf/config (assoc cf/config :file-data-backend "storage")]
+    (let [profile (th/create-profile* 1)
+          params  {:profile-id (:id profile)
+                   :project-id (:default-project-id profile)}
+          library (th/create-file* 1 (assoc params :is-shared true))
+          file    (th/create-file* 2 params)]
+      (th/link-file-to-library* {:file-id (:id file)
+                                 :library-id (:id library)})
+
+      ;; Ensure the test exercises storage reads for both files.
+      (let [rows (th/db-exec! ["SELECT backend, data FROM file_data WHERE type = 'main'"])]
+        (t/is (= 2 (count rows)))
+        (t/is (every? #(= "storage" (:backend %)) rows))
+        (t/is (every? (comp nil? :data) rows)))
+
+      (th/run-task! :delete-object
+                    {:object :file
+                     :deleted-at (ct/now)
+                     :id (:id library)})
+
+      ;; The task swallows absorption errors, so verify the persisted result.
+      (let [deleted (db/get* th/*pool* :file {:id (:id library)}
+                             {::db/remove-deleted false})
+            out     (th/command! {::th/type :get-file
+                                  ::rpc/profile-id (:id profile)
+                                  :id (:id file)})]
+        (t/is (some? (:deleted-at deleted)))
+        (t/is (false? (:is-shared deleted)))
+        (t/is (th/success? out))
+        (t/is (= (inc (:revn file)) (get-in out [:result :revn])))
+        (t/is (= (:id file) (get-in out [:result :data :id])))))))
+
 (t/deftest deleted-files-permanently-delete
   (let [prof    (th/create-profile* 1 {:is-active true})
         team-id (:default-team-id prof)


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

### Related Ticket

Closes #11535

### Summary

Deleting a shared library with `PENPOT_FILE_DATA_BACKEND=storage` fails to absorb the library into referencing files because the `delete-object` task does not receive the storage component. The absorption operation raises `Assert failed: (valid-storage? storage)`, but the task is still marked as completed.

This PR:
- Injects the storage component into the `delete-object` handler.
- Validates the storage dependency during handler initialization.
- Adds an integration test that deletes a storage-backed shared library and verifies that the referencing file's revision is updated.

The regression test fails before the fix and passes afterward. All 822 backend tests pass locally (4,966 assertions), along with the backend lint and formatting checks. Verification used filesystem object storage; the original report used S3-compatible storage.

### Steps to reproduce

1. Run Penpot with `PENPOT_FILE_DATA_BACKEND=storage` and a configured object storage backend.
2. Create a shared library containing a component.
3. Create another file, link it to the library, and add an instance of that component.
4. Delete the shared library and wait for the `delete-object` background task to run.
5. Inspect the backend logs and the referencing file.

Before the fix, the backend logs `error on absorbing library` with `Assert failed: (valid-storage? storage)`, and the absorption operation does not update the referencing file.

After the fix, library absorption succeeds and the referencing file is updated.

The automated regression test can be run from `backend/`:

```sh
clojure -M:dev:test --focus backend-tests.rpc-file-test/delete-shared-library-with-storage-file-data
```

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable. — Not applicable: backend-only changes.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide. — Not applicable: no SCSS changes.
- [x] Check CI passes successfully.