### PR TITLE
:lipstick: Adjust release notes 2.18 titles

### DIFF
--- a/frontend/src/app/main/ui/releases/v2_18.cljs
+++ b/frontend/src/app/main/ui/releases/v2_18.cljs
@@ -158,7 +158,7 @@
         [:div {:class (stl/css :modal-content)}
          [:div {:class (stl/css :modal-header)}
           [:h1 {:class (stl/css :modal-title)}
-           "Advanced permissions: An Admin Panel to rule them all"]]
+           "An Admin Panel to rule them all"]]
 
          [:div {:class (stl/css :feature)}
           [:p {:class (stl/css :feature-content)}
@@ -190,7 +190,7 @@
         [:div {:class (stl/css :modal-content)}
          [:div {:class (stl/css :modal-header)}
           [:h1 {:class (stl/css :modal-title)}
-           "Advanced permissions: Penpot Enterprise billing"]]
+           "Penpot Enterprise billing"]]
 
          [:div {:class (stl/css :feature)}
           [:p {:class (stl/css :feature-content)}


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

Removed the redundant "Advanced permissions:" prefix from two feature titles in the 2.18 release notes modal:
- "Advanced permissions: An Admin Panel to rule them all" → "An Admin Panel to rule them all"
- "Advanced permissions: Penpot Enterprise billing" → "Penpot Enterprise billing"

## Why

The prefix is already communicated by the section context in the release notes UI, so repeating it in each title is unnecessary visual noise.

## How

Straightforward string edit in `frontend/src/app/main/ui/releases/v2_18.cljs` — trimmed the prefix from both title strings.