### PR TITLE
:tada: Avoid interacting with clipped content

### DIFF
--- a/common/src/app/common/types/shape_tree.cljc
+++ b/common/src/app/common/types/shape_tree.cljc
@@ -272,6 +272,20 @@
               -1))))
       items))))
 
+(defn- clipped-by-ancestor?
+  "Checks whether position falls outside the visible (clipped) bounds of
+  some ancestor frame with clip content enabled. Used so that a nested
+  frame that extends beyond a clipping ancestor's own bounds is never
+  considered hit/reachable in the invisible, clipped-away region."
+  [objects shape position]
+  (->> (cfh/get-parent-ids objects (dm/get-prop shape :id))
+       (keep (d/getf objects))
+       (some (fn [ancestor]
+               (and (not= (dm/get-prop ancestor :id) uuid/zero)
+                    ^boolean (cfh/frame-shape? ancestor)
+                    (not (:show-content ancestor))
+                    (not ^boolean (gsh/has-point? ancestor position)))))))
+
 (defn get-frame-by-position
   ([objects position]
    (get-frame-by-position objects position nil))
@@ -287,6 +301,7 @@
          validator (or (get options :validator) #(-> true))]
      (or (d/seek #(and ^boolean (some? position)
                        ^boolean (gsh/has-point? % position)
+                       ^boolean (not (clipped-by-ancestor? objects % position))
                        ^boolean (validator %))
                  frames)
          (get objects uuid/zero)))))
@@ -302,7 +317,8 @@
   ([objects position options]
    (->> (get-frames objects options)
         (filter #(and ^boolean (some? position)
-                      ^boolean (gsh/has-point? % position)))
+                      ^boolean (gsh/has-point? % position)
+                      ^boolean (not (clipped-by-ancestor? objects % position))))
         (sort-z-index-objects objects))))
 
 (defn top-nested-frame

--- a/common/test/common_tests/types_shape_tree_test.cljc
+++ b/common/test/common_tests/types_shape_tree_test.cljc
@@ -1,0 +1,58 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS INC Sucursal en España SL
+
+(ns common-tests.types-shape-tree-test
+  (:require
+   [app.common.geom.point :as gpt]
+   [app.common.types.shape-tree :as ctt]
+   [app.common.uuid :as uuid]
+   [clojure.test :as t]))
+
+(defn- make-frame
+  [id parent-id shapes x y width height show-content]
+  {:id id
+   :type :frame
+   :parent-id parent-id
+   :frame-id parent-id
+   :shapes (vec shapes)
+   :x x
+   :y y
+   :width width
+   :height height
+   :rotation nil
+   :hidden false
+   :blocked false
+   :show-content show-content})
+
+(t/deftest top-nested-frame-clip-content-test
+  (t/testing "board A (clip) contains a wider board B; point inside both resolves to B"
+    (let [a-id     (uuid/next)
+          b-id     (uuid/next)
+          objects  {a-id (make-frame a-id uuid/zero [b-id] 0 0 200 200 false)
+                    b-id (make-frame b-id a-id [] 50 50 300 300 false)}
+          position (gpt/point 150 150)
+          result   (ctt/top-nested-frame objects position)]
+      (t/is (= b-id result))))
+
+  (t/testing "point inside B but outside A's clipped bounds is not reachable at all"
+    (let [a-id     (uuid/next)
+          b-id     (uuid/next)
+          objects  {a-id (make-frame a-id uuid/zero [b-id] 0 0 200 200 false)
+                    b-id (make-frame b-id a-id [] 50 50 300 300 false)}
+          position (gpt/point 300 300)
+          result   (ctt/top-nested-frame objects position)]
+      ;; Outside A (the clip ancestor) and B's visible/clipped region there is
+      ;; not visible either, so no frame should be resolved at that point.
+      (t/is (= uuid/zero result))))
+
+  (t/testing "with show-content true on A, the same point can resolve into B"
+    (let [a-id     (uuid/next)
+          b-id     (uuid/next)
+          objects  {a-id (make-frame a-id uuid/zero [b-id] 0 0 200 200 true)
+                    b-id (make-frame b-id a-id [] 50 50 300 300 false)}
+          position (gpt/point 300 300)
+          result   (ctt/top-nested-frame objects position)]
+      (t/is (= b-id result)))))

--- a/frontend/src/app/worker/selection.cljs
+++ b/frontend/src/app/worker/selection.cljs
@@ -245,16 +245,20 @@
 
         overlaps-parent?
         (fn [clip-parents]
-          (->> clip-parents (some (comp not overlaps?)) not))]
+          (->> clip-parents
+               ;; When clip-children? is false (e.g. deep/penetrate selection with
+               ;; a modifier key held) we still must not reach into the clipped-away,
+               ;; invisible area of an ancestor board with clip content enabled.
+               ;; Only the bool/mask clip-parents (non-frame) are relaxed in that case.
+               (remove #(and (not clip-children?) (not ^boolean (cfh/frame-shape? %))))
+               (every? overlaps?)))]
 
     ;; Shapes after filters of overlapping and criteria
     (into (d/ordered-set)
           (comp (map #(unchecked-get % "data"))
                 (filter match-criteria?)
                 (filter overlaps?)
-                (filter (if clip-children?
-                          (comp overlaps-parent? :clip-parents)
-                          (constantly true)))
+                (filter (comp overlaps-parent? :clip-parents))
                 (keep :id))
           result)))
 


### PR DESCRIPTION
### Related Ticket

This PR closes this enhancement https://github.com/penpot/penpot/issues/11412

### Summary
Fixes two related bugs around boards with "Clip content" enabled where the invisible, clipped-away area of a nested board was still treated as interactable:

1. Drag & drop reparenting into a clipped-away area — when dragging a shape over the part of a nested board that extends outside its clipping ancestor's visible bounds, the nested board was still resolved as a valid drop target. The shape would get reparented there and disappear from view since it was clipped by the ancestor. Fixed the shared frame/board hit-testing (get-frame-by-position, get-frames-by-position, top-nested-frame in common/src/app/common/types/shape_tree.cljc) to reject any point that falls outside a clipping ancestor's own bounds.

2. Ctrl/Cmd+click deep-select reaching into a clipped-away area — holding Ctrl/Cmd and clicking (to select the most nested shape under the cursor) could select a shape sitting inside a board's clipped-away region, because the modifier-key path disabled clip-ancestor enforcement entirely (a side effect of an earlier fix for boolean/mask selection). Scoped the relaxation in frontend/src/app/worker/selection.cljs so only boolean/mask clip-ancestors are relaxed under the modifier key — board "Clip content" ancestors are always enforced.

### Steps to reproduce 

- Create board A with "Clip content" enabled.
- Inside A, create board B that is wider/taller than A, so part of B extends outside A's visible bounds.
- Add some rectangles inside B.
- Bug 1: Drag a shape from outside any board and hover it over the part of B that lies outside A. Before the fix, B was highlighted/targeted and the dragged shape disappeared on drop. After the fix, that area is not a valid target.
- Bug 2: Hold Ctrl/Cmd and click on the part of B that lies outside A. Before the fix, it could select a rectangle inside B. After the fix, it cannot.



### Checklist

- [ ] Choose the correct target branch; use `develop` by default.
- [ ] Provide a brief summary of the changes introduced.
- [ ] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [ ] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

Co-Authored-By: Claude Sonnet 5 

