### PR TITLE
:recycle: Rebalance CI runners and drop pinned ubuntu-24.04

### DIFF
--- a/.github/workflows/build-docker-devenv.yml
+++ b/.github/workflows/build-docker-devenv.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-push:
     name: Build and push DevEnv Docker image
-    runs-on: penpot-extended-runner
+    runs-on: penpot-standar-runner
 
     steps:
       - name: Set common environment variables

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -46,7 +46,7 @@ jobs:
   # ── 1. Resolve the build key and check the whole set at once ───────────
   prepare:
     name: Prepare
-    runs-on: penpot-extended-runner
+    runs-on: penpot-standar-runner
     timeout-minutes: 15
     outputs:
       gh_ref: ${{ steps.vars.outputs.gh_ref }}
@@ -135,7 +135,7 @@ jobs:
   # ── 2. One build per image, in parallel, only when needed ──────────────
   build:
     name: Build ${{ matrix.image }}
-    runs-on: penpot-extended-runner
+    runs-on: penpot-standar-runner
     timeout-minutes: 60
     needs: prepare
     if: needs.prepare.outputs.exists == 'false'
@@ -248,7 +248,7 @@ jobs:
   # the S3 marker guarantees the branch tags were already moved.
   promote:
     name: Promote image set
-    runs-on: penpot-extended-runner
+    runs-on: penpot-standar-runner
     timeout-minutes: 10
     needs: [prepare, build]
 
@@ -302,7 +302,7 @@ jobs:
   # ── 4. Single failure notification for the whole workflow ─────────────
   notify:
     name: Notify failure
-    runs-on: penpot-extended-runner
+    runs-on: penpot-standar-runner
     timeout-minutes: 5
     needs: [prepare, build, promote]
     if: failure()

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -46,7 +46,7 @@ jobs:
 
   notify:
     name: Notifications
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs:
       - build-docker
       - build-docker-admin-console

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.gh_ref }}
       release_notes: ${{ steps.extract_release_notes.outputs.release_notes }}

--- a/.github/workflows/tests-exporter.yml
+++ b/.github/workflows/tests-exporter.yml
@@ -32,7 +32,7 @@ jobs:
   test-exporter:
     if: ${{ !github.event.pull_request.draft }}
     name: "Exporter Tests"
-    runs-on: penpot-runner-02
+    runs-on: penpot-extended-runner
     container:
       image: penpotapp/devenv:latest
       volumes:


### PR DESCRIPTION
Move build-docker and build-docker-devenv jobs from penpot-extended-runner to penpot-standar-runner, point tests-exporter at the canonical penpot-extended-runner label instead of the stale penpot-runner-02 alias, and switch build-tag/release notify jobs from ubuntu-24.04 to ubuntu-latest.