### PR TITLE
:bug: Fix selrect auto-width on selrect click and selrect resize

### DIFF
--- a/frontend/src/app/main/data/workspace/texts.cljs
+++ b/frontend/src/app/main/data/workspace/texts.cljs
@@ -123,7 +123,8 @@
 (defn- await-font-faces
   "Waits for missing WASM faces, then resizes the affected texts."
   [stream face-keys ids]
-  (let [resize-stream (->> (rx/from ids) (rx/map dwwt/resize-wasm-text))]
+  (let [resize-opts   {:stack-undo? true :undo-transation? false}
+        resize-stream (->> (rx/from ids) (rx/map #(dwwt/resize-wasm-text % resize-opts)))]
     (if (empty? face-keys)
       resize-stream
       (->> (rx/merge wasm.fonts/font-stored-stream

--- a/frontend/src/app/main/data/workspace/wasm_text.cljs
+++ b/frontend/src/app/main/data/workspace/wasm_text.cljs
@@ -79,20 +79,26 @@
 
 (defn resize-wasm-text
   "Resize a single text shape (auto-width/auto-height) by id.
-  No-op if the id is not a text shape or is :fixed."
-  [id]
-  (ptk/reify ::resize-wasm-text
-    ptk/WatchEvent
-    (watch [_ state _]
-      (let [objects (dsh/lookup-page-objects state)
-            shape   (get objects id)
-            resize-stream
-            (if (and (some? shape)
-                     (cfh/text-shape? shape)
-                     (not= :fixed (:grow-type shape)))
-              (rx/of (dwm/apply-wasm-modifiers (resize-wasm-text-modifiers shape)))
-              (rx/empty))]
-        (wrf/with-pending :text-resize [id] resize-stream)))))
+  No-op if the id is not a text shape or is :fixed.
+  `opts` are forwarded to `apply-wasm-modifiers`, so a caller whose undo
+  transaction is already closed when the resize lands can still get the
+  geometry into the right undo entry."
+  ([id]
+   (resize-wasm-text id nil))
+  ([id opts]
+   (ptk/reify ::resize-wasm-text
+     ptk/WatchEvent
+     (watch [_ state _]
+       (let [objects (dsh/lookup-page-objects state)
+             shape   (get objects id)
+             apply-opts (or opts {})
+             resize-stream
+             (if (and (some? shape)
+                      (cfh/text-shape? shape)
+                      (not= :fixed (:grow-type shape)))
+               (rx/of (dwm/apply-wasm-modifiers (resize-wasm-text-modifiers shape) apply-opts))
+               (rx/empty))]
+         (wrf/with-pending :text-resize [id] resize-stream))))))
 
 (defn resize-wasm-text-debounce-commit
   ([]

--- a/frontend/src/app/main/ui/workspace/viewport/selection.cljs
+++ b/frontend/src/app/main/ui/workspace/viewport/selection.cljs
@@ -18,6 +18,7 @@
    [app.main.data.helpers :as dsh]
    [app.main.data.workspace :as dw]
    [app.main.data.workspace.shapes :as dwsh]
+   [app.main.data.workspace.undo :as dwu]
    [app.main.data.workspace.wasm-text :as dwwt]
    [app.main.features :as features]
    [app.main.refs :as refs]
@@ -307,11 +308,14 @@
                                :bottom :auto-height
                                nil)]
                (when (some? grow-type)
-                 (st/emit! (dwsh/update-shapes [shape-id] #(assoc % :grow-type grow-type)))
-                 ;; The WASM renderer needs an explicit reflow after the grow-type change
-                 (when (features/active-feature? @st/state "render-wasm/v1")
-                   (st/emit! (dwwt/resize-wasm-text-all [shape-id])
-                             (ptk/data-event :layout/update {:ids [shape-id]}))))))))]
+                 (let [uid (js/Symbol)]
+                   (st/emit! (dwu/start-undo-transaction uid)
+                             (dwsh/update-shapes [shape-id] #(assoc % :grow-type grow-type)))
+                   ;; The WASM renderer needs an explicit reflow after the grow-type change
+                   (if (features/active-feature? @st/state "render-wasm/v1")
+                     (st/emit! (dwwt/resize-wasm-text-all [shape-id] {:undo-id uid})
+                               (ptk/data-event :layout/update {:ids [shape-id]}))
+                     (st/emit! (dwu/commit-undo-transaction uid)))))))))]
 
     [:g.resize-handler
      (when ^boolean show-handler


### PR DESCRIPTION
### Related Ticket

https://github.com/penpot/penpot/issues/11480

Note: this PR was created with AI assistance

### Summary

This PR closes two issues at once:
- Clicking on the sides of a text selrect with shift applies auto-width or auto-height
- Applying "undo" after changing a font type updates the selrect correctly

### Steps to reproduce 

[screen-recorder-mon-sep-07-2026-17-46-50.webm](https://github.com/user-attachments/assets/ffb3e4c6-c83b-437b-9493-85dc44308069)

