### PR TITLE
:bug: Preserve custom dash/gap on stroke color change

### DIFF
--- a/frontend/src/app/main/data/workspace/colors.cljs
+++ b/frontend/src/app/main/data/workspace/colors.cljs
@@ -333,6 +333,8 @@
   [:stroke-style
    :stroke-alignment
    :stroke-width
+   :stroke-dash
+   :stroke-gap
    :stroke-per-side
    :stroke-width-top
    :stroke-width-right

--- a/frontend/test/frontend_tests/basic_shapes_test.cljs
+++ b/frontend/test/frontend_tests/basic_shapes_test.cljs
@@ -76,3 +76,55 @@
            (t/is (= (:stroke-alignment stroke') :inner))
            (t/is (= (:stroke-color stroke') "#FABADA"))
            (t/is (= (:stroke-width stroke') 2))))))))
+
+(t/deftest test-update-stroke-color-preserves-dash-gap
+  ;; Custom dash/gap on a dashed stroke describe stroke geometry, not color;
+  ;; a stroke color change must preserve them (issue #11549).
+  (t/async
+    done
+    (let [;; ==== Setup
+          store
+          (ths/setup-store
+           (-> (cthf/sample-file :file1 :page-label :page1)
+               (cths/add-sample-shape :shape1 :strokes [{:stroke-color "#000000"
+                                                         :stroke-opacity 1
+                                                         :stroke-width 2
+                                                         :stroke-style :dashed
+                                                         :stroke-dash 4
+                                                         :stroke-gap 20}])
+               (cths/add-sample-shape :shape2 :strokes [{:stroke-color "#000000"
+                                                         :stroke-opacity 1
+                                                         :stroke-width 2
+                                                         :stroke-style :dashed}])))
+
+          ;; ==== Action
+          events
+          [(dc/change-stroke-color #{(cthi/id :shape1)} {:color "#FABADA"} 0)
+           (dc/change-stroke-color #{(cthi/id :shape2)} {:color "#FABADA"} 0)]]
+
+      (ths/run-store
+       store done events
+       (fn [new-state]
+         (let [;; ==== Get
+               objects (dsh/lookup-page-objects new-state)
+               shape1' (get objects (cthi/id :shape1))
+               stroke1' (first (:strokes shape1'))
+               shape2' (get objects (cthi/id :shape2))
+               stroke2' (first (:strokes shape2'))]
+
+           ;; ==== Check
+           ;; dashed stroke with custom dash/gap keeps them after color change
+           (t/is (some? shape1'))
+           (t/is (= (:stroke-color stroke1') "#FABADA"))
+           (t/is (= (:stroke-style stroke1') :dashed))
+           (t/is (= (:stroke-width stroke1') 2))
+           (t/is (= (:stroke-dash stroke1') 4))
+           (t/is (= (:stroke-gap stroke1') 20))
+
+           ;; dashed stroke without explicit dash/gap stays unset:
+           ;; no implicit default is materialized into stored data
+           (t/is (some? shape2'))
+           (t/is (= (:stroke-color stroke2') "#FABADA"))
+           (t/is (= (:stroke-style stroke2') :dashed))
+           (t/is (nil? (:stroke-dash stroke2')))
+           (t/is (nil? (:stroke-gap stroke2')))))))))


### PR DESCRIPTION
### Related Ticket

Closes #11549

### Summary

`update-shape-stroke-color` rebuilds a stroke from `stroke-style-attrs` before replacing its color attributes. The recently added `:stroke-dash` and `:stroke-gap` fields were not part of that preservation set, so stroke color updates — including token-driven ones — discarded custom dash/gap values.

This PR adds both properties to the preserved stroke-style attributes and extends the existing stroke color regression coverage in `basic_shapes_test`.

### Design notes

The existing reconstruction behavior of `update-shape-stroke-color` is intentional: a color change should replace the stroke's color representation while keeping its geometry/style attributes, so stale fields from a previous representation (e.g. `:stroke-color-gradient`, `:stroke-color-ref-id`, `:stroke-color-ref-file`, `:stroke-image`) are discarded when a plain solid color is applied. This patch follows that boundary — it only extends the preserved style-attribute whitelist with the two new stroke geometry keys, without turning the color update into a generic merge of the old stroke.

### Steps to reproduce

1. Create a rectangle and add a stroke.
2. Set stroke style to Dashed with custom values, e.g. Dash = 4, Gap = 20.
3. Change the stroke color.
4. Before this fix: Dash/Gap revert to their defaults. After: Dash 4 / Gap 20 are preserved.

The same applies when a color token drives the stroke color (a theme switch resolves a new color through the same stroke color update path).

### Verification status

**Checks actually performed locally** (agent environments lacked a JVM, so the cljs test run itself was not executed):

- `clj-kondo` on the two touched files: 0 errors, 0 warnings (repository-wide lint reports only pre-existing warnings in untouched files).
- `python scripts/check-commit`: all 5 validators pass; the commit includes a `Signed-off-by` trailer matching the author.
- Manual code-level analysis of the preservation boundary: explicit `:stroke-dash`/`:stroke-gap` survive the rebuild, unset values stay unset (`d/without-nils` only strips nils), stale color fields are still discarded, and other strokes / stroke positions are untouched.

**Not yet performed**: running the cljs store tests locally (`pnpm test` requires a JVM/shadow-cljs toolchain that is not available in our environment), and a manual browser reproduction of the steps above. The regression test `test-update-stroke-color-preserves-dash-gap` covers both the custom-value and the unset-value cases once executed.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. (no UI change)
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable. (`test-update-stroke-color-preserves-dash-gap`)
- [ ] Refactor any modified SCSS files following the refactor guide. (not applicable)
- [ ] Check CI passes successfully.
