### PR TITLE
:sparkles: Add size limits to profile props and plugin registry writes

### DIFF
--- a/backend/resources/rlimit.edn
+++ b/backend/resources/rlimit.edn
@@ -223,7 +223,9 @@
    :main/update-profile-notifications
    :main/delete-profile
    :main/delete-profile-photo
-   :main/request-email-change}
+   :main/request-email-change
+   :main/add-profile-plugin
+   :main/remove-profile-plugin}
  [[:profile-mutations :bucket "30/15/1m"]]
 
  ;; ═══════════════════════════════════════════════

--- a/backend/src/app/config.clj
+++ b/backend/src/app/config.clj
@@ -72,6 +72,7 @@
 
    :telemetry-uri "https://telemetry.penpot.app/"
 
+   :profile-props-max-size (* 1024 1024 2) ; 2MiB
    :media-max-file-size (* 1024 1024 30) ; 30MiB
    :font-max-file-size  (* 1024 1024 30) ; 30MiB
 
@@ -135,6 +136,7 @@
     [:auto-file-snapshot-every {:optional true} ::sm/int]
     [:auto-file-snapshot-timeout {:optional true} ::ct/duration]
 
+    [:profile-props-max-size {:optional true} ::sm/int]
     [:media-max-file-size {:optional true} ::sm/int]
     [:font-max-file-size  {:optional true} ::sm/int]
 

--- a/backend/src/app/rpc/commands/plugins.clj
+++ b/backend/src/app/rpc/commands/plugins.clj
@@ -45,10 +45,15 @@
         plugins (-> plugins
                     (update :ids #(vec (distinct (conj % plugin-id))))
                     (assoc-in [:data plugin-id] plugin))]
-    (db/update! conn :profile
-                {:props (db/tjson (assoc (:props profile) :plugins plugins))}
-                {:id profile-id}
-                {::db/return-keys false})
+
+    (when (> (count (:ids plugins)) ctp/max-registry-entries)
+      (ex/raise :type :validation
+                :code :too-many-plugins
+                :hint "the plugin registry has reached its maximum size"
+                :max-entries ctp/max-registry-entries))
+
+    (profile/persist-props! conn profile-id (:props profile)
+                            (assoc (:props profile) :plugins plugins))
     plugin))
 
 (def ^:private
@@ -68,8 +73,6 @@
         plugins (-> plugins
                     (update :ids #(vec (remove (partial = plugin-id-str) %)))
                     (update :data dissoc plugin-id-str))]
-    (db/update! conn :profile
-                {:props (db/tjson (assoc (:props profile) :plugins plugins))}
-                {:id profile-id}
-                {::db/return-keys false})
+    (profile/persist-props! conn profile-id (:props profile)
+                            (assoc (:props profile) :plugins plugins))
     nil))

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -33,7 +33,9 @@
    [app.tokens :as tokens]
    [app.util.services :as sv]
    [app.worker :as wrk]
-   [cuerdas.core :as str]))
+   [cuerdas.core :as str])
+  (:import
+   org.postgresql.util.PGobject))
 
 (declare check-profile-existence!)
 (declare decode-row)
@@ -469,6 +471,39 @@
   [:map {:title "update-profile-props"}
    [:props schema:props-writeable]])
 
+(def default-props-max-size
+  "Default maximum size (in bytes) for the encoded profile props."
+  (* 1024 1024 2))
+
+(defn- encoded-size
+  [value]
+  (if (some? value)
+    (alength (.getBytes (.getValue ^PGobject value) "UTF-8"))
+    0))
+
+(defn persist-props!
+  "Encode and persist the profile props, rejecting writes that make an
+  already oversized (or newly oversized) props document grow."
+  [conn profile-id prev-props props]
+  (let [value    (db/tjson props)
+        size     (encoded-size value)
+        max-size (or (cf/get :profile-props-max-size) default-props-max-size)]
+
+    ;; We only reject growth; shrinking or steady writes on already
+    ;; large profiles are always allowed
+    (when (and (> size max-size)
+               (> size (encoded-size (db/tjson prev-props))))
+      (ex/raise :type :validation
+                :code :props-too-large
+                :hint "profile props exceeds the maximum allowed size"
+                :size size
+                :max-size max-size))
+
+    (db/update! conn :profile
+                {:props value}
+                {:id profile-id}
+                {::db/return-keys false})))
+
 (defn update-profile-props
   [{:keys [::db/conn] :as cfg} profile-id props]
   (let [profile (get-profile conn profile-id ::db/for-update true)
@@ -482,10 +517,7 @@
                            (:props profile)
                            (apply dissoc props system-managed-props))]
 
-    (db/update! conn :profile
-                {:props (db/tjson props)}
-                {:id profile-id}
-                {::db/return-keys false})
+    (persist-props! conn profile-id (:props profile) props)
 
     (filter-props props)))
 

--- a/backend/test/backend_tests/rpc_profile_test.clj
+++ b/backend/test/backend_tests/rpc_profile_test.clj
@@ -1385,3 +1385,41 @@
     (t/is (th/ex-info? (:error out)))
     (t/is (th/ex-of-type? (:error out) :validation))
     (t/is (th/ex-of-code? (:error out) :weak-password))))
