### PR TITLE
:sparkles: Add instance-wide user and membership management

### DIFF
--- a/backend/src/app/rpc.clj
+++ b/backend/src/app/rpc.clj
@@ -396,6 +396,7 @@
           'app.rpc.commands.files-update
           'app.rpc.commands.files-snapshot
           'app.rpc.commands.files-thumbnails
+          'app.rpc.commands.instance-admin
           'app.rpc.commands.ldap
           'app.rpc.commands.management
           'app.rpc.commands.media

--- a/backend/src/app/rpc/commands/instance_admin.clj
+++ b/backend/src/app/rpc/commands/instance_admin.clj
@@ -1,0 +1,138 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS SUBSIDIARY SL
+
+(ns app.rpc.commands.instance-admin
+  (:require
+   [app.common.exceptions :as ex]
+   [app.common.schema :as sm]
+   [app.common.types.team :as types.team]
+   [app.config :as cf]
+   [app.db :as db]
+   [app.db.sql :as-alias sql]
+   [app.msgbus :as mbus]
+   [app.nitrate :as nitrate]
+   [app.rpc :as-alias rpc]
+   [app.rpc.commands.profile :as profile]
+   [app.rpc.commands.teams :as teams]
+   [app.rpc.doc :as-alias doc]
+   [app.rpc.quotes :as quotes]
+   [app.util.services :as sv]))
+
+(defn check-admin!
+  [cfg id]
+  (let [account (profile/get-profile cfg id)]
+    (when-not (and (:is-active account)
+                   (not (:is-blocked account))
+                   (contains? (cf/get :admins #{}) (:email account)))
+      (ex/raise :type :restriction :code :only-admins-allowed))))
+
+(defn- affiliations
+  [cfg id]
+  {:teams (db/exec! cfg
+                    ["SELECT t.id, t.name, t.is_default, r.is_owner, r.is_admin, r.can_edit
+                        FROM team_profile_rel r JOIN team t ON t.id = r.team_id
+                       WHERE r.profile_id = ? AND t.deleted_at IS NULL ORDER BY t.name, t.id" id])
+   :projects (db/exec! cfg
+                       ["SELECT p.id, p.name, p.team_id, p.is_default, r.is_owner, r.is_admin, r.can_edit
+                           FROM project_profile_rel r JOIN project p ON p.id = r.project_id
+                           JOIN team t ON t.id = p.team_id
+                          WHERE r.profile_id = ? AND p.deleted_at IS NULL AND t.deleted_at IS NULL
+                          ORDER BY p.name, p.id" id])})
+
+(sv/defmethod ::get-instance-users
+  "List accounts and their explicit team and project memberships."
+  {::doc/module :management
+   ::sm/params [:map
+                [:search {:optional true} [:string {:max 250}]]
+                [:offset {:optional true} [::sm/int {:min 0}]]
+                [:limit {:optional true} [::sm/int {:min 1 :max 100}]]]}
+  [cfg {:keys [::rpc/profile-id search offset limit] :or {search "" offset 0 limit 50}}]
+  (check-admin! cfg profile-id)
+  (db/run! cfg
+           (fn [cfg]
+             (let [pattern (str "%" search "%")
+                   rows    (db/exec! cfg
+                                     ["SELECT id, fullname, email, is_active, is_blocked, auth_backend
+                                         FROM profile WHERE deleted_at IS NULL
+                                          AND (email ILIKE ? OR fullname ILIKE ?)
+                                         ORDER BY email, id LIMIT ? OFFSET ?" pattern pattern limit offset])
+                   total   (:total (db/exec-one! cfg
+                                                 ["SELECT count(*) AS total FROM profile WHERE deleted_at IS NULL
+                                                    AND (email ILIKE ? OR fullname ILIKE ?)" pattern pattern]))]
+               {:users (mapv #(merge % (affiliations cfg (:id %))) rows)
+                :total total}))))
+
+(sv/defmethod ::get-instance-membership-targets
+  "Find shared teams or projects to which an administrator can add accounts."
+  {::doc/module :management
+   ::sm/params [:map
+                [:kind [::sm/one-of #{:team :project}]]
+                [:search {:optional true} [:string {:max 250}]]
+                [:offset {:optional true} [::sm/int {:min 0}]]]}
+  [cfg {:keys [::rpc/profile-id kind search offset] :or {search "" offset 0}}]
+  (check-admin! cfg profile-id)
+  (let [pattern (str "%" search "%")]
+    (if (= kind :team)
+      (db/exec! cfg ["SELECT id, name FROM team WHERE deleted_at IS NULL AND NOT is_default
+                       AND name ILIKE ? ORDER BY name, id LIMIT 50 OFFSET ?" pattern offset])
+      (db/exec! cfg ["SELECT p.id, p.name, t.name AS team_name FROM project p JOIN team t ON t.id = p.team_id
+                      WHERE p.deleted_at IS NULL AND t.deleted_at IS NULL AND NOT t.is_default
+                        AND p.name ILIKE ? ORDER BY p.name, p.id LIMIT 50 OFFSET ?" pattern offset]))))
+
+(sv/defmethod ::set-instance-user-membership
+  "Add, update or remove an explicit membership without an invitation email."
+  {::doc/module :management
+   ::db/transaction true
+   ::sm/params [:map
+                [:member-id ::sm/uuid]
+                [:kind [::sm/one-of #{:team :project}]]
+                [:target-id ::sm/uuid]
+                [:role [::sm/one-of #{:admin :editor :viewer :none}]]]}
+  [cfg {:keys [::rpc/profile-id member-id kind target-id role]}]
+  (check-admin! cfg profile-id)
+  (let [member  (profile/get-profile cfg member-id)
+        project (when (= kind :project) (db/get-by-id cfg :project target-id))
+        team-id (if project (:team-id project) target-id)
+        team    (db/get-by-id cfg :team team-id ::sql/for-update true)
+        table   (if project :project-profile-rel :team-profile-rel)
+        key     (if project :project-id :team-id)
+        where   {:profile-id member-id key target-id}
+        current (db/get* cfg table where)
+        flags   (get types.team/permissions-for-role role)]
+    (when (or (:is-default team) (:is-owner current))
+      (ex/raise :type :restriction :code :protected-membership
+                :hint "Personal workspaces and owners cannot be changed here"))
+    (when (and project (not= role :none)
+               (nil? (db/get* cfg :team-profile-rel {:team-id team-id :profile-id member-id})))
+      (ex/raise :type :restriction :code :team-membership-required
+                :hint "Add the user to the enclosing team before granting project access"))
+    (cond
+      (= role :none)
+      (db/delete! cfg table where)
+
+      current
+      (db/update! cfg table flags where)
+
+      project
+      (teams/create-project-role cfg member-id target-id role)
+
+      :else
+      (do
+        (quotes/check! (assoc cfg ::quotes/profile-id (:id member)
+                              ::quotes/team-id team-id ::quotes/incr 1)
+                       {::quotes/id ::quotes/profiles-per-team})
+        (teams/add-profile-to-team! cfg (merge where flags))))
+    ;; Project grants do not change the user's role in the enclosing team.
+    (when (and (not project) (::mbus/msgbus cfg))
+      (let [removed? (= role :none)
+            viewer?  (and removed? (nitrate/organization-owner-of-team? cfg member-id team-id))
+            message  (if (and removed? (not viewer?))
+                       {:type :team-membership-change :change :removed
+                        :team-id team-id :team-name (:name team)}
+                       {:type :team-role-change :topic member-id :team-id team-id
+                        :role (if viewer? :viewer role)})]
+        (mbus/pub! (::mbus/msgbus cfg) :topic member-id :message message)))
+    (affiliations cfg member-id)))

--- a/backend/src/app/rpc/commands/profile.clj
+++ b/backend/src/app/rpc/commands/profile.clj
@@ -89,6 +89,7 @@
    [:email ::sm/email]
    [:theme {:optional true} :string]
    [:is-admin {:optional true} ::sm/boolean]
+   [:is-instance-admin {:optional true} ::sm/boolean]
    [:is-active {:optional true} ::sm/boolean]
    [:is-blocked {:optional true} ::sm/boolean]
    [:is-demo {:optional true} ::sm/boolean]
@@ -646,7 +647,11 @@
 (defn strip-private-attrs
   "Only selects a publicly visible profile attrs."
   [row]
-  (dissoc row :password :deleted-at))
+  (-> row
+      (assoc :is-instance-admin (boolean (and (:is-active row)
+                                               (not (:is-blocked row))
+                                               (contains? (cf/get :admins #{}) (:email row)))))
+      (dissoc :password :deleted-at)))
 
 (defn filter-props
   "Removes all namespace qualified props from `props` attr."

--- a/backend/test/backend_tests/instance_admin_test.clj
+++ b/backend/test/backend_tests/instance_admin_test.clj
@@ -1,0 +1,84 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS SUBSIDIARY SL
+
+(ns backend-tests.instance-admin-test
+  (:require
+   [app.config :as cf]
+   [app.db :as db]
+   [app.rpc :as-alias rpc]
+   [backend-tests.helpers :as th]
+   [clojure.test :as t]))
+
+(t/use-fixtures :once th/state-init)
+(t/use-fixtures :each th/database-reset)
+
+(t/deftest instance-administration-requires-active-configured-admin
+  (let [account (th/create-profile* 1 {:is-active true})
+        params  {::th/type :get-instance-users ::rpc/profile-id (:id account)}]
+    (t/is (th/ex-of-code? (:error (th/command! params)) :only-admins-allowed))
+    (with-redefs [cf/config (assoc cf/config :admins #{(:email account)})]
+      (t/is (nil? (:error (th/command! params))))
+      (db/update! th/*pool* :profile {:is-blocked true} {:id (:id account)})
+      (t/is (th/ex-of-code? (:error (th/command! params)) :only-admins-allowed)))))
+
+(t/deftest user-list-is-paginated-and-does-not-expose-credentials
+  (let [admin (th/create-profile* 1 {:is-active true})
+        user  (th/create-profile* 2)]
+    (with-redefs [cf/config (assoc cf/config :admins #{(:email admin)})]
+      (let [out (th/command! {::th/type :get-instance-users ::rpc/profile-id (:id admin)
+                              :search (:email user) :limit 1})
+            row (first (get-in out [:result :users]))]
+        (t/is (nil? (:error out)))
+        (t/is (= 1 (get-in out [:result :total])))
+        (t/is (= (:id user) (:id row)))
+        (t/is (= (:default-team-id user) (:id (first (:teams row)))))
+        (t/is (not-any? #(contains? row %) [:password :props :default-team-id]))))))
+
+(t/deftest administrator-can-manage-shared-memberships-without-invitations
+  (let [admin  (th/create-profile* 1 {:is-active true})
+        owner  (th/create-profile* 2 {:is-active true})
+        member (th/create-profile* 3 {:is-active true})
+        team   (:result (th/command! {::th/type :create-team ::rpc/profile-id (:id owner)
+                                      :name "Shared design"}))
+        params {::th/type :set-instance-user-membership ::rpc/profile-id (:id admin)
+                :member-id (:id member) :kind :team :target-id (:id team)}]
+    (t/is (th/ex-of-code? (:error (th/command! (assoc params :role :editor))) :only-admins-allowed))
+    (with-redefs [cf/config (assoc cf/config :admins #{(:email admin)})]
+      (doseq [role [:editor :viewer :admin]]
+        (let [out (th/command! (assoc params :role role))
+              rel (th/db-get :team-profile-rel {:team-id (:id team) :profile-id (:id member)})]
+          (t/is (nil? (:error out)))
+          (t/is (= (= role :admin) (:is-admin rel)))
+          (t/is (= (not= role :viewer) (:can-edit rel)))))
+      (t/is (nil? (:error (th/command! (assoc params :role :none)))))
+      (t/is (empty? (db/query th/*pool* :team-profile-rel
+                              {:team-id (:id team) :profile-id (:id member)})))
+      (t/is (th/ex-of-code? (:error (th/command! (assoc params :member-id (:id owner) :role :none)))
+                            :protected-membership))
+      (t/is (th/ex-of-code? (:error (th/command! (assoc params :target-id (:default-team-id member) :role :none)))
+                            :protected-membership))
+      (t/is (empty? (db/query th/*pool* :team-invitation {:team-id (:id team)}))))))
+
+(t/deftest administrator-can-manage-explicit-project-affiliations
+  (let [admin  (th/create-profile* 1 {:is-active true})
+        member (th/create-profile* 2 {:is-active true})
+        team   (:result (th/command! {::th/type :create-team ::rpc/profile-id (:id admin) :name "Shared"}))
+        params {::th/type :set-instance-user-membership ::rpc/profile-id (:id admin)
+                :member-id (:id member) :kind :project :target-id (:default-project-id team)}]
+    (with-redefs [cf/config (assoc cf/config :admins #{(:email admin)})]
+      (t/is (th/ex-of-code? (:error (th/command! (assoc params :role :editor))) :team-membership-required))
+      (t/is (nil? (:error (th/command! (assoc params :kind :team :target-id (:id team) :role :viewer)))))
+      (t/is (nil? (:error (th/command! (assoc params :role :editor)))))
+      (let [file (th/create-file* 1 {:profile-id (:id admin) :project-id (:default-project-id team)})
+            out (th/command! {::th/type :get-file ::rpc/profile-id (:id member) :id (:id file)})]
+        (t/is (nil? (:error out)))
+        (t/is (get-in out [:result :permissions :can-edit])))
+      (let [out (th/command! {::th/type :get-instance-users ::rpc/profile-id (:id admin) :search (:email member)})]
+        (t/is (some #(= (:default-project-id team) (:id %))
+                    (get-in out [:result :users 0 :projects]))))
+      (t/is (nil? (:error (th/command! (assoc params :role :none)))))
+      (t/is (empty? (db/query th/*pool* :project-profile-rel
+                              {:project-id (:default-project-id team) :profile-id (:id member)}))))))

--- a/docs/technical-guide/configuration.md
+++ b/docs/technical-guide/configuration.md
@@ -310,6 +310,31 @@ PENPOT_LDAP_ATTRS_FULLNAME: cn
 PENPOT_LDAP_ATTRS_PHOTO: jpegPhoto
 ```
 
+## User administration
+
+Self-hosted instance administrators can open **User administration** from account
+settings, or go to `/#/admin/users`. Configure their existing, verified account
+email addresses in the backend:
+
+```bash
+PENPOT_ADMINS="admin@example.com second-admin@example.com"
+```
+
+Only active, unblocked accounts in this list can use the administration API.
+Team owners and team administrators do not receive instance administration
+rights automatically. The page lists users, their team memberships and their
+direct project memberships, with search and pagination. Administrators can add,
+change or remove memberships without sending invitation emails.
+
+Team membership also grants access to the team's projects. Removing a direct
+project membership does not revoke access inherited from a team. Personal
+workspaces and owner memberships cannot be changed on this page. Use the team's
+ownership transfer flow before removing an owner.
+
+Project grants require membership in the enclosing team so the user can open
+its workspace. Add the user as a team viewer, then grant editor access to the
+chosen project when they should edit only that project.
+
 ## Penpot URI
 
 You will need to set the <code class="language-bash">PENPOT_PUBLIC_URI</code> environment variable in case you go to serve Penpot to the users;

--- a/frontend/src/app/main/ui.cljs
+++ b/frontend/src/app/main/ui.cljs
@@ -196,7 +196,8 @@
        :nitrate-entry
        [:> nitrate-entry/nitrate-entry-page* {:profile profile}]
 
-       (:settings-profile
+       (:settings-instance-users
+        :settings-profile
         :settings-password
         :settings-options
         :settings-feedback

--- a/frontend/src/app/main/ui/routes.cljs
+++ b/frontend/src/app/main/ui/routes.cljs
@@ -41,6 +41,8 @@
    (when (contains? cf/flags :admin-console)
      ["/subscribe-nitrate" :nitrate-entry])
 
+   ["/admin/users" :settings-instance-users]
+
    ["/settings"
     ["/profile"       :settings-profile]
     ["/password"      :settings-password]

--- a/frontend/src/app/main/ui/settings.cljs
+++ b/frontend/src/app/main/ui/settings.cljs
@@ -16,6 +16,7 @@
    [app.main.ui.settings.change-email]
    [app.main.ui.settings.delete-account]
    [app.main.ui.settings.feedback :refer [feedback-page*]]
+   [app.main.ui.settings.instance-users :refer [instance-users-page*]]
    [app.main.ui.settings.integrations :refer [integrations-page*]]
    [app.main.ui.settings.notifications :refer [notifications-page*]]
    [app.main.ui.settings.options :refer [options-page*]]
@@ -58,6 +59,11 @@
        [:> header*]
        [:div {:class (stl/css :dashboard-container)}
         (case section
+          :settings-instance-users
+          (if (:is-instance-admin profile)
+            [:> instance-users-page*]
+            [:p {:role "alert"} (tr "admin.users.forbidden")])
+
           :settings-profile
           [:> profile-page*]
 

--- a/frontend/src/app/main/ui/settings/instance_users.cljs
+++ b/frontend/src/app/main/ui/settings/instance_users.cljs
@@ -1,0 +1,164 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS SUBSIDIARY SL
+
+(ns app.main.ui.settings.instance-users
+  (:require-macros [app.main.style :as stl])
+  (:require
+   [app.common.uuid :as uuid]
+   [app.main.repo :as rp]
+   [app.main.ui.icons :as i]
+   [app.util.dom :as dom]
+   [app.util.i18n :refer [tr]]
+   [beicon.v2.core :as rx]
+   [rumext.v2 :as mf]))
+
+(defn membership-role
+  [{:keys [is-owner is-admin can-edit]}]
+  (cond is-owner :owner is-admin :admin can-edit :editor :else :viewer))
+
+(mf/defc membership-list*
+  [{:keys [items kind busy on-change]}]
+  [:ul {:class (stl/css :memberships)}
+   (for [item items]
+     [:li {:key (:id item)}
+      [:span (:name item)]
+      [:select {:aria-label (str (tr "admin.users.role") " — " (:name item))
+                :value (name (membership-role item))
+                :disabled (or busy (:is-owner item) (and (= kind :team) (:is-default item)))
+                :on-change #(on-change kind (:id item) (keyword (dom/get-target-val %)))}
+       (when (:is-owner item) [:option {:value "owner"} (tr "labels.owner")])
+       (for [role [:viewer :editor :admin]]
+         [:option {:key role :value (name role)} (tr (str "labels." (name role)))])]
+      (when-not (or (:is-owner item) (and (= kind :team) (:is-default item)))
+        [:button {:class (stl/css :button) :type "button" :disabled busy
+                  :on-click #(on-change kind (:id item) :none)}
+         (tr "labels.remove")])])])
+
+(mf/defc add-membership*
+  [{:keys [busy on-change]}]
+  (let [kind    (mf/use-state :team)
+        search  (mf/use-state "")
+        offset  (mf/use-state 0)
+        targets (mf/use-state [])
+        target  (mf/use-state "")
+        role    (mf/use-state :editor)
+        error   (mf/use-state false)]
+    (mf/with-effect [@kind @search @offset]
+      (reset! target "")
+      (reset! targets [])
+      (reset! error false)
+      (let [sub (->> (rp/cmd! :get-instance-membership-targets
+                              {:kind @kind :search @search :offset @offset})
+                     (rx/subs! #(reset! targets %) #(reset! error true)))]
+        #(rx/dispose! sub)))
+    [:form {:class (stl/css :add-membership)
+            :on-submit (fn [event]
+                         (dom/prevent-default event)
+                         (when-let [id (uuid/parse* @target)]
+                           (on-change @kind id @role)))}
+     [:label (tr "admin.users.kind")
+      [:select {:value (name @kind) :on-change #(do (reset! offset 0)
+                                                    (reset! kind (keyword (dom/get-target-val %))))}
+       [:option {:value "team"} (tr "admin.users.teams")]
+       [:option {:value "project"} (tr "admin.users.projects")]]]
+     [:label (tr "admin.users.find-target")
+      [:input {:type "search" :value @search
+               :on-change #(do (reset! offset 0) (reset! search (dom/get-target-val %)))}]]
+     [:label (tr "admin.users.target")
+      [:select {:required true :value @target :on-change #(reset! target (dom/get-target-val %))}
+       [:option {:value ""} (tr "admin.users.select-target")]
+       (for [item @targets]
+         [:option {:key (:id item) :value (str (:id item))}
+          (str (when (:team-name item) (str (:team-name item) " / ")) (:name item))])]]
+     [:div {:class (stl/css :pagination)}
+      [:button {:class (stl/css :button) :type "button" :disabled (zero? @offset) :on-click #(swap! offset - 50)} (tr "admin.users.previous")]
+      [:button {:class (stl/css :button) :type "button" :disabled (< (count @targets) 50) :on-click #(swap! offset + 50)} (tr "admin.users.next")]]
+     [:label (tr "admin.users.role")
+      [:select {:value (name @role) :on-change #(reset! role (keyword (dom/get-target-val %)))}
+       (for [value [:viewer :editor :admin]]
+         [:option {:key value :value (name value)} (tr (str "labels." (name value)))])]]
+     (when @error [:p {:role "alert"} (tr "admin.users.load-error")])
+     [:button {:class (stl/css :button) :type "submit" :disabled (or busy (empty? @target))} (tr "admin.users.add")]]))
+
+(mf/defc instance-users-page*
+  []
+  (let [search   (mf/use-state "")
+        query    (mf/use-state "")
+        offset   (mf/use-state 0)
+        revision (mf/use-state 0)
+        result   (mf/use-state {:users [] :total 0})
+        selected (mf/use-state nil)
+        loading  (mf/use-state true)
+        busy     (mf/use-state false)
+        error    (mf/use-state nil)
+        account  (some #(when (= @selected (:id %)) %) (:users @result))
+        change   (mf/use-fn
+                  (mf/deps @selected)
+                  (fn [kind target-id role]
+                    (reset! busy true)
+                    (reset! error nil)
+                    (->> (rp/cmd! :set-instance-user-membership
+                                  {:member-id @selected :kind kind :target-id target-id :role role})
+                         (rx/subs! (fn [_] (reset! busy false) (swap! revision inc))
+                                   (fn [cause]
+                                     (reset! busy false)
+                                     (reset! error (if (= :team-membership-required (:code (ex-data cause)))
+                                                     (tr "admin.users.team-required")
+                                                     (tr "admin.users.save-error"))))))))]
+    (mf/with-effect [@query @offset @revision]
+      (reset! loading true)
+      (reset! error nil)
+      (let [sub (->> (rp/cmd! :get-instance-users {:search @query :offset @offset :limit 50})
+                     (rx/subs! (fn [data] (reset! result data) (reset! loading false))
+                               (fn [_] (reset! loading false) (reset! error (tr "admin.users.load-error")))))]
+        #(rx/dispose! sub)))
+    [:section {:class (stl/css :users) :aria-labelledby "instance-users-title"}
+     [:h2 {:id "instance-users-title"} (tr "admin.users.title")]
+     [:form {:class (stl/css :search)
+             :on-submit #(do (dom/prevent-default %) (reset! offset 0) (reset! query @search))}
+      [:div {:class (stl/css :search-field)}
+       [:span {:class (stl/css :search-icon) :aria-hidden true} i/search]
+       [:input {:id "instance-user-search" :type "search" :value @search
+                :aria-label (tr "admin.users.search")
+                :placeholder (tr "admin.users.search")
+                :on-change #(reset! search (dom/get-target-val %))}]]
+      [:button {:class (stl/css :button :search-button) :type "submit" :disabled (or @busy @loading)}
+       (tr "admin.users.search-action")]]
+     (when @error
+       [:div {:class (stl/css :error-notice) :role "alert"}
+        [:p @error]
+        [:button {:class (stl/css :button) :type "button" :disabled (or @busy @loading)
+                  :on-click #(swap! revision inc)} (tr "labels.retry")]])
+     (if @loading
+       [:p {:role "status"} (tr "labels.loading")]
+       [:table
+        [:thead [:tr [:th (tr "admin.users.name")] [:th (tr "admin.users.email")]
+                 [:th (tr "admin.users.teams")] [:th (tr "admin.users.projects")]
+                 [:th (tr "admin.users.manage")]]]
+        [:tbody
+         (for [user (:users @result)]
+           [:tr {:key (:id user)}
+            [:td (:fullname user)] [:td (:email user)]
+            [:td (for [team (:teams user)] [:div {:key (:id team)} (:name team)])]
+            [:td (for [project (:projects user)] [:div {:key (:id project)} (:name project)])]
+            [:td [:button {:class (stl/css :button) :type "button" :disabled @busy :on-click #(reset! selected (:id user))}
+                  (tr "admin.users.manage")]]])]])
+     (when (and (not @error) (not @loading) (pos? (:total @result)))
+       [:div {:class (stl/css :pagination)}
+        [:button {:class (stl/css :button) :type "button" :disabled (or @busy @loading (zero? @offset))
+                  :on-click #(do (reset! selected nil) (swap! offset - 50))} (tr "admin.users.previous")]
+        [:span (str (min (+ @offset 50) (:total @result)) " / " (:total @result))]
+        [:button {:class (stl/css :button) :type "button" :disabled (or @busy @loading (>= (+ @offset 50) (:total @result)))
+                  :on-click #(do (reset! selected nil) (swap! offset + 50))} (tr "admin.users.next")]])
+     (when account
+       [:section {:class (stl/css :editor) :aria-label (:email account)}
+        [:h3 (:email account)]
+        [:p (tr "admin.users.inheritance")]
+        [:h4 (tr "admin.users.teams")]
+        [:> membership-list* {:items (:teams account) :kind :team :busy @busy :on-change change}]
+        [:h4 (tr "admin.users.projects")]
+        [:> membership-list* {:items (:projects account) :kind :project :busy @busy :on-change change}]
+        [:> add-membership* {:busy @busy :on-change change}]])]))

--- a/frontend/src/app/main/ui/settings/instance_users.scss
+++ b/frontend/src/app/main/ui/settings/instance_users.scss
@@ -1,0 +1,160 @@
+@use "ds/mixins.scss" as *;
+@use "ds/borders.scss" as *;
+@use "ds/typography.scss" as t;
+@use "ds/sizes.scss" as *;
+@use "../ds/buttons/buttons" as *;
+
+.users {
+  @include t.use-typography("body-medium");
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-l);
+  padding: var(--sp-l);
+  overflow: auto;
+  color: var(--color-foreground-primary);
+}
+
+.users table {
+  border-collapse: collapse;
+}
+
+.users th,
+.users td {
+  padding: var(--sp-s);
+  text-align: start;
+  border-bottom: $b-1 solid var(--color-background-tertiary);
+}
+
+.users input,
+.users select {
+  padding: var(--sp-xs);
+  color: var(--color-foreground-primary);
+  background: var(--color-background-secondary);
+  border: $b-1 solid var(--color-foreground-secondary);
+  border-radius: $br-4;
+}
+
+.users button:disabled {
+  opacity: 0.5;
+}
+
+.search,
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-s);
+}
+
+.editor,
+.add-membership {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-s);
+}
+
+.add-membership label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-s);
+}
+
+.memberships {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+  padding: 0;
+  list-style: none;
+}
+
+.memberships li {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-s);
+}
+
+.users h2 {
+  margin: 0;
+}
+
+.button {
+  @extend %base-button;
+  @extend %base-button-secondary;
+  @include t.use-typography("body-medium");
+
+  padding-inline: var(--sp-m);
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.button:disabled {
+  cursor: default;
+}
+
+.search-button {
+  @extend %base-button-primary;
+}
+
+.search {
+  flex-wrap: wrap;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-s);
+  width: min(100%, #{$sz-400});
+  height: $sz-32;
+  padding-inline: var(--sp-s);
+  border: $b-1 solid var(--color-background-quaternary);
+  border-radius: $br-8;
+  background: var(--color-background-primary);
+}
+
+.search-field:focus-within {
+  border-color: var(--color-accent-primary);
+}
+
+.search-field input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+}
+
+.search-field input::placeholder {
+  color: var(--color-foreground-secondary);
+}
+
+.search-icon {
+  display: flex;
+  color: var(--color-foreground-secondary);
+}
+
+.search-icon svg {
+  width: $sz-16;
+  height: $sz-16;
+}
+
+.error-notice {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-m);
+  padding: var(--sp-m);
+  background: var(--color-background-secondary);
+  border: $b-1 solid var(--color-background-quaternary);
+  border-radius: $br-8;
+}
+
+.error-notice p {
+  margin: 0;
+}
+
+.pagination {
+  justify-content: flex-end;
+}

--- a/frontend/src/app/main/ui/settings/instance_users.scss
+++ b/frontend/src/app/main/ui/settings/instance_users.scss
@@ -28,7 +28,12 @@
 
 .users input,
 .users select {
-  padding: var(--sp-xs);
+  box-sizing: border-box;
+  height: $sz-32;
+  margin: 0;
+  padding: 0 var(--sp-s);
+  font: inherit;
+  line-height: normal;
   color: var(--color-foreground-primary);
   background: var(--color-background-secondary);
   border: $b-1 solid var(--color-foreground-secondary);
@@ -54,7 +59,8 @@
 }
 
 .add-membership label {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   align-items: center;
   gap: var(--sp-s);
 }
@@ -82,6 +88,10 @@
   @extend %base-button-secondary;
   @include t.use-typography("body-medium");
 
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
   padding-inline: var(--sp-m);
   flex-shrink: 0;
   cursor: pointer;
@@ -119,6 +129,10 @@
   flex: 1;
   min-width: 0;
   height: 100%;
+  margin: 0;
+  box-sizing: border-box;
+  font: inherit;
+  line-height: normal;
   padding: 0;
   border: 0;
   outline: none;
@@ -137,6 +151,8 @@
 .search-icon svg {
   width: $sz-16;
   height: $sz-16;
+  fill: none;
+  stroke: currentcolor;
 }
 
 .error-notice {
@@ -157,4 +173,59 @@
 
 .pagination {
   justify-content: flex-end;
+}
+
+.editor {
+  border-block-start: $b-1 solid var(--color-background-quaternary);
+  padding-block-start: var(--sp-l);
+  gap: var(--sp-m);
+}
+
+.editor h3,
+.editor h4,
+.editor p {
+  margin: 0;
+}
+
+.editor h3 {
+  overflow-wrap: anywhere;
+}
+
+.memberships {
+  margin: 0;
+}
+
+.memberships li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) $sz-120 $sz-64;
+  max-width: $sz-500;
+}
+
+.memberships span {
+  overflow-wrap: anywhere;
+}
+
+.add-membership {
+  width: 100%;
+  max-width: $sz-500;
+  gap: var(--sp-m);
+  padding-block-start: var(--sp-m);
+}
+
+.add-membership input,
+.add-membership select {
+  width: 100%;
+  min-width: 0;
+}
+
+.add-membership label {
+  margin: 0;
+}
+
+.add-membership > .button {
+  align-self: flex-end;
+}
+
+.users td {
+  vertical-align: top;
 }

--- a/frontend/src/app/main/ui/settings/sidebar.cljs
+++ b/frontend/src/app/main/ui/settings/sidebar.cljs
@@ -90,6 +90,11 @@
      [:nav {:class (stl/css :sidebar-content-section)
             :aria-label (tr "labels.settings")}
       [:ul {:class (stl/css :sidebar-nav-settings)}
+       (when (:is-instance-admin profile)
+         [:li {:class (stl/css-case :current (= section :settings-instance-users)
+                                    :settings-item true)
+                :on-click #(st/emit! (rt/nav :settings-instance-users))}
+          [:span {:class (stl/css :element-title)} (tr "admin.users.title")]])
        [:li {:class (stl/css-case :current profile?
                                   :settings-item true)
              :on-click go-settings-profile}

--- a/frontend/test/frontend_tests/runner.cljs
+++ b/frontend/test/frontend_tests/runner.cljs
@@ -84,6 +84,7 @@
    [frontend-tests.ui.gradient-handlers-test]
    [frontend-tests.ui.layout-container-multiple-test]
    [frontend-tests.ui.measures-menu-props-test]
+   [frontend-tests.ui.instance-users-test]
    [frontend-tests.ui.routes-test]
    [frontend-tests.ui.settings-password-schema-test]
    [frontend-tests.ui.settings-shortcuts-test]
@@ -188,6 +189,7 @@
    'frontend-tests.ui.gradient-handlers-test
    'frontend-tests.ui.layout-container-multiple-test
    'frontend-tests.ui.measures-menu-props-test
+   'frontend-tests.ui.instance-users-test
    'frontend-tests.ui.routes-test
    'frontend-tests.render-dimensions-test
    'frontend-tests.text-editor-paste-guard-test

--- a/frontend/test/frontend_tests/ui/instance_users_test.cljs
+++ b/frontend/test/frontend_tests/ui/instance_users_test.cljs
@@ -1,0 +1,93 @@
+;; This Source Code Form is subject to the terms of the Mozilla Public
+;; License, v. 2.0. If a copy of the MPL was not distributed with this
+;; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;;
+;; Copyright (c) KALEIDOS SUBSIDIARY SL
+
+(ns frontend-tests.ui.instance-users-test
+  (:require
+   ["jsdom" :refer [JSDOM]]
+   ["react" :as react]
+   ["react-dom/client" :as client]
+   [app.common.uuid :as uuid]
+   [app.main.repo :as rp]
+   [app.main.ui.settings.instance-users :as users]
+   [app.util.globals :as globals]
+   [app.util.i18n :as i18n]
+   [beicon.v2.core :as rx]
+   [cljs.test :as t :include-macros true]
+   [clojure.string :as str]
+   [promesa.core :as p]))
+
+(t/deftest administrator-can-load-users-and-edit-memberships
+  (t/async done
+    (let [browser (JSDOM. "<!doctype html><html><body><div id='root'></div></body></html>"
+                          #js {:url "http://localhost/"})
+          window  (.-window browser)
+          doc     (.-document window)
+          before  {:window (.-window js/globalThis) :document (.-document js/globalThis)
+                   :globals-window globals/window :globals-document globals/document
+                   :tr i18n/tr :cmd rp/cmd! :act (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)}
+          id      (uuid/random)
+          team-id (uuid/random)
+          new-id  (uuid/random)
+          model   (atom {:id id :fullname "Example User" :email "user@example.com"
+                         :teams [{:id team-id :name "Design" :can-edit false}]
+                         :projects []})
+          calls   (atom [])
+          root    (client/createRoot (.getElementById doc "root"))
+          button  (fn [label] (some #(when (= label (.-textContent %)) %) (array-seq (.querySelectorAll doc "button"))))
+          click   (fn [element] (.dispatchEvent element (js/Reflect.construct (.-MouseEvent window) #js ["click" #js {:bubbles true}])))
+          change  (fn [element value]
+                    (set! (.-value element) value)
+                    (.dispatchEvent element (js/Reflect.construct (.-Event window) #js ["change" #js {:bubbles true}])))]
+      (set! (.-window js/globalThis) window)
+      (set! (.-document js/globalThis) doc)
+      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+      (set! globals/window window)
+      (set! globals/document doc)
+      (set! i18n/tr (fn ([key] key) ([key & _] key)))
+      (set! rp/cmd!
+            (fn rpc-stub
+              ([command] (rpc-stub command {}))
+              ([command params]
+               (swap! calls conj [command params])
+               (case command
+                 :get-instance-users (rx/of {:users [@model] :total 1})
+                 :get-instance-membership-targets (rx/of [{:id new-id :name "Research"}])
+                 :set-instance-user-membership
+                 (do
+                   (swap! model assoc :teams
+                          (case (:role params)
+                            :none []
+                            [{:id (:target-id params)
+                              :name (if (= new-id (:target-id params)) "Research" "Design")
+                              :can-edit true}]))
+                   (rx/of (select-keys @model [:teams :projects])))
+                 (rx/throw (js/Error. (str "Unexpected RPC: " command)))))))
+      (-> (p/let [_ (react/act #(.render root (react/createElement users/instance-users-page* #js {})))
+                  _ (t/is (str/includes? (.-textContent (.-body doc)) "user@example.com"))
+                  _ (react/act #(click (button "admin.users.manage")))
+                  _ (react/act #(change (.querySelector doc "select[aria-label]") "editor"))
+                  _ (t/is (some #(= [:set-instance-user-membership
+                                     {:member-id id :kind :team :target-id team-id :role :editor}] %) @calls))
+                  _ (react/act #(click (button "labels.remove")))
+                  _ (t/is (empty? (:teams @model)))
+                  _ (react/act #(change (.querySelector doc (str "select:has(option[value='" new-id "'])")) (str new-id)))
+                  _ (react/act #(.dispatchEvent (.closest (button "admin.users.add") "form")
+                                                (js/Reflect.construct (.-Event window) #js ["submit" #js {:bubbles true :cancelable true}])))]
+            (t/is (= new-id (:id (first (:teams @model)))))
+            (t/is (str/includes? (.-textContent (.-body doc)) "Research")))
+          (p/catch (fn [cause] (t/is false (str cause))))
+          (p/finally
+            (fn []
+              (react/act #(.unmount root))
+              (set! rp/cmd! (:cmd before))
+              (set! i18n/tr (:tr before))
+              (set! globals/window (:globals-window before))
+              (set! globals/document (:globals-document before))
+              (set! (.-window js/globalThis) (:window before))
+              (set! (.-document js/globalThis) (:document before))
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) (:act before))
+              (.close window)
+              (done)))))))

--- a/frontend/translations/en.po
+++ b/frontend/translations/en.po
@@ -11,6 +11,96 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
+#: src/app/main/ui/settings/instance_users.cljs:84
+msgid "admin.users.add"
+msgstr "Add membership"
+
+#: src/app/main/ui/settings/instance_users.cljs:138
+msgid "admin.users.email"
+msgstr "Email"
+
+#: src/app/main/ui/settings/instance_users.cljs:67
+msgid "admin.users.find-target"
+msgstr "Find a team or project"
+
+#: src/app/main/ui/settings.cljs:65
+msgid "admin.users.forbidden"
+msgstr "Only instance administrators can manage users."
+
+#: src/app/main/ui/settings/instance_users.cljs:159
+msgid "admin.users.inheritance"
+msgstr ""
+"Team membership also grants access to its projects. Removing a direct "
+"project membership does not remove access inherited from a team. Owners and "
+"personal workspaces are protected."
+
+#: src/app/main/ui/settings/instance_users.cljs:62
+msgid "admin.users.kind"
+msgstr "Membership type"
+
+#: src/app/main/ui/settings/instance_users.cljs:83, src/app/main/ui/settings/instance_users.cljs:116
+msgid "admin.users.load-error"
+msgstr "Unable to load users or memberships. Try again."
+
+#: src/app/main/ui/settings/instance_users.cljs:140, src/app/main/ui/settings/instance_users.cljs:148
+msgid "admin.users.manage"
+msgstr "Manage memberships"
+
+#: src/app/main/ui/settings/instance_users.cljs:138
+msgid "admin.users.name"
+msgstr "Name"
+
+#: src/app/main/ui/settings/instance_users.cljs:78, src/app/main/ui/settings/instance_users.cljs:155
+msgid "admin.users.next"
+msgstr "Next"
+
+#: src/app/main/ui/settings/instance_users.cljs:77, src/app/main/ui/settings/instance_users.cljs:152
+msgid "admin.users.previous"
+msgstr "Previous"
+
+#: src/app/main/ui/settings/instance_users.cljs:66, src/app/main/ui/settings/instance_users.cljs:139, src/app/main/ui/settings/instance_users.cljs:162
+msgid "admin.users.projects"
+msgstr "Direct project memberships"
+
+#: src/app/main/ui/settings/instance_users.cljs:28, src/app/main/ui/settings/instance_users.cljs:79
+msgid "admin.users.role"
+msgstr "Role"
+
+#: src/app/main/ui/settings/instance_users.cljs:110
+msgid "admin.users.save-error"
+msgstr "Unable to change this membership. Check your access and try again."
+
+#: src/app/main/ui/settings/instance_users.cljs:125, src/app/main/ui/settings/instance_users.cljs:126
+msgid "admin.users.search"
+msgstr "Search by name or email"
+
+#: src/app/main/ui/settings/instance_users.cljs:129
+msgid "admin.users.search-action"
+msgstr "Search"
+
+#: src/app/main/ui/settings/instance_users.cljs:72
+msgid "admin.users.select-target"
+msgstr "Select a team or project"
+
+#: src/app/main/ui/settings/instance_users.cljs:70
+msgid "admin.users.target"
+msgstr "Add to"
+
+#: src/app/main/ui/settings/instance_users.cljs:109
+msgid "admin.users.team-required"
+msgstr ""
+"Add this user to the enclosing team first. Viewer membership allows "
+"project-specific edit permissions."
+
+#: src/app/main/ui/settings/instance_users.cljs:65, src/app/main/ui/settings/instance_users.cljs:139, src/app/main/ui/settings/instance_users.cljs:160
+msgid "admin.users.teams"
+msgstr "Teams"
+
+#: src/app/main/ui/settings/instance_users.cljs:119, src/app/main/ui/settings/sidebar.cljs:97
+msgid "admin.users.title"
+msgstr "User administration"
+
+
 #: src/app/main/ui/auth/register.cljs:214, src/app/main/ui/static.cljs:180, src/app/main/ui/viewer/login.cljs:100
 msgid "auth.already-have-account"
 msgstr "Already have an account?"

--- a/frontend/translations/jpn_JP.po
+++ b/frontend/translations/jpn_JP.po
@@ -11,6 +11,92 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.6.dev0\n"
 
+#: src/app/main/ui/settings/instance_users.cljs:84
+msgid "admin.users.add"
+msgstr "所属を追加"
+
+#: src/app/main/ui/settings/instance_users.cljs:138
+msgid "admin.users.email"
+msgstr "メールアドレス"
+
+#: src/app/main/ui/settings/instance_users.cljs:67
+msgid "admin.users.find-target"
+msgstr "チーム・プロジェクトを検索"
+
+#: src/app/main/ui/settings.cljs:65
+msgid "admin.users.forbidden"
+msgstr "ユーザー管理はインスタンス管理者のみ利用できます。"
+
+#: src/app/main/ui/settings/instance_users.cljs:159
+msgid "admin.users.inheritance"
+msgstr ""
+"チームのメンバーはそのプロジェクトにもアクセスできます。直接の所属を削除しても、チーム経由のアクセスは残ります。Ownerと個人領域はここでは変更できま"
+"せん。"
+
+#: src/app/main/ui/settings/instance_users.cljs:62
+msgid "admin.users.kind"
+msgstr "所属の種類"
+
+#: src/app/main/ui/settings/instance_users.cljs:83, src/app/main/ui/settings/instance_users.cljs:116
+msgid "admin.users.load-error"
+msgstr "ユーザーまたは所属を取得できませんでした。再試行してください。"
+
+#: src/app/main/ui/settings/instance_users.cljs:140, src/app/main/ui/settings/instance_users.cljs:148
+msgid "admin.users.manage"
+msgstr "所属を管理"
+
+#: src/app/main/ui/settings/instance_users.cljs:138
+msgid "admin.users.name"
+msgstr "名前"
+
+#: src/app/main/ui/settings/instance_users.cljs:78, src/app/main/ui/settings/instance_users.cljs:155
+msgid "admin.users.next"
+msgstr "次へ"
+
+#: src/app/main/ui/settings/instance_users.cljs:77, src/app/main/ui/settings/instance_users.cljs:152
+msgid "admin.users.previous"
+msgstr "前へ"
+
+#: src/app/main/ui/settings/instance_users.cljs:66, src/app/main/ui/settings/instance_users.cljs:139, src/app/main/ui/settings/instance_users.cljs:162
+msgid "admin.users.projects"
+msgstr "プロジェクトへの直接の所属"
+
+#: src/app/main/ui/settings/instance_users.cljs:28, src/app/main/ui/settings/instance_users.cljs:79
+msgid "admin.users.role"
+msgstr "ロール"
+
+#: src/app/main/ui/settings/instance_users.cljs:110
+msgid "admin.users.save-error"
+msgstr "所属を変更できませんでした。権限を確認して再試行してください。"
+
+#: src/app/main/ui/settings/instance_users.cljs:125, src/app/main/ui/settings/instance_users.cljs:126
+msgid "admin.users.search"
+msgstr "名前・メールアドレスで検索"
+
+#: src/app/main/ui/settings/instance_users.cljs:129
+msgid "admin.users.search-action"
+msgstr "検索"
+
+#: src/app/main/ui/settings/instance_users.cljs:72
+msgid "admin.users.select-target"
+msgstr "チームまたはプロジェクトを選択"
+
+#: src/app/main/ui/settings/instance_users.cljs:70
+msgid "admin.users.target"
+msgstr "追加先"
+
+#: src/app/main/ui/settings/instance_users.cljs:109
+msgid "admin.users.team-required"
+msgstr "まず対象プロジェクトのチームにこのユーザーを追加してください。チームの閲覧権限に、プロジェクト単位の編集権限を追加できます。"
+
+#: src/app/main/ui/settings/instance_users.cljs:65, src/app/main/ui/settings/instance_users.cljs:139, src/app/main/ui/settings/instance_users.cljs:160
+msgid "admin.users.teams"
+msgstr "チーム"
+
+#: src/app/main/ui/settings/instance_users.cljs:119, src/app/main/ui/settings/sidebar.cljs:97
+msgid "admin.users.title"
+msgstr "ユーザー管理"
+
 #: src/app/main/ui/auth/register.cljs:214, src/app/main/ui/static.cljs:180, src/app/main/ui/viewer/login.cljs:100
 msgid "auth.already-have-account"
 msgstr "アカウントをお持ちですか？"
@@ -515,10 +601,6 @@ msgstr "Eメール"
 msgid "dashboard.your-name"
 msgstr "名前"
 
-#: src/app/main/ui/dashboard/file_menu.cljs:40, src/app/main/ui/dashboard/fonts.cljs:46, src/app/main/ui/dashboard/libraries.cljs:55, src/app/main/ui/dashboard/projects.cljs:352, src/app/main/ui/dashboard/search.cljs:47, src/app/main/ui/dashboard/sidebar.cljs:411, src/app/main/ui/dashboard/team.cljs:616, src/app/main/ui/dashboard/team.cljs:1191, src/app/main/ui/dashboard/team.cljs:1471, src/app/main/ui/dashboard/team.cljs:1577
-msgid "dashboard.your-penpot"
-msgstr "あなたのPenpot"
-
 #: src/app/main/ui/comments.cljs:693, src/app/main/ui/confirm.cljs:42, src/app/main/ui/settings/subscription.cljs:303, src/app/main/ui/settings/subscription.cljs:336, src/app/main/ui/settings/subscription.cljs:776, src/app/main/ui/settings/subscription.cljs:823, src/app/main/ui/workspace/plugins.cljs:373, src/app/main/ui/workspace/plugins.cljs:436
 msgid "ds.confirm-cancel"
 msgstr "キャンセル"
@@ -647,10 +729,6 @@ msgstr "題名"
 #: src/app/main/ui/settings/feedback.cljs:155
 msgid "feedback.twitter-title"
 msgstr "Xサポートアカウント"
-
-#: src/app/main/ui/exports/files.cljs:141
-msgid "files-download-modal.options.all.title"
-msgstr "共有ライブラリとしてエクスポート"
 
 #: src/app/main/ui/settings/password.cljs:31
 msgid "generic.error"


### PR DESCRIPTION
### Related Ticket

<!-- Reference the related GitHub/Taiga ticket. -->

### Summary

Add an instance administration page at /#/admin/users so administrators can manage existing users and their memberships from one place.

- Provide user search and pagination.
- Allow administrators to manage team memberships and direct project permissions.
- Restrict access to active, unblocked accounts configured in PENPOT_ADMINS, with authorization enforced by the backend.
- Protect personal workspaces and owner memberships from changes through this page.

Require team membership before assigning direct project permissions, while allowing a team viewer to receive editor access to a specific project.

**Validation**: Added backend authorization and membership tests, plus frontend coverage. The administration UI test passed with 5 assertions in the combined integration checkout.

**Note**: This PR was prepared with AI assistance.

### Steps to reproduce

1. Configure an active account in the backend PENPOT_ADMINS setting and restart the backend.
1. Sign in with that account and open /#/admin/users.
1. Search for an existing user and verify that pagination works.
1. Add the user to a shared team, then assign direct permissions for a project in that team.
1. Verify that assigning project permissions without team membership is rejected.
1. Verify that personal workspaces and owner memberships cannot be modified through this page.
1. Sign in with an account outside PENPOT_ADMINS and verify that both the page and its administration API operations are inaccessible. 

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide.
- [ ] Check CI passes successfully.

<!-- For more details, check the contribution guidelines: https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md -->
