### PR TITLE
:bug: Fix workspace crash when resolving thumbnail data URIs

### DIFF
--- a/frontend/src/app/main/refs.cljs
+++ b/frontend/src/app/main/refs.cljs
@@ -19,6 +19,7 @@
    [app.main.store :as st]
    [app.main.streams :as ms]
    [beicon.v2.core :as rx]
+   [clojure.string :as str]
    [okulary.core :as l]))
 
 ;; ---- Global refs
@@ -583,13 +584,21 @@
                (dm/get-in state [:viewer-local :zoom-type]))
              st/state))
 
+(defn- resolved-uri?
+  "Returns true if the uri is already a fully resolved URI (blob or data)."
+  [uri]
+  (or (str/starts-with? uri "blob:")
+      (str/starts-with? uri "data:")))
+
 (defn workspace-thumbnail-by-id
   [object-id]
   (l/derived
    (fn [state]
      (when-let [entry (dm/get-in state [:thumbnails object-id])]
        (cond-> entry
-         (:uri entry) (update :uri cf/resolve-media))))
+         (and (:uri entry)
+              (not (resolved-uri? (:uri entry))))
+         (update :uri cf/resolve-media))))
    st/state))
 
 (def workspace-text-modifier


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Workspace crashes with "too much recursion" error when editing grid layouts
- Error occurs in thumbnail URL resolution when data URIs are processed

## Why

The `workspace-thumbnail-by-id` ref unconditionally called `resolve-media` on thumbnail URIs. When thumbnails were rendered via WASM, they produced data URIs (which can be megabytes long for large images). These data URIs contain thousands of `/` characters (base64 uses `/` as one of its 64 characters), causing `lambdaisland.uri/join` to iterate thousands of times in `remove-dot-segments` and overflow the JavaScript call stack.

## How

- Added `resolved-uri?` helper to detect blob and data URIs
- Modified `workspace-thumbnail-by-id` to skip `resolve-media` for already-resolved URIs
- Only call `resolve-media` when the URI is a plain UUID (media-id from the server)

Closes #11562
