### PR TITLE
:bug: Store audit initiator as plain string for shared-key callers

### DIFF
--- a/backend/src/app/loggers/audit.clj
+++ b/backend/src/app/loggers/audit.clj
@@ -204,7 +204,7 @@
         token-id            (::actoken/id request)
         token-type          (::actoken/type request)]
     {:external-session-id session-id
-     :initiator (or key-id "app")
+     :initiator (or (d/name key-id) "app")
      :access-token-id (some-> token-id str)
      :access-token-type (some-> token-type str)
      :client-event-origin client-event-origin

--- a/backend/test/backend_tests/rpc_audit_test.clj
+++ b/backend/test/backend_tests/rpc_audit_test.clj
@@ -35,6 +35,21 @@
         "x-forwarded-for" "127.0.0.44"
         "x-real-ip" "127.0.0.43"))))
 
+(t/deftest prepare-context-initiator-is-plain-string
+  ;; The initiator must always be a plain string, never a keyword: shared-key
+  ;; authenticated callers (exporter, admin-console) arrive as keywords on
+  ;; :app.http/auth-key-id and transit would persist them as "~:exporter".
+  (let [base {:headers {"x-forwarded-for" "127.0.0.44"}}]
+    (t/is (= "app" (:initiator (audit/prepare-context-from-request base))))
+    (t/is (= "exporter"
+             (:initiator (audit/prepare-context-from-request
+                          (assoc base :app.http/auth-key-id :exporter)))))
+    (t/is (= "admin-console"
+             (:initiator (audit/prepare-context-from-request
+                          (assoc base :app.http/auth-key-id :admin-console)))))
+    (t/is (string? (:initiator (audit/prepare-context-from-request
+                                (assoc base :app.http/auth-key-id :nexus)))))))
+
 (t/deftest push-events-1
   (with-redefs [app.config/flags #{:audit-log}]
     (let [prof    (th/create-profile* 1 {:is-active true})

--- a/backend/test/backend_tests/rpc_management_nitrate_test.clj
+++ b/backend/test/backend_tests/rpc_management_nitrate_test.clj
@@ -1943,3 +1943,26 @@
           (t/is (= "bar" (get-in event [:context :foo])))
           (t/is (= (:full cf/version) (get-in event [:context :version])))
           (t/is (= "app" (get-in event [:context :initiator]))))))))
+
+(t/deftest push-audit-events-initiator-is-plain-string
+  ;; Shared-key callers (e.g. admin-console) carry :app.http/auth-key-id as a
+  ;; keyword; the stored initiator must be a plain string, and a
+  ;; caller-supplied initiator must never survive (server context wins).
+  (with-mocks [audit-mock {:target 'app.loggers.audit/submit :return nil}]
+    (binding [cf/flags #{:audit-log}]
+      (let [prof   (th/create-profile* 1 {:is-active true})
+            params {::th/type :push-audit-events
+                    :events [{:name "context-test"
+                              :profile-id (:id prof)
+                              :type "action"
+                              :context {:custom-key "custom-val"
+                                        :initiator "spoofed"}}]}
+            params (with-meta params
+                     {::http/request (assoc http-request
+                                            ::http/auth-key-id :admin-console)})
+            out    (th/management-command! params)]
+        (t/is (nil? (:error out)))
+        (let [[_ event] (:call-args @audit-mock)]
+          (t/is (= "custom-val" (get-in event [:context :custom-key])))
+          (t/is (= "admin-console" (get-in event [:context :initiator])))
+          (t/is (string? (get-in event [:context :initiator]))))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Audit event context `initiator` is now always a plain string (`"app"`, `"exporter"`, `"admin-console"`, ...) instead of a mix of `"app"` and transit-encoded keywords (`"~:exporter"`, `"~:admin-console"`).
- Adds regression tests pinning the string type at the origin and through the nitrate `push-audit-events` path, including caller-spoofing precedence.

## Why

- Shared-key authenticated callers (exporter service, nitrate admin-console) carry their key id as a keyword on the request, and the audit context builder stored it as-is while regular traffic stored the `"app"` string; transit json-verbose then persisted keywords as `"~:..."`, breaking grouping and analysis on this field as events accumulate (191k exporter rows, 3k admin-console rows already affected).

## How

- **Backend:** coerce with `d/name` at the single origin (`prepare-context-from-request`), so all RPC audit events, `push-audit-events`, and telemetry copies are fixed at once; verified nitrate never sends `initiator` itself and the server-side merge order already overwrites any caller-supplied value, so no nitrate/exporter change is needed.
- **Tests:** new unit test for the origin plus a shared-key `push-audit-events` test; full backend suite green (748 tests, 4681 assertions, 0 failures), `lint:clj` and `check-fmt:clj` clean.

## Existing rows (manual follow-up, run off-peak)

This PR only fixes new rows. To normalize historical values (`context` is `jsonb` holding transit json-verbose, hence the literal `"~:initiator"` key; the parent-table `UPDATE` routes to the partitions):

```sql
-- 1) Inspect current distribution (read-only):
SELECT context->'~:initiator' AS initiator, count(*)
FROM audit_log
GROUP BY 1 ORDER BY 2;

-- 2) Normalize historical values:
UPDATE audit_log SET context = jsonb_set(context, '{~:initiator}', '"exporter"')
WHERE context->>'~:initiator' = '~:exporter';
UPDATE audit_log SET context = jsonb_set(context, '{~:initiator}', '"admin-console"')
WHERE context->>'~:initiator' = '~:admin-console';
```

Closes #11628
