### PR TITLE
:sparkles: Add Penpot-specific board size presets

### DIFF
--- a/frontend/src/app/main/constants.cljs
+++ b/frontend/src/app/main/constants.cljs
@@ -299,7 +299,21 @@
     :height 1152}
    {:name "YouTube thumb"
     :width 1280
-    :height 720}])
+    :height 720}
+
+   {:name "PENPOT"}
+   {:name "File thumbnail"
+    :width 300
+    :height 200}
+   {:name "Template cover"
+    :width 1390
+    :height 781}
+   {:name "Plugin icon"
+    :width 400
+    :height 400}
+   {:name "Plugin cover"
+    :width 1390
+    :height 724}])
 
 (def max-input-length 255)
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Add a new "PENPOT" section to the board size presets list (positioned last), with four presets:
  - File thumbnail — 300 x 200
  - Template cover — 1390 x 781
  - Plugin icon — 400 x 400
  - Plugin cover — 1390 x 724

Closes #11561

## Why

Designers creating thumbnails for Penpot files, template submissions, or plugin listings currently have to look up the exact required dimensions manually. These sizes are already fixed by the dashboard's file thumbnail rendering and by the template/plugin submission forms, so they're good candidates for ready-made board presets.

## How

- Extended the existing `size-presets` vector in `constants.cljs` with a new header marker (`{:name "PENPOT"}`) followed by the four preset entries, following the same flat-list/header-marker convention already used for the other sections (APPLE, PRINT, SOCIAL MEDIA, etc.).
- No changes needed to the preset filtering/rendering logic — it's already generic over this convention.
