### PR TITLE
:recycle: Use uniform URI building pattern for OIDC redirects

### DIFF
--- a/backend/src/app/auth/oidc.clj
+++ b/backend/src/app/auth/oidc.clj
@@ -453,10 +453,15 @@
         [fitem & items]  (str/split path separator)]
     (into [(keyword (:type provider) (str/kebab fitem))] (map keyword) items)))
 
+(defn- public-uri-with-path
+  [path]
+  (let [public    (u/uri (cf/get :public-uri))
+        base-path (str/replace (or (:path public) "") #"/+$" "")]
+    (assoc public :path (str base-path path))))
+
 (defn- build-redirect-uri
   []
-  (let [public (u/uri (cf/get :public-uri))]
-    (str (assoc public :path "/api/auth/oidc/callback"))))
+  (str (public-uri-with-path "/api/auth/oidc/callback")))
 
 (defn build-auth-redirect-uri
   [provider token]
@@ -687,8 +692,7 @@
   ([error hint]
    (let [params {:error error :hint hint}
          params (d/without-nils params)
-         uri    (-> (u/uri (cf/get :public-uri))
-                    (assoc :path "/#/auth/login")
+         uri    (-> (public-uri-with-path "/#/auth/login")
                     (assoc :query (u/map->query-string params)))]
      (redirect-response uri))))
 
@@ -713,15 +717,13 @@
         params (d/without-nils params)]
 
     (redirect-response
-     (-> (u/uri (cf/get :public-uri))
-         (assoc :path "/#/auth/register/validate")
+     (-> (public-uri-with-path "/#/auth/register/validate")
          (assoc :query (u/map->query-string params))))))
 
 (defn- redirect-to-verify-token
   [token]
   (let [params {:token token}
-        uri    (-> (u/uri (cf/get :public-uri))
-                   (assoc :path "/#/auth/verify-token")
+        uri    (-> (public-uri-with-path "/#/auth/verify-token")
                    (assoc :query (u/map->query-string params)))]
 
     (redirect-response uri)))

--- a/backend/src/app/auth/oidc.clj
+++ b/backend/src/app/auth/oidc.clj
@@ -453,15 +453,30 @@
         [fitem & items]  (str/split path separator)]
     (into [(keyword (:type provider) (str/kebab fitem))] (map keyword) items)))
 
-(defn- public-uri-with-path
+(defn- build-public-uri
+  "Join a relative path onto the configured public URI, preserving any
+  subpath. Uses `u/ensure-path-slash` + `u/join` to match the pattern
+  used throughout the backend and frontend.
+  `path` must not start with `/` — a leading slash would be treated as
+  absolute by `u/join`, silently dropping the configured subpath."
   [path]
-  (let [public    (u/uri (cf/get :public-uri))
-        base-path (str/replace (or (:path public) "") #"/+$" "")]
-    (assoc public :path (str base-path path))))
+  {:pre [(not (str/starts-with? path "/"))]}
+  (-> (cf/get :public-uri)
+      (u/uri)
+      (u/ensure-path-slash)
+      (u/join path)))
+
+(defn- build-fragment-uri
+  "Build a public URI with a hash-route fragment and query params
+  placed inside that fragment."
+  [path params]
+  (reduce-kv #(u/append-query-param %1 (name %2) %3)
+             (build-public-uri path)
+             params))
 
 (defn- build-redirect-uri
   []
-  (str (public-uri-with-path "/api/auth/oidc/callback")))
+  (str (build-public-uri "api/auth/oidc/callback")))
 
 (defn build-auth-redirect-uri
   [provider token]
@@ -692,8 +707,7 @@
   ([error hint]
    (let [params {:error error :hint hint}
          params (d/without-nils params)
-         uri    (-> (public-uri-with-path "/#/auth/login")
-                    (assoc :query (u/map->query-string params)))]
+         uri    (build-fragment-uri "#/auth/login" params)]
      (redirect-response uri))))
 
 (defn- redirect-with-organization-sso-error
@@ -714,17 +728,15 @@
         params {:token (tokens/generate cfg info)
                 :provider (:provider (:id provider))
                 :fullname (:fullname info)}
-        params (d/without-nils params)]
+        params (d/without-nils params)
+        uri    (build-fragment-uri "#/auth/register/validate" params)]
 
