### PR TITLE
:sparkles: Add 3x export scale option

### DIFF
--- a/frontend/src/app/main/ui/inspect/exports.cljs
+++ b/frontend/src/app/main/ui/inspect/exports.cljs
@@ -135,6 +135,7 @@
                       {:value "1" :label "1x"}
                       {:value "1.5" :label "1.5x"}
                       {:value "2" :label "2x"}
+                      {:value "3" :label "3x"}
                       {:value "4" :label "4x"}
                       {:value "6" :label "6x"}]
 

--- a/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs
+++ b/frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs
@@ -193,6 +193,7 @@
                       {:value "1" :label "1x"}
                       {:value "1.5" :label "1.5x"}
                       {:value "2" :label "2x"}
+                      {:value "3" :label "3x"}
                       {:value "4" :label "4x"}
                       {:value "6" :label "6x"}]
 


### PR DESCRIPTION
### Related Ticket

Closes #10740

### Summary

Adds a `3x` option to the export scale selector, between `2x` and `4x`.

Mobile work needs @1x/@2x/@3x assets, and without a 3x option you have to export at some other scale and resize the file yourself.

The scale list is duplicated in two components, so I added the entry in both:

- `frontend/src/app/main/ui/workspace/sidebar/options/menus/exports.cljs` (design sidebar)
- `frontend/src/app/main/ui/inspect/exports.cljs` (viewer inspect panel)

No backend change. `:scale` is `::sm/safe-number` in `common/src/app/common/types/shape/export.cljc`, not a fixed set, so 3 was already valid and just wasn't offered in the UI.

### Steps to reproduce

1. Select any shape or board in the workspace.
2. Add an export in the design sidebar.
3. Open the scale dropdown. It now reads `0.5x, 0.75x, 1x, 1.5x, 2x, 3x, 4x, 6x`.
4. Pick `3x` and export.
5. Same option shows up in view mode under Inspect > Code > Export.

I checked the output on a 290 x 316 rectangle:

| Scale | Exported PNG |
|-------|--------------|
| 2x    | 580 x 632    |
| 3x    | 870 x 948    |

Before

<img width="900" height="1200" alt="before-crop" src="https://github.com/user-attachments/assets/46cd2c07-51e6-4555-bbef-d80ff0f7b967" />

After

<img width="900" height="1200" alt="after-crop" src="https://github.com/user-attachments/assets/d7e6cad8-09d2-44ce-86d3-aa7c8eb9eb81" />



### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [x] Check CI passes successfully.
