### PR TITLE
:bug: Preserve stroke dash and gap values on color change

### DIFF
--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -333,6 +333,8 @@
   [:stroke-style
    :stroke-alignment
    :stroke-width
+   :stroke-dash
+   :stroke-gap
    :stroke-per-side
    :stroke-width-top
    :stroke-width-right

--- a/frontend/test/frontend_tests/basic_shapes_test.cljs
+++ b/frontend/test/frontend_tests/basic_shapes_test.cljs
@@ -76,3 +76,48 @@
            (t/is (= (:stroke-alignment stroke') :inner))
            (t/is (= (:stroke-color stroke') "#FABADA"))
            (t/is (= (:stroke-width stroke') 2))))))))
+(t/deftest test-update-stroke-color-preserves-dash-gap
+  ;; Custom dash/gap on a dashed stroke describe stroke geometry, not color;
+  ;; a stroke color change must preserve them (issue #11549).
+  (t/async
+   done
+   (let [store (ths/setup-store
+                (-> (cthf/sample-file :file1 :page-label :page1)
+                    (cths/add-sample-shape :shape1 :strokes
+                                           [{:stroke-color "#000000"
+                                             :stroke-opacity 1
+                                             :stroke-width 2
+                                             :stroke-style :dashed
+                                             :stroke-dash 4
+                                             :stroke-gap 20}])
+                    (cths/add-sample-shape :shape2 :strokes
+                                           [{:stroke-color "#000000"
+                                             :stroke-opacity 1
+                                             :stroke-width 2
+                                             :stroke-style :dashed}])))
+         events [(dc/change-stroke-color #{(cthi/id :shape1)} {:color "#FABADA"} 0)
+                 (dc/change-stroke-color #{(cthi/id :shape2)} {:color "#FABADA"} 0)]]
+     (ths/run-store
+      store done events
+      (fn [new-state]
+        (let [objects (dsh/lookup-page-objects new-state)
+              shape1' (get objects (cthi/id :shape1))
+              stroke1' (first (:strokes shape1'))
+              shape2' (get objects (cthi/id :shape2))
+              stroke2' (first (:strokes shape2'))]
+          
+          ;; dashed stroke with custom dash/gap keeps them after color change
+          (t/is (some? shape1'))
+          (t/is (= (:stroke-color stroke1') "#FABADA"))
+          (t/is (= (:stroke-style stroke1') :dashed))
+          (t/is (= (:stroke-width stroke1') 2))
+          (t/is (= (:stroke-dash stroke1') 4))
+          (t/is (= (:stroke-gap stroke1') 20))
+          
+          ;; dashed stroke without explicit dash/gap stays unset:
+          ;; no implicit default is materialized into stored data
+          (t/is (some? shape2'))
+          (t/is (= (:stroke-color stroke2') "#FABADA"))
+          (t/is (= (:stroke-style stroke2') :dashed))
+          (t/is (nil? (:stroke-dash stroke2')))
+          (t/is (nil? (:stroke-gap stroke2')))))))))


### PR DESCRIPTION
### Related Ticket

Closes #11549

### Summary

Fixed a bug where changing the color of a dashed stroke would reset the custom Dash and Gap values back to their defaults.

This PR extends the preserved style-attribute whitelist in `colors.cljs` by adding `:stroke-dash` and `:stroke-gap`. This ensures that custom dash geometry is preserved even when the color representation changes (e.g., switching from a gradient to a solid color, which forces a stroke rebuild). 

Also included the regression test `test-update-stroke-color-preserves-dash-gap` to cover both custom values and unset cases.

### Steps to reproduce 

1. Create a rectangle and add a stroke.
2. Change the stroke style to "Dashed" and set custom Dash (e.g., 4) and Gap (e.g., 20) values.
3. Change the stroke color.
4. **Before this PR:** The dash and gap reset to default values.
5. **After this PR:** The custom dash and gap values are preserved perfectly.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Check CI passes successfully.