### PR TITLE
:bug: Re-upload WASM text after WebGL context restore

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -658,7 +658,9 @@
 
 (defn use-shape
   [id]
-  (when (initialized?)
+  ;; Use `wasm/live?` (not `initialized?`) so context-restore reload can
+  ;; select shapes while `reloading?` still blocks external app callers.
+  (when (wasm/live?)
     (let [buffer (uuid/get-u32 id)]
       (h/call wasm/internal-module "_use_shape"
               (aget buffer 0)
@@ -668,7 +670,7 @@
 
 (defn has-shape
   [id]
-  (when (initialized?)
+  (when (wasm/live?)
     (let [buffer (uuid/get-u32 id)
 
           result
@@ -686,9 +688,11 @@
   ;; Cache content for text editor sync
   (text-editor/cache-shape-text-content! shape-id content)
 
-  ;; The WASM design state may not be ready (e.g. while switching renderer
-  ;; with a text shape being edited). Skip the WASM layout calls in that case.
-  (when (initialized?)
+  ;; Skip when the GL/WASM context is not usable. Use `wasm/live?` (not
+  ;; `initialized?`) so context-restore reload can re-upload text while
+  ;; `reloading?` still blocks external app callers. Geometry shapes already
+  ;; use `live?` via `set-shape-base-props`; text must match that path.
+  (when (wasm/live?)
     (h/call wasm/internal-module "_clear_shape_text")
 
     (set-shape-vertical-align (get content :vertical-align))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- After a WebGL context loss/restore, geometry shapes came back but text shapes stayed blank.

## Why

- `reload-renderer!` keeps `reloading?` true until reload finishes, so `initialized?` / `ready?` stay false while `set-objects` re-uploads the page (especially the sync path for files with fewer than 100 shapes).
- Text content went through `set-shape-text-content`, which was gated on `initialized?` and was skipped.
- Geometry already used `wasm/live?` via `set-shape-base-props`, so rects/circles/etc. recovered normally.

## How

- Gate `use-shape`, `has-shape`, and `set-shape-text-content` on `wasm/live?` instead of `initialized?`, matching other reload-internal ops. External app callers still see `ready?`/`initialized?` false until reload completes.

## How to reproduce (before) / verify (after)

In the browser console on a workspace with text + other shapes:

```js
const canvas = document.getElementById("render");
let gl = canvas.getContext("webgl2");
const loseContextExt = gl.getExtension("WEBGL_lose_context");

// Simulate a crash right now
loseContextExt.loseContext();

// Simulate the browser recovering the GPU after a 2-second delay
setTimeout(() => {
    loseContextExt.restoreContext();
}, 2000);
```

After restore, texts should be visible again along with the other shapes.
