### PR TITLE
:bug: Fix fontFamilies token property mapping in Plugin API

### DIFF
--- a/frontend/src/app/plugins/tokens.cljs
+++ b/frontend/src/app/plugins/tokens.cljs
@@ -40,7 +40,9 @@
    :m1 :margin-top
    :m2 :margin-right
    :m3 :margin-bottom
-   :m4 :margin-left})
+   :m4 :margin-left
+
+   :font-family :font-families})
 
 (def ^:private map:token-attr-plugin->token-attr
   (merge

--- a/frontend/test/frontend_tests/plugins/tokens_test.cljs
+++ b/frontend/test/frontend_tests/plugins/tokens_test.cljs
@@ -80,6 +80,18 @@
   (t/is (= :m3 (ptok/token-attr-plugin->token-attr :margin-bottom)))
   (t/is (= :m4 (ptok/token-attr-plugin->token-attr :margin-left))))
 
+(t/deftest token-attr-plugin->token-attr-resolves-font-family-alias
+  ;; Plugin-facing `fontFamilies` (kebab-cased to `:font-families` by the
+  ;; schema layer) maps to the canonical internal `:font-family`.
+  (t/is (= :font-family (ptok/token-attr-plugin->token-attr :font-families)))
+  (t/is (= :font-family (ptok/token-attr-plugin->token-attr "font-families"))))
+
+(t/deftest token-attr->token-attr-plugin-resolves-font-family-alias
+  ;; Symmetric direction: the canonical internal attribute maps to the
+  ;; plural plugin-facing name so applied-token readback serializes as
+  ;; camelCase `fontFamilies`, not the undocumented singular `fontFamily`.
+  (t/is (= :font-families (ptok/token-attr->token-attr-plugin :font-family))))
+
 (t/deftest token-attr-plugin->token-attr-coerces-string-input
   ;; This is the actual regression — JS plugin calls supply strings.
   (t/is (= :fill (ptok/token-attr-plugin->token-attr "fill")))
@@ -146,6 +158,57 @@
                     (get-in @store
                             [:files (:id file) :data :pages-index page-id
                              :objects shape-id :applied-tokens :p1])))
