### PR TITLE
:zap: Fetch only caller share-link in view-only bundle

### DIFF
--- a/backend/src/app/rpc/commands/viewer.clj
+++ b/backend/src/app/rpc/commands/viewer.clj
@@ -89,18 +89,27 @@
                      (mapv (fn [{:keys [id] :as lib}]
                              (merge lib (bfc/get-file cfg id)))))
 
-        links   (cond->> (->> (db/query conn :share-link {:file-id file-id})
-                              (mapv (fn [row]
-                                      (-> row
-                                          (update :pages db/decode-pgarray #{})
-                                          ;; NOTE: the flags are deprecated but are still present
-                                          ;; on the table on old rows. The flags are pgarray and
-                                          ;; for avoid decoding it (because they are no longer used
-                                          ;; on frontend) we just dissoc the column attribute from
-                                          ;; row.
-                                          (dissoc :flags)))))
-                  (= :share-link (:type perms))
-                  (filterv #(= (:id %) share-id)))
+        decode-link
+        (fn [row]
+          (-> row
+              (update :pages db/decode-pgarray #{})
+              ;; NOTE: the flags are deprecated but are still present
+              ;; on the table on old rows. The flags are pgarray and
+              ;; for avoid decoding it (because they are no longer used
+              ;; on frontend) we just dissoc the column attribute from
+              ;; row.
+              (dissoc :flags)))
+
+        ;; NOTE: on the share-link path we fetch at most the caller's own
+        ;; row with a composite (id, file-id) predicate, so sibling tokens
+        ;; never leave postgres. The membership path keeps the full list
+        ;; the share-management UI needs. A nil share-id never falls back
+        ;; to the full query; it simply resolves to an empty vector.
+        links   (if (= :share-link (:type perms))
+                  (if-some [row (db/get* conn :share-link {:id share-id :file-id file-id})]
+                    [(decode-link row)]
+                    [])
+                  (mapv decode-link (db/query conn :share-link {:file-id file-id})))
 
         fonts   (db/query conn :team-font-variant
                           {:team-id (:id team)

--- a/backend/test/backend_tests/rpc_viewer_test.clj
+++ b/backend/test/backend_tests/rpc_viewer_test.clj
@@ -206,6 +206,41 @@
         (t/is (some #(= link-a-id (:id %)) share-links))
         (t/is (some #(= link-b-id (:id %)) share-links))))
 
+    (t/testing "share-link viewer does not query sibling share-links"
+      ;; Direct regression test for the predicate-pushdown invariant:
+      ;; on the share-link path the bundle must resolve the caller's
+      ;; row with a composite (id, file-id) single-row lookup and must
+      ;; never run the full {:file-id} query that would load sibling
+      ;; tokens into the backend process. The with-redefs spies only
+      ;; record and delegate, following the instrumentation style used
+      ;; elsewhere in this suite (e.g. auth-ldap-test).
+      (let [share-queries (atom [])
+            share-gets    (atom [])
+            orig-query    @#'db/query
+            orig-get*     @#'db/get*]
+        (with-redefs [db/query (fn [conn table params & opts]
+                                 (when (= :share-link table)
+                                   (swap! share-queries conj params))
+                                 (apply orig-query conn table params opts))
+                      db/get*  (fn [conn table params & opts]
+                                 (when (= :share-link table)
+                                   (swap! share-gets conj params))
+                                 (apply orig-get* conn table params opts))]
+          (let [out    (th/command! {::th/type :get-view-only-bundle
+                                     :share-id link-a-id
+                                     :file-id (:id file)})
+                result (:result out)]
+            (t/is (nil? (:error out)))
+            (t/is (= 1 (count (:share-links result))))
+            (t/is (= link-a-id (:id (first (:share-links result)))))
+            ;; No full-file sibling query ran on this path.
+            (t/is (empty? @share-queries))
+            ;; Only composite single-row lookups ran (the permission
+            ;; check plus the bundle itself, same predicate in both).
+            (t/is (seq @share-gets))
+            (t/is (every? #(= {:id link-a-id :file-id (:id file)} %)
+                          @share-gets))))))
+
     (t/testing "cross-file share-id replay fails closed"
       (let [other-file (th/create-file* 2 {:profile-id (:id owner)
                                            :project-id proj-id
@@ -213,15 +248,6 @@
             out (th/command! {::th/type :get-view-only-bundle
                               :share-id link-a-id
                               :file-id (:id other-file)})
-            error (:error out)
-            error-data (ex-data error)]
-        (t/is (th/ex-info? error))
-        (t/is (= :not-found (:type error-data)))
-        (t/is (= :object-not-found (:code error-data)))))
-
-    (t/testing "anonymous without share-id fails closed"
-      (let [out (th/command! {::th/type :get-view-only-bundle
-                              :file-id (:id file)})
             error (:error out)
             error-data (ex-data error)]
         (t/is (th/ex-info? error))

--- a/backend/test/backend_tests/rpc_viewer_test.clj
+++ b/backend/test/backend_tests/rpc_viewer_test.clj
@@ -204,4 +204,26 @@
         ;; Team member should see both share-links
         (t/is (= 2 (count share-links)))
         (t/is (some #(= link-a-id (:id %)) share-links))
-        (t/is (some #(= link-b-id (:id %)) share-links))))))
+        (t/is (some #(= link-b-id (:id %)) share-links))))
+
+    (t/testing "cross-file share-id replay fails closed"
+      (let [other-file (th/create-file* 2 {:profile-id (:id owner)
+                                           :project-id proj-id
+                                           :is-shared false})
+            out (th/command! {::th/type :get-view-only-bundle
+                              :share-id link-a-id
+                              :file-id (:id other-file)})
+            error (:error out)
+            error-data (ex-data error)]
+        (t/is (th/ex-info? error))
+        (t/is (= :not-found (:type error-data)))
+        (t/is (= :object-not-found (:code error-data)))))
+
+    (t/testing "anonymous without share-id fails closed"
+      (let [out (th/command! {::th/type :get-view-only-bundle
+                              :file-id (:id file)})
+            error (:error out)
+            error-data (ex-data error)]
+        (t/is (th/ex-info? error))
+        (t/is (= :not-found (:type error-data)))
+        (t/is (= :object-not-found (:code error-data)))))))


### PR DESCRIPTION
**Note:** This PR was created with AI assistance.

### Related Ticket

Closes #11633

### Summary

`get-view-only-bundle` no longer loads every sibling share-link row for a file and filters in memory. When the caller authenticates via share-link, the handler now resolves only the caller's row with a composite `(id, file-id)` predicate (`db/get*`), then decodes `:pages` and strips deprecated `:flags` exactly as before, wrapped in a one-element vector (empty vector when the row is absent). The membership/owner path still fetches the full share-link list with `db/query {:file-id ...}`, so the share-management UI is unaffected. No permission-model, schema, frontend, migration, or linked-library changes.

### Steps to reproduce

1. Create a file with two share-links L1 and L2.
2. Request the view-only bundle with L1 as an anonymous caller.
3. Response `:share-links` contains only L1 (previously the backend read all sibling rows before filtering).
4. Request the same bundle as the file owner: both L1 and L2 are returned.
5. Replaying L1 against a different file fails closed (`:not-found` / `:object-not-found`); anonymous requests without a share-id also return `not-found`.

### Verification status

- `git diff --check` and `./scripts/check-commit` pass on the head commit.
- `cljfmt check` on the two changed files (`viewer.clj`, `rpc_viewer_test.clj`) passes: "All source files formatted correctly".
- `clj-kondo` lint (same args as the backend script): errors 0, warnings 11 — all pre-existing in unrelated files, 0 in `viewer.clj`.
- Backend suite (`rpc_viewer_test`, including `share-link-token-disclosure` and the two new regression tests) has NOT been executed: no `clojure` CLI, no Postgres credentials (password prompt, not guessed), no Valkey/Redis or docker in the contributing environment. Not claimed as passing.

### Checklist

- [x] Choose the correct target branch; use `develop` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable. (Not applicable: backend-only change.)
- [x] Add or modify existing integration tests in case of bugs or new features, if applicable. (Extended \share-link-token-disclosure` with a predicate-pushdown regression test and cross-file replay coverage.)`
- [ ] Refactor any modified SCSS files following the refactor guide. (Not applicable.)
- [ ] Check CI passes successfully. (Triage pass; commit-message check skipping. See Verification status for locally-run checks.)
