### PR TITLE
:bug: Bind MCP PluginBridge WebSocket to configured host

### DIFF
--- a/mcp/packages/server/src/PluginBridge.ts
+++ b/mcp/packages/server/src/PluginBridge.ts
@@ -94,7 +94,7 @@ export class PluginBridge {
         private readonly taskTimeoutSecs: number,
         private readonly redisBridge?: RedisBridge
     ) {
-        this.wsServer = new WebSocketServer({ port: port });
+        this.wsServer = new WebSocketServer({ port: port, host: mcpServer.host });
         this.setupWebSocketHandlers();
     }
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- The MCP plugin WebSocket bridge now binds to `PENPOT_MCP_SERVER_HOST` (default `localhost`) instead of all network interfaces, closing GHSA-ch2q-6x56-qg5r (critical, CWE-284/306).
- Binding to `0.0.0.0` still works when explicitly configured for remote setups.

Closes #11603.

## Why

- `PluginBridge` constructed its `WebSocketServer` with only `{ port }`, so the `ws` library defaulted to all interfaces regardless of the documented `PENPOT_MCP_SERVER_HOST` setting.
- In the default single-user setup that socket needs no credentials, so any network-reachable host could pose as the user's browser tab, receive task payloads, return forged results, or deny service with a second connection.
- The main HTTP server and the REPL server (after the GHSA-22qr-rp27-j9wm fix) already bind the configured host; the bridge was the one sibling left out.

## How

- **Fix:** pass the already-resolved `mcpServer.host` into the `WebSocketServer` options (one line, no signature or call-site change), mirroring the precedent `ReplServer` fix.
- **Verification:** `types:check`, `fmt:check`, and `build` pass; full MCP suite passes (21 server + 12 plugin tests, 0 fail); bind check against the real class shows `::1` for `localhost` and `0.0.0.0` on explicit opt-in.
- **Scope note:** per the agreed plan, no new regression test was committed and no authentication changes were made; REPL `/execute` auth belongs to GHSA-852x-m8p9-558v.