+
+(t/deftest update-profile-props-rejects-oversized-props
+  (let [profile (th/create-profile* 1)
+        big     (apply str (repeat (* 1024 1024 3) "a"))
+        data    {::th/type :update-profile-props
+                 ::rpc/profile-id (:id profile)
+                 :props {:custom-shortcuts {:big {:key big}}}}
+        out     (th/command! data)]
+
+    (t/is (th/ex-info? (:error out)))
+    (t/is (th/ex-of-type? (:error out) :validation))
+    (t/is (th/ex-of-code? (:error out) :props-too-large))
+
+    ;; And nothing should be persisted
+    (let [saved (th/db-get :profile {:id (:id profile)})
+          props (profile/decode-row saved)]
+      (t/is (nil? (get-in props [:props :custom-shortcuts]))))))
+
+(t/deftest update-profile-props-accepts-shrinking-oversized-props
+  ;; An already oversized profile can still be updated as long as the
+  ;; props document does not grow
+  (let [profile (th/create-profile* 1)
+        big     (apply str (repeat (* 1024 1024 3) "a"))]
+
+    (th/db-update! :profile
+                   {:props (db/tjson {:custom-shortcuts {:big {:key big}}})}
+                   {:id (:id profile)})
+
+    (let [data {::th/type :update-profile-props
+                ::rpc/profile-id (:id profile)
+                :props {:custom-shortcuts {}}}
+          out  (th/command! data)]
+
+      (t/is (nil? (:error out)))
+
+      (let [saved (th/db-get :profile {:id (:id profile)})
+            props (profile/decode-row saved)]
+        (t/is (= {} (get-in props [:props :custom-shortcuts])))))))

--- a/common/src/app/common/types/plugins.cljc
+++ b/common/src/app/common/types/plugins.cljc
@@ -41,21 +41,29 @@
   "Schema for plugin permissions - a set of valid permission strings."
   [:set {:gen/max 11} (into [:enum] (sort valid-permissions))])
 
+(def max-code-length
+  "Maximum length for the plugin code (or code url) entry."
+  (* 64 1024))
+
+(def max-registry-entries
+  "Maximum number of plugins that can be registered on a profile."
+  100)
+
 (def schema:registry-entry
   [:map
-   [:plugin-id :string]
+   [:plugin-id [:string {:max 250}]]
    [:version {:optional true} :int]
-   [:name :string]
-   [:description {:optional true} :string]
-   [:host :string]
-   [:code :string]
-   [:icon {:optional true} :string]
+   [:name [:string {:max 250}]]
+   [:description {:optional true} [:string {:max 1000}]]
+   [:host [:string {:max 2048}]]
+   [:code [:string {:max max-code-length}]]
+   [:icon {:optional true} [:string {:max 2048}]]
    [:permissions schema:permissions]])
 
 (def schema:plugin-registry
   [:map
-   [:ids [:vector :string]]
+   [:ids [:vector {:max max-registry-entries} :string]]
    [:data
-    [:map-of {:gen/max 5}
+    [:map-of {:gen/max 5 :max max-registry-entries}
      :string
      schema:registry-entry]]])


### PR DESCRIPTION
### Related Ticket

Closes #11592

### Summary

`profile.props` (which also holds the installed plugin registry) accepted writes of unbounded size through `update-profile-props` and the dedicated plugin RPCs. Every write rewrites the whole settings document, so repeated or oversized writes could grow a single database row until the internal database limit surfaced as an uncontrolled error.

- **Total size limit.** A new `persist-props!` helper in `app.rpc.commands.profile` encodes the merged props and rejects the write with a `:validation` / `:props-too-large` error when the encoded document exceeds `PENPOT_PROFILE_PROPS_MAX_SIZE` (2 MiB by default, `:profile-props-max-size` in config). Only growth is rejected, so shrinking or steady updates on an already oversized profile keep working.
- **Shared by all writers.** `update-profile-props`, `add-profile-plugin` and `remove-profile-plugin` persist through that helper, so the plugin endpoints cannot bypass the ceiling.
- **Plugin registry caps.** `schema:registry-entry` caps code (64 KiB), plugin id and name (250), description (1000), host and icon (2048); the registry is capped at 100 entries, enforced both in the schema and on the add path with a `:too-many-plugins` error.
- **Rate limiting.** `add-profile-plugin` and `remove-profile-plugin` are back in the `:profile-mutations` bucket, so the install/uninstall cycle is throttled like the other profile mutations.

No UI change and no migration needed.

### Steps to reproduce

Automated:

```
cd backend
clojure -M:dev:test --focus backend-tests.rpc-profile-test --focus backend-tests.rpc-plugins-test
```

Two new tests in `backend_tests/rpc_profile_test.clj`: an oversized write is rejected with `:props-too-large` and nothing is persisted, and a profile whose props are already over the limit can still be updated as long as the document shrinks. Reverting `app/rpc/commands/profile.clj` to `develop` makes the first one fail, with the 3 MiB value persisted.

Results on this branch:

```
clojure -M:dev:test --focus backend-tests.rpc-profile-test    # 50 tests, 260 assertions, 0 failures
clojure -M:dev:test --focus backend-tests.rpc-plugins-test    # 7 tests, 0 failures
(common) clojure -M:dev:test                                  # 1218 tests, 25760 assertions, 0 failures
```

clj-kondo and cljfmt are clean on both `backend` and `common`.

Manually, logged in, from the browser console:

```js
fetch('/api/rpc/command/update-profile-props', {
  method: 'POST',
  headers: {'content-type': 'application/json'},
  body: JSON.stringify({props: {'custom-shortcuts': {big: {key: 'a'.repeat(3*1024*1024)}}}})
}).then(async r => console.log(r.status, await r.text()));
```

Returns `400` with `props-too-large`, while normal settings changes still save.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. Backend only, nothing user visible.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide. No SCSS touched.
- [x] Check CI passes successfully.
