### PR TITLE
:bug: Hard-clip tile atlas blit to avoid seam hairlines

### DIFF
--- a/render-wasm/src/render/surfaces.rs
+++ b/render-wasm/src/render/surfaces.rs
@@ -40,7 +40,9 @@ fn draw_surface_src_rect_to_dst(
         return;
     }
     to_canvas.save();
-    to_canvas.clip_rect(dst, None, true);
+    // Hard clip: AA softens shared tile edges so the backbuffer background
+    // shows through as 1px seams when tiles are composed with SrcOver.
+    to_canvas.clip_rect(dst, None, false);
     let sx = dst.width() / src.width();
     let sy = dst.height() / src.height();
     to_canvas.translate((dst.left, dst.top));


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Removes 1px background-colored hairlines that appeared on tile seams (x/y = 512·k) at 100% zoom when a fill crossed the tile grid.

## Why

- The Current→atlas blit introduced in #11093 clipped the destination with antialiasing. Soft edges left shared tile borders partially transparent, so the backbuffer background showed through when tiles were composed with SrcOver.

## How

- Use a hard clip (`antialias = false`) in `draw_surface_src_rect_to_dst`.

Closes #11638
