### PR TITLE
:fire: Remove unused comment profiles code in the frontend

### DIFF
--- a/frontend/src/app/main/data/comments.cljs
+++ b/frontend/src/app/main/data/comments.cljs
@@ -441,7 +441,6 @@
                (rx/catch #(rx/throw {:type :comment-error}))))))))
 
 
-;; FIXME: revisit
 (defn retrieve-unread-comment-threads
   "A event used mainly in dashboard for retrieve all unread threads of a team."
   [team-id]
@@ -449,18 +448,9 @@
   (ptk/reify ::retrieve-unread-comment-threads
     ptk/WatchEvent
     (watch [_ _ _]
-      (let [fetched-comments #(assoc %2 :comment-threads (d/index-by :id %1))
-            fetched-users #(assoc %2 :current-team-comments-users %1)]
+      (let [fetched-comments #(assoc %2 :comment-threads (d/index-by :id %1))]
         (->> (rp/cmd! :get-unread-comment-threads {:team-id team-id})
-             (rx/merge-map
-              (fn [comments]
-                (rx/concat
-                 (rx/of (partial fetched-comments comments))
-
-                 (->> (rx/from (into #{} (map :file-id) comments))
-                      (rx/merge-map #(rp/cmd! :get-profiles-for-file-comments {:file-id %}))
-                      (rx/reduce #(merge %1 (d/index-by :id %2)) {})
-                      (rx/map #(partial fetched-users %))))))
+             (rx/map #(partial fetched-comments %))
              (rx/catch #(rx/throw {:type :comment-error})))))))
 
 (defn mark-all-threads-as-read

--- a/frontend/src/app/main/data/profile.cljs
+++ b/frontend/src/app/main/data/profile.cljs
@@ -377,20 +377,6 @@
                        (js/console.error "delete-photo failed" cause)
                        (rx/of (refresh-profile))))))))
 
-(defn fetch-file-comments-users
-  [{:keys [team-id]}]
-  (assert (uuid? team-id) "expected a valid uuid for `team-id`")
-  (letfn [(fetched [users state]
-            (->> users
-                 (d/index-by :id)
-                 (assoc state :file-comments-users)))]
-    (ptk/reify ::fetch-file-comments-users
-      ptk/WatchEvent
-      (watch [_ state _]
-        (let [share-id (-> state :viewer-local :share-id)]
-          (->> (rp/cmd! :get-profiles-for-file-comments {:team-id team-id :share-id share-id})
-               (rx/map #(partial fetched %))))))))
-
 ;; --- EVENT: request-account-deletion
 
 (def profile-deleted-event?

--- a/frontend/src/app/main/data/viewer.cljs
+++ b/frontend/src/app/main/data/viewer.cljs
@@ -44,8 +44,7 @@
    :selected #{}
    :collapsed #{}
    :hover nil
-   :share-id ""
-   :file-comments-users []})
+   :share-id ""})
 
 (declare fetch-comment-threads)
 (declare fetch-bundle)


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- The dashboard comment notifications no longer issue one request per file with unread comments, and the frontend no longer carries the dead comment-users event and state key.

## Why

- `retrieve-unread-comment-threads` fanned out to one `get-profiles-for-file-comments` call per distinct file id and stored the result in `:current-team-comments-users`, a state key nothing reads. The dashboard renders thread authors from the thread payload itself.
- `fetch-file-comments-users` had no callers, wrote the unused `:file-comments-users` viewer key, and passed `:team-id` where the RPC requires `:file-id`.

## How

- Drop the per-file fan-out and the unused state writes; the dashboard event now issues a single `get-unread-comment-threads` call.
- Remove the dead `fetch-file-comments-users` event and the `:file-comments-users` state key.

Closes #11623
