### PR TITLE
:bug: Export svg-raw shapes through WASM SVG draw_svg

### DIFF
--- a/render-wasm/src/render/svg/fixtures.rs
+++ b/render-wasm/src/render/svg/fixtures.rs
@@ -209,6 +209,20 @@ pub(super) fn add_group(
     }
 }
 
+/// SVG-raw leaf with markup (same form `get-static-markup` uploads to WASM).
+pub(super) fn add_svg_raw(
+    pool: &mut ShapesPool,
+    id: Uuid,
+    parent: Uuid,
+    (l, t, r, b): (f32, f32, f32, f32),
+    content: &str,
+) {
+    let shape = pool.add_shape(id);
+    shape.set_parent(parent);
+    shape.set_svg_raw_content(content.to_string());
+    shape.set_selrect(l, t, r, b);
+}
+
 /// Adds a single-line text shape using the embedded default font.
 pub(super) fn add_solid_text(
     pool: &mut ShapesPool,

--- a/render-wasm/src/render/svg/mod.rs
+++ b/render-wasm/src/render/svg/mod.rs
@@ -194,6 +194,14 @@ fn render_leaf(
     {
         if matches!(element.shape_type, Type::Text(_)) {
             render_text_fill(builder, shared, element)?;
+        } else if matches!(element.shape_type, Type::SVGRaw(_)) {
+            let matrix = element.centered_transform();
+            let canvas = builder.canvas();
+            canvas.save();
+            canvas.concat(&matrix);
+            let mut renderer = VectorRenderer::new(canvas, shared, scale, false);
+            renderer.draw_svg(element)?;
+            canvas.restore();
         } else {
             emit_fills(builder, shared, element, &element.fills, tree, scale)?;
 

--- a/render-wasm/src/render/svg/tests.rs
+++ b/render-wasm/src/render/svg/tests.rs
@@ -126,6 +126,36 @@ fn exports_a_group_with_two_rects_and_group_opacity() {
 }
 
 #[test]
+fn loads_svg_raw_dom_like_wasm_upload() {
+    // Production paints svg-raw via Dom::render after set_shape_svg_raw_content.
+    // Native SkSVGCanvas does not serialize those draws, so the export string
+    // stays empty here; we assert Dom parse + that export does not panic.
+    let mut pool = ShapesPool::new();
+    let id = uid(1);
+    add_svg_raw(
+        &mut pool,
+        id,
+        Uuid::nil(),
+        (0.0, 0.0, 307.0, 243.0),
+        concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg">"#,
+            r#"<text x="10" y="24" fill="black">HOLA</text>"#,
+            r#"</svg>"#,
+        ),
+    );
+
+    let resources = crate::render::RenderResources::try_new_headless().expect("headless");
+    let font_manager = skia::FontMgr::from(resources.fonts.font_provider().clone());
+    {
+        let shape = pool.get_mut(&id).unwrap();
+        shape.update_svg_raw_content(font_manager);
+        assert!(shape.svg.is_some(), "Dom must parse like WASM upload");
+    }
+
+    let _svg = render(&pool, id);
+}
+
+#[test]
 fn exports_a_clipped_frame_with_overflowing_child() {
     let mut pool = ShapesPool::new();
     let frame_id = uid(1);


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Imported SVG (`svg-raw`) shapes are included in WASM SVG export instead of producing an empty `<svg>`.

Relates to #10546

## Why

- SVG export treated `SVGRaw` like a plain fill/stroke leaf and never called `draw_svg`, so uploaded markup was ignored.

## How

- Route `SVGRaw` leaves through `VectorRenderer::draw_svg` (same Dom path as canvas/PDF).
- Add a small fixture/test that mirrors WASM upload (`update_svg_raw_content`) and checks export does not panic. Native `SkSVGCanvas` still does not serialize `Dom::render` into the export string, so the test does not assert on markup body.
