### PR TITLE
:bug: Add bounds checking to remove-interaction to prevent crashes

### DIFF
--- a/common/src/app/common/types/shape/interactions.cljc
+++ b/common/src/app/common/types/shape/interactions.cljc
@@ -714,8 +714,10 @@
 (defn remove-interaction
   [interactions index]
   (let [interactions (or interactions [])]
-    (into (subvec interactions 0 index)
-          (subvec interactions (inc index)))))
+    (if (and (>= index 0) (< index (count interactions)))
+      (into (subvec interactions 0 index)
+            (subvec interactions (inc index)))
+      interactions)))
 
 (defn update-interaction
   [interactions index update-fn]

--- a/common/test/common_tests/types/shape_interactions_test.cljc
+++ b/common/test/common_tests/types/shape_interactions_test.cljc
@@ -861,6 +861,37 @@
         (t/is (= (:action-type (last new-interactions)) :open-url))))))
 
 
+(t/deftest remove-interaction-bounds-check
+  (let [i1 (ctsi/set-action-type ctsi/default-interaction :open-overlay)
+        i2 (ctsi/set-action-type ctsi/default-interaction :close-overlay)
+        i3 (ctsi/set-action-type ctsi/default-interaction :prev-screen)
+        interactions [i1 i2 i3]]
+
+    (t/testing "Remove interaction with valid index"
+      (let [new-interactions (ctsi/remove-interaction interactions 1)]
+        (t/is (= 2 (count new-interactions)))
+        (t/is (= :open-overlay (:action-type (first new-interactions))))
+        (t/is (= :prev-screen (:action-type (second new-interactions))))))
+
+    (t/testing "Remove interaction with index out of bounds (too high)"
+      (let [new-interactions (ctsi/remove-interaction interactions 10)]
+        (t/is (= 3 (count new-interactions)))
+        (t/is (= interactions new-interactions))))
+
+    (t/testing "Remove interaction with negative index"
+      (let [new-interactions (ctsi/remove-interaction interactions -1)]
+        (t/is (= 3 (count new-interactions)))
+        (t/is (= interactions new-interactions))))
+
+    (t/testing "Remove interaction from empty vector"
+      (let [new-interactions (ctsi/remove-interaction [] 0)]
+        (t/is (= 0 (count new-interactions)))))
+
+    (t/testing "Remove interaction from nil"
+      (let [new-interactions (ctsi/remove-interaction nil 0)]
+        (t/is (= 0 (count new-interactions)))))))
+
+
 (t/deftest remap-interactions
   (let [frame1 (cts/setup-shape {:type :frame})
         frame2 (cts/setup-shape {:type :frame})


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- The workspace crashes with "Index out of bounds" when removing multiple interactions in rapid succession
- The error occurs in `app.common.types.shape.interactions/remove-interaction` when attempting to use `subvec` with an invalid index

## Why

The `remove-interaction` function didn't validate that the index was within bounds before calling `subvec`. When removing interactions rapidly, indices become stale:

- Initial state: `[A, B, C]` at indices `[0, 1, 2]`
- User removes index 0 → `[B, C]` (B is now at 0, C is at 1)
- UI still shows old indices, user removes index 2 → ERROR (only 2 items left)

## How

- Added bounds checking to `remove-interaction` to validate the index is within `[0, count)`
- Returns the unchanged interactions vector for invalid indices (idempotent behavior)
- Added comprehensive tests covering valid index, out-of-bounds, negative, empty vector, and nil cases

Closes #11546
