### PR TITLE
:bug: Fix email already used showing a toast instead of an input error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,6 @@
 - Fix triple-click not selecting the full line in text editor v3 [#11483](https://github.com/penpot/penpot/issues/11483) (PR: [#11493](https://github.com/penpot/penpot/pull/11493))
 - Fix pasted text losing formatting on last lines after resizing and adding new lines from the top [#11501](https://github.com/penpot/penpot/issues/11501) (PR: [#11503](https://github.com/penpot/penpot/pull/11503))
 - Fix variant property dropdown appearing empty and throwing an internal error when the component has no sibling variants [#11524](https://github.com/penpot/penpot/issues/11524) (PR: [#11499](https://github.com/penpot/penpot/pull/11499))
-- Fix registering with an already used email showing a toast instead of an error on the email input [#10890](https://github.com/penpot/penpot/issues/10890)
 
 ### :sparkles: New features & Enhancements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Fix triple-click not selecting the full line in text editor v3 [#11483](https://github.com/penpot/penpot/issues/11483) (PR: [#11493](https://github.com/penpot/penpot/pull/11493))
 - Fix pasted text losing formatting on last lines after resizing and adding new lines from the top [#11501](https://github.com/penpot/penpot/issues/11501) (PR: [#11503](https://github.com/penpot/penpot/pull/11503))
 - Fix variant property dropdown appearing empty and throwing an internal error when the component has no sibling variants [#11524](https://github.com/penpot/penpot/issues/11524) (PR: [#11499](https://github.com/penpot/penpot/pull/11499))
+- Fix registering with an already used email showing a toast instead of an error on the email input [#10890](https://github.com/penpot/penpot/issues/10890)
 
 ### :sparkles: New features & Enhancements
 

--- a/frontend/playwright/data/register/prepare-register-profile-email-already-exists.json
+++ b/frontend/playwright/data/register/prepare-register-profile-email-already-exists.json
@@ -1,0 +1,5 @@
+{
+  "~:type": "~:validation",
+  "~:code": "~:email-already-exists",
+  "~:hint": "email already exists"
+}

--- a/frontend/playwright/ui/pages/RegisterPage.js
+++ b/frontend/playwright/ui/pages/RegisterPage.js
@@ -21,6 +21,14 @@ export class RegisterPage extends BasePage {
     await this.registerButton.click();
   }
 
+  async setupEmailAlreadyExistsError() {
+    await this.mockRPC(
+      "prepare-register-profile",
+      "register/prepare-register-profile-email-already-exists.json",
+      { status: 400 },
+    );
+  }
+
   async setupMismatchedEmailError() {
     await this.mockRPC(
       "prepare-register-profile",

--- a/frontend/playwright/ui/specs/register.spec.js
+++ b/frontend/playwright/ui/specs/register.spec.js
@@ -24,4 +24,23 @@ test.describe("Register form errors", () => {
       page.getByText("Email does not match the invitation."),
     ).toBeVisible();
   });
+
+  test("User gets the already used email error on the email input", async ({
+    page,
+  }) => {
+    const registerPage = new RegisterPage(page);
+    await registerPage.setupEmailAlreadyExistsError();
+
+    await registerPage.fillRegisterFormInputs(
+      "John Doe",
+      "john.doe@example.com",
+      "password123",
+    );
+    await registerPage.clickRegisterButton();
+
+    await expect(page.getByTestId("email-input-error")).toHaveText(
+      "Email already used",
+    );
+    await expect(page.getByRole("alert")).toHaveCount(0);
+  });
 });

--- a/frontend/src/app/main/ui/auth/register.cljs
+++ b/frontend/src/app/main/ui/auth/register.cljs
@@ -79,6 +79,7 @@
 
         on-error
         (mf/use-fn
+         (mf/deps form)
          (fn [cause]
            (reset! submitted? false)
            (let [{:keys [type code] :as edata} (ex-data cause)]
@@ -98,8 +99,12 @@
                [:restriction :email-has-complaints]
                (st/emit! (ntf/error (tr "errors.email-has-permanent-bounces" (:email edata))))
 
+               ;; Reported on the email input itself, the way the recovery and
+               ;; password forms report server side errors, so the field that
+               ;; needs fixing is the one marked as invalid
                [:validation :email-already-exists]
-               (st/emit! (ntf/error (tr "errors.email-already-exists")))
+               (swap! form assoc-in [:extra-errors :email]
+                      {:message (tr "errors.email-already-exists")})
 
                [:validation :email-as-password]
                (st/emit! (ntf/error (tr "errors.email-as-password")))


### PR DESCRIPTION
### Related Ticket

Fixes #10890

### Summary

Registering with an email that already has an account reported the problem with a toast, while the email input kept its valid state. That reads as if the form went through.

The error now goes on the email input itself, the same way the recovery and change password forms report server side errors.

It is written to `:extra-errors` rather than `:errors`, because the form mutator recomputes `:errors` from the schema on every change, so anything set there is dropped on the next render.

### Steps to reproduce

1. Register an account and verify it from the email link.
2. Log out and go to `#/auth/register`.
3. Register again with the same email.

Before, the email input stays green and a toast appears:

![before](https://raw.githubusercontent.com/ShreyashAgare26/penpot/pr-assets/docs/before.png)

After, the email input is marked invalid with the message below it and no toast:

![after](https://raw.githubusercontent.com/ShreyashAgare26/penpot/pr-assets/docs/after.png)

Covered by a new case in `playwright/ui/specs/register.spec.js`.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [x] Include screenshots or videos, if applicable.
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide. No SCSS changed.
- [ ] Check CI passes successfully.
