### PR TITLE
:lipstick: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If your organization is scaling and needs extra support, we’re here to help. [
 
 - [Why Penpot](#why-penpot)
 - [Getting Started](#getting-started)
+- [Penpot Enterprise](#penpot-enterprise)
 - [Community](#community)
 - [Contributing](#contributing)
 - [Resources](#resources)
@@ -92,6 +93,12 @@ Penpot brings [design systems](https://penpot.app/design/design-systems) to code
 Penpot is the only design & prototype platform that is deployment agnostic. You can use it in our [SAAS](https://design.penpot.app) or deploy it anywhere.
 
 Learn how to install it with Docker, Kubernetes, Elestio or other options on [our website](https://penpot.app/self-host).
+
+<img width="100%" height="1010" alt="2" src="https://github.com/user-attachments/assets/243e796e-a140-481a-b68f-b24be6a70e37" />
+
+## Penpot Enterprise ##
+
+Penpot Enterprise is our paid plan for organizations that need to scale their design work across multiple teams with advanced governance, security, and administration. Manage teams and access from a centralized **Admin Console**, configure advanced permissions, and connect your **identity provider through SSO**. Available for cloud and self-hosted environments, it combines enterprise controls with Penpot’s open-source foundation and open standards.
 
 ## Community ##
 


### PR DESCRIPTION
## What

- Adds a Penpot Enterprise section to the README, with a TOC entry and hero image, describing the paid plan for organizations (centralized Admin Console, advanced permissions, SSO identity provider, available for cloud and self-hosted).

## Why

- The README had no mention of the Enterprise plan launching alongside 2.18, so organizations evaluating Penpot for scale could not learn about its governance, security and administration controls from the repo front page.

## How

- **README:** adds the `Penpot Enterprise` TOC entry, a full-width hero image, and a concise section covering centralized administration, advanced permissions, SSO and cloud/self-hosted availability on top of the open-source foundation.
