### PR TITLE
:bug: Restart progressive render on canvas background change

### DIFF
--- a/frontend/src/app/render_wasm/api.cljs
+++ b/frontend/src/app/render_wasm/api.cljs
@@ -2211,6 +2211,10 @@
   [background]
   (when (initialized?)
     (let [rgba (sr-clr/hex->u32argb background 1)]
+      ;; Background is baked into every tile. Cancel Partial/ViewportReady so we
+      ;; do not continue a progressive pass whose tile cache was just cleared —
+      ;; that drops already-finished tiles from the queue and leaves bg-only holes.
+      (stop-progressive-render!)
       (h/call wasm/internal-module "_set_canvas_background" rgba)
       (request-render "set-canvas-background"))))
 


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

## What

- Changing the canvas background by dragging the color picker could leave some tiles rendered as solid background only (sometimes the previous color), with shape content missing.

## Why

- Canvas background is baked into each tile. A background change invalidates the tile cache, but if a progressive Partial/ViewportReady pass was already in flight, `request-render` was coalesced away and the continue path never re-queued tiles that had already been popped — leaving background-only holes.

## How

- Call `stop-progressive-render!` in `set-canvas-background` before updating WASM and requesting a new render, so the next frame starts a full render loop with the latest background.

Closes #11642