-    (redirect-response
-     (-> (public-uri-with-path "/#/auth/register/validate")
-         (assoc :query (u/map->query-string params))))))
+    (redirect-response uri)))
 
 (defn- redirect-to-verify-token
   [token]
   (let [params {:token token}
-        uri    (-> (public-uri-with-path "/#/auth/verify-token")
-                   (assoc :query (u/map->query-string params)))]
+        uri    (build-fragment-uri "#/auth/verify-token" params)]
 
     (redirect-response uri)))
 

--- a/backend/test/backend_tests/auth_oidc_test.clj
+++ b/backend/test/backend_tests/auth_oidc_test.clj
@@ -156,6 +156,12 @@
         (t/is (.contains loc "error=auth-error"))
         (t/is (not (.contains loc "hint=")))))))
 
+(t/deftest redirect-with-error-preserves-public-uri-subpath
+  (binding [cf/config {:public-uri "http://localhost:3449/penpot"}]
+    (let [result (#'oidc/redirect-with-error "auth-error")
+          loc    (get-in result [::yres/headers "location"])]
+      (t/is (.contains loc "http://localhost:3449/penpot/#/auth/login?")))))
+
 (t/deftest redirect-to-verify-token-builds-verify-url
   (binding [cf/config {:public-uri "http://localhost:3449"}]
     (let [result (#'oidc/redirect-to-verify-token "test-token-value")
@@ -164,9 +170,20 @@
       (t/is (.contains loc "http://localhost:3449/#/auth/verify-token?"))
       (t/is (.contains loc "token=test-token-value")))))
 
+(t/deftest redirect-to-verify-token-preserves-public-uri-subpath
+  (binding [cf/config {:public-uri "http://localhost:3449/penpot"}]
+    (let [result (#'oidc/redirect-to-verify-token "test-token-value")
+          loc    (get-in result [::yres/headers "location"])]
+      (t/is (.contains loc "http://localhost:3449/penpot/#/auth/verify-token?")))))
+
 (t/deftest build-redirect-uri-constructs-redirect
   (binding [cf/config {:public-uri "http://localhost:3449"}]
     (t/is (= "http://localhost:3449/api/auth/oidc/callback"
+             (#'oidc/build-redirect-uri)))))
+
+(t/deftest build-redirect-uri-preserves-public-uri-subpath
+  (binding [cf/config {:public-uri "http://localhost:3449/penpot"}]
+    (t/is (= "http://localhost:3449/penpot/api/auth/oidc/callback"
              (#'oidc/build-redirect-uri)))))
 
 (t/deftest fetch-user-info-returns-decoded-body-on-success
@@ -476,7 +493,7 @@
   (let [cfg     (dissoc base-cfg :app.email/blacklist :app.email/whitelist)
         state   (make-state-token cfg {})
         request (default-request cfg :state state)]
-    (binding [cf/config {:public-uri "http://localhost:3449"}
+    (binding [cf/config {:public-uri "http://localhost:3449/penpot"}
               cf/flags #{:registration}]
       (with-redefs [app.auth.oidc/resolve-provider (constantly {:type "oidc" :id "oidc"})
                     app.auth.oidc/get-info         (constantly {:email "u@e.com" :fullname "U"
@@ -485,7 +502,7 @@
                     app.auth.oidc/get-profile      (constantly (assoc test-profile :is-active false))]
         (let [result (#'oidc/callback-handler cfg request)
               loc    (redirect-location result)]
-          (t/is (.contains loc "http://localhost:3449/#/auth/register/validate?"))
+          (t/is (.contains loc "http://localhost:3449/penpot/#/auth/register/validate?"))
           (t/is (.contains loc "token=")))))))
 
 (t/deftest callback-success-flow

--- a/backend/test/backend_tests/auth_oidc_test.clj
+++ b/backend/test/backend_tests/auth_oidc_test.clj
@@ -186,6 +186,64 @@
     (t/is (= "http://localhost:3449/penpot/api/auth/oidc/callback"
              (#'oidc/build-redirect-uri)))))
 
+(t/deftest build-redirect-uri-with-subpath-and-trailing-slash
+  (binding [cf/config {:public-uri "http://localhost:3449/penpot/"}]
+    (t/is (= "http://localhost:3449/penpot/api/auth/oidc/callback"
+             (#'oidc/build-redirect-uri)))))
+
+(t/deftest redirect-with-error-subpath-query-inside-fragment
+  (binding [cf/config {:public-uri "http://localhost:3449/penpot"}]
+    (let [result (#'oidc/redirect-with-error "auth-error" "hint message")
+          loc    (get-in result [::yres/headers "location"])]
+      (t/is (.contains loc "http://localhost:3449/penpot/#/auth/login?"))
+      (t/is (.contains loc "error=auth-error"))
+      (t/is (.contains loc "hint=hint"))
+      ;; Query params must appear after the hash, not before
+      (t/is (re-find #"#/auth/login\?" loc)))))
+
+(t/deftest redirect-to-register-subpath
+  (let [test-key (byte-array (map byte (range 32)))
+        cfg      {::setup/props {:tokens-key test-key}}]
+    (binding [cf/config {:public-uri "http://localhost:3449/penpot"}]
+      (let [info     {:email "u@e.com" :fullname "U" :backend "oidc"
+                      :email-verified false :props {}}
+            provider {:type "oidc" :id "oidc"}
+            result   (#'oidc/redirect-to-register cfg info provider)
+            loc      (get-in result [::yres/headers "location"])]
+        (t/is (.contains loc "http://localhost:3449/penpot/#/auth/register/validate?"))
+        (t/is (.contains loc "token="))))))
+
+(t/deftest redirect-to-register-no-subpath
+  (let [test-key (byte-array (map byte (range 32)))
+        cfg      {::setup/props {:tokens-key test-key}}]
+    (binding [cf/config {:public-uri "http://localhost:3449"}]
+      (let [info     {:email "u@e.com" :fullname "U" :backend "oidc"
+                      :email-verified false :props {}}
+            provider {:type "oidc" :id "oidc"}
+            result   (#'oidc/redirect-to-register cfg info provider)
+            loc      (get-in result [::yres/headers "location"])]
+        (t/is (.contains loc "http://localhost:3449/#/auth/register/validate?"))
+        (t/is (.contains loc "token="))))))
+
+(t/deftest redirect-to-verify-token-subpath-no-trailing-slash
+  (binding [cf/config {:public-uri "http://localhost:3449/my-app"}]
+    (let [result (#'oidc/redirect-to-verify-token "test-token-value")
+          loc    (get-in result [::yres/headers "location"])]
+      (t/is (.contains loc "http://localhost:3449/my-app/#/auth/verify-token?")))))
+
+(t/deftest build-public-uri-no-subpath
+  (binding [cf/config {:public-uri "http://localhost:3449"}]
+    (t/is (= "http://localhost:3449/api/auth/oidc/callback"
+             (str (#'oidc/build-public-uri "api/auth/oidc/callback"))))))
+
+(t/deftest build-public-uri-hash-route-query-in-fragment
+  (binding [cf/config {:public-uri "http://localhost:3449/penpot"}]
+    (let [uri (#'oidc/build-public-uri "#/auth/login")]
+      ;; The URI map should have the hash route as fragment
+      (t/is (= "/auth/login" (:fragment uri)))
+      ;; Path should end with trailing slash
+      (t/is (= "/penpot/" (:path uri))))))
+
 (t/deftest fetch-user-info-returns-decoded-body-on-success
   (let [cfg      {}
         provider {:user-uri "https://provider.example.com/userinfo"}


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- OIDC redirects now preserve the subpath configured in `PENPOT_PUBLIC_URI` (e.g. `/penpot`).
- Callback URL, login error, registration validation, and token verification redirects all respect the configured subpath.

## Why

The original implementation in #11441 solved this with an ad-hoc helper that manually manipulated URI path strings. This PR replaces it with the canonical `u/ensure-path-slash` + `u/join` pattern already used throughout the backend (`app.rpc`, `app.nitrate`, `app.rpc.doc`) and frontend (`resolve-href`), making the code consistent and maintainable.

For hash routes (frontend URLs), query params are now placed inside the fragment using `u/append-query-param`, matching the expected URL structure.

## How

- **`build-public-uri`** — joins a relative path onto the public URI using `u/ensure-path-slash` + `u/join`. Includes a runtime assertion to catch misuse (path must not start with `/`).
- **`build-fragment-uri`** — builds a hash-route URI with query params inside the fragment.
- Refactored `build-redirect-uri`, `redirect-with-error`, `redirect-to-register`, and `redirect-to-verify-token` to use these helpers.
- Added 7 new tests covering subpath edge cases (trailing slash, no subpath, fragment query param placement).

Closes #11537
Relates to #11441
