### PR TITLE
:bug: Return null from createComponent when creation fails

### DIFF
--- a/common/src/app/common/media.cljc
+++ b/common/src/app/common/media.cljc
@@ -80,25 +80,27 @@
 
 (defn parse-font-weight
   [variant]
-  (cond
-    (re-seq #"(?i)(?:^|[-_\s])(hairline|thin)(?=(?:[-_\s]|$|italic\b))" variant)               100
-    (re-seq #"(?i)(?:^|[-_\s])(extra\s*light|ultra\s*light)(?=(?:[-_\s]|$|italic\b))" variant) 200
-    (re-seq #"(?i)(?:^|[-_\s])(light)(?=(?:[-_\s]|$|italic\b))" variant)                       300
-    (re-seq #"(?i)(?:^|[-_\s])(normal|regular)(?=(?:[-_\s]|$|italic\b))" variant)              400
-    (re-seq #"(?i)(?:^|[-_\s])(medium)(?=(?:[-_\s]|$|italic\b))" variant)                      500
-    (re-seq #"(?i)(?:^|[-_\s])(semi\s*bold|demi\s*bold)(?=(?:[-_\s]|$|italic\b))" variant)     600
-    (re-seq #"(?i)(?:^|[-_\s])(extra\s*bold|ultra\s*bold)(?=(?:[-_\s]|$|italic\b))" variant)   800
-    (re-seq #"(?i)(?:^|[-_\s])(bold)(?=(?:[-_\s]|$|italic\b))" variant)                        700
-    (re-seq #"(?i)(?:^|[-_\s])(extra\s*black|ultra\s*black)(?=(?:[-_\s]|$|italic\b))" variant) 950
-    (re-seq #"(?i)(?:^|[-_\s])(black|heavy|solid)(?=(?:[-_\s]|$|italic\b))" variant)           900
-    :else                                                                                      400))
+  (let [variant-str (str variant)]
+    (cond
+      (re-seq #"(?i)(?:^|[-_\s])(hairline|thin)(?=(?:[-_\s]|$|italic\b))" variant-str)               100
+      (re-seq #"(?i)(?:^|[-_\s])(extra\s*light|ultra\s*light)(?=(?:[-_\s]|$|italic\b))" variant-str) 200
+      (re-seq #"(?i)(?:^|[-_\s])(light)(?=(?:[-_\s]|$|italic\b))" variant-str)                       300
+      (re-seq #"(?i)(?:^|[-_\s])(normal|regular)(?=(?:[-_\s]|$|italic\b))" variant-str)              400
+      (re-seq #"(?i)(?:^|[-_\s])(medium)(?=(?:[-_\s]|$|italic\b))" variant-str)                      500
+      (re-seq #"(?i)(?:^|[-_\s])(semi\s*bold|demi\s*bold)(?=(?:[-_\s]|$|italic\b))" variant-str)     600
+      (re-seq #"(?i)(?:^|[-_\s])(extra\s*bold|ultra\s*bold)(?=(?:[-_\s]|$|italic\b))" variant-str)   800
+      (re-seq #"(?i)(?:^|[-_\s])(bold)(?=(?:[-_\s]|$|italic\b))" variant-str)                        700
+      (re-seq #"(?i)(?:^|[-_\s])(extra\s*black|ultra\s*black)(?=(?:[-_\s]|$|italic\b))" variant-str) 950
+      (re-seq #"(?i)(?:^|[-_\s])(black|heavy|solid)(?=(?:[-_\s]|$|italic\b))" variant-str)           900
+      :else 400))) 
 
 (defn parse-font-style
   [variant]
-  (if (or (re-seq #"(?i)(?:^|[-_\s])(italic)(?:[-_\s]|$)" variant)
-          (re-seq #"(?i)italic$" variant))
-    "italic"
-    "normal"))
+  (let [variant-str (str variant)]
+    (if (or (re-seq #"(?i)(?:^|[-_\s])(italic)(?:[-_\s]|$)" variant-str)
+            (re-seq #"(?i)italic$" variant-str))
+      "italic"
+      "normal")))
 
 (defn font-weight->name
   [weight]

--- a/common/test/common_tests/media_test.cljc
+++ b/common/test/common_tests/media_test.cljc
@@ -28,7 +28,11 @@
     (t/is (= 400 (media/parse-font-weight "Lighthaus")))
     (t/is (= 400 (media/parse-font-weight "Blackwood")))
     (t/is (= 400 (media/parse-font-weight "Thinker")))
-    (t/is (= 400 (media/parse-font-weight "Mediaeval")))))
+    (t/is (= 400 (media/parse-font-weight "Mediaeval"))))
+    
+  (t/testing "safely handles nil and non-string metadata without crashing"
+    (t/is (= 400 (media/parse-font-weight nil)))
+    (t/is (= 400 (media/parse-font-weight 700)))))
 
 (t/deftest test-parse-font-style
   (t/testing "matches italic with proper boundaries"
@@ -40,7 +44,11 @@
 
   (t/testing "does not match italic embedded in words"
     (t/is (= "normal" (media/parse-font-style "Italica")))
-    (t/is (= "normal" (media/parse-font-style "Roboto-Regular")))))
+    (t/is (= "normal" (media/parse-font-style "Roboto-Regular"))))
+    
+  (t/testing "safely handles nil and non-string metadata without crashing"
+    (t/is (= "normal" (media/parse-font-style nil)))
+    (t/is (= "normal" (media/parse-font-style 123)))))
 
 (t/deftest test-strip-image-extension
   (t/testing "removes extension from supported image files"

--- a/frontend/src/app/plugins/library.cljs
+++ b/frontend/src/app/plugins/library.cljs
@@ -1013,7 +1013,8 @@
               ids (into #{} (map #(obj/get % "$id")) shapes)]
           (st/emit! (-> (dwl/add-component id-ref ids)
                         (se/add-event plugin-id)))
-          (lib-component-proxy plugin-id file-id @id-ref))))
+          (when @id-ref
+            (lib-component-proxy plugin-id file-id @id-ref)))))
 
     ;; Plugin data
     :getPluginData


### PR DESCRIPTION
### Related Ticket

Closes #11485 

### Summary

Fixed a bug in the Plugin API where `penpot.library.local.createComponent()` would silently fail and return a broken proxy object (with an empty ID and null name) if the component creation was rejected (e.g. attempting to nest a main instance inside a main instance). 

I added a `nil` check on `@id-ref` in `frontend/src/app/plugins/library.cljs`. If `dwl/add-component` bails out silently and does not set the `id-ref`, the API will now correctly return `null` so the plugin caller can detect the failure.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Check CI passes successfully.