### PR TITLE
:wrench: Use mutex so only one test owns global at a time

### DIFF
--- a/render-wasm/src/globals.rs
+++ b/render-wasm/src/globals.rs
@@ -124,14 +124,21 @@ macro_rules! with_current_shape {
 #[cfg(test)]
 pub(crate) struct TestRenderResourcesGuard {
     prev: *mut RenderResources,
+    _lock: std::sync::MutexGuard<'static, ()>,
 }
+
+#[cfg(test)]
+static TEST_RENDER_RESOURCES_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 impl TestRenderResourcesGuard {
     pub(crate) fn install(resources: &mut RenderResources) -> Self {
+        let lock = TEST_RENDER_RESOURCES_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let prev = unsafe { RENDER_RESOURCES };
         unsafe { RENDER_RESOURCES = resources as *mut _ };
-        Self { prev }
+        Self { prev, _lock: lock }
     }
 }
 


### PR DESCRIPTION
### Related Ticket

no ticket

### Summary

CI is failing sometimes on the render wasm tests pipeline and seems to be a race condition:

```
[0](https://github.com/penpot/penpot/actions/runs/34317261567/job/102479472790#step:6:231)
thread 'render::svg::tests::exports_text_with_multiple_solid_fills' (2764) panicked at /opt/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-safe-0.93.1/src/prelude.rs:129:18:
misaligned pointer dereference: address must be a multiple of 0x8 but is 0xb
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
test render::svg::tests::exports_rect_with_solid_center_stroke ... ok
test render::svg::tests::exports_rect_with_solid_outer_stroke ... ok
error: test failed, to rerun pass `--bin render_wasm`

Caused by:
  process didn't exit successfully: `/__w/penpot/penpot/render-wasm/target/frontend/x86_64-unknown-linux-gnu/debug/deps/render_wasm-e8a45689c9798733 --show-output` (signal: 6, SIGABRT: process abort signal)
+ exit 101
```