+           (done)))
+       0))))
+
+(t/deftest shape-apply-token-accepts-font-families
+  (t/async
+    done
+    (let [set-id    (cthi/new-id! :token-set)
+          token-id  (cthi/new-id! :font-family-token)
+          file      (-> (cthf/sample-file :file1 :page-label :page1)
+                        (ctho/add-frame :frame1 {:layout :flex})
+                        (ctht/add-tokens-lib)
+                        (ctht/update-tokens-lib
+                         #(-> %
+                              (ctob/add-set
+                               (ctob/make-token-set :id set-id
+                                                    :name "fonts"))
+                              (ctob/add-theme
+                               (ctob/make-token-theme :name "theme"
+                                                      :sets #{"fonts"}))
+                              (ctob/set-active-themes #{"/theme"})
+                              (ctob/add-token
+                               set-id
+                               (ctob/make-token :id token-id
+                                                :name "font.primary"
+                                                :type :font-family
+                                                :value ["Inter"])))))
+          store     (ths/setup-store file)
+          _         (set! st/state store)
+          _         (set! st/stream (ptk/input-stream store))
+          ^js context   (api/create-context "00000000-0000-0000-0000-000000000000")
+          ^js page      (.-currentPage context)
+          ^js shape     (.getShapeById page (str (cthi/id :frame1)))
+          ^js library   (.-library context)
+          ^js local     (.-local library)
+          ^js catalog   (.-tokens local)
+          ^js token-set (.getSetById catalog (str set-id))
+          ^js token     (.getTokenById token-set (str token-id))]
+      (.applyToken shape token #js ["fontFamilies"])
+      (js/setTimeout
+       (fn []
+         (let [shape-id (cthi/id :frame1)
+               page-id  (cthf/current-page-id file)]
+           ;; Plugin readback exposes the documented plural key.
+           (t/is (= "font.primary" (.. shape -tokens -fontFamilies)))
+           ;; The undocumented singular spelling must not leak.
+           (t/is (undefined? (.. shape -tokens -fontFamily)))
+           ;; Internal state keeps the canonical `:font-family` key.
+           (t/is (= "font.primary"
+                    (get-in @store
+                            [:files (:id file) :data :pages-index page-id
+                             :objects shape-id :applied-tokens :font-family])))
            (done)))
        0))))
 

--- a/frontend/test/frontend_tests/plugins/tokens_test.cljs
+++ b/frontend/test/frontend_tests/plugins/tokens_test.cljs
@@ -167,7 +167,7 @@
     (let [set-id    (cthi/new-id! :token-set)
           token-id  (cthi/new-id! :font-family-token)
           file      (-> (cthf/sample-file :file1 :page-label :page1)
-                        (ctho/add-frame :frame1 {:layout :flex})
+                        (ctho/add-text :text1 "Hello World!")
                         (ctht/add-tokens-lib)
                         (ctht/update-tokens-lib
                          #(-> %
@@ -189,7 +189,7 @@
           _         (set! st/stream (ptk/input-stream store))
           ^js context   (api/create-context "00000000-0000-0000-0000-000000000000")
           ^js page      (.-currentPage context)
-          ^js shape     (.getShapeById page (str (cthi/id :frame1)))
+          ^js shape     (.getShapeById page (str (cthi/id :text1)))
           ^js library   (.-library context)
           ^js local     (.-local library)
           ^js catalog   (.-tokens local)
@@ -198,7 +198,7 @@
       (.applyToken shape token #js ["fontFamilies"])
       (js/setTimeout
        (fn []
-         (let [shape-id (cthi/id :frame1)
+         (let [shape-id (cthi/id :text1)
                page-id  (cthf/current-page-id file)]
            ;; Plugin readback exposes the documented plural key.
            (t/is (= "font.primary" (.. shape -tokens -fontFamilies)))

--- a/frontend/test/frontend_tests/plugins/tokens_test.cljs
+++ b/frontend/test/frontend_tests/plugins/tokens_test.cljs
@@ -21,9 +21,14 @@
    [cljs.test :as t :include-macros true]
    [frontend-tests.helpers.mock :as mock]
    [frontend-tests.helpers.state :as ths]
+   [frontend-tests.helpers.wasm :as thw]
    [potok.v2.core :as ptk]))
 
-(t/use-fixtures :each {:before cthi/reset-idmap!})
+(t/use-fixtures :each
+  {:before (fn []
+             (cthi/reset-idmap!)
+             (thw/setup-wasm-mocks!))
+   :after thw/teardown-wasm-mocks!})
 
 (def ^:private get-resolved-value @#'ptok/get-resolved-value)
 

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **plugins-runtime**: `Library.createComponent()` now rejects invalid input (an empty shape list, or a shape inside a component copy) with a validation error instead of returning a component proxy pointing at nothing.
 - **plugins-runtime**: Setting an individual padding/margin side (`leftPadding`, `topMargin`, …) now re-derives the padding/margin type, switching to `multiple` when the four sides stop being symmetric (so the value is actually painted) and back to `simple` once top/bottom and left/right are mirrored again.
 - **plugins-runtime**: Removed the premature deep-hardening of the host plugin context, which froze shared host functions (including `Function.prototype`) before SES override taming, causing `TypeError: Cannot assign to read only property 'toString'` on later host-side function extension. Related to #11001.
+- **plugins-runtime**: Fixed the `fontFamilies` token property mapping so `Shape.applyToken(token, ["fontFamilies"])` resolves to the canonical `:font-family` attribute and applied-token readback exposes the documented `fontFamilies` key instead of the undocumented singular `fontFamily`. Closes #11405.
 
 ## 1.5.0 (2026-07-08)
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

### Related Ticket

Closes #11405

### Summary

The Plugin API exposes the font-family token property as `fontFamilies`, while Penpot stores the canonical applied-token attribute as `:font-family`.

- The existing bidirectional plugin/internal attribute map did not contain that alias, so explicit `applyToken(..., ["fontFamilies"])` validation rejected the property with `Field 1 is invalid: should be a set of strings.`
- When the property argument was omitted instead, the token applied but the binding was exposed as the undocumented singular `text.tokens.fontFamily`.

Add `:font-family -> :font-families` to the existing canonical alias map. The reverse mapping is derived automatically, keeping application and readback symmetric without introducing a font-specific code path.

### Steps to reproduce 

**Failure case (explicit property):**

1. Create or retrieve an active `fontFamilies` token (e.g. resolved value `["Inter"]`).
2. Get a text shape through the Plugin API.
3. Call `text.applyToken(fontFamilyToken, ["fontFamilies"]);`
4. Before this change the call fails validation with `Field 1 is invalid: should be a set of strings.`

**Silent mis-naming case (property omitted):**

1. Call `text.applyToken(fontFamilyToken);` without the property argument.
2. Before this change the token applies, but the binding is exposed as the undocumented singular `text.tokens.fontFamily` instead of the declared `fontFamilies`.

**After the fix:** the explicit call succeeds, the persisted binding keeps the canonical `:font-family` key, and `text.tokens.fontFamilies` returns the applied token name.

### Testing notes

Change-request follow-up (head `46ef49909b`): merged `setup-wasm-mocks!`/`teardown-wasm-mocks!` into the `:each` fixture of the text-shape `shape-apply-token-accepts-font-families` test (same pattern as `page_test.cljs`) and added the `plugins/CHANGELOG.md` entry for #11405. Local CLJS focus test was SKIPped (no Clojure toolchain / `target/tests/test.js` in this Windows env); Frontend Tests and format results for the current head are unconfirmed and covered by CI.

### Checklist

- [ ] Choose the correct target branch; use `develop` by default. (done: `develop`)
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. (No UI change.)
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide. (No SCSS change.)
- [ ] Check CI passes successfully. (pending — current head `46ef49909b` CI running; only Check Commit Message confirmed so far)

